### PR TITLE
feat: increase hosting queue batch size to 1000 and make it configurable

### DIFF
--- a/docs/self-hosting/6-advanced-configuration.md
+++ b/docs/self-hosting/6-advanced-configuration.md
@@ -1,9 +1,17 @@
 ---
 title: "Advanced Configuration"
-description: Advanced configuration options for self-hosted Stormkit instances, including HTTP timeout tuning.
+description: Advanced configuration options for self-hosted Stormkit instances, including HTTP timeout tuning and queue configuration.
 ---
 
 # Advanced Configuration
+
+## Hosting Queue
+
+The hosting queue is a Redis list used to buffer incoming analytics, logs, and usage metrics before they are written to the database. A background worker drains this queue every 5 seconds.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `STORMKIT_HOSTING_QUEUE_BATCH_SIZE` | `1000` | Number of items consumed from the hosting queue per worker run. Increase this value if the queue grows faster than it is being drained. |
 
 ## HTTP Timeouts
 

--- a/src/ce/workerserver/job_handler_forward.go
+++ b/src/ce/workerserver/job_handler_forward.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/applog"
@@ -32,44 +33,44 @@ type HostingRecord struct {
 	FunctionInvoked bool               `json:"functionInvoked"`
 }
 
-// IngestHandlerForward reads last 100 rows from redis, and inserts them into the database.
+// IngestHandlerForward reads rows from redis and inserts them into the database.
+// The batch size defaults to 1000 and can be overridden via STORMKIT_HOSTING_QUEUE_BATCH_SIZE.
 //
 // Here's an example calculation on finding the number of data we can handle:
 // - Let's assume this method is called every 5 seconds
 // - Executions per minute:   12
 // - Executions per hour:     720
 // - Executions per day:      17'280
-// - Executions per day:      17'280
-// - Daily records handled:   17'280 x 100 = 1'728'000
-// - Monthly records handled: 51'840'000
+// - Daily records handled:   17'280 x 1000 = 17'280'000
+// - Monthly records handled: 518'400'000
 func IngestHandlerForward(ctx context.Context) error {
 	client := rediscache.Client()
 	analyticsRecords := []analytics.Record{}
 	logRecords := []*applog.Log{}
 	stats := map[string]map[string]int64{} // userId -> metric -> value
-	rows := 100
+	rows := utils.StringToInt(os.Getenv("STORMKIT_HOSTING_QUEUE_BATCH_SIZE"))
 
-	for i := 0; i < rows; i = i + 1 {
-		msg, err := client.LPop(ctx, HostingQueueName).Result()
+	if rows <= 0 {
+		rows = 1000
+	}
 
-		if rediscache.IsConnectionError(err) {
-			return err
-		}
+	msgs, err := client.LPopCount(ctx, HostingQueueName, rows).Result()
 
-		if err != nil && errors.Is(err, redis.Nil) {
-			break
-		}
+	if rediscache.IsConnectionError(err) {
+		return err
+	}
 
-		if err != nil {
-			slog.Errorf("error while popping from redis: %v", err)
-			break
-		}
+	if err != nil && !errors.Is(err, redis.Nil) {
+		slog.Errorf("error while popping from redis: %v", err)
+		return err
+	}
 
+	for _, msg := range msgs {
 		record := HostingRecord{}
 
 		if err := json.Unmarshal([]byte(msg), &record); err != nil {
 			slog.Errorf("cannot unmarshal log: %v", err)
-			break
+			continue
 		}
 
 		if record.Analytics != nil {

--- a/src/ce/workerserver/job_handler_forward_test.go
+++ b/src/ce/workerserver/job_handler_forward_test.go
@@ -118,6 +118,7 @@ func (s *JobHandlerForwardTest) Test_IngestHandlerForward_MultipleRecords() {
 }
 
 func (s *JobHandlerForwardTest) Test_IngestHandlerForward_BatchLimit() {
+	s.T().Setenv("STORMKIT_HOSTING_QUEUE_BATCH_SIZE", "100")
 
 	// Push more than 100 records to test batch limit
 	for i := 0; i < 150; i++ {


### PR DESCRIPTION
## Problem

The `hosting_forward_queue` Redis list was growing unbounded because the worker could only consume **100 items per 5s** (1,200/min), while ingest rate was higher.

## Changes

- **Default batch size** raised from `100` → `1000` items per worker run
- **Configurable** via `STORMKIT_HOSTING_QUEUE_BATCH_SIZE` environment variable (no redeploy needed to tune)
- **Docs** updated in `docs/self-hosting/6-advanced-configuration.md` with the new variable

## Throughput

| | Before | After |
|---|---|---|
| Items per run | 100 | 1,000 (default) |
| Items per minute | 1,200 | 12,000 |
| Items per month | ~51M | ~518M |