### PR TITLE
fix: use UTC timezone in deployment timeout and cleanup queries

### DIFF
--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -61,7 +61,7 @@ var stmt = &statement{
 		FROM
 			deployments d
 		WHERE
-			d.created_at < NOW() - INTERVAL '15 minutes' AND
+			d.created_at < NOW() AT TIME ZONE 'UTC' - INTERVAL '15 minutes' AND
 			d.exit_code IS NULL
 		LIMIT 100;
 	`,
@@ -75,7 +75,7 @@ var stmt = &statement{
 			deployments_published dp ON dp.deployment_id = d.deployment_id
 		WHERE
 			(
-				d.created_at < NOW() - INTERVAL '{{ .days }} days' OR 
+				d.created_at < NOW() AT TIME ZONE 'UTC' - INTERVAL '{{ .days }} days' OR 
 				d.deleted_at IS NOT NULL
 			)
 			AND


### PR DESCRIPTION
## Problem

`NOW()` in PostgreSQL returns the current timestamp using the **server's configured timezone**, which may not be UTC. This caused the deployment timeout check (15-minute threshold) and the old deployment cleanup query (N-day threshold) to compare timestamps against a potentially incorrect clock.

## Fix

Replace `NOW()` with `NOW() AT TIME ZONE 'UTC'` in both queries in `ws_statements.go`, ensuring the interval comparisons are always relative to UTC regardless of the PostgreSQL server's timezone setting.