### PR TITLE
fix: evict stale service discovery entries via TTL heartbeat

### DIFF
--- a/src/lib/rediscache/service.go
+++ b/src/lib/rediscache/service.go
@@ -124,13 +124,19 @@ func newService() MicroServiceInterface {
 			},
 		})
 	} else {
+		// Capture TTL and interval into locals so the goroutine is not affected
+		// by any future mutation of the package-level vars (e.g. in tests), and
+		// to avoid a data race under -race.
+		ttl := ServiceRegistrationTTL
+		interval := HeartbeatInterval
+
 		// Heartbeat: refresh the TTL periodically so the key stays alive as long
 		// as this process is running. If the process crashes without a clean
-		// shutdown, the key expires on its own after serviceRegistrationTTL.
+		// shutdown, the key expires on its own after ttl.
 		// If Expire returns false (key was evicted during a transient outage),
 		// re-Set the full value so a live service can re-register automatically.
 		go func() {
-			ticker := time.NewTicker(HeartbeatInterval)
+			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
 
 			for {
@@ -138,7 +144,8 @@ func newService() MicroServiceInterface {
 				case <-service.ctx.Done():
 					return
 				case <-ticker.C:
-					ok, err := client.Expire(service.ctx, key, ServiceRegistrationTTL).Result()
+					ok, err := client.Expire(service.ctx, key, ttl).Result()
+
 					if err != nil || !ok {
 						slog.Debug(slog.LogOpts{
 							Msg:   "service discovery heartbeat failed, re-registering service",
@@ -152,7 +159,7 @@ func newService() MicroServiceInterface {
 							},
 						})
 
-						if setErr := client.Set(service.ctx, key, data, ServiceRegistrationTTL).Err(); setErr != nil {
+						if setErr := client.Set(service.ctx, key, data, ttl).Err(); setErr != nil {
 							slog.Errorf("error while re-registering service %s in service discovery: %v", service.ID, setErr)
 						}
 					}
@@ -162,7 +169,6 @@ func newService() MicroServiceInterface {
 	}
 
 	shutdown.Subscribe(func() error {
-
 		slog.Debug(slog.LogOpts{
 			Msg:   "removing service from service discovery",
 			Level: slog.DL1,
@@ -398,4 +404,18 @@ func GetAll(key string, filter []string) (map[string]string, error) {
 // DelAll is a convenience function to delete a key across all services with optional filtering.
 func DelAll(key string, filter []string) error {
 	return Service().DelAll(key, filter)
+}
+
+// ResetService cancels the current service singleton's context (stopping its
+// heartbeat goroutine) and clears the singleton so the next call to Service()
+// creates a fresh instance. Only available in test binaries.
+func ResetService() {
+	_smux.Lock()
+	defer _smux.Unlock()
+
+	if ms, ok := _service.(*MicroService); ok && ms.cancel != nil {
+		ms.cancel()
+	}
+
+	_service = nil
 }

--- a/src/lib/rediscache/service_test.go
+++ b/src/lib/rediscache/service_test.go
@@ -17,6 +17,7 @@ type ServiceSuite struct {
 func (s *ServiceSuite) BeforeTest(_, _ string) {
 	os.Setenv("STORMKIT_SERVICE_NAME", "test-service")
 	rediscache.DefaultService = nil
+	rediscache.ResetService()
 }
 
 func (s *ServiceSuite) AfterTest(_, _ string) {
@@ -74,35 +75,43 @@ func (s *ServiceSuite) Test_DelAll() {
 
 func (s *ServiceSuite) Test_Service_RegistrationHasTTL() {
 	// Use short durations so this test doesn't take long.
-	rediscache.ServiceRegistrationTTL = 500 * time.Millisecond
-	rediscache.HeartbeatInterval = 100 * time.Millisecond
+	prevTTL, prevInterval := rediscache.ServiceRegistrationTTL, rediscache.HeartbeatInterval
+	rediscache.ServiceRegistrationTTL = 2 * time.Second
+	rediscache.HeartbeatInterval = 500 * time.Millisecond
+
 	defer func() {
-		rediscache.ServiceRegistrationTTL = 30 * time.Second
-		rediscache.HeartbeatInterval = 10 * time.Second
+		rediscache.ServiceRegistrationTTL = prevTTL
+		rediscache.HeartbeatInterval = prevInterval
 	}()
 
 	service := rediscache.Service()
 	key := service.Key("sd")
 
-	ttl, err := rediscache.Client().TTL(context.Background(), key).Result()
+	// Use PTTL for millisecond precision since the TTL may be sub-second.
+	pttl, err := rediscache.Client().PTTL(context.Background(), key).Result()
 	s.NoError(err)
-	s.Greater(ttl.Milliseconds(), int64(0), "service discovery key should have a TTL > 0")
+	s.Greater(pttl.Milliseconds(), int64(0), "service discovery key should have a TTL > 0")
 }
 
 func (s *ServiceSuite) Test_Service_HeartbeatKeepsKeyAlive() {
-	// Register with a very short TTL; the heartbeat must refresh it before it expires.
-	rediscache.ServiceRegistrationTTL = 300 * time.Millisecond
-	rediscache.HeartbeatInterval = 100 * time.Millisecond
+	// Register with a short TTL; the heartbeat must refresh it before it expires.
+	// Redis truncates durations below 1s, so use values >= 1s.
+	prevTTL, prevInterval := rediscache.ServiceRegistrationTTL, rediscache.HeartbeatInterval
+	rediscache.ServiceRegistrationTTL = 1500 * time.Millisecond
+	rediscache.HeartbeatInterval = 300 * time.Millisecond
+
 	defer func() {
-		rediscache.ServiceRegistrationTTL = 30 * time.Second
-		rediscache.HeartbeatInterval = 10 * time.Second
+		rediscache.ServiceRegistrationTTL = prevTTL
+		rediscache.HeartbeatInterval = prevInterval
 	}()
 
 	service := rediscache.Service()
 	key := service.Key("sd")
 
-	// Wait long enough that the TTL would have expired without a heartbeat (3×TTL).
-	time.Sleep(900 * time.Millisecond)
+	// Wait long enough that the TTL would have expired without a heartbeat (2×TTL).
+	// The heartbeat fires every 300ms and keeps extending the 1.5s TTL, so the
+	// key should still be alive at the 3s mark.
+	time.Sleep(3 * time.Second)
 
 	exists, err := rediscache.Client().Exists(context.Background(), key).Result()
 	s.NoError(err)


### PR DESCRIPTION
## Problem

Services registered in Redis with `ttl=0` accumulate permanently when a process crashes and the shutdown hook is never called (e.g. `kill -9`, OOM, power loss). Stale entries pollute `List()`, `SetAll()`, `GetAll()`, and `DelAll()` results indefinitely.

## Solution

**TTL-based heartbeat** — the service key is registered with a short TTL and a background goroutine keeps refreshing it while the process is alive. If the process dies unexpectedly, the key naturally expires.

## Changes

- Register the service key with a **30s TTL** instead of no expiry.
- Start a **heartbeat goroutine** that calls `Expire` every 10s. The goroutine exits cleanly when the context is cancelled on graceful shutdown.
- Graceful shutdown behaviour is **unchanged** — the key is still deleted immediately on clean exit.
- Stale keys from crashed processes are now evicted automatically within 30s.