### PR TITLE
fix: refresh references after a deployment is complete

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/[deployment-id]/Deployment.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/[deployment-id]/Deployment.spec.tsx
@@ -1,9 +1,11 @@
 import type { Scope } from "nock";
-import { describe, expect, it, vi } from "vitest";
-import { RenderResult, waitFor } from "@testing-library/react";
+import { describe, beforeEach, afterEach, expect, it, vi } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router";
+import { RenderResult, waitFor, render, act } from "@testing-library/react";
+import { AppContext } from "~/pages/apps/[id]/App.context";
+import mockApp from "~/testing/data/mock_app";
 import mockDeployments from "~/testing/data/mock_deployments_v2";
 import { mockFetchDeployments } from "~/testing/nocks/nock_deployments_v2";
-import { renderWithRouter } from "~/testing/helpers";
 import Deployment from "./Deployment";
 
 interface Props {
@@ -17,9 +19,21 @@ vi.mock("~/utils/helpers/deployments", () => ({
 describe("~/apps/[id]/environments/[env-id]/deployments/Deployment.tsx", () => {
   let wrapper: RenderResult;
   let currentDeploy: DeploymentV2;
+  let currentApp: App;
   let scope: Scope;
+  let setRefreshToken = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
 
   const createWrapper = ({ deployment }: Props | undefined = {}) => {
+    currentApp = mockApp();
     currentDeploy = deployment || mockDeployments()[0];
 
     scope = mockFetchDeployments({
@@ -27,14 +41,55 @@ describe("~/apps/[id]/environments/[env-id]/deployments/Deployment.tsx", () => {
       response: { deployments: [currentDeploy] },
     });
 
-    wrapper = renderWithRouter({
-      el: () => <Deployment />,
-      path: "/apps/:appId/environments/:envId/deployments/:deploymentId",
-      initialEntries: [
-        `/apps/${currentDeploy.appId}/environments/${currentDeploy.envId}/deployments/${currentDeploy.id}`,
-      ],
-    });
+    wrapper = render(
+      <MemoryRouter initialEntries={[`/${currentDeploy.id}`]} initialIndex={0}>
+        <Routes>
+          <Route
+            path="/:deploymentId"
+            element={
+              <AppContext.Provider
+                value={{
+                  app: currentApp,
+                  environments: [],
+                  setRefreshToken,
+                }}
+              >
+                <Deployment />
+              </AppContext.Provider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
   };
+
+  it("should continuously poll the deployment until it is not running anymore", async () => {
+    const deployment = mockDeployments()[0];
+    deployment.status = "running";
+
+    createWrapper({ deployment });
+
+    // Wait for the first fetch to complete
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    // Set up a second mock for the polling request (nock consumes interceptors)
+    const secondScope = mockFetchDeployments({
+      deploymentId: deployment.id,
+      response: { deployments: [{ ...deployment, status: "success" }] },
+    });
+
+    // Advance timers to trigger the polling interval (wrapped in act)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    // Verify the second fetch was made
+    await waitFor(() => {
+      expect(secondScope.isDone()).toBe(true);
+    });
+  });
 
   it("should display deployment details", async () => {
     createWrapper();
@@ -79,7 +134,7 @@ describe("~/apps/[id]/environments/[env-id]/deployments/Deployment.tsx", () => {
 
     await waitFor(() => {
       expect(
-        wrapper.getByLabelText(`Deployment ${currentDeploy.id} menu`)
+        wrapper.getByLabelText(`Deployment ${currentDeploy.id} menu`),
       ).toBeTruthy();
     });
   });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/[deployment-id]/Deployment.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/[deployment-id]/Deployment.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useParams } from "react-router";
 import Button from "@mui/material/Button";
 import Card from "~/components/Card";
@@ -6,19 +6,20 @@ import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
 import Error404 from "~/components/Errors/Error404";
 import Spinner from "~/components/Spinner";
-import { useFetchDeployment, useWithPageRefresh } from "../actions";
+import { AppContext } from "~/pages/apps/[id]/App.context";
+import { useFetchDeployment } from "../actions";
 import DeploymentRow from "~/shared/deployments/DeploymentRow";
 import DeploymentLogs from "./DeploymentLogs";
 
 export default function Deployment() {
   const { deploymentId } = useParams();
-  const [refreshToken, setRefreshToken] = useState<number>();
+  const { setRefreshToken: refreshApp } = useContext(AppContext);
+  const [restartToken, setRestartToken] = useState(0);
   const { deployment, error, loading } = useFetchDeployment({
     deploymentId,
-    refreshToken,
+    restartToken,
+    refreshApp,
   });
-
-  useWithPageRefresh({ deployment, setRefreshToken });
 
   const isRunningLogs =
     deployment?.status === "running" && !deployment.stoppedAt;
@@ -69,7 +70,7 @@ export default function Deployment() {
           {deployment && (
             <DeploymentRow
               deployment={deployment}
-              setRefreshToken={setRefreshToken}
+              setRefreshToken={setRestartToken}
               viewDetails={false}
               exactTime
               sx={{ borderTop: "none !important" }}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/actions.ts
@@ -44,7 +44,7 @@ export const publishDeployments = ({
 
   if (total !== 100) {
     return Promise.reject(
-      `The sum of percentages has be to 100. Currently it is ${total}.`
+      `The sum of percentages has to be 100. Currently it is ${total}.`,
     );
   }
 
@@ -135,14 +135,14 @@ export const useFetchDeployments = ({
 
     api
       .fetch<{ deployments: DeploymentV2[] }>(
-        `/my/deployments?${params.toString()}`
+        `/my/deployments?${params.toString()}`,
       )
       .then(res => {
         if (unmounted !== true) {
           setDeployments(
             from && from > 0
               ? [...deployments, ...res.deployments]
-              : res.deployments
+              : res.deployments,
           );
         }
       })
@@ -181,12 +181,14 @@ export const stopDeployment = ({
 
 interface FetchDeploymentProps {
   deploymentId?: string;
-  refreshToken?: number;
+  restartToken?: number;
+  refreshApp: (n: number) => void;
 }
 
 export const useFetchDeployment = ({
   deploymentId,
-  refreshToken,
+  restartToken,
+  refreshApp,
 }: FetchDeploymentProps) => {
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState(true);
@@ -208,7 +210,7 @@ export const useFetchDeployment = ({
 
     api
       .fetch<{ deployments: DeploymentV2[] }>(
-        `/my/deployments?deploymentId=${deploymentId}`
+        `/my/deployments?deploymentId=${deploymentId}`,
       )
       .then(res => {
         const deployment = res.deployments[0];
@@ -221,18 +223,24 @@ export const useFetchDeployment = ({
           setDeploy(deployment);
         }
 
+        if (time && time > 0 && deployment.status === "success") {
+          refreshApp(Date.now());
+        }
+
         // If the deployment is still running, then refetch it every 5 seconds
         // by refreshing the time to trigger a new call.
         setTimeout(() => {
-          if (unmounted !== true && deployment.status === "running") {
-            setTime(Date.now());
+          if (unmounted) {
+            return;
           }
+
+          setTime(deployment.status === "running" ? Date.now() : 0);
         }, 5000);
       })
       .catch(() => {
         if (unmounted !== true) {
           setError(
-            "Something went wrong on our side while fetching deployments. Please try again and if the problem persists contact us from Discord or email."
+            "Something went wrong on our side while fetching deployments. Please try again and if the problem persists contact us from Discord or email.",
           );
         }
       })
@@ -241,35 +249,9 @@ export const useFetchDeployment = ({
       });
 
     return () => {
-      unmounted = false;
+      unmounted = true;
     };
-  }, [deploymentId, refreshToken, time]);
+  }, [deploymentId, restartToken, time]);
 
   return { deployment: deploy, loading, error };
-};
-
-interface WithPageRefreshProps {
-  deployment?: DeploymentV2;
-  setRefreshToken: (val: number) => void;
-}
-
-let shouldRefresh = false;
-
-// Refresh app and envs when a deployment completes running
-export const useWithPageRefresh = ({
-  deployment,
-  setRefreshToken,
-}: WithPageRefreshProps) => {
-  useEffect(() => {
-    const isRunning = deployment?.status === "running";
-
-    if (isRunning) {
-      shouldRefresh = true;
-      return;
-    }
-
-    if (shouldRefresh) {
-      setRefreshToken?.(Date.now());
-    }
-  }, [deployment?.status]);
 };

--- a/src/ui/src/shared/deployments/DeploymentRow.tsx
+++ b/src/ui/src/shared/deployments/DeploymentRow.tsx
@@ -60,7 +60,7 @@ export default function DeploymentRow({
         envId: deployment.envId,
       }).then(() => {
         navigate(
-          `/apps/${deployment.appId}/environments/${deployment.envId}/deployments/${deployment.id}`
+          `/apps/${deployment.appId}/environments/${deployment.envId}/deployments/${deployment.id}`,
         );
         setRefreshToken(Date.now());
       });
@@ -123,7 +123,7 @@ export default function DeploymentRow({
               .catch(() => {
                 setLoading(false);
                 setError(
-                  "Something went wrong while deleting deployment. Please try again."
+                  "Something went wrong while deleting deployment. Please try again.",
                 );
               });
           }}
@@ -151,7 +151,7 @@ export default function DeploymentRow({
               .catch(() => {
                 setLoading(false);
                 setError(
-                  "Something went wrong while stopping deployment. Please try again."
+                  "Something went wrong while stopping deployment. Please try again.",
                 );
               });
           }}


### PR DESCRIPTION
## Description

This fixes a bug where the Runtime Logs would still point to the old deployment after a deployment is a complete.

## Screenshots/Demo

If applicable, add screenshots or a demo of the changes.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated relevant documentation

## Breaking Changes

If this PR introduces breaking changes, please describe them here and update the checklist:

- [ ] I have documented all breaking changes
- [ ] I have updated the migration guide (if applicable)
- [ ] I have bumped the major version number (if applicable)