### PR TITLE
feat: show deleted record count in jobs success message

### DIFF
--- a/src/ui/src/pages/admin/Jobs.spec.tsx
+++ b/src/ui/src/pages/admin/Jobs.spec.tsx
@@ -37,5 +37,47 @@ describe("~/pages/admin/Jobs.tsx", () => {
         expect(scope.isDone()).toBe(true);
       });
     });
+
+    it("shows a generic success message when no deleted IDs are returned", async () => {
+      nock(process.env.API_DOMAIN || "")
+        .post(endpoint)
+        .reply(200, {});
+
+      fireEvent.click(wrapper.getAllByText("Sync").at(index)!);
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText("Job has been successfully run.")
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  it("shows deleted count in success message when Remove old artifacts returns deleted IDs", async () => {
+    nock(process.env.API_DOMAIN || "")
+      .post("/admin/jobs/remove-old-artifacts")
+      .reply(200, { deleted: ["1", "2", "3"] });
+
+    fireEvent.click(wrapper.getAllByText("Sync").at(3)!);
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByText("Deleted 3 records successfully.")
+      ).toBeTruthy();
+    });
+  });
+
+  it("shows singular form when only 1 record is deleted", async () => {
+    nock(process.env.API_DOMAIN || "")
+      .post("/admin/jobs/remove-old-artifacts")
+      .reply(200, { deleted: ["42"] });
+
+    fireEvent.click(wrapper.getAllByText("Sync").at(3)!);
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByText("Deleted 1 record successfully.")
+      ).toBeTruthy();
+    });
   });
 });

--- a/src/ui/src/pages/admin/Jobs.tsx
+++ b/src/ui/src/pages/admin/Jobs.tsx
@@ -59,9 +59,14 @@ export default function Jobs() {
               onClick={() => {
                 setLoading(index);
 
-                Api.post(job.endpoint)
-                  .then(() => {
-                    setSuccess("Job has been successfully run.");
+                Api.post<{ deleted?: string[] }>(job.endpoint)
+                  .then((res) => {
+                    const count = res?.deleted?.length;
+                    setSuccess(
+                      count
+                        ? `Deleted ${count} record${count === 1 ? "" : "s"} successfully.`
+                        : "Job has been successfully run."
+                    );
                     setError(undefined);
                   })
                   .catch(() => {


### PR DESCRIPTION
## Changes

The **Remove old artifacts** job endpoint already returns the list of deleted deployment IDs (`{ deleted: string[] }`). The UI was not using this data.

### Before
All jobs showed a generic `"Job has been successfully run."` message on success.

### After
- If the response includes `deleted` IDs, the message reads: `"Deleted N records successfully."` (with correct singular/plural)
- All other jobs (analytics sync, etc.) still show the generic message

## Tests

Updated `Jobs.spec.tsx` with 3 new cases:
- Generic message when no `deleted` IDs returned (covers all 4 jobs)
- Plural form: `Deleted 3 records successfully.`
- Singular form: `Deleted 1 record successfully.`