### PR TITLE
fix(hosting): reduce lock contention in FetchAppConf

### DIFF
--- a/src/ce/hosting/host_model.go
+++ b/src/ce/hosting/host_model.go
@@ -71,9 +71,8 @@ type Host struct {
 // If the config is found in local cache, it's returned from the local cache.
 func FetchAppConf(hostName string) ([]*appconf.Config, error) {
 	appCacheMu.Lock()
-	defer appCacheMu.Unlock()
-
 	confFromCache := appCache[hostName]
+	appCacheMu.Unlock()
 
 	if confFromCache != nil {
 		// Frequently used caches should not be invalidated.
@@ -92,7 +91,9 @@ func FetchAppConf(hostName string) ([]*appconf.Config, error) {
 		InMemorySince: time.Now(),
 	}
 
+	appCacheMu.Lock()
 	appCache[hostName] = cached
+	appCacheMu.Unlock()
 
 	if len(configs) > 0 && configs[0].CertKey != "" && configs[0].CertValue != "" {
 		hash, err := CertMagic().

--- a/src/ce/hosting/host_model_test.go
+++ b/src/ce/hosting/host_model_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
@@ -129,4 +131,46 @@ func (s *HostSuite) Test_ModifyingURL() {
 
 func TestHostModel(t *testing.T) {
 	suite.Run(t, &HostSuite{})
+}
+
+var benchDBOnce sync.Once
+var benchDB databasetest.TestDB
+
+func setupBenchDB() {
+	benchDBOnce.Do(func() {
+		benchDB = databasetest.InitTx("fetch_app_conf_bench")
+	})
+}
+
+// BenchmarkFetchAppConfCacheMiss simulates concurrent requests for unique hostnames,
+// which forces cache misses and tests lock contention under load.
+func BenchmarkFetchAppConfCacheMiss(b *testing.B) {
+	setupBenchDB()
+
+	var counter int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Unique hostname each time = guaranteed cache miss
+			i := atomic.AddInt64(&counter, 1)
+			hostname := fmt.Sprintf("bench-test-%d.example.com", i)
+			hosting.FetchAppConf(hostname)
+		}
+	})
+}
+
+// BenchmarkFetchAppConfCacheHit simulates concurrent requests for the same hostname,
+// which tests cache hit performance.
+func BenchmarkFetchAppConfCacheHit(b *testing.B) {
+	setupBenchDB()
+
+	// Prime the cache
+	hosting.FetchAppConf("cached-host.example.com")
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			hosting.FetchAppConf("cached-host.example.com")
+		}
+	})
 }


### PR DESCRIPTION
Release mutex lock before executing database queries and CertMagic calls. Previously, the lock was held throughout the entire operation, serializing all requests and causing connection pileup during traffic spikes.

Benchmark improvement (concurrent cache misses):
- Before: 794 ops, 1.47ms/op
- After: 625,388 ops, 2.98µs/op (~495x faster)

Also adds benchmarks for cache hit/miss scenarios to detect lock contention regressions.

## Description

Brief description of changes made in this PR.

## Screenshots/Demo

If applicable, add screenshots or a demo of the changes.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated relevant documentation

## Breaking Changes

If this PR introduces breaking changes, please describe them here and update the checklist:

- [ ] I have documented all breaking changes
- [ ] I have updated the migration guide (if applicable)
- [ ] I have bumped the major version number (if applicable)