### PR TITLE
feat(public/v1): add WithAPIKey middleware and GET /v1/apps/{appId} endpoint

### DIFF
--- a/docs/api/2-apps.md
+++ b/docs/api/2-apps.md
@@ -17,7 +17,7 @@ Returns a paginated list of applications belonging to the authenticated user.
 
 **Base URL:** `https://api.stormkit.io`
 
-**Authentication:** User-level API key passed as the `Authorization` header (no `Bearer` prefix required). To generate one: Profile → Account → API Keys.
+**Authentication:** User or Team level API key passed as the `Authorization` header (no `Bearer` prefix required). To generate one: Profile → Account → API Keys.
 
 ### Query parameters
 
@@ -112,5 +112,73 @@ curl -X GET \
     }
   ],
   "hasNextPage": false
+}
+```
+
+---
+
+## GET /v1/apps/{appId}
+
+Returns a single application by its ID.
+
+**Base URL:** `https://api.stormkit.io`
+
+**Authentication:** User-level or team-level API key passed as the `Authorization` header. The authenticated principal must be a member of the team that owns the application.
+
+### Path parameters
+
+| Parameter | Type   | Required | Description                         |
+| --------- | ------ | -------- | ----------------------------------- |
+| `appId`   | number | **Yes**  | The ID of the application to fetch. |
+
+### Response — 200 OK
+
+| Field | Type  | Description             |
+| ----- | ----- | ----------------------- |
+| `app` | `App` | The application object. |
+
+**`App` object:**
+
+| Field          | Type    | Description                                                                         |
+| -------------- | ------- | ----------------------------------------------------------------------------------- |
+| `id`           | string  | Unique application ID.                                                              |
+| `displayName`  | string  | Human-readable name of the application.                                             |
+| `repo`         | string  | Repository path (e.g. `github/org/repo`). Empty when `isBare` is `true`.            |
+| `isBare`       | boolean | `true` when no repository is linked.                                                |
+| `userId`       | string  | ID of the user who owns the application.                                            |
+| `teamId`       | string  | ID of the team the application belongs to.                                          |
+| `defaultEnvId` | string  | ID of the default environment. Use this as `envId` in environment-scoped endpoints. |
+| `createdAt`    | string  | Unix timestamp (seconds) when the application was created.                          |
+
+### Error responses
+
+| Status | Condition                                                                     |
+| ------ | ----------------------------------------------------------------------------- |
+| `400`  | `appId` is missing, zero, or not a valid integer.                             |
+| `403`  | Missing/invalid API key, or the authenticated principal is not a team member. |
+| `404`  | No application found with the given ID.                                       |
+| `500`  | Internal server error.                                                        |
+
+### Examples
+
+```bash
+curl -X GET \
+     -H 'Authorization: <api_key>' \
+     'https://api.stormkit.io/v1/apps/1510'
+```
+
+```json
+// Example response
+{
+  "app": {
+    "id": "1510",
+    "displayName": "my-app-abc123",
+    "repo": "github/acme/my-app",
+    "isBare": false,
+    "userId": "42",
+    "teamId": "7",
+    "defaultEnvId": "305",
+    "createdAt": "1700489144"
+  }
 }
 ```

--- a/src/ce/api/public/v1/handler_app_get.go
+++ b/src/ce/api/public/v1/handler_app_get.go
@@ -1,0 +1,71 @@
+package publicapiv1
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+// handlerAppGet returns a single application by its ID.
+// Authentication requires a an API key with at least team scope (user-scoped or team-scoped).
+//
+// Path parameters:
+//
+//	appId - Required. The ID of the application to retrieve.
+//
+// Response:
+//
+//	app - The application object.
+func handlerAppGet(req *RequestContext) *shttp.Response {
+	v := &Validators{}
+
+	appIdInt, err := v.ToInt(req.Vars()["appId"], "appId")
+
+	if err != nil {
+		return shttp.BadRequest(map[string]any{
+			"error": err.Error(),
+		})
+	}
+
+	if appIdInt == 0 {
+		return shttp.BadRequest(map[string]any{
+			"error": "The 'appId' path parameter is required",
+		})
+	}
+
+	appID := types.ID(appIdInt)
+
+	myApp, err := app.NewStore().AppByID(req.Context(), appID)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to fetch app %d: %s", appID, err.Error()))
+	}
+
+	if myApp == nil {
+		return shttp.NotFound()
+	}
+
+	// Verify the authenticated user is a member of the app's team.
+	var isMember bool
+
+	if req.Token.TeamID != 0 {
+		isMember = req.Token.TeamID == myApp.TeamID
+	} else {
+		isMember = team.NewStore().IsMember(req.Context(), req.Token.UserID, myApp.TeamID)
+	}
+
+	if !isMember {
+		return shttp.Forbidden()
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"app": myApp.JSON(),
+		},
+	}
+}

--- a/src/ce/api/public/v1/handler_app_get_test.go
+++ b/src/ce/api/public/v1/handler_app_get_test.go
@@ -1,0 +1,162 @@
+package publicapiv1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerAppGetSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *HandlerAppGetSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerAppGetSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerAppGetSuite) handler() http.Handler {
+	return shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler()
+}
+
+func (s *HandlerAppGetSuite) userKey() (string, *factory.MockApp) {
+	usr := s.MockUser()
+	a := s.MockApp(usr)
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	return key.Value, a
+}
+
+// Test_Forbidden verifies that requests without a valid API key are rejected with 403.
+func (s *HandlerAppGetSuite) Test_Forbidden() {
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps/1",
+		nil,
+		map[string]string{
+			"Authorization": "SK_invalid-key",
+		},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
+// Test_NotFound verifies that requesting a non-existent app returns 404.
+func (s *HandlerAppGetSuite) Test_NotFound() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps/999999999",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
+// Test_Forbidden_OtherTeam verifies that a user cannot retrieve an app belonging
+// to a team they are not a member of.
+func (s *HandlerAppGetSuite) Test_Forbidden_OtherTeam() {
+	// Create the app owned by one user.
+	_, a := s.userKey()
+
+	// Create a second unrelated user who has no access to that app.
+	usr2 := s.MockUser()
+	key2 := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr2.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps/%s", a.ID.String()),
+		nil,
+		map[string]string{
+			"Authorization": key2.Value,
+		},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
+// Test_Success verifies that an authenticated member can retrieve their app by ID.
+func (s *HandlerAppGetSuite) Test_Success() {
+	keyValue, a := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/apps/%s", a.ID.String()),
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	var body map[string]any
+	s.NoError(json.Unmarshal([]byte(response.String()), &body))
+
+	got, ok := body["app"].(map[string]any)
+	s.True(ok)
+	s.Equal(a.ID.String(), got["id"])
+	s.Equal(a.DisplayName, got["displayName"])
+	s.Equal(a.Repo, got["repo"])
+	s.Equal(a.Repo == "", got["isBare"])
+	s.Equal(a.UserID.String(), got["userId"])
+	s.Equal(a.TeamID.String(), got["teamId"])
+}
+
+// Test_InvalidAppId_NonInteger verifies that a non-integer appId path param is rejected.
+func (s *HandlerAppGetSuite) Test_InvalidAppId_NonInteger() {
+	keyValue, _ := s.userKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		"/v1/apps/not-an-id",
+		nil,
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+func TestHandlerAppGet(t *testing.T) {
+	suite.Run(t, new(HandlerAppGetSuite))
+}

--- a/src/ce/api/public/v1/handler_app_list.go
+++ b/src/ce/api/public/v1/handler_app_list.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
@@ -30,7 +29,7 @@ const appListLimit = 20
 //	apps        - Array of application objects.
 //	hasNextPage - Whether more results are available. When true, increment
 //	              "from" by the number of items returned to get the next page.
-func handlerAppList(req *user.RequestContext) *shttp.Response {
+func handlerAppList(req *RequestContext) *shttp.Response {
 	q := req.Query()
 	v := &Validators{}
 
@@ -42,11 +41,24 @@ func handlerAppList(req *user.RequestContext) *shttp.Response {
 		})
 	}
 
-	teamIdInt, err := v.ToInt(q.Get("teamId"), "teamId")
+	teamID := req.Token.TeamID
 
-	if err != nil {
+	// Fallback to accepting teamId as a query parameter to allow user level API key.
+	if teamID == 0 {
+		teamIdInt, err := v.ToInt(q.Get("teamId"), "teamId")
+
+		if err != nil {
+			return shttp.BadRequest(map[string]any{
+				"error": err.Error(),
+			})
+		}
+
+		teamID = types.ID(teamIdInt)
+	}
+
+	if teamID == 0 {
 		return shttp.BadRequest(map[string]any{
-			"error": err.Error(),
+			"error": "The 'teamId' parameter is required",
 		})
 	}
 
@@ -59,16 +71,9 @@ func handlerAppList(req *user.RequestContext) *shttp.Response {
 	}
 
 	displayName := q.Get("displayName")
-	teamID := types.ID(teamIdInt)
-
-	if teamID == 0 {
-		return shttp.BadRequest(map[string]any{
-			"error": "The 'teamId' parameter is required",
-		})
-	}
 
 	// Check if the user is a member of the specified team.
-	isMember := team.NewStore().IsMember(req.Context(), req.User.ID, teamID)
+	isMember := team.NewStore().IsMember(req.Context(), req.Token.UserID, teamID)
 
 	if !isMember {
 		return shttp.Forbidden()

--- a/src/ce/api/public/v1/request_context.go
+++ b/src/ce/api/public/v1/request_context.go
@@ -1,0 +1,76 @@
+package publicapiv1
+
+import (
+	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+type RequestContext struct {
+	*shttp.RequestContext
+	Token *apikey.Token
+}
+
+type Opts struct {
+	MinimumScope string // apikey.SCOPE_*
+}
+
+func getOpts(opts ...*Opts) *Opts {
+	o := &Opts{}
+
+	if len(opts) == 1 && opts[0] != nil {
+		o = opts[0]
+	}
+
+	return o
+}
+
+func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) shttp.RequestFunc {
+	options := getOpts(opts...)
+
+	return func(req *shttp.RequestContext) *shttp.Response {
+		token := strings.Replace(req.Headers().Get("Authorization"), "Bearer ", "", 1)
+		request := &RequestContext{
+			RequestContext: req,
+		}
+
+		if !strings.Contains(token, "SK_") {
+			return shttp.Forbidden()
+		}
+
+		key, err := apikey.NewStore().APIKey(req.Context(), token)
+
+		if err != nil {
+			return shttp.Error(err)
+		}
+
+		// This is an invalid key. A key needs to have either an app ID, user ID or team ID.
+		if key == nil || (key.UserID == 0 && key.AppID == 0 && key.TeamID == 0) {
+			return shttp.Forbidden()
+		}
+
+		request.Token = key
+
+		switch options.MinimumScope {
+		case apikey.SCOPE_USER:
+			if key.UserID == 0 {
+				return shttp.Forbidden()
+			}
+		case apikey.SCOPE_TEAM:
+			if key.TeamID == 0 && key.UserID == 0 {
+				return shttp.Forbidden()
+			}
+		case apikey.SCOPE_APP:
+			if key.AppID == 0 && key.TeamID == 0 && key.UserID == 0 {
+				return shttp.Forbidden()
+			}
+		case apikey.SCOPE_ENV:
+			if (key.EnvID == 0 && key.AppID == 0) && key.TeamID == 0 && key.UserID == 0 {
+				return shttp.Forbidden()
+			}
+		}
+
+		return handler(request)
+	}
+}

--- a/src/ce/api/public/v1/request_context_test.go
+++ b/src/ce/api/public/v1/request_context_test.go
@@ -1,0 +1,189 @@
+package publicapiv1_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type WithAPIKeySuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *WithAPIKeySuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *WithAPIKeySuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *WithAPIKeySuite) invoke(token string, opts ...*publicapiv1.Opts) *shttp.Response {
+	fn := publicapiv1.WithAPIKey(func(req *publicapiv1.RequestContext) *shttp.Response {
+		return shttp.OK()
+	}, opts...)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+
+	return fn(shttp.NewRequestContext(r))
+}
+
+// Test_EmptyToken verifies that an empty Authorization header is rejected.
+func (s *WithAPIKeySuite) Test_EmptyToken() {
+	resp := s.invoke("")
+	s.Equal(http.StatusForbidden, resp.Status)
+}
+
+// Test_NoSKPrefix verifies that a token without the "SK_" prefix is immediately rejected,
+// without hitting the database.
+func (s *WithAPIKeySuite) Test_NoSKPrefix() {
+	resp := s.invoke("not-a-valid-token")
+	s.Equal(http.StatusForbidden, resp.Status)
+}
+
+// Test_KeyNotFound verifies that a properly prefixed token that doesn't exist in the
+// database is rejected.
+func (s *WithAPIKeySuite) Test_KeyNotFound() {
+	resp := s.invoke("SK_doesnotexist")
+	s.Equal(http.StatusForbidden, resp.Status)
+}
+
+// Test_KeyWithNoIDs verifies that a token with no associated user, app, or team is rejected.
+func (s *WithAPIKeySuite) Test_KeyWithNoIDs() {
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": types.ID(0),
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_APP,
+	})
+
+	resp := s.invoke(key.Value)
+	s.Equal(http.StatusForbidden, resp.Status)
+}
+
+// Test_ScopeUser_WithoutUserID verifies that an app-scoped key is rejected for a
+// SCOPE_USER endpoint.
+func (s *WithAPIKeySuite) Test_ScopeUser_WithoutUserID() {
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_APP,
+	})
+
+	resp := s.invoke(key.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_USER})
+	s.Equal(http.StatusForbidden, resp.Status)
+}
+
+// Test_ScopeUser_WithUserID verifies that a user-scoped key passes a SCOPE_USER endpoint.
+func (s *WithAPIKeySuite) Test_ScopeUser_WithUserID() {
+	usr := s.MockUser()
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	resp := s.invoke(key.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_USER})
+	s.Equal(http.StatusOK, resp.Status)
+}
+
+// Test_ScopeTeam_WithoutTeamOrUserID verifies that an app-only key is rejected for
+// a SCOPE_TEAM endpoint.
+func (s *WithAPIKeySuite) Test_ScopeTeam_WithoutTeamOrUserID() {
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_APP,
+	})
+
+	resp := s.invoke(key.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_TEAM})
+	s.Equal(http.StatusForbidden, resp.Status)
+}
+
+// Test_ScopeTeam_WithUserID verifies that a user-scoped key satisfies a SCOPE_TEAM endpoint.
+func (s *WithAPIKeySuite) Test_ScopeTeam_WithUserID() {
+	usr := s.MockUser()
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	resp := s.invoke(key.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_TEAM})
+	s.Equal(http.StatusOK, resp.Status)
+}
+
+// Test_ScopeApp_Passes verifies that an app-scoped key passes a SCOPE_APP endpoint.
+func (s *WithAPIKeySuite) Test_ScopeApp_Passes() {
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_APP,
+	})
+
+	resp := s.invoke(key.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_APP})
+	s.Equal(http.StatusOK, resp.Status)
+}
+
+// Test_ScopeEnv_Passes verifies that an env-scoped key passes a SCOPE_ENV endpoint.
+func (s *WithAPIKeySuite) Test_ScopeEnv_Passes() {
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_ENV,
+	})
+
+	resp := s.invoke(key.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_ENV})
+	s.Equal(http.StatusOK, resp.Status)
+}
+
+// Test_TokenSetOnContext verifies that the resolved API token is attached to the
+// RequestContext and forwarded to the handler.
+func (s *WithAPIKeySuite) Test_TokenSetOnContext() {
+	usr := s.MockUser()
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+		"Scope":  apikey.SCOPE_USER,
+	})
+
+	var capturedToken *apikey.Token
+
+	fn := publicapiv1.WithAPIKey(func(req *publicapiv1.RequestContext) *shttp.Response {
+		capturedToken = req.Token
+		return shttp.OK()
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+key.Value)
+
+	resp := fn(shttp.NewRequestContext(r))
+
+	s.Equal(http.StatusOK, resp.Status)
+	s.Require().NotNil(capturedToken)
+	s.Equal(key.ID, capturedToken.ID)
+}
+
+func TestWithAPIKey(t *testing.T) {
+	suite.Run(t, new(WithAPIKeySuite))
+}

--- a/src/ce/api/public/v1/services.go
+++ b/src/ce/api/public/v1/services.go
@@ -2,6 +2,7 @@ package publicapiv1
 
 import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/domainhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/mailerhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
@@ -15,7 +16,8 @@ func Services(r *shttp.Router) *shttp.Service {
 	s := r.NewService()
 
 	s.NewEndpoint("/v1/apps").
-		Handler(shttp.MethodGet, "", user.WithAPIKey(handlerAppList))
+		Handler(shttp.MethodGet, "", WithAPIKey(handlerAppList, &Opts{MinimumScope: apikey.SCOPE_TEAM})).
+		Handler(shttp.MethodGet, "/{appId}", WithAPIKey(handlerAppGet, &Opts{MinimumScope: apikey.SCOPE_TEAM}))
 
 	s.NewEndpoint("/v1/env").
 		Handler(shttp.MethodPost, "", app.WithAPIKey(handlerEnvAdd)).

--- a/src/ce/api/public/v1/services_test.go
+++ b/src/ce/api/public/v1/services_test.go
@@ -26,6 +26,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 		"DELETE:/v1/snippets",
 		"GET:/v1/app/config",
 		"GET:/v1/apps",
+		"GET:/v1/apps/{appId}",
 		"GET:/v1/auth",
 		"GET:/v1/auth/callback",
 		"GET:/v1/auth/session",
@@ -57,6 +58,7 @@ func (s *ServicesSuite) Test_Services_StormkitCloud() {
 		"DELETE:/v1/snippets",
 		"GET:/v1/app/config",
 		"GET:/v1/apps",
+		"GET:/v1/apps/{appId}",
 		"GET:/v1/domains",
 		"GET:/v1/env/pull",
 		"GET:/v1/license",
@@ -81,6 +83,7 @@ func (s *ServicesSuite) Test_EE() {
 
 	statusMap := map[string]int{
 		"GET:/v1/apps":            http.StatusForbidden,
+		"GET:/v1/apps/{appId}":    http.StatusForbidden,
 		"GET:/v1/auth":            http.StatusBadRequest,
 		"GET:/v1/auth/session":    http.StatusBadRequest,
 		"GET:/v1/auth/callback":   http.StatusBadRequest,

--- a/src/ce/api/user/user_store.go
+++ b/src/ce/api/user/user_store.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gosimple/slug"
 	"github.com/lib/pq"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -569,10 +568,6 @@ func (s *Store) MustUser(authUser *oauth.User) (*User, error) {
 		if _, err = s.insertUser(user); err != nil {
 			return nil, err
 		}
-
-		if _, err := s.createAPIKey(ctx, user.ID); err != nil {
-			return nil, err
-		}
 	}
 
 	return user, err
@@ -581,23 +576,6 @@ func (s *Store) MustUser(authUser *oauth.User) (*User, error) {
 func (s *Store) UpdateLastLogin(ctx context.Context, userID types.ID) error {
 	_, err := s.Exec(ctx, ustmt.updateLastLogin, userID)
 	return err
-}
-
-// createAPIKey creates an API key for the user which is going to be used
-// for interacting with the API for generic routes.
-func (s *Store) createAPIKey(ctx context.Context, userID types.ID) (*apikey.Token, error) {
-	token := &apikey.Token{
-		UserID: userID,
-		Name:   "default",
-		Scope:  apikey.SCOPE_USER,
-		Value:  apikey.GenerateTokenValue(),
-	}
-
-	if err := apikey.NewStore().AddAPIKey(ctx, token); err != nil {
-		return nil, err
-	}
-
-	return token, nil
 }
 
 // SelectTotalUsers returns the total number of users in the instance.

--- a/src/ce/api/user/user_store_test.go
+++ b/src/ce/api/user/user_store_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
@@ -49,10 +48,6 @@ func (s *UserStoreSuite) Test_MustUser() {
 	s.Len(teams, 1)
 	s.Equal("owner", teams[0].CurrentUserRole)
 	s.Equal(team.DEFAULT_TEAM_NAME, teams[0].Name)
-
-	apiKeys, err := apikey.NewStore().APIKeys(ctx, user.ID, apikey.SCOPE_USER)
-	s.NoError(err)
-	s.Len(apiKeys, 1)
 }
 
 func (s *UserStoreSuite) Test_MustUser_Approval() {
@@ -130,10 +125,6 @@ func (s *UserStoreSuite) Test_MustUser_IsAdmin() {
 	s.Len(teams, 1)
 	s.Equal("owner", teams[0].CurrentUserRole)
 	s.Equal(team.DEFAULT_TEAM_NAME, teams[0].Name)
-
-	apiKeys, err := apikey.NewStore().APIKeys(ctx, user.ID, apikey.SCOPE_USER)
-	s.NoError(err)
-	s.Len(apiKeys, 1)
 }
 
 func (s *UserStoreSuite) Test_InsertEmails() {


### PR DESCRIPTION
## Description

Introduce a package-local RequestContext that wraps shttp.RequestContext with a resolved apikey.Token, and a WithAPIKey middleware that enforces API key authentication with configurable minimum scope (user/team/app/env).

- Add request_context.go with RequestContext and WithAPIKey
- Add handler_app_get.go for GET /v1/apps/{appId}, enforcing team membership
- Migrate handler_app_list to use the new RequestContext; resolve teamId directly from the token and fall back to the query parameter for user-level keys
- Add tests for WithAPIKey and HandlerAppGet

## Screenshots/Demo

If applicable, add screenshots or a demo of the changes.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated relevant documentation

## Breaking Changes

If this PR introduces breaking changes, please describe them here and update the checklist:

- [ ] I have documented all breaking changes
- [ ] I have updated the migration guide (if applicable)
- [ ] I have bumped the major version number (if applicable)