### PR TITLE
chore: use advisory lock instead of lock table

### DIFF
--- a/src/lib/database/databasetest/databasetest.go
+++ b/src/lib/database/databasetest/databasetest.go
@@ -50,7 +50,6 @@ func init() {
 	// Clean up schema_migrations
 	var stmts = []string{
 		"DROP TABLE IF EXISTS public.migrations;",
-		"DROP TABLE IF EXISTS public.migrations_lock;",
 		fmt.Sprintf(`DROP SCHEMA IF EXISTS %s CASCADE`, database.Config.Schema),
 	}
 

--- a/src/migrations/migrate.go
+++ b/src/migrations/migrate.go
@@ -127,30 +127,19 @@ func Up(db *sql.DB, conf database.DBConf) bool {
 	var seedVersion int
 	var isDirty bool
 
-	_, err := db.Exec("CREATE TABLE public.migrations_lock ( )")
+	expo := 1
+	store := database.NewStore()
+
+	slog.Infof("acquiring lock for migrating database")
 
 	// If the table already exists, another instance is running migrations
-	if err != nil {
-		expo := 1
-
-		// We should wait until the lock table is dropped
-		for {
-			slog.Infof("another instance is running migrations, waiting for %d second(s)...", expo)
-			time.Sleep(time.Duration(expo) * time.Second)
-			expo *= 2
-
-			var count int
-
-			err := db.QueryRow("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'migrations_lock';").Scan(&count)
-
-			// Now check if the lock table still exists
-			if err == nil && count == 0 {
-				return false
-			}
-		}
+	for store.AdvisoryLock(0) != nil {
+		slog.Infof("another instance is running migrations, waiting for %d second(s)...", expo)
+		time.Sleep(time.Duration(expo) * time.Second)
+		expo *= 2
 	}
 
-	defer db.Exec("DROP TABLE public.migrations_lock")
+	defer store.AdvisoryUnlock(0)
 
 	_ = db.
 		QueryRow("SELECT migration_version, seed_version, dirty FROM public.migrations").


### PR DESCRIPTION
## Description

Uses the built-in `pg_advisory_lock` instead of creating a new table for this task.

## Screenshots/Demo

If applicable, add screenshots or a demo of the changes.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated relevant documentation

## Breaking Changes

If this PR introduces breaking changes, please describe them here and update the checklist:

- [ ] I have documented all breaking changes
- [ ] I have updated the migration guide (if applicable)
- [ ] I have bumped the major version number (if applicable)

## Related Issues

Closes #[issue number]
Relates to #[issue number]

## Additional Notes

Any additional information that reviewers should know about this PR.
