### PR TITLE
feat: allow managing pending users

### DIFF
--- a/src/ce/api/admin/adminhandlers/handler_users_manage.go
+++ b/src/ce/api/admin/adminhandlers/handler_users_manage.go
@@ -1,0 +1,44 @@
+package adminhandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+type UserManageRequest struct {
+	UserIDs []types.ID `json:"userIds"`
+	Action  string     `json:"action"` // "approve" or "reject"
+}
+
+func handlerUsersManage(req *user.RequestContext) *shttp.Response {
+	data := UserManageRequest{}
+
+	if err := req.Post(&data); err != nil {
+		return shttp.Error(err)
+	}
+
+	if data.Action != "approve" && data.Action != "reject" {
+		return shttp.BadRequest(map[string]any{
+			"error": "Invalid action provided. Must be either 'approve' or 'reject'",
+		})
+	}
+
+	if len(data.UserIDs) == 0 {
+		return shttp.BadRequest(map[string]any{
+			"error": "No user IDs provided",
+		})
+	}
+
+	err := user.NewStore().UpdateApprovalStatus(req.Context(), data.UserIDs, data.Action == "approve")
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+	}
+}

--- a/src/ce/api/admin/adminhandlers/handler_users_manage_test.go
+++ b/src/ce/api/admin/adminhandlers/handler_users_manage_test.go
@@ -1,0 +1,162 @@
+package adminhandlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin/adminhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/guregu/null.v3"
+)
+
+type HandlerUsersManageSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *HandlerUsersManageSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerUsersManageSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerUsersManageSuite) Test_Success_Approve() {
+	admin := s.MockUser(map[string]any{
+		"IsAdmin": true,
+	})
+
+	pendingUser := s.MockUser(map[string]any{
+		"IsApproved": null.Bool{},
+	})
+
+	s.False(pendingUser.IsApproved.Valid)
+	s.False(pendingUser.IsApproved.ValueOrZero())
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/admin/users/manage",
+		map[string]any{
+			"userIds": []string{pendingUser.ID.String()},
+			"action":  "approve",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(admin.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	usr, err := user.NewStore().UserByID(pendingUser.ID)
+	s.NoError(err)
+	s.True(usr.IsApproved.ValueOrZero())
+}
+
+func (s *HandlerUsersManageSuite) Test_Success_Reject() {
+	admin := s.MockUser(map[string]any{
+		"IsAdmin": true,
+	})
+
+	pendingUser := s.MockUser(map[string]any{
+		"IsApproved": null.Bool{},
+	})
+
+	s.False(pendingUser.IsApproved.Valid)
+	s.False(pendingUser.IsApproved.ValueOrZero())
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/admin/users/manage",
+		map[string]any{
+			"userIds": []string{pendingUser.ID.String()},
+			"action":  "reject",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(admin.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	usr, err := user.NewStore().UserByID(pendingUser.ID)
+	s.NoError(err)
+	s.False(usr.IsApproved.ValueOrZero())
+}
+
+func (s *HandlerUsersManageSuite) Test_InvalidAction() {
+	admin := s.MockUser(map[string]any{
+		"IsAdmin": true,
+	})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/admin/users/manage",
+		map[string]any{
+			"userIds": []string{"1"},
+			"action":  "invalid",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(admin.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "Invalid action provided")
+}
+
+func (s *HandlerUsersManageSuite) Test_EmptyUserIDs() {
+	admin := s.MockUser(map[string]any{
+		"IsAdmin": true,
+	})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/admin/users/manage",
+		map[string]any{
+			"userIds": []string{},
+			"action":  "approve",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(admin.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "No user IDs provided")
+}
+
+func (s *HandlerUsersManageSuite) Test_NonAdmin() {
+	usr := s.MockUser(map[string]any{"IsAdmin": false})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/admin/users/manage",
+		map[string]any{
+			"userIds": []string{"123"},
+			"action":  "approve",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusUnauthorized, response.Code)
+}
+
+func TestHandlerUsersManage(t *testing.T) {
+	suite.Run(t, &HandlerUsersManageSuite{})
+}

--- a/src/ce/api/admin/adminhandlers/services.go
+++ b/src/ce/api/admin/adminhandlers/services.go
@@ -38,7 +38,8 @@ func Services(r *shttp.Router) *shttp.Service {
 	s.NewEndpoint("/admin/users").
 		Handler(shttp.MethodGet, "/sign-up-mode", user.WithAdmin(handlerUserManagementGet)).
 		Handler(shttp.MethodPost, "/sign-up-mode", user.WithAdmin(handlerUserManagementSet)).
-		Handler(shttp.MethodGet, "/pending", user.WithAdmin(handlerUsersPending))
+		Handler(shttp.MethodGet, "/pending", user.WithAdmin(handlerUsersPending)).
+		Handler(shttp.MethodPost, "/manage", user.WithAdmin(handlerUsersManage))
 
 	if config.IsStormkitCloud() || config.IsDevelopment() {
 		s.NewEndpoint("/admin/cloud").

--- a/src/ce/api/admin/adminhandlers/services_test.go
+++ b/src/ce/api/admin/adminhandlers/services_test.go
@@ -36,6 +36,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 		"POST:/admin/license",
 		"POST:/admin/system/mise",
 		"POST:/admin/system/runtimes",
+		"POST:/admin/users/manage",
 		"POST:/admin/users/sign-up-mode",
 		"PUT:/admin/system/proxies",
 	}
@@ -70,6 +71,7 @@ func (s *ServicesSuite) Test_Services_Cloud() {
 		"POST:/admin/license",
 		"POST:/admin/system/mise",
 		"POST:/admin/system/runtimes",
+		"POST:/admin/users/manage",
 		"POST:/admin/users/sign-up-mode",
 		"PUT:/admin/system/proxies",
 	}

--- a/src/ce/api/user/user_statements.go
+++ b/src/ce/api/user/user_statements.go
@@ -26,6 +26,7 @@ type userStatement struct {
 	updateLastLogin           string
 	userMetrics               string
 	updateUsageMetrics        string
+	updateApprovalStatus      string
 }
 
 var ustmt = &userStatement{
@@ -240,5 +241,9 @@ var ustmt = &userStatement{
 		DO UPDATE SET
 			bandwidth_bytes = user_metrics.bandwidth_bytes + EXCLUDED.bandwidth_bytes,
 			function_invocations = user_metrics.function_invocations + EXCLUDED.function_invocations;
+	`,
+
+	updateApprovalStatus: `
+		UPDATE users SET is_approved = $1 WHERE user_id = ANY($2);
 	`,
 }

--- a/src/ce/api/user/user_store.go
+++ b/src/ce/api/user/user_store.go
@@ -152,6 +152,12 @@ func (s *Store) PendingUsers(ctx context.Context) ([]*User, error) {
 	return s.selectUsers(ctx, wr.String())
 }
 
+// UpdateApprovalStatus updates the approval status for the given user ids.
+func (s *Store) UpdateApprovalStatus(ctx context.Context, userIDs []types.ID, approved bool) error {
+	_, err := s.Exec(ctx, ustmt.updateApprovalStatus, approved, pq.Array(userIDs))
+	return err
+}
+
 // TeamOwner returns the owner user of a team.
 func (s *Store) TeamOwner(teamID types.ID) (*User, error) {
 	var wr bytes.Buffer


### PR DESCRIPTION
## Description

Adds an admin endpoint (`/admin/users/manage`) to approve or reject pending users.

## Screenshots/Demo

If applicable, add screenshots or a demo of the changes.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated relevant documentation

## Breaking Changes

If this PR introduces breaking changes, please describe them here and update the checklist:

- [ ] I have documented all breaking changes
- [ ] I have updated the migration guide (if applicable)
- [ ] I have bumped the major version number (if applicable)

## Related Issues

Relates to #8