### PR TITLE
fix: add Content-MD5 header to Alibaba OSS DeleteObjects requests

### DIFF
--- a/src/lib/integrations/client_alibaba.go
+++ b/src/lib/integrations/client_alibaba.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -96,11 +97,15 @@ func Alibaba(args ClientArgs) (*AlibabaClient, error) {
 	}
 
 	// Alibaba is S3 Compatible, so use that interface.
+	// AddContentChecksumMiddleware injects a Content-MD5 header for all S3
+	// operations that carry a request body. This is required by Alibaba OSS for
+	// DeleteObjects (which fails with MissingArgument without it) and is harmless
+	// for other operations such as PutObject.
 	awscli, err := AWS(
 		ClientArgs{
 			AccessKey:   args.AccessKey,
 			SecretKey:   args.SecretKey,
-			Middlewares: args.Middlewares,
+			Middlewares: append(args.Middlewares, smithyhttp.AddContentChecksumMiddleware),
 		}, &AWSOptions{
 			awsConf: &cfg,
 			s3Only:  true,

--- a/src/lib/integrations/client_alibaba_oss_test.go
+++ b/src/lib/integrations/client_alibaba_oss_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -206,6 +207,55 @@ func (s *AlibabaOSSSuite) Test_GetFile() {
 	s.Equal("Hello world", string(result.Content))
 	s.Equal(int64(len("Hello world")), result.Size)
 	s.Equal("text/html; charset=utf-8", result.ContentType)
+}
+
+// Test_DeleteArtifacts_ContentMD5Header verifies that DeleteObjects requests sent
+// to Alibaba OSS include the Content-Md5 header required by the OSS API.
+func (s *AlibabaOSSSuite) Test_DeleteArtifacts_ContentMD5Header() {
+	contentMD5Seen := ""
+
+	oss, err := integrations.Alibaba(integrations.ClientArgs{
+		AccessKey: "my-access-key",
+		SecretKey: "my-secret-key",
+		Middlewares: []func(stack *middleware.Stack) error{
+			func(stack *middleware.Stack) error {
+				return stack.Finalize.Add(
+					middleware.FinalizeMiddlewareFunc("AssertContentMD5", func(ctx context.Context, fi middleware.FinalizeInput, fh middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+						opName := awsmiddleware.GetOperationName(ctx)
+
+						switch opName {
+						case "ListObjectsV2":
+							return middleware.FinalizeOutput{
+								Result: &s3.ListObjectsV2Output{
+									Contents:    []s3types.Object{{Key: utils.Ptr("1/50919/index.html")}},
+									IsTruncated: utils.Ptr(false),
+								},
+							}, middleware.Metadata{}, nil
+						case "DeleteObjects":
+							if req, ok := fi.Request.(*smithyhttp.Request); ok {
+								contentMD5Seen = req.Header.Get("Content-Md5")
+							}
+							return middleware.FinalizeOutput{
+								Result: &s3.DeleteObjectsOutput{},
+							}, middleware.Metadata{}, nil
+						default:
+							return middleware.FinalizeOutput{}, middleware.Metadata{}, errors.New("unexpected AWS operation: " + opName)
+						}
+					}),
+					middleware.Before,
+				)
+			},
+		},
+	})
+
+	s.Require().NoError(err)
+
+	err = oss.DeleteArtifacts(context.Background(), integrations.DeleteArtifactsArgs{
+		StorageLocation: "alibaba:my-s3-bucket/1/50919",
+	})
+
+	s.NoError(err)
+	s.NotEmpty(contentMD5Seen, "Content-Md5 header must be present on DeleteObjects requests to Alibaba OSS")
 }
 
 func TestAlibabaOSS(t *testing.T) {


### PR DESCRIPTION
## Problem

`DeleteObjects` on Alibaba OSS was failing with:

```
api error MissingArgument: Missing Some Required Arguments
```

Debug logging revealed the outgoing request headers:

```
map[Amz-Sdk-Invocation-Id:[...] Content-Type:[application/xml] User-Agent:[...]]
```

No `Content-MD5` header was present. Alibaba OSS's S3-compatible `DeleteObjects` API **requires** this header, but the AWS SDK v2 does not add it automatically for non-AWS endpoints.

## Fix

Add `smithyhttp.AddContentChecksumMiddleware` to the Alibaba client's API option stack. This is a built-in smithy-go middleware that computes the MD5 checksum of the request body and sets the `Content-Md5` header before the request is sent.