### PR TITLE
fix: flaky instancehandlers services test due to map iteration order

### DIFF
--- a/src/ce/api/user/instancehandlers/services_test.go
+++ b/src/ce/api/user/instancehandlers/services_test.go
@@ -19,11 +19,11 @@ func (ss *ServicesSuite) Test_Services() {
 	ss.NotNil(s)
 
 	handlers := []string{
-		"GET:/instance",
 		"GET:/changelog",
+		"GET:/instance",
 	}
 
-	ss.Equal(handlers, s.Handlers())
+	ss.Equal(handlers, s.HandlerKeys())
 }
 
 func TestServices(t *testing.T) {


### PR DESCRIPTION
## Problem

`services_test.go:26` was flaky in CI because `Handlers()` iterates over a Go map, which has non-deterministic order. The test compared the result against a fixed-order slice, so it passed or failed randomly depending on map iteration order.

## Fix

Switch to `HandlerKeys()`, which returns the same keys sorted alphabetically. Update the expected slice to match the sorted order (`changelog` before `instance`).