### PR TITLE
chore: migrate /v1/snippets to local WithAPIKey and consolidate shared logic

### DIFF
--- a/docs/api/6-snippets.md
+++ b/docs/api/6-snippets.md
@@ -28,7 +28,7 @@ interface Response {
 
 curl -X POST \
      -H 'Authorization: <api_key>' \
-     -H 'Content-Type: application/javascript' \
+     -H 'Content-Type: application/json' \
      'https://api.stormkit.io/v1/snippets' \
      -d '{ "snippets": [{ "title": "Snippet title", "content":  "Hello World", "enabled":  true, "prepend":  false, "location": "head", "rules": { "hosts": ["example.org", "*.dev"], "path": "/my-path" } }] }'
 ```
@@ -36,8 +36,14 @@ curl -X POST \
 | Response | Definition                                           |
 | -------- | ---------------------------------------------------- |
 | 201      | Snippet was created successfully.                    |
-| 400      | Snippet is invalid. Check your parameters.           |
+| 400      | Snippet is invalid. Check the `errors` array.        |
 | 409      | Snippet content is duplicate within the environment. |
+
+On error, the response body contains an `errors` array:
+
+```json
+{ "errors": ["Snippet title is a required field."] }
+```
 
 </details>
 
@@ -57,7 +63,7 @@ interface QueryString {
 }
 
 interface Response {
-  snippets: []Redirect
+  snippets: []Snippet
   pagination: Pagination
 }
 ```
@@ -67,7 +73,6 @@ interface Response {
 
 curl -X GET \
      -H 'Authorization: <api_key>' \
-     -H 'Content-Type: application/javascript' \
      'https://api.stormkit.io/v1/snippets'
 ```
 
@@ -124,7 +129,7 @@ interface Response {
 
 curl -X PUT \
      -H 'Authorization: <api_key>' \
-     -H 'Content-Type: application/javascript' \
+     -H 'Content-Type: application/json' \
      'https://api.stormkit.io/v1/snippets' \
      -d '{ "snippet": { "id": 1501, "title": "New title", "content":  "Hello World", "enabled":  true, "prepend":  false, "location": "head", "rules": { "hosts": ["example.org", "*.dev"], "path": "/my-path" } } }'
 ```
@@ -132,8 +137,14 @@ curl -X PUT \
 | Response | Definition                                           |
 | -------- | ---------------------------------------------------- |
 | 200      | Snippet was updated successfully.                    |
-| 400      | Snippet is invalid. Check your parameters.           |
+| 400      | Snippet is invalid. Check the `errors` array.        |
 | 409      | Snippet content is duplicate within the environment. |
+
+On error, the response body contains an `errors` array:
+
+```json
+{ "errors": ["Snippet title is a required field."] }
+```
 
 </details>
 
@@ -143,7 +154,7 @@ curl -X PUT \
   <span>DELETE </span><span>/v1/snippets</span>
 </summary>
 
-Delete Snippets with the given ids. You can delete maximum `100` snippets at a time.
+Delete snippets with the given ids. You can delete a maximum of `100` snippets at a time.
 
 ```typescript
 interface QueryString {
@@ -158,10 +169,20 @@ interface Response {
 ```bash
 # Example
 
-curl -X PUT \
+curl -X DELETE \
      -H 'Authorization: <api_key>' \
-     -H 'Content-Type: application/javascript' \
      'https://api.stormkit.io/v1/snippets?ids=1501,5061'
+```
+
+| Response | Definition                                    |
+| -------- | --------------------------------------------- |
+| 200      | Snippets were deleted successfully.           |
+| 400      | Request is invalid. Check the `errors` array. |
+
+On error, the response body contains an `errors` array:
+
+```json
+{ "errors": ["ID should be an integer."] }
 ```
 
 </details>
@@ -199,4 +220,4 @@ interface Pagination {
 | rules.hosts | Inject snippet only for the provided hosts.                                                              |
 | rules.path  | If specified, snippet will be injected only when the path matches.                                       |
 
-**Note:** To inject snippets for all development endpoints, specify `*.dev` for the `rules.hosts` property. Specifying an indivual deployment endpoint will enable the snippet for all development endpoints.
+**Note:** To inject snippets for all development endpoints, specify `*.dev` for the `rules.hosts` property. Specifying an individual deployment endpoint will enable the snippet for all development endpoints.

--- a/src/ce/api/app/buildconf/snippets_model.go
+++ b/src/ce/api/app/buildconf/snippets_model.go
@@ -1,12 +1,15 @@
 package buildconf
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/dlclark/regexp2"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 )
 
@@ -105,4 +108,91 @@ func (s *Snippet) ContentHash() string {
 	h := sha256.New()
 	h.Write([]byte(s.Content))
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// JSON returns a plain map representation of the snippet suitable for JSON responses.
+func (s *Snippet) JSON() map[string]any {
+	var rules map[string]any
+
+	if s.Rules != nil {
+		rules = map[string]any{
+			"hosts": s.Rules.Hosts,
+			"path":  s.Rules.Path,
+		}
+	}
+
+	return map[string]any{
+		"id":       s.ID.String(),
+		"location": s.Location,
+		"prepend":  s.Prepend,
+		"enabled":  s.Enabled,
+		"title":    s.Title,
+		"content":  s.Content,
+		"rules":    rules,
+	}
+}
+
+const SnippetLocationHead = "head"
+const SnippetLocationBody = "body"
+
+// ValidateSnippet validates a snippet's fields and trims whitespace in-place.
+// Returns a slice of human-readable error messages; returns nil when the snippet is valid.
+func ValidateSnippet(snippet *Snippet) []string {
+	var errs []string
+
+	if snippet.Location != SnippetLocationHead && snippet.Location != SnippetLocationBody {
+		errs = append(errs, "Location must be either 'head' or 'body'.")
+	}
+
+	snippet.Title = strings.TrimSpace(snippet.Title)
+	snippet.Content = strings.TrimSpace(snippet.Content)
+
+	if snippet.Title == "" {
+		errs = append(errs, "Snippet title is a required field.")
+	}
+
+	if snippet.Content == "" {
+		errs = append(errs, "Snippet content is a required field.")
+	}
+
+	if snippet.Rules != nil && snippet.Rules.Path != "" {
+		if _, err := regexp2.Compile(snippet.Rules.Path, regexp2.None); err != nil {
+			errs = append(errs, "Snippet path must be a valid regular expression.")
+		}
+	}
+
+	return errs
+}
+
+// ValidateSnippetDomains checks that every host referenced in the given snippets
+// exists as a domain for the environment. Returns an error listing any missing hosts.
+func ValidateSnippetDomains(snippets []*Snippet, envID types.ID) error {
+	hosts := []string{}
+
+	for _, snippet := range snippets {
+		if snippet.Rules != nil && len(snippet.Rules.Hosts) > 0 {
+			for _, host := range snippet.Rules.Hosts {
+				if host != "*.dev" {
+					hosts = append(hosts, host)
+				}
+			}
+		}
+	}
+
+	if len(hosts) == 0 {
+		return nil
+	}
+
+	missingHosts, err := SnippetsStore().MissingHosts(context.Background(), hosts, envID)
+
+	if err != nil {
+		slog.Errorf("error while fetching missing hosts: %s", err.Error())
+		return err
+	}
+
+	if len(missingHosts) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("Invalid or missing domain name(s): %s", strings.Join(missingHosts, ", "))
 }

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_add.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_add.go
@@ -24,23 +24,18 @@ func HandlerSnippetsAdd(req *app.RequestContext) *shttp.Response {
 	}
 
 	if len(data.Snippets) == 0 {
-		return &shttp.Response{
-			Status: http.StatusBadRequest,
-			Data: map[string]string{
-				"error": "Nothing to add.",
-			},
-		}
+		return shttp.BadRequest(map[string]any{"errors": []string{"Nothing to add."}})
 	}
 
 	snippets := []*buildconf.Snippet{}
 	titles := []string{}
 
 	for _, snippet := range data.Snippets {
-		if err := validateSnippet(snippet, snippet.Location); err != nil {
-			return badRequest(err)
+		if errs := buildconf.ValidateSnippet(snippet); len(errs) > 0 {
+			return shttp.BadRequest(map[string]any{"errors": errs})
 		}
 
-		normalizeRules(snippet.Rules)
+		NormalizeSnippetRules(snippet.Rules)
 
 		snippet.EnvID = req.EnvID
 		snippet.AppID = req.App.ID
@@ -48,8 +43,8 @@ func HandlerSnippetsAdd(req *app.RequestContext) *shttp.Response {
 		titles = append(titles, snippet.Title)
 	}
 
-	if err := validateDomains(snippets, req.EnvID); err != nil {
-		return badRequest(err)
+	if err := buildconf.ValidateSnippetDomains(snippets, req.EnvID); err != nil {
+		return shttp.BadRequest(map[string]any{"errors": []string{err.Error()}})
 	}
 
 	if err := store.Insert(req.Context(), snippets); err != nil {
@@ -85,10 +80,14 @@ func HandlerSnippetsAdd(req *app.RequestContext) *shttp.Response {
 		}
 	}
 
+	result := []map[string]any{}
+
+	for _, s := range snippets {
+		result = append(result, s.JSON())
+	}
+
 	return &shttp.Response{
 		Status: http.StatusCreated,
-		Data: map[string]any{
-			"snippets": toJSON(snippets),
-		},
+		Data:   map[string]any{"snippets": result},
 	}
 }

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_add_test.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_add_test.go
@@ -330,7 +330,7 @@ func (s *HandlerSnippetsAddSuite) Test_Fail_InvalidHost() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(`{"error": "Invalid or missing domain name(s): www.stormkit.io" }`, response.String())
+	s.JSONEq(`{"errors": ["Invalid or missing domain name(s): www.stormkit.io"]}`, response.String())
 }
 
 func (s *HandlerSnippetsAddSuite) TestInvalidRequest_NoSnippets() {
@@ -352,7 +352,7 @@ func (s *HandlerSnippetsAddSuite) TestInvalidRequest_NoSnippets() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Nothing to add."}`)
+	s.JSONEq(response.String(), `{"errors": ["Nothing to add."]}`)
 }
 
 func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidLocation() {
@@ -378,7 +378,7 @@ func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidLocation() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Location must be either 'head' or 'body'."}`)
+	s.JSONEq(response.String(), `{"errors": ["Location must be either 'head' or 'body'."]}`)
 }
 
 func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidTitle() {
@@ -403,7 +403,7 @@ func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidTitle() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Snippet title is a required field."}`)
+	s.JSONEq(response.String(), `{"errors": ["Snippet title is a required field."]}`)
 }
 
 func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidContent() {
@@ -428,7 +428,7 @@ func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidContent() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Snippet content is a required field."}`)
+	s.JSONEq(response.String(), `{"errors": ["Snippet content is a required field."]}`)
 }
 
 func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidPathRegexp() {
@@ -455,7 +455,7 @@ func (s *HandlerSnippetsAddSuite) TestInvalidRequest_InvalidPathRegexp() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Snippet path must be a valid regular expression."}`)
+	s.JSONEq(response.String(), `{"errors": ["Snippet path must be a valid regular expression."]}`)
 }
 
 func TestHandlerSnippetsAdd(t *testing.T) {

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_delete.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_delete.go
@@ -1,7 +1,6 @@
 package snippetshandlers
 
 import (
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -22,12 +21,7 @@ func HandlerSnippetsDelete(req *app.RequestContext) *shttp.Response {
 	}
 
 	if len(ids) == 0 {
-		return &shttp.Response{
-			Status: http.StatusBadRequest,
-			Data: map[string]string{
-				"error": "Nothing to delete.",
-			},
-		}
+		return shttp.BadRequest(map[string]any{"errors": []string{"Nothing to delete."}})
 	}
 
 	counter := 0
@@ -36,24 +30,14 @@ func HandlerSnippetsDelete(req *app.RequestContext) *shttp.Response {
 	deleteStr := make([]string, idsLen)
 
 	if idsLen > 100 {
-		return &shttp.Response{
-			Status: http.StatusBadRequest,
-			Data: map[string]string{
-				"error": "Please delete maximum 100 snippets at a time.",
-			},
-		}
+		return shttp.BadRequest(map[string]any{"errors": []string{"Please delete maximum 100 snippets at a time."}})
 	}
 
 	for _, id := range ids {
 		idInt, err := strconv.Atoi(id)
 
 		if err != nil {
-			return &shttp.Response{
-				Status: http.StatusBadRequest,
-				Data: map[string]string{
-					"error": "ID should be an integer.",
-				},
-			}
+			return shttp.BadRequest(map[string]any{"errors": []string{"ID should be an integer."}})
 		}
 
 		delete[counter] = types.ID(idInt)

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_delete_test.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_delete_test.go
@@ -130,7 +130,7 @@ func (s *HandlerSnippetsDeleteSuite) TestInvalidRequest_InvalidID() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "ID should be an integer."}`)
+	s.JSONEq(response.String(), `{"errors": ["ID should be an integer."]}`)
 }
 
 func TestHandlerSnippetsDelete(t *testing.T) {

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_get.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_get.go
@@ -49,10 +49,16 @@ func HandlerSnippetsGet(req *app.RequestContext) *shttp.Response {
 		snippets = snippets[:snippetsLen-1]
 	}
 
+	result := []map[string]any{}
+
+	for _, s := range snippets {
+		result = append(result, s.JSON())
+	}
+
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Data: map[string]any{
-			"snippets":   toJSON(snippets),
+			"snippets":   result,
 			"pagination": pagination,
 		},
 	}

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_put.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_put.go
@@ -1,7 +1,6 @@
 package snippetshandlers
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
@@ -28,19 +27,19 @@ func HandlerSnippetsPut(req *app.RequestContext) *shttp.Response {
 	}
 
 	if data.Snippet == nil {
-		return badRequest(errors.New("no-item"))
+		return shttp.BadRequest(map[string]any{"errors": []string{"Nothing to update."}})
 	}
 
 	data.Snippet.EnvID = req.EnvID
 
-	if err := validateSnippet(data.Snippet, data.Snippet.Location); err != nil {
-		return badRequest(err)
+	if errs := buildconf.ValidateSnippet(data.Snippet); len(errs) > 0 {
+		return shttp.BadRequest(map[string]any{"errors": errs})
 	}
 
-	normalizeRules(data.Snippet.Rules)
+	NormalizeSnippetRules(data.Snippet.Rules)
 
-	if err := validateDomains([]*buildconf.Snippet{data.Snippet}, req.EnvID); err != nil {
-		return badRequest(err)
+	if err := buildconf.ValidateSnippetDomains([]*buildconf.Snippet{data.Snippet}, req.EnvID); err != nil {
+		return shttp.BadRequest(map[string]any{"errors": []string{err.Error()}})
 	}
 
 	store := buildconf.SnippetsStore()
@@ -114,8 +113,6 @@ func HandlerSnippetsPut(req *app.RequestContext) *shttp.Response {
 func duplicateSnippetError() *shttp.Response {
 	return &shttp.Response{
 		Status: http.StatusConflict,
-		Data: map[string]string{
-			"error": "A snippet with the same content already exists for this environment.",
-		},
+		Data:   map[string]any{"errors": []string{"A snippet with the same content already exists for this environment."}},
 	}
 }

--- a/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_put_test.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/handler_snippets_put_test.go
@@ -240,7 +240,7 @@ func (s *HandlerSnippetsPutSuite) Test_Fail_InvalidHost() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(`{"error": "Invalid or missing domain name(s): www.example.org" }`, response.String())
+	s.JSONEq(`{"errors": ["Invalid or missing domain name(s): www.example.org"]}`, response.String())
 }
 
 func (s *HandlerSnippetsPutSuite) Test_Success_SavingSameObject() {
@@ -307,7 +307,7 @@ func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_NoSnippet() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Nothing to update."}`)
+	s.JSONEq(response.String(), `{"errors": ["Nothing to update."]}`)
 
 	// Should not update the environment's updated at property
 	environment, err := buildconf.NewStore().EnvironmentByID(context.Background(), env.ID)
@@ -341,7 +341,7 @@ func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_NoSnippetID() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Nothing to update."}`)
+	s.JSONEq(response.String(), `{"errors": ["Nothing to update."]}`)
 }
 
 func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_InvalidLocation() {
@@ -371,7 +371,7 @@ func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_InvalidLocation() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Location must be either 'head' or 'body'."}`)
+	s.JSONEq(response.String(), `{"errors": ["Location must be either 'head' or 'body'."]}`)
 }
 
 func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_InvalidTitle() {
@@ -401,7 +401,7 @@ func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_InvalidTitle() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Snippet title is a required field."}`)
+	s.JSONEq(response.String(), `{"errors": ["Snippet title is a required field."]}`)
 }
 
 func (s *HandlerSnippetsPutSuite) Test_Fail_Duplicate() {
@@ -468,7 +468,7 @@ func (s *HandlerSnippetsPutSuite) Test_InvalidRequest_InvalidContent() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(response.String(), `{"error": "Snippet content is a required field."}`)
+	s.JSONEq(response.String(), `{"errors": ["Snippet content is a required field."]}`)
 }
 
 func TestHandlerSnippetsPut(t *testing.T) {

--- a/src/ce/api/app/buildconf/snippetshandlers/helpers_snippets.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/helpers_snippets.go
@@ -1,38 +1,18 @@
 package snippetshandlers
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"net/http"
 	"strings"
 
-	"github.com/dlclark/regexp2"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
-	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/slog"
-	"github.com/stormkit-io/stormkit-io/src/lib/types"
 )
 
-const LOCATION_HEAD = "head"
-const LOCATION_BODY = "body"
-
-var errorsMap = map[string]string{
-	"invalid-location":    "Location must be either 'head' or 'body'.",
-	"invalid-content":     "Snippet content is a required field.",
-	"invalid-title":       "Snippet title is a required field.",
-	"invalid-path-regexp": "Snippet path must be a valid regular expression.",
-	"no-item":             "Nothing to update.",
-}
-
-// CalculateResetDomains will calculate the domains to be reset when
-// a snippet gets updated.
+// CalculateResetDomains returns the cache domains to reset when snippets change.
 //
-// - If the returned string array is nil, all domains should be updated.
-// - If it's empty an empty string array, no domain should be updated.
-// - Otherwise only keys returned should be updated.
+//   - nil        → reset all domains
+//   - []string{} → reset nothing
+//   - non-empty  → reset only those keys
 func CalculateResetDomains(appDisplayName string, snippets []*buildconf.Snippet) []string {
 	reset := map[string]bool{}
 
@@ -72,84 +52,9 @@ func CalculateResetDomains(appDisplayName string, snippets []*buildconf.Snippet)
 	return slice
 }
 
-func validateDomains(snippets []*buildconf.Snippet, envID types.ID) error {
-	hosts := []string{}
-
-	for _, snippet := range snippets {
-		if snippet.Rules != nil && len(snippet.Rules.Hosts) > 0 {
-			for _, host := range snippet.Rules.Hosts {
-				if host != "*.dev" {
-					hosts = append(hosts, host)
-				}
-			}
-		}
-	}
-
-	if len(hosts) == 0 {
-		return nil
-	}
-
-	missingHosts, err := buildconf.SnippetsStore().MissingHosts(context.Background(), hosts, envID)
-
-	if err != nil {
-		slog.Errorf("error while fetching missing hosts: %s", err.Error())
-		return err
-	}
-
-	if len(missingHosts) == 0 {
-		return nil
-	}
-
-	return fmt.Errorf("invalid or missing domain name(s): %s", strings.Join(missingHosts, ", "))
-}
-
-func validateSnippet(snippet *buildconf.Snippet, location string) error {
-	if location != LOCATION_HEAD && location != LOCATION_BODY {
-		return errors.New("invalid-location")
-	}
-
-	snippet.Title = strings.TrimSpace(snippet.Title)
-	snippet.Content = strings.TrimSpace(snippet.Content)
-
-	if snippet.Title == "" {
-		return errors.New("invalid-title")
-	}
-
-	if snippet.Content == "" {
-		return errors.New("invalid-content")
-	}
-
-	if snippet.Rules != nil && snippet.Rules.Path != "" {
-		_, err := regexp2.Compile(snippet.Rules.Path, regexp2.None)
-
-		if err != nil {
-			return errors.New("invalid-path-regexp")
-		}
-	}
-
-	return nil
-}
-
-// badRequest is a short-hand function to return a bad request response.
-func badRequest(err error) *shttp.Response {
-	msg := errorsMap[err.Error()]
-
-	if msg == "" {
-		msg = err.Error()
-		msg = strings.ToUpper(msg[0:1]) + msg[1:]
-	}
-
-	return &shttp.Response{
-		Status: http.StatusBadRequest,
-		Data: map[string]string{
-			"error": msg,
-		},
-	}
-}
-
-// normalizeRules will perform the following actions:
-// - Remove all development endpoints in favor of *.dev
-func normalizeRules(rules *buildconf.SnippetRule) {
+// NormalizeSnippetRules replaces individual stormkit dev hostnames with the
+// wildcard "*.dev" token and lower-cases all other hosts.
+func NormalizeSnippetRules(rules *buildconf.SnippetRule) {
 	if rules == nil {
 		return
 	}
@@ -170,3 +75,4 @@ func normalizeRules(rules *buildconf.SnippetRule) {
 
 	rules.Hosts = hosts
 }
+

--- a/src/ce/api/app/buildconf/snippetshandlers/services.go
+++ b/src/ce/api/app/buildconf/snippetshandlers/services.go
@@ -2,36 +2,8 @@ package snippetshandlers
 
 import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
-
-func toJSON(snippets []*buildconf.Snippet) []map[string]any {
-	r := []map[string]any{}
-
-	for _, snippet := range snippets {
-		var rules map[string]any
-
-		if snippet.Rules != nil {
-			rules = map[string]any{
-				"hosts": snippet.Rules.Hosts,
-				"path":  snippet.Rules.Path,
-			}
-		}
-
-		r = append(r, map[string]any{
-			"id":       snippet.ID.String(),
-			"location": snippet.Location,
-			"prepend":  snippet.Prepend,
-			"enabled":  snippet.Enabled,
-			"title":    snippet.Title,
-			"content":  snippet.Content,
-			"rules":    rules,
-		})
-	}
-
-	return r
-}
 
 // Services sets the Handlers for this service.
 func Services(r *shttp.Router) *shttp.Service {

--- a/src/ce/api/public/v1/handler_snippets_add.go
+++ b/src/ce/api/public/v1/handler_snippets_add.go
@@ -1,0 +1,10 @@
+package publicapiv1
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func handlerSnippetsAdd(req *RequestContext) *shttp.Response {
+	return snippetshandlers.HandlerSnippetsAdd(req.asAppContext())
+}

--- a/src/ce/api/public/v1/handler_snippets_delete.go
+++ b/src/ce/api/public/v1/handler_snippets_delete.go
@@ -1,0 +1,10 @@
+package publicapiv1
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func handlerSnippetsDelete(req *RequestContext) *shttp.Response {
+	return snippetshandlers.HandlerSnippetsDelete(req.asAppContext())
+}

--- a/src/ce/api/public/v1/handler_snippets_get.go
+++ b/src/ce/api/public/v1/handler_snippets_get.go
@@ -1,0 +1,10 @@
+package publicapiv1
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func handlerSnippetsGet(req *RequestContext) *shttp.Response {
+	return snippetshandlers.HandlerSnippetsGet(req.asAppContext())
+}

--- a/src/ce/api/public/v1/handler_snippets_put.go
+++ b/src/ce/api/public/v1/handler_snippets_put.go
@@ -1,0 +1,10 @@
+package publicapiv1
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func handlerSnippetsPut(req *RequestContext) *shttp.Response {
+	return snippetshandlers.HandlerSnippetsPut(req.asAppContext())
+}

--- a/src/ce/api/public/v1/request_context.go
+++ b/src/ce/api/public/v1/request_context.go
@@ -88,6 +88,25 @@ func (req *RequestContext) GetAuditData() audit.AuditData {
 	return d
 }
 
+// asAppContext converts this RequestContext into an *app.RequestContext so that
+// internal handlers can be reused without duplicating logic.
+func (req *RequestContext) asAppContext() *app.RequestContext {
+	envID := types.ID(0)
+
+	if req.Env != nil {
+		envID = req.Env.ID
+	}
+
+	return &app.RequestContext{
+		RequestContext: &user.RequestContext{
+			RequestContext: req.RequestContext,
+		},
+		App:   req.App,
+		EnvID: envID,
+		Token: req.Token,
+	}
+}
+
 type Opts struct {
 	MinimumScope string // apikey.SCOPE_*
 }

--- a/src/ce/api/public/v1/services.go
+++ b/src/ce/api/public/v1/services.go
@@ -5,7 +5,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/domainhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/mailerhandlers"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/volumes"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -39,10 +38,10 @@ func Services(r *shttp.Router) *shttp.Service {
 		Handler(shttp.MethodGet, "/pull", WithAPIKey(handlerEnvPull, &Opts{MinimumScope: apikey.SCOPE_ENV}))
 
 	s.NewEndpoint("/v1/snippets").
-		Handler(shttp.MethodGet, "", app.WithAPIKey(snippetshandlers.HandlerSnippetsGet, &app.Opts{Env: true})).
-		Handler(shttp.MethodPost, "", app.WithAPIKey(snippetshandlers.HandlerSnippetsAdd, &app.Opts{Env: true})).
-		Handler(shttp.MethodPut, "", app.WithAPIKey(snippetshandlers.HandlerSnippetsPut, &app.Opts{Env: true})).
-		Handler(shttp.MethodDelete, "", app.WithAPIKey(snippetshandlers.HandlerSnippetsDelete, &app.Opts{Env: true}))
+		Handler(shttp.MethodGet, "", WithAPIKey(handlerSnippetsGet, &Opts{MinimumScope: apikey.SCOPE_ENV})).
+		Handler(shttp.MethodPost, "", WithAPIKey(handlerSnippetsAdd, &Opts{MinimumScope: apikey.SCOPE_ENV})).
+		Handler(shttp.MethodPut, "", WithAPIKey(handlerSnippetsPut, &Opts{MinimumScope: apikey.SCOPE_ENV})).
+		Handler(shttp.MethodDelete, "", WithAPIKey(handlerSnippetsDelete, &Opts{MinimumScope: apikey.SCOPE_ENV}))
 
 	s.NewEndpoint("/v1/redirects").
 		Handler(shttp.MethodGet, "", WithAPIKey(handlerRedirectsGet, &Opts{MinimumScope: apikey.SCOPE_ENV})).

--- a/src/ce/api/public/v1/services_test.go
+++ b/src/ce/api/public/v1/services_test.go
@@ -119,6 +119,10 @@ func (s *ServicesSuite) Test_EE() {
 		"GET:/v1/license":                          http.StatusOK,
 		"GET:/v1/license/check":                    http.StatusBadRequest,
 		"POST:/v1/volumes":                         http.StatusForbidden,
+		"GET:/v1/snippets":                         http.StatusForbidden,
+		"POST:/v1/snippets":                        http.StatusForbidden,
+		"PUT:/v1/snippets":                         http.StatusForbidden,
+		"DELETE:/v1/snippets":                      http.StatusForbidden,
 	}
 
 	for k, fn := range services.HandlerFuncs() {

--- a/src/ui/src/components/Card/Card.tsx
+++ b/src/ui/src/components/Card/Card.tsx
@@ -13,7 +13,7 @@ import CardContext, { Size } from "./Card.context";
 interface Props extends BoxProps {
   successTitle?: string | false;
   errorTitle?: string | false;
-  error?: React.ReactNode;
+  error?: React.ReactNode | string[];
   info?: React.ReactNode;
   success?: React.ReactNode;
   contentPadding?: boolean; // When false, the content will not have padding x.
@@ -121,7 +121,17 @@ function Card({
             onClose={onErrorClose}
           >
             {errorTitle && <AlertTitle>{errorTitle}</AlertTitle>}
-            <Box>{error}</Box>
+            {Array.isArray(error) ? (
+              <Box component="ul" sx={{ m: 0, pl: 2, listStyleType: "disc" }}>
+                {error.map((e, i) => (
+                  <Box component="li" key={i}>
+                    {e}
+                  </Box>
+                ))}
+              </Box>
+            ) : (
+              <Box>{error}</Box>
+            )}
           </Alert>
         )}
         {!loading && success && (

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/snippets/SnippetModal.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/snippets/SnippetModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, FormEventHandler } from "react";
+import { useState, useContext, SubmitEventHandler } from "react";
 import { html } from "@codemirror/lang-html";
 import CodeMirror from "@uiw/react-codemirror";
 import Box from "@mui/material/Box";
@@ -47,14 +47,14 @@ export default function SnippetModal({
 }: Props) {
   const { app } = useContext(AppContext);
   const { environment } = useContext(EnvironmentContext);
-  const [error, setError] = useState<string>();
+  const [error, setError] = useState<string | string[]>();
   const [loading, setLoading] = useState(false);
   const [selectedHosts, setSelectedHosts] = useState<string[]>();
   const [codeContent, setCodeContent] = useState<string>(
     snippet?.content || defaultContent,
   );
 
-  const handleSubmit: FormEventHandler = e => {
+  const handleSubmit: SubmitEventHandler = e => {
     e.preventDefault();
 
     setLoading(true);
@@ -95,6 +95,11 @@ export default function SnippetModal({
 
           if (typeof data.error === "string") {
             setError(data.error);
+            return;
+          }
+
+          if (Array.isArray(data.errors) && data.errors.length > 0) {
+            setError(data.errors);
             return;
           }
 


### PR DESCRIPTION
## Summary

Migrates the `/v1/snippets` endpoints in `publicapiv1/services.go` from `app.WithAPIKey` to the package-local `WithAPIKey` with proper `*RequestContext` handler signatures. Shared snippet logic is consolidated to avoid duplication, and the public handlers are thin wrappers over the existing internal handlers.

> **Depends on #128** — the diff shown here includes those commits; once #128 merges the PR will show only the snippets migration changes.

## Changes

### Domain layer (`buildconf`)
- `ValidateSnippet(*Snippet) []string` — returns all validation errors (nil if valid), replacing the old single-error return
- `ValidateSnippetDomains` — moved here from snippetshandlers
- `SnippetLocationHead` / `SnippetLocationBody` constants
- `Snippet.JSON()` method for serialisation

### Internal handlers (`snippetshandlers`)
- Removed private `badRequest` helper; call sites now use `shttp.BadRequest` directly
- Removed duplicated validation logic (now in `buildconf`)
- `NormalizeSnippetRules` and `CalculateResetDomains` remain here (they depend on `appconf`/`appcache` which import `buildconf`, so they cannot move down)

### Public API (`publicapiv1`)
- Added `asAppContext()` on `RequestContext` to bridge `publicapiv1.RequestContext` → `app.RequestContext`
- `handler_snippets_{get,add,put,delete}.go` are now one-liner wrappers: `return snippetshandlers.Handler*(req.asAppContext())`
- `services.go` — snippet endpoints now use local `WithAPIKey(handlerSnippets*, &Opts{MinimumScope: apikey.SCOPE_ENV})`
- `services_test.go` — snippet endpoints now expect 403 Forbidden for unauthenticated requests

### Frontend
- `Card` component: `error` prop changed from `React.ReactNode` to `string | string[]`; arrays are rendered as a bullet list
- `SnippetModal`: state type updated to `string | string[]`; `data.errors` array is passed directly to `setError` instead of being joined; handles both `error` (singular string) and `errors` (string array) in API responses