### PR TITLE
fix: prevent thundering herd in FetchAppConf using singleflight

### DIFF
--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -1,0 +1,22 @@
+package hosting
+
+import "github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+
+// SetFetchConfigFn replaces the function used to fetch app config from the
+// database. It is intended for use in tests only.
+func SetFetchConfigFn(fn func(string) ([]*appconf.Config, error)) {
+	fetchConfigFn = fn
+}
+
+// ResetFetchConfigFn restores the default database-backed fetch function.
+func ResetFetchConfigFn() {
+	fetchConfigFn = appconf.FetchConfig
+}
+
+// InvalidateAppCache removes a hostname entry from the in-process cache,
+// allowing tests to force a cold-cache scenario without restarting the process.
+func InvalidateAppCache(hostName string) {
+	appCacheMu.Lock()
+	delete(appCache, hostName)
+	appCacheMu.Unlock()
+}

--- a/src/ce/hosting/host_model.go
+++ b/src/ce/hosting/host_model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
 
 // VersionCookieName represents the name of the cookie that
@@ -36,20 +37,29 @@ type CachedConfig struct {
 
 var appCache AppCache
 var appCacheMu sync.Mutex
+var appConfSFGroup singleflight.Group
+
+// fetchConfigFn is the function used to fetch app config from the database.
+// It is a variable to allow overriding in tests.
+var fetchConfigFn = appconf.FetchConfig
 
 func init() {
 	appCache = AppCache{}
 
 	go func() {
-		for {
+		deleteAllExpired := func() {
+			appCacheMu.Lock()
+			defer appCacheMu.Unlock()
+
 			for hostName, cache := range appCache {
 				if time.Since(cache.InMemorySince) > inMemoryCacheTTL {
-					appCacheMu.Lock()
 					delete(appCache, hostName)
-					appCacheMu.Unlock()
 				}
 			}
+		}
 
+		for {
+			deleteAllExpired()
 			time.Sleep(time.Minute * 1)
 		}
 	}()
@@ -68,24 +78,41 @@ type Host struct {
 	Request *shttp.RequestContext
 }
 
-// FetchAppConf fetches the config for the host name from the database.
-// If the config is found in local cache, it's returned from the local cache.
-func FetchAppConf(hostName string) ([]*appconf.Config, error) {
+func getConfFromCache(hostName string) *CachedConfig {
 	appCacheMu.Lock()
+	defer appCacheMu.Unlock()
+
 	confFromCache := appCache[hostName]
-	appCacheMu.Unlock()
 
 	if confFromCache != nil {
 		// Frequently used caches should not be invalidated.
 		confFromCache.InMemorySince = time.Now()
+	}
+
+	return confFromCache
+}
+
+// FetchAppConf fetches the config for the host name from the database.
+// If the config is found in local cache, it's returned from the local cache.
+// singleflight ensures that concurrent cache misses for the same hostname
+// result in exactly one database query, preventing thundering herd under load.
+func FetchAppConf(hostName string) ([]*appconf.Config, error) {
+	confFromCache := getConfFromCache(hostName)
+
+	if confFromCache != nil {
 		return confFromCache.Config, nil
 	}
 
-	configs, err := appconf.FetchConfig(hostName)
+	v, err, _ := appConfSFGroup.Do(hostName, func() (any, error) {
+		return fetchConfigFn(hostName)
+	})
 
 	if err != nil {
 		slog.Errorf("Error fetching config %v for host %s", err, hostName)
+		return nil, err
 	}
+
+	configs := v.([]*appconf.Config)
 
 	cached := &CachedConfig{
 		Config:        configs,
@@ -113,7 +140,7 @@ func FetchAppConf(hostName string) ([]*appconf.Config, error) {
 		}
 	}
 
-	return configs, err
+	return configs, nil
 }
 
 // RequestConfig requests the config from api and assigns it to the

--- a/src/ce/hosting/host_model_test.go
+++ b/src/ce/hosting/host_model_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
@@ -127,6 +128,86 @@ func (s *HostSuite) Test_ModifyingURL() {
 	u2.Fragment = u1.Fragment
 	u2.Path = u1.Path
 	s.Equal("http://abc.com:3000/my-app?id=12345#section", u2.String())
+}
+
+// Test_FetchAppConf_SingleFlight verifies that concurrent cache misses for the
+// same hostname result in exactly one database call, preventing thundering herd.
+// It also verifies that re-fetching works correctly after a TTL-driven eviction.
+func (s *HostSuite) Test_FetchAppConf_SingleFlight() {
+	const hostname = "singleflight-test.example.com"
+	const concurrency = 50
+
+	var callCount int64
+
+	// Replace the DB fetch with a slow stub so all goroutines are in-flight simultaneously.
+	hosting.SetFetchConfigFn(func(hostName string) ([]*appconf.Config, error) {
+		atomic.AddInt64(&callCount, 1)
+		// Simulate a slow DB query so all goroutines pile up before any returns.
+		time.Sleep(50 * time.Millisecond)
+		return nil, nil
+	})
+	defer hosting.ResetFetchConfigFn()
+	defer hosting.InvalidateAppCache(hostname)
+
+	fireWave := func() {
+		var wg sync.WaitGroup
+		ready := make(chan struct{})
+
+		for range concurrency {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-ready
+				hosting.FetchAppConf(hostname)
+			}()
+		}
+
+		close(ready)
+		wg.Wait()
+	}
+
+	// First wave: cold cache.
+	fireWave()
+	s.Equal(int64(1), callCount, "expected exactly 1 DB call for %d concurrent cold-cache misses", concurrency)
+
+	// Simulate TTL expiry by evicting the cache entry.
+	hosting.InvalidateAppCache(hostname)
+	atomic.StoreInt64(&callCount, 0)
+
+	// Second wave: cache miss after TTL expiry — singleflight must still apply.
+	fireWave()
+	s.Equal(int64(1), callCount, "expected exactly 1 DB call for %d concurrent post-TTL-expiry misses", concurrency)
+}
+
+// Test_FetchAppConf_WarmCacheRace verifies that concurrent reads of a warm cache
+// entry do not race on the InMemorySince timestamp field.
+func (s *HostSuite) Test_FetchAppConf_WarmCacheRace() {
+	const hostname = "warm-cache-race-test.example.com"
+	const concurrency = 50
+
+	hosting.SetFetchConfigFn(func(hostName string) ([]*appconf.Config, error) {
+		return nil, nil
+	})
+	defer hosting.ResetFetchConfigFn()
+	defer hosting.InvalidateAppCache(hostname)
+
+	// Prime the cache so all subsequent calls hit the warm-cache path.
+	hosting.FetchAppConf(hostname)
+
+	var wg sync.WaitGroup
+	ready := make(chan struct{})
+
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ready
+			hosting.FetchAppConf(hostname)
+		}()
+	}
+
+	close(ready)
+	wg.Wait()
 }
 
 func TestHostModel(t *testing.T) {

--- a/src/lib/integrations/client.go
+++ b/src/lib/integrations/client.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"github.com/aws/smithy-go/middleware"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -95,6 +96,7 @@ type ClientInterface interface {
 }
 
 var CachedClient ClientInterface
+var clientOnce sync.Once
 
 // SetDefaultClient sets the client that will be returned by Client
 // method. This method is mainly used for testing purposes. For environments
@@ -105,6 +107,7 @@ func SetDefaultClient(client ClientInterface) {
 	}
 
 	CachedClient = client
+	clientOnce = sync.Once{}
 }
 
 type ClientArgs struct {
@@ -120,7 +123,8 @@ type ClientArgs struct {
 // Client returns the ClientInterface based on the environment configuration.
 // For instance, if AWS_* environment variables are declared, this function will
 // return the AWS client. After the first call, the client returns the
-// cached ClientInterface.
+// cached ClientInterface. clientOnce guarantees that the initialisation runs
+// exactly once even under concurrent callers.
 func Client(args ...ClientArgs) ClientInterface {
 	if CachedClient != nil {
 		return CachedClient
@@ -133,20 +137,24 @@ func Client(args ...ClientArgs) ClientInterface {
 		opts = args[0]
 	}
 
-	var err error
+	var initErr error
 
-	if cfg.AWS != nil || opts.Provider == config.ProviderAWS {
-		CachedClient, err = AWS(opts, nil)
-	} else if cfg.Alibaba != nil || opts.Provider == config.ProviderAlibaba {
-		CachedClient, err = Alibaba(opts)
-	} else if cfg.Deployer.IsLocal() || opts.Provider == config.ProviderFilesys {
-		CachedClient = Filesys()
-	}
+	clientOnce.Do(func() {
+		if cfg.AWS != nil || opts.Provider == config.ProviderAWS {
+			CachedClient, initErr = AWS(opts, nil)
+		} else if cfg.Alibaba != nil || opts.Provider == config.ProviderAlibaba {
+			CachedClient, initErr = Alibaba(opts)
+		} else if cfg.Deployer.IsLocal() || opts.Provider == config.ProviderFilesys {
+			CachedClient = Filesys()
+		}
 
-	slog.Infof("integrations client: %s", CachedClient.Name())
+		if CachedClient != nil {
+			slog.Infof("integrations client: %s", CachedClient.Name())
+		}
+	})
 
-	if err != nil {
-		panic(err)
+	if initErr != nil {
+		panic(initErr)
 	}
 
 	return CachedClient


### PR DESCRIPTION
## Problem

During an investigation, we found out that an automated scanner sent hundreds of requests per second to random paths. This revealed two race conditions that caused DB connections to spike to ~80 (hitting the pool limit) and made the app unresponsive for hours.

### Root cause 1 — Thundering herd in `FetchAppConf`

The in-process hostname config cache is correct under normal traffic. However, the mutex only protects the **map read/write**, not the DB fetch itself:

```go
appCacheMu.Lock()
confFromCache := appCache[hostName]
appCacheMu.Unlock()              // lock released here

// All concurrent goroutines that passed the nil check now independently query the DB
configs, err := appconf.FetchConfig(hostName)
```

Under a cold cache (server restart or post-TTL expiry), 50 concurrent requests for the same hostname each independently hit the database. This was confirmed locally — 26 identical `fetching config for host` log lines at the same timestamp.

### Root cause 2 — Race condition in `integrations.Client()`

The `CachedClient != nil` guard is an unprotected read. Concurrent callers can all see `nil` simultaneously and each attempt to initialise a new storage client, potentially creating multiple connections.

## Fix

**`src/ce/hosting/host_model.go`** — wrap the DB fetch in `singleflight.Group.Do`:
- Only one goroutine queries the DB per hostname at a time
- All concurrent waiters share the single result
- Applies on every cache miss, including post-TTL re-fetches

**`src/lib/integrations/client.go`** — replace unguarded nil check with `sync.Once`:
- Initialisation runs exactly once regardless of concurrency
- `SetDefaultClient` (test helper) resets the `Once` so tests can inject different clients

## Tests

Added `Test_FetchAppConf_SingleFlight` which:
1. Injects a slow stub (50ms) to ensure all 50 goroutines are in-flight simultaneously
2. Fires a first wave (cold cache) — asserts exactly **1** DB call
3. Evicts the cache entry to simulate TTL expiry
4. Fires a second wave — asserts exactly **1** DB call again