### PR TITLE
fix: treat VersionNotFound 404 as success in DeleteArtifacts

### DIFF
--- a/src/lib/integrations/client_alibaba.go
+++ b/src/lib/integrations/client_alibaba.go
@@ -5,10 +5,12 @@ package integrations
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	alibaba "github.com/alibabacloud-go/fc-20230330/v4/client"
+	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
@@ -206,6 +208,12 @@ func (a AlibabaClient) DeleteArtifacts(ctx context.Context, args DeleteArtifacts
 		}
 
 		_, err := a.client.DeleteFunctionVersion(&fnName, &fnVersion)
+
+		if e, ok := err.(*tea.SDKError); ok && e.StatusCode != nil && *e.StatusCode == http.StatusNotFound {
+			// The function version no longer exists; treat as already deleted.
+			return nil
+		}
+
 		return err
 	}
 

--- a/src/lib/integrations/client_alibaba_functions_test.go
+++ b/src/lib/integrations/client_alibaba_functions_test.go
@@ -308,6 +308,46 @@ func (s *AlibabaFunctionsSuite) Test_Upload_API() {
 	s.NotNil(result)
 }
 
+// Test_DeleteArtifacts_VersionNotFound verifies that a 404 SDKError from DeleteFunctionVersion
+// is treated as success so the deployment is still marked as deleted.
+func (s *AlibabaFunctionsSuite) Test_DeleteArtifacts_VersionNotFound() {
+	notFound := tea.NewSDKError(map[string]interface{}{
+		"statusCode": http.StatusNotFound,
+		"code":       "VersionNotFound",
+	})
+
+	s.sdk.On("DeleteFunctionVersion", mock.Anything, mock.Anything).Once().Return(nil, notFound)
+
+	alibaba, err := integrations.Alibaba(integrations.ClientArgs{})
+	s.Require().NoError(err)
+
+	err = alibaba.DeleteArtifacts(context.Background(), integrations.DeleteArtifactsArgs{
+		FunctionLocation: "alibaba:functions/sk-1-1-local/1",
+	})
+
+	s.NoError(err)
+}
+
+// Test_DeleteArtifacts_OtherErrorIsReturned verifies that non-404 errors from DeleteFunctionVersion
+// are propagated to the caller.
+func (s *AlibabaFunctionsSuite) Test_DeleteArtifacts_OtherErrorIsReturned() {
+	internalError := tea.NewSDKError(map[string]interface{}{
+		"statusCode": http.StatusInternalServerError,
+		"code":       "InternalError",
+	})
+
+	s.sdk.On("DeleteFunctionVersion", mock.Anything, mock.Anything).Once().Return(nil, internalError)
+
+	alibaba, err := integrations.Alibaba(integrations.ClientArgs{})
+	s.Require().NoError(err)
+
+	err = alibaba.DeleteArtifacts(context.Background(), integrations.DeleteArtifactsArgs{
+		FunctionLocation: "alibaba:functions/sk-1-1-local/1",
+	})
+
+	s.Error(err)
+}
+
 func TestAlibabaFunctionsSuite(t *testing.T) {
 	suite.Run(t, &AlibabaFunctionsSuite{})
 }


### PR DESCRIPTION
## Problem

When `DeleteFunctionVersion` is called on Alibaba Function Compute for a version that no longer exists, it returns a `404 VersionNotFound` `SDKError`. The current code in `job_deployments.go` treats any error from `DeleteArtifacts` as fatal — skipping the deployment from being marked as deleted. This means stale deployments accumulate and the same 404 error is logged repeatedly on every cleanup run.

## Fix

In `client_alibaba.go`, `deleteFunctionVersion` now checks whether the error is a `*tea.SDKError` with `StatusCode == 404`. If so, the function version is already gone and the operation is treated as successful. Other errors are still propagated normally.

## Tests

Added two new tests to `client_alibaba_functions_test.go`:
- `Test_DeleteArtifacts_VersionNotFound` — verifies that a 404 SDKError is swallowed and `DeleteArtifacts` returns `nil`
- `Test_DeleteArtifacts_OtherErrorIsReturned` — verifies that non-404 errors are still returned to the caller