### PR TITLE
feat: api endpoint for retrieving apps

### DIFF
--- a/docs/api/2-apps.md
+++ b/docs/api/2-apps.md
@@ -1,0 +1,116 @@
+---
+title: Apps API
+description: Retrieve the list of applications that belong to your Stormkit account using the Apps API.
+---
+
+# Apps API
+
+## Overview
+
+The Apps API lets you list applications in your Stormkit account. It is useful for discovering `appId` values that are required by other API endpoints.
+
+---
+
+## GET /v1/apps
+
+Returns a paginated list of applications belonging to the authenticated user.
+
+**Base URL:** `https://api.stormkit.io`
+
+**Authentication:** User-level API key passed as the `Authorization` header (no `Bearer` prefix required). To generate one: Profile → Account → API Keys.
+
+### Query parameters
+
+| Parameter     | Type   | Required | Default | Description                                                                   |
+| ------------- | ------ | -------- | ------- | ----------------------------------------------------------------------------- |
+| `teamId`      | number | **Yes**  | —       | ID of the team to scope results to. The API key owner must be a member.       |
+| `from`        | number | No       | `0`     | Pagination offset. Must be ≥ 0.                                               |
+| `repo`        | string | No       | —       | Exact case-insensitive match on the repository path (e.g. `github/org/repo`). |
+| `displayName` | string | No       | —       | Exact case-insensitive match on the application display name.                 |
+
+> `repo` and `displayName` can be combined and are applied as AND conditions.
+
+### Response — 200 OK
+
+| Field         | Type    | Description                                                                                      |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `apps`        | `App[]` | Array of application objects for the current page.                                               |
+| `hasNextPage` | boolean | `true` when more results exist. To fetch the next page, add `from=<current_offset + len(apps)>`. |
+
+**`App` object:**
+
+| Field          | Type    | Description                                                                         |
+| -------------- | ------- | ----------------------------------------------------------------------------------- |
+| `id`           | string  | Unique application ID. Use this as `appId` in other endpoints.                      |
+| `displayName`  | string  | Human-readable name of the application.                                             |
+| `repo`         | string  | Repository path (e.g. `github/org/repo`). Empty when `isBare` is `true`.            |
+| `isBare`       | boolean | `true` when no repository is linked.                                                |
+| `userId`       | string  | ID of the user who owns the application.                                            |
+| `teamId`       | string  | ID of the team the application belongs to.                                          |
+| `defaultEnvId` | string  | ID of the default environment. Use this as `envId` in environment-scoped endpoints. |
+| `createdAt`    | string  | Unix timestamp (seconds) when the application was created.                          |
+
+### Error responses
+
+| Status | Condition                                                           |
+| ------ | ------------------------------------------------------------------- |
+| `400`  | Missing or invalid parameter (e.g. `teamId` omitted, non-integer).  |
+| `403`  | Missing/invalid API key, or user is not a member of the given team. |
+| `500`  | Internal server error.                                              |
+
+### Pagination
+
+The page size is fixed at 20 items. To iterate all pages:
+
+1. Start with `from=0`.
+2. If `hasNextPage` is `true`, set `from = from + len(apps)` and repeat.
+3. Stop when `hasNextPage` is `false`.
+
+### Examples
+
+```bash
+# First page
+curl -X GET \
+     -H 'Authorization: <api_key>' \
+     'https://api.stormkit.io/v1/apps?teamId=7'
+```
+
+```bash
+# Second page
+curl -X GET \
+     -H 'Authorization: <api_key>' \
+     'https://api.stormkit.io/v1/apps?teamId=7&from=20'
+```
+
+```bash
+# Exact match by repository
+curl -X GET \
+     -H 'Authorization: <api_key>' \
+     'https://api.stormkit.io/v1/apps?teamId=7&repo=github/acme/my-app'
+```
+
+```bash
+# Exact match by display name
+curl -X GET \
+     -H 'Authorization: <api_key>' \
+     'https://api.stormkit.io/v1/apps?teamId=7&displayName=my-app-abc123'
+```
+
+```json
+// Example response
+{
+  "apps": [
+    {
+      "id": "1510",
+      "displayName": "my-app-abc123",
+      "repo": "github/acme/my-app",
+      "isBare": false,
+      "userId": "42",
+      "teamId": "7",
+      "defaultEnvId": "305",
+      "createdAt": "1700489144"
+    }
+  ],
+  "hasNextPage": false
+}
+```

--- a/src/ce/api/app/app_store.go
+++ b/src/ce/api/app/app_store.go
@@ -353,13 +353,16 @@ func (s *Store) savePrivateKey(ctx context.Context, a *App) error {
 }
 
 type AppsArgs struct {
-	From        int
-	Limit       int
-	AppID       types.ID
-	TeamID      types.ID
-	EnvID       types.ID
+	From   int
+	Limit  int
+	AppID  types.ID
+	TeamID types.ID
+	EnvID  types.ID
+	// Filter performs a case-insensitive substring match across both the repo
+	// and display name fields. Use Repo or DisplayName for exact matches.
 	Filter      string
 	DisplayName string
+	Repo        string
 	DomainName  string
 }
 
@@ -393,6 +396,11 @@ func (s *Store) Apps(ctx context.Context, args AppsArgs) ([]*App, error) {
 	if args.DisplayName != "" {
 		params = append(params, args.DisplayName)
 		where = append(where, fmt.Sprintf("LOWER(a.display_name) = LOWER($%d)", len(params)))
+	}
+
+	if args.Repo != "" {
+		params = append(params, args.Repo)
+		where = append(where, fmt.Sprintf("LOWER(a.repo) = LOWER($%d)", len(params)))
 	}
 
 	if args.AppID != 0 {

--- a/src/ce/api/app/app_store_test.go
+++ b/src/ce/api/app/app_store_test.go
@@ -104,6 +104,91 @@ func (s *AppStoreSuite) Test_DeployCandidates() {
 	s.Equal("smtp://test:test-pwd@smtp.gmail.com:587", candidates[0].MailerConf.String())
 }
 
+func (s *AppStoreSuite) Test_Apps_FilterByRepo() {
+	usr := s.MockUser()
+	apl := s.MockApp(usr)
+	s.MockApp(usr, map[string]any{"Repo": "github/other/unrelated"})
+
+	apps, err := app.NewStore().Apps(context.Background(), app.AppsArgs{
+		TeamID: usr.DefaultTeamID,
+		Filter: apl.Repo,
+	})
+	s.NoError(err)
+	s.Len(apps, 1)
+	s.Equal(apl.ID, apps[0].ID)
+}
+
+func (s *AppStoreSuite) Test_Apps_FilterByDisplayName() {
+	usr := s.MockUser()
+	apl := s.MockApp(usr)
+	s.MockApp(usr)
+
+	apps, err := app.NewStore().Apps(context.Background(), app.AppsArgs{
+		TeamID: usr.DefaultTeamID,
+		Filter: apl.DisplayName,
+	})
+	s.NoError(err)
+	s.Len(apps, 1)
+	s.Equal(apl.ID, apps[0].ID)
+}
+
+func (s *AppStoreSuite) Test_Apps_ExactRepo() {
+	usr := s.MockUser()
+	apl := s.MockApp(usr, map[string]any{"Repo": "github/acme/exact-repo"})
+	s.MockApp(usr, map[string]any{"Repo": "github/acme/exact-repo-other"})
+
+	apps, err := app.NewStore().Apps(context.Background(), app.AppsArgs{
+		TeamID: usr.DefaultTeamID,
+		Repo:   "github/acme/exact-repo",
+	})
+	s.NoError(err)
+	s.Len(apps, 1)
+	s.Equal(apl.ID, apps[0].ID)
+}
+
+func (s *AppStoreSuite) Test_Apps_ExactRepo_CaseInsensitive() {
+	usr := s.MockUser()
+	apl := s.MockApp(usr, map[string]any{"Repo": "github/acme/My-App"})
+
+	apps, err := app.NewStore().Apps(context.Background(), app.AppsArgs{
+		TeamID: usr.DefaultTeamID,
+		Repo:   "GITHUB/ACME/MY-APP",
+	})
+	s.NoError(err)
+	s.Len(apps, 1)
+	s.Equal(apl.ID, apps[0].ID)
+}
+
+func (s *AppStoreSuite) Test_Apps_ExactDisplayName() {
+	usr := s.MockUser()
+	apl := s.MockApp(usr)
+	s.MockApp(usr) // different display name
+
+	apps, err := app.NewStore().Apps(context.Background(), app.AppsArgs{
+		TeamID:      usr.DefaultTeamID,
+		DisplayName: apl.DisplayName,
+	})
+	s.NoError(err)
+	s.Len(apps, 1)
+	s.Equal(apl.ID, apps[0].ID)
+}
+
+func (s *AppStoreSuite) Test_Apps_ExactRepoAndDisplayName() {
+	usr := s.MockUser()
+	apl := s.MockApp(usr, map[string]any{"Repo": "github/acme/combo"})
+	// Same repo, different display name:
+	s.MockApp(usr, map[string]any{"Repo": "github/acme/combo"})
+
+	apps, err := app.NewStore().Apps(context.Background(), app.AppsArgs{
+		TeamID:      usr.DefaultTeamID,
+		Repo:        "github/acme/combo",
+		DisplayName: apl.DisplayName,
+	})
+	s.NoError(err)
+	s.Len(apps, 1)
+	s.Equal(apl.ID, apps[0].ID)
+}
+
 func TestAppStore(t *testing.T) {
 	suite.Run(t, &AppStoreSuite{})
 }

--- a/src/ce/api/public/v1/handler_app_list.go
+++ b/src/ce/api/public/v1/handler_app_list.go
@@ -1,0 +1,109 @@
+package publicapiv1
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+// appListLimit is the maximum number of apps returned per page.
+const appListLimit = 20
+
+// handlerAppList returns a paginated list of applications that belong to the
+// authenticated user. Authentication requires a user-scoped API key.
+//
+// Query parameters:
+//
+//	teamId      - Required. ID of the team to scope the query to. The authenticated user must be a member.
+//	from        - Offset for pagination (default: 0). Use the value of the next
+//	              page's "from" field returned in the response to fetch subsequent pages.
+//	repo        - Optional exact (case-insensitive) match on the repository path (e.g. "github/org/repo").
+//	displayName - Optional exact (case-insensitive) match on the application display name.
+//
+// Response:
+//
+//	apps        - Array of application objects.
+//	hasNextPage - Whether more results are available. When true, increment
+//	              "from" by the number of items returned to get the next page.
+func handlerAppList(req *user.RequestContext) *shttp.Response {
+	q := req.Query()
+	v := &Validators{}
+
+	from, err := v.ToInt(q.Get("from"), "from")
+
+	if err != nil {
+		return shttp.BadRequest(map[string]any{
+			"error": err.Error(),
+		})
+	}
+
+	teamIdInt, err := v.ToInt(q.Get("teamId"), "teamId")
+
+	if err != nil {
+		return shttp.BadRequest(map[string]any{
+			"error": err.Error(),
+		})
+	}
+
+	repo, repoValid := v.NormalizeRepo(q.Get("repo"))
+
+	if !repoValid {
+		return shttp.BadRequest(map[string]any{
+			"error": "The 'repo' parameter must be in the format 'github/org/repo', 'gitlab/org/repo', or 'bitbucket/org/repo'",
+		})
+	}
+
+	displayName := q.Get("displayName")
+	teamID := types.ID(teamIdInt)
+
+	if teamID == 0 {
+		return shttp.BadRequest(map[string]any{
+			"error": "The 'teamId' parameter is required",
+		})
+	}
+
+	// Check if the user is a member of the specified team.
+	isMember := team.NewStore().IsMember(req.Context(), req.User.ID, teamID)
+
+	if !isMember {
+		return shttp.Forbidden()
+	}
+
+	myApps, err := app.NewStore().Apps(req.Context(), app.AppsArgs{
+		Repo:        repo,
+		DisplayName: displayName,
+		TeamID:      teamID,
+		From:        from,
+		Limit:       appListLimit + 1,
+	})
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to fetch apps for team id %d: %s", teamID, err.Error()))
+	}
+
+	hasNextPage := false
+
+	if len(myApps) > appListLimit {
+		hasNextPage = true
+		myApps = myApps[:appListLimit]
+	}
+
+	apps := make([]map[string]any, 0, len(myApps))
+
+	for _, a := range myApps {
+		apps = append(apps, a.JSON())
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"apps":        apps,
+			"hasNextPage": hasNextPage,
+		},
+	}
+}

--- a/src/ce/api/public/v1/handler_app_list_test.go
+++ b/src/ce/api/public/v1/handler_app_list_test.go
@@ -1,0 +1,336 @@
+package publicapiv1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerAppListSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *HandlerAppListSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerAppListSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerAppListSuite) handler() http.Handler {
+	return shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler()
+}
+
+func (s *HandlerAppListSuite) userKey() (string, *factory.MockApp) {
+	usr := s.MockUser()
+	a := s.MockApp(usr)
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	return key.Value, a
+}
+
+// Test_Forbidden verifies that requests without a valid user-scoped API key
+// are rejected with 403.
+func (s *HandlerAppListSuite) Test_Forbidden() {
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps",
+		nil,
+		map[string]string{
+			"Authorization": "SK_invalid-key",
+		},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
+// Test_InvalidFrom verifies that a negative 'from' value is rejected.
+func (s *HandlerAppListSuite) Test_InvalidFrom() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps?from=-1",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_InvalidFrom_NonInteger verifies that a non-integer 'from' value is rejected.
+func (s *HandlerAppListSuite) Test_InvalidFrom_NonInteger() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps?from=abc",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_MissingTeamId verifies that omitting the required teamId parameter returns 400.
+func (s *HandlerAppListSuite) Test_MissingTeamId() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_Success verifies that an authenticated user can retrieve their apps.
+func (s *HandlerAppListSuite) Test_Success() {
+	keyValue, a := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps?teamId=%s", a.TeamID.String()),
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	var body map[string]any
+	s.NoError(json.Unmarshal([]byte(response.String()), &body))
+
+	apps, _ := body["apps"].([]any)
+
+	s.False(body["hasNextPage"].(bool))
+	s.Len(apps, 1)
+
+	first := apps[0].(map[string]any)
+	s.Equal(a.ID.String(), first["id"])
+	s.Equal(a.DisplayName, first["displayName"])
+	s.Equal(a.Repo, first["repo"])
+	s.Equal(a.Repo == "", first["isBare"])
+	s.Equal(a.UserID.String(), first["userId"])
+	s.Equal(a.TeamID.String(), first["teamId"])
+}
+
+// Test_FilterByRepo verifies that the repo query parameter restricts results to exact matches.
+func (s *HandlerAppListSuite) Test_FilterByRepo() {
+	keyValue, a := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps?teamId=%s&repo=%s", a.TeamID.String(), a.Repo),
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	var body map[string]any
+	s.NoError(json.Unmarshal([]byte(response.String()), &body))
+
+	apps, _ := body["apps"].([]any)
+	s.Len(apps, 1)
+	s.Equal(a.ID.String(), apps[0].(map[string]any)["id"])
+}
+
+// Test_FilterByDisplayName verifies that the displayName query parameter restricts results to exact matches.
+func (s *HandlerAppListSuite) Test_FilterByDisplayName() {
+	keyValue, a := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps?teamId=%s&displayName=%s", a.TeamID.String(), a.DisplayName),
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	var body map[string]any
+	s.NoError(json.Unmarshal([]byte(response.String()), &body))
+
+	apps, _ := body["apps"].([]any)
+	s.Len(apps, 1)
+	s.Equal(a.ID.String(), apps[0].(map[string]any)["id"])
+}
+
+// Test_InvalidTeamId_NonInteger verifies that a non-integer teamId is rejected.
+func (s *HandlerAppListSuite) Test_InvalidTeamId_NonInteger() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps?teamId=abc",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_InvalidTeamId_Negative verifies that a negative teamId is rejected.
+func (s *HandlerAppListSuite) Test_InvalidTeamId_Negative() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps?teamId=-1",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_InvalidRepo_Format verifies that a repo without a valid vcs prefix is rejected.
+func (s *HandlerAppListSuite) Test_InvalidRepo_Format() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps?repo=not-a-valid-repo",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_FilterByTeamId verifies that results are scoped to the given teamId.
+func (s *HandlerAppListSuite) Test_FilterByTeamId() {
+	usr := s.MockUser()
+	a := s.MockApp(usr)
+	// A second user with their own team and app — should not appear in results.
+	usr2 := s.MockUser()
+	s.MockApp(usr2)
+
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps?teamId=%s", usr.DefaultTeamID.String()),
+		nil,
+		map[string]string{
+			"Authorization": key.Value,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	var body map[string]any
+	s.NoError(json.Unmarshal([]byte(response.String()), &body))
+
+	apps, _ := body["apps"].([]any)
+	s.Len(apps, 1)
+	s.Equal(a.ID.String(), apps[0].(map[string]any)["id"])
+}
+
+// Test_Forbidden_WhenNotTeamMember verifies that a user cannot access apps scoped
+// to a team they do not belong to.
+func (s *HandlerAppListSuite) Test_Forbidden_WhenNotTeamMember() {
+	usr := s.MockUser()
+	// A second user — usr is not a member of this user's default team.
+	otherUsr := s.MockUser()
+
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps?teamId=%s", otherUsr.DefaultTeamID.String()),
+		nil,
+		map[string]string{
+			"Authorization": key.Value,
+		},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
+// Test_FilterNoMatch verifies that non-matching filters return an empty list.
+func (s *HandlerAppListSuite) Test_FilterNoMatch() {
+	keyValue, a := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps?teamId=%s&repo=github/does-not/exist", a.TeamID.String()),
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(`{"apps": [], "hasNextPage": false}`, response.String())
+}
+
+func TestHandlerAppListSuite(t *testing.T) {
+	suite.Run(t, new(HandlerAppListSuite))
+}

--- a/src/ce/api/public/v1/services.go
+++ b/src/ce/api/public/v1/services.go
@@ -14,6 +14,9 @@ import (
 func Services(r *shttp.Router) *shttp.Service {
 	s := r.NewService()
 
+	s.NewEndpoint("/v1/apps").
+		Handler(shttp.MethodGet, "", user.WithAPIKey(handlerAppList))
+
 	s.NewEndpoint("/v1/env").
 		Handler(shttp.MethodPost, "", app.WithAPIKey(handlerEnvAdd)).
 		Handler(shttp.MethodDelete, "", app.WithAPIKey(handlerEnvDel, &app.Opts{Env: true})).

--- a/src/ce/api/public/v1/services_test.go
+++ b/src/ce/api/public/v1/services_test.go
@@ -25,6 +25,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 		"DELETE:/v1/env",
 		"DELETE:/v1/snippets",
 		"GET:/v1/app/config",
+		"GET:/v1/apps",
 		"GET:/v1/auth",
 		"GET:/v1/auth/callback",
 		"GET:/v1/auth/session",
@@ -55,6 +56,7 @@ func (s *ServicesSuite) Test_Services_StormkitCloud() {
 		"DELETE:/v1/env",
 		"DELETE:/v1/snippets",
 		"GET:/v1/app/config",
+		"GET:/v1/apps",
 		"GET:/v1/domains",
 		"GET:/v1/env/pull",
 		"GET:/v1/license",
@@ -78,6 +80,10 @@ func (s *ServicesSuite) Test_EE() {
 	s.NotNil(services)
 
 	statusMap := map[string]int{
+		"GET:/v1/apps":            http.StatusForbidden,
+		"GET:/v1/auth":            http.StatusBadRequest,
+		"GET:/v1/auth/session":    http.StatusBadRequest,
+		"GET:/v1/auth/callback":   http.StatusBadRequest,
 		"PUT:/v1/domains/cert":    http.StatusPaymentRequired,
 		"DELETE:/v1/domains/cert": http.StatusPaymentRequired,
 		"GET:/v1/license":         http.StatusOK,

--- a/src/ce/api/public/v1/validators.go
+++ b/src/ce/api/public/v1/validators.go
@@ -1,0 +1,63 @@
+package publicapiv1
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Validators struct{}
+
+func (v *Validators) ToInt(raw, paramName string) (int, error) {
+	if raw == "" {
+		return 0, nil
+	}
+
+	i, err := strconv.Atoi(raw)
+
+	if err != nil {
+		return 0, fmt.Errorf("The '%s' parameter must be a valid integer", paramName)
+	}
+
+	if i < 0 {
+		return 0, fmt.Errorf("The '%s' parameter cannot be smaller than 0", paramName)
+	}
+
+	return i, nil
+}
+
+// NormalizeRepo normalizes repo to lower-case and validates that it matches the
+// full provider/org/repo shape for a known VCS provider. It returns the
+// normalized value and whether the value is valid. An empty string is
+// considered valid (no filter applied) and is returned as-is.
+func (v *Validators) NormalizeRepo(repo string) (string, bool) {
+	if repo == "" {
+		return "", true
+	}
+
+	normalized := strings.ToLower(repo)
+	parts := strings.Split(normalized, "/")
+
+	// Require at least provider + org + repo segments, all non-empty.
+	if len(parts) < 3 {
+		return "", false
+	}
+
+	for _, part := range parts {
+		if part == "" {
+			return "", false
+		}
+	}
+
+	validProviders := map[string]struct{}{
+		"github":    {},
+		"gitlab":    {},
+		"bitbucket": {},
+	}
+
+	if _, ok := validProviders[parts[0]]; !ok {
+		return "", false
+	}
+
+	return normalized, true
+}

--- a/src/ce/api/public/v1/validators_test.go
+++ b/src/ce/api/public/v1/validators_test.go
@@ -1,0 +1,104 @@
+package publicapiv1_test
+
+import (
+	"testing"
+
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stretchr/testify/suite"
+)
+
+type ValidatorsSuite struct {
+	suite.Suite
+	v *publicapiv1.Validators
+}
+
+func (s *ValidatorsSuite) SetupTest() {
+	s.v = &publicapiv1.Validators{}
+}
+
+func (s *ValidatorsSuite) Test_ToInt_Empty_ReturnsZero() {
+	i, err := s.v.ToInt("", "from")
+	s.NoError(err)
+	s.Equal(0, i)
+}
+
+func (s *ValidatorsSuite) Test_ToInt_ValidInteger() {
+	i, err := s.v.ToInt("42", "from")
+	s.NoError(err)
+	s.Equal(42, i)
+}
+
+func (s *ValidatorsSuite) Test_ToInt_Zero() {
+	i, err := s.v.ToInt("0", "from")
+	s.NoError(err)
+	s.Equal(0, i)
+}
+
+func (s *ValidatorsSuite) Test_ToInt_Negative_ReturnsError() {
+	_, err := s.v.ToInt("-1", "from")
+	s.EqualError(err, "The 'from' parameter cannot be smaller than 0")
+}
+
+func (s *ValidatorsSuite) Test_ToInt_NonInteger_ReturnsError() {
+	_, err := s.v.ToInt("abc", "teamId")
+	s.EqualError(err, "The 'teamId' parameter must be a valid integer")
+}
+
+func (s *ValidatorsSuite) Test_ToInt_Float_ReturnsError() {
+	_, err := s.v.ToInt("1.5", "from")
+	s.EqualError(err, "The 'from' parameter must be a valid integer")
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_Empty_IsValid() {
+	normalized, ok := s.v.NormalizeRepo("")
+	s.True(ok)
+	s.Equal("", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_Github() {
+	normalized, ok := s.v.NormalizeRepo("github/org/repo")
+	s.True(ok)
+	s.Equal("github/org/repo", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_Github_MixedCase() {
+	normalized, ok := s.v.NormalizeRepo("GITHUB/Org/Repo")
+	s.True(ok)
+	s.Equal("github/org/repo", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_Gitlab() {
+	normalized, ok := s.v.NormalizeRepo("gitlab/org/repo")
+	s.True(ok)
+	s.Equal("gitlab/org/repo", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_Bitbucket() {
+	normalized, ok := s.v.NormalizeRepo("bitbucket/org/repo")
+	s.True(ok)
+	s.Equal("bitbucket/org/repo", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_PrefixOnly_Invalid() {
+	_, ok := s.v.NormalizeRepo("github/")
+	s.False(ok)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_MissingRepo_Invalid() {
+	_, ok := s.v.NormalizeRepo("github/org")
+	s.False(ok)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_InvalidPrefix() {
+	_, ok := s.v.NormalizeRepo("codeberg/org/repo")
+	s.False(ok)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_NoSlash() {
+	_, ok := s.v.NormalizeRepo("myrepo")
+	s.False(ok)
+}
+
+func TestValidators(t *testing.T) {
+	suite.Run(t, new(ValidatorsSuite))
+}


### PR DESCRIPTION
## Description

Adds a public `GET /v1/apps` API endpoint that returns a paginated list of applications belonging to the authenticated user. This endpoint is intended for both human and AI agent usage — it is the standard entry point for discovering `appId` and `defaultEnvId` values needed by other API endpoints.

**Changes:**

- **`handler_app_list.go`** — new handler authenticated via a user-scoped API key (`user.WithAPIKey`). Supports `from` (pagination offset) and `filter` (display name substring) query parameters and returns `{ apps, hasNextPage }`.
- **`services.go`** — registers `GET /v1/apps`.
- **`services_test.go`** — adds the new route to the handler key assertions and expected status map.
- **`handler_app_list_test.go`** — tests covering: forbidden access, negative `from` rejection, successful listing, and display-name filtering.
- **`docs/api/2-apps.md`** — API documentation structured for both humans and agents: full field tables with usage guidance, error table, pagination algorithm, and a concrete response example.

## Screenshots/Demo

N/A — backend API endpoint.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated relevant documentation

## Breaking Changes

None.

## Related Issues

N/A

## Additional Notes

The endpoint requires a **user-level** API key (scope `user`). App-level, env-level, and team-level keys will receive `403 Forbidden`. The page size is fixed at 20 items and pagination uses an offset (`from`) model consistent with the existing private `handlerAppIndex`.