### PR TITLE
chore: add client-specific oauth2 methods

### DIFF
--- a/src/ce/api/app/skauth/client_google.go
+++ b/src/ce/api/app/skauth/client_google.go
@@ -71,6 +71,10 @@ func (g *GoogleClient) UserInfo(ctx context.Context, token *oauth2.Token) (*User
 	}, nil
 }
 
-func (g *GoogleClient) Config() *oauth2.Config {
-	return g.oauth2Config
+func (g *GoogleClient) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	return g.oauth2Config.Exchange(ctx, code)
+}
+
+func (g *GoogleClient) AuthCodeURL(state string) string {
+	return g.oauth2Config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 }

--- a/src/ce/api/app/skauth/client_x.go
+++ b/src/ce/api/app/skauth/client_x.go
@@ -73,6 +73,16 @@ func (x *XClient) UserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo,
 	}, nil
 }
 
-func (x *XClient) Config() *oauth2.Config {
-	return x.oauth2Config
+func (x *XClient) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	return x.oauth2Config.Exchange(ctx, code)
+}
+
+func (x *XClient) AuthCodeURL(state string) string {
+	return x.oauth2Config.AuthCodeURL(
+		state,
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("code_challenge", "CHALLENGE"),
+		oauth2.SetAuthURLParam("code_challenge_method", "plain"),
+		oauth2.SetAuthURLParam("response_type", "code"),
+	)
 }

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -80,7 +80,8 @@ func (p *Provider) Client() Client {
 
 type Client interface {
 	UserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo, error)
-	Config() *oauth2.Config
+	AuthCodeURL(state string) string
+	Exchange(ctx context.Context, code string) (*oauth2.Token, error)
 }
 
 type OAuth struct {

--- a/src/ce/api/app/skauth/skauthhandlers/services.go
+++ b/src/ce/api/app/skauth/skauthhandlers/services.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
-	"golang.org/x/oauth2"
 )
 
 // Services sets the Handlers for this service.
@@ -32,9 +31,4 @@ var AuthUser = func(ctx context.Context, env *buildconf.Env, authID types.ID) (*
 	}
 
 	return store.AuthUser(ctx, authID)
-}
-
-// Exchange is a wrapper around oauth2.Config.Exchange to allow mocking in tests.
-var Exchange = func(ctx context.Context, config *oauth2.Config, code string) (*oauth2.Token, error) {
-	return config.Exchange(ctx, code)
 }

--- a/src/ce/api/public/v1/handler_auth_callback.go
+++ b/src/ce/api/public/v1/handler_auth_callback.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -29,7 +28,7 @@ func HandlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), utils.StringToID(envID))
 
 	if err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to get environment by ID %s", envID))
 	}
 
 	if env == nil || env.SchemaConf == nil {
@@ -39,7 +38,7 @@ func HandlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 	prv, err := skauth.NewStore().Provider(req.Context(), env.ID, provider)
 
 	if err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to get provider for env %d and provider %s", env.ID, provider))
 	}
 
 	if prv == nil || !prv.Status {
@@ -48,30 +47,29 @@ func HandlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 
 	// Exchange authorization code for token
 	client := prv.Client()
-	config := client.Config()
 
-	if config == nil {
+	if client == nil {
 		return shttp.BadRequest(map[string]any{
 			"error": "Provider is not an OAuth2 provider",
 		})
 	}
 
-	token, err := skauthhandlers.Exchange(req.Context(), config, req.FormValue("code"))
+	token, err := client.Exchange(req.Context(), req.FormValue("code"))
 
 	if err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to exchange authorization code for token: %s", err.Error()))
 	}
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
 
 	if err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to get store for environment: %s", err.Error()))
 	}
 
 	info, err := client.UserInfo(req.Context(), token)
 
 	if err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to get user info: %s", err.Error()))
 	}
 
 	if info == nil {
@@ -95,7 +93,7 @@ func HandlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 	}
 
 	if err := store.InsertAuthUser(req.Context(), &oauth, &usr); err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to insert auth user: %s", err.Error()))
 	}
 
 	var secret string
@@ -110,7 +108,7 @@ func HandlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 	}, secret)
 
 	if err != nil {
-		return shttp.Error(err)
+		return shttp.Error(err, fmt.Sprintf("failed to generate JWT: %s", err.Error()))
 	}
 
 	return &shttp.Response{

--- a/src/ce/api/public/v1/handler_auth_callback_test.go
+++ b/src/ce/api/public/v1/handler_auth_callback_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -33,12 +32,10 @@ type HandlerAuthCallbackSuite struct {
 	conn       databasetest.TestDB
 	app        *factory.MockApp
 	mockClient *mocks.Client
-	exchangeFn func(ctx context.Context, config *oauth2.Config, code string) (*oauth2.Token, error)
 }
 
 func (s *HandlerAuthCallbackSuite) BeforeTest(suiteName, _ string) {
 	s.mockClient = &mocks.Client{}
-	s.exchangeFn = skauthhandlers.Exchange
 	s.conn = databasetest.InitTx(suiteName)
 	s.Factory = factory.New(s.conn)
 	s.app = s.MockApp(s.MockUser(nil), nil)
@@ -49,7 +46,6 @@ func (s *HandlerAuthCallbackSuite) BeforeTest(suiteName, _ string) {
 func (s *HandlerAuthCallbackSuite) AfterTest(_, _ string) {
 	s.conn.CloseTx()
 	skauth.DefaultClient = nil
-	skauthhandlers.Exchange = s.exchangeFn
 	config.SetIsSelfHosted(false)
 }
 
@@ -103,11 +99,7 @@ func (s *HandlerAuthCallbackSuite) Test_Success() {
 
 	s.NoError(err)
 
-	skauthhandlers.Exchange = func(ctx context.Context, config *oauth2.Config, code string) (*oauth2.Token, error) {
-		return tkn, nil
-	}
-
-	s.mockClient.On("Config").Return(&oauth2.Config{}).Once()
+	s.mockClient.On("Exchange", mock.Anything, "test-code").Return(tkn, nil).Once()
 
 	s.mockClient.On("UserInfo", mock.Anything, tkn).Return(&skauth.UserInfo{
 		AccountID: "test-account-id",

--- a/src/ce/api/public/v1/handler_auth_redirect.go
+++ b/src/ce/api/public/v1/handler_auth_redirect.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
-	"golang.org/x/oauth2"
 )
 
 // HandlerAuthRedirect initiates the OAuth2 authentication process by redirecting the user to the provider's authorization URL.
@@ -49,7 +48,7 @@ func HandlerAuthRedirect(req *shttp.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
-	req.Redirect(prv.Client().Config().AuthCodeURL(state, oauth2.ApprovalForce, oauth2.AccessTypeOffline), http.StatusFound)
+	req.Redirect(prv.Client().AuthCodeURL(state), http.StatusFound)
 
 	return nil
 }

--- a/src/mocks/client.go
+++ b/src/mocks/client.go
@@ -16,24 +16,52 @@ type Client struct {
 	mock.Mock
 }
 
-// Config provides a mock function with no fields
-func (_m *Client) Config() *oauth2.Config {
-	ret := _m.Called()
+// AuthCodeURL provides a mock function with given fields: state
+func (_m *Client) AuthCodeURL(state string) string {
+	ret := _m.Called(state)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Config")
+		panic("no return value specified for AuthCodeURL")
 	}
 
-	var r0 *oauth2.Config
-	if rf, ok := ret.Get(0).(func() *oauth2.Config); ok {
-		r0 = rf()
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(state)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*oauth2.Config)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0
+}
+
+// Exchange provides a mock function with given fields: ctx, code
+func (_m *Client) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	ret := _m.Called(ctx, code)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Exchange")
+	}
+
+	var r0 *oauth2.Token
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*oauth2.Token, error)); ok {
+		return rf(ctx, code)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *oauth2.Token); ok {
+		r0 = rf(ctx, code)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*oauth2.Token)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, code)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UserInfo provides a mock function with given fields: ctx, token


### PR DESCRIPTION
## Description

Adds Client specific oAuth2 methods. This is required because X for instance require different URL parameters.

## Screenshots/Demo

If applicable, add screenshots or a demo of the changes.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated relevant documentation

## Breaking Changes

If this PR introduces breaking changes, please describe them here and update the checklist:

- [ ] I have documented all breaking changes
- [ ] I have updated the migration guide (if applicable)
- [ ] I have bumped the major version number (if applicable)

## Related Issues

Closes #[issue number]
Relates to #[issue number]

## Additional Notes

Any additional information that reviewers should know about this PR.
