### PR TITLE
fix: prevent codemirror from overflowing its container

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx
@@ -171,8 +171,21 @@ export default function EnvironmentConfig() {
   }, [selectedItem]);
 
   return (
-    <Box sx={{ display: "flex", flexDirection: { xs: "column", md: "row" } }}>
-      <Box component="nav" sx={{ mr: 2, minWidth: "250px" }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", md: "row" },
+      }}
+    >
+      <Box
+        component="nav"
+        sx={{
+          mr: 2,
+          mb: { xs: 2, md: 0 },
+          minWidth: { xs: "100%", md: "250px" },
+          maxWidth: { xs: "100%", md: "250px" },
+        }}
+      >
         <List
           sx={{ position: "sticky", top: 0, py: 0 }}
           data-testid="env-config-nav"
@@ -242,7 +255,15 @@ export default function EnvironmentConfig() {
           </ListItem>
         </List>
       </Box>
-      <Box sx={{ flex: 1 }}>
+      <Box
+        sx={{
+          flex: 1,
+          maxWidth: {
+            xs: "100%",
+            md: "calc(100% - 266px)" /* 250px nav + 16px margin */,
+          },
+        }}
+      >
         <Tab
           app={app}
           environment={environment}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/Editor.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/Editor.tsx
@@ -15,7 +15,7 @@ export default function Editor({ value, docsLink, onChange }: Props) {
   const { mode } = useContext(RootContext);
 
   return (
-    <>
+    <div style={{ minWidth: 0, overflow: "hidden" }}>
       <CodeMirror
         maxHeight="200px"
         value={value}
@@ -30,6 +30,6 @@ export default function Editor({ value, docsLink, onChange }: Props) {
         </Link>{" "}
         for more information.
       </Typography>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

When a CodeMirror editor contains long lines (e.g. a minified JSON or a wide manifest), the `.cm-editor` element grows wider than its parent container, breaking the page layout.

## Fix

Adjust parent components using max-width, max-height.