### PR TITLE
feat: configurable http timeouts via env vars

### DIFF
--- a/docs/self-hosting/6-advanced-configuration.md
+++ b/docs/self-hosting/6-advanced-configuration.md
@@ -1,0 +1,16 @@
+---
+title: "Advanced Configuration"
+description: Advanced configuration options for self-hosted Stormkit instances, including HTTP timeout tuning.
+---
+
+# Advanced Configuration
+
+## HTTP Timeouts
+
+The following environment variables control the HTTP server timeouts. Values are parsed as Go duration strings; you should include a unit suffix (e.g. `30s`, `1m`, `500ms`). Bare integers without a unit (e.g. `30`) are interpreted as nanoseconds (e.g. `30` → `30ns`), which results in an extremely short timeout and is almost never desired. When unset, the defaults shown below are used.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `STORMKIT_HTTP_READ_TIMEOUT` | `30s` | Maximum time to read an entire request, including the body. |
+| `STORMKIT_HTTP_WRITE_TIMEOUT` | `30s` | Maximum time to write a response. |
+| `STORMKIT_HTTP_IDLE_TIMEOUT` | `60s` | Maximum time to wait for the next request on a keep-alive connection. |

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -267,9 +267,9 @@ func New() *Config {
 		},
 
 		HTTPTimeouts: &HttpTimeoutsConfig{
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 30 * time.Second,
-			IdleTimeout:  60 * time.Second,
+			ReadTimeout:  getDuration(os.Getenv("STORMKIT_HTTP_READ_TIMEOUT"), 30*time.Second),
+			WriteTimeout: getDuration(os.Getenv("STORMKIT_HTTP_WRITE_TIMEOUT"), 30*time.Second),
+			IdleTimeout:  getDuration(os.Getenv("STORMKIT_HTTP_IDLE_TIMEOUT"), 60*time.Second),
 		},
 
 		DbConfigTimeouts: &DbConfigTimeouts{
@@ -568,7 +568,25 @@ func validate(c *Config) *Config {
 	return c
 }
 
-// get is a helper function to get one of the two values.
+// getDuration parses a Go duration string (e.g. "30s", "1m") and returns it.
+// Returns def when val is empty, unparseable, or non-positive.
+// Note: bare integers without a unit (e.g. "30") are parsed as nanoseconds by
+// time.ParseDuration — always include a unit suffix such as "s" or "m".
+func getDuration(val string, def time.Duration) time.Duration {
+	if val == "" {
+		return def
+	}
+
+	d, err := time.ParseDuration(val)
+	if err != nil || d <= 0 {
+		slog.Infof("config: invalid duration %q, using default %s", val, def)
+		return def
+	}
+
+	return d
+}
+
+// get returns the first non-empty string from vals.
 func get(vals ...string) string {
 	for _, v := range vals {
 		if v != "" {

--- a/src/lib/config/config_test.go
+++ b/src/lib/config/config_test.go
@@ -3,7 +3,9 @@ package config_test
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -23,6 +25,40 @@ func (s *PackageSuite) BeforeTest(_, _ string) {
 func (s *PackageSuite) AfterTest(_, _ string) {
 	os.Unsetenv("AWS_REGION")
 	os.Unsetenv("STORMKIT_APP_SECRET")
+	os.Unsetenv("STORMKIT_HTTP_READ_TIMEOUT")
+	os.Unsetenv("STORMKIT_HTTP_WRITE_TIMEOUT")
+	os.Unsetenv("STORMKIT_HTTP_IDLE_TIMEOUT")
+}
+
+func (s *PackageSuite) Test_HTTPTimeouts_Defaults() {
+	c := config.New()
+	s.Equal(30*time.Second, c.HTTPTimeouts.ReadTimeout)
+	s.Equal(30*time.Second, c.HTTPTimeouts.WriteTimeout)
+	s.Equal(60*time.Second, c.HTTPTimeouts.IdleTimeout)
+}
+
+func (s *PackageSuite) Test_HTTPTimeouts_ValidValues() {
+	os.Setenv("STORMKIT_HTTP_READ_TIMEOUT", "5s")
+	os.Setenv("STORMKIT_HTTP_WRITE_TIMEOUT", "10s")
+	os.Setenv("STORMKIT_HTTP_IDLE_TIMEOUT", "2m")
+
+	c := config.New()
+	s.Equal(5*time.Second, c.HTTPTimeouts.ReadTimeout)
+	s.Equal(10*time.Second, c.HTTPTimeouts.WriteTimeout)
+	s.Equal(2*time.Minute, c.HTTPTimeouts.IdleTimeout)
+}
+
+func (s *PackageSuite) Test_HTTPTimeouts_InvalidValue_FallsBackToDefault() {
+	// Unparseable duration should fall back to default.
+	os.Setenv("STORMKIT_HTTP_READ_TIMEOUT", "notaduration")
+	// Non-positive durations should also fall back to defaults.
+	os.Setenv("STORMKIT_HTTP_WRITE_TIMEOUT", "0s")
+	os.Setenv("STORMKIT_HTTP_IDLE_TIMEOUT", "-1s")
+
+	c := config.New()
+	s.Equal(30*time.Second, c.HTTPTimeouts.ReadTimeout)
+	s.Equal(30*time.Second, c.HTTPTimeouts.WriteTimeout)
+	s.Equal(60*time.Second, c.HTTPTimeouts.IdleTimeout)
 }
 
 func TestPackages(t *testing.T) {


### PR DESCRIPTION
## Description

Allow `HTTP_READ_TIMEOUT`, `HTTP_WRITE_TIMEOUT`, and `HTTP_IDLE_TIMEOUT` environment variables to override the hard-coded 30/30/60s defaults.

The helper `getDuration(val, default)` parses the env value and falls back to the default when the value is empty, unparseable, or non-positive.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated relevant documentation

## Breaking Changes

None.