### PR TITLE
feat: add DELETE /v1/deployments/{id} endpoint

### DIFF
--- a/docs/api/7-deployments.md
+++ b/docs/api/7-deployments.md
@@ -377,3 +377,45 @@ curl -X POST \
 // Example response
 { "ok": true }
 ```
+
+---
+
+## DELETE /v1/deployments/{id}
+
+Soft-deletes a deployment and resets the environment cache. The deployment must belong to the environment of the API key.
+
+**Base URL:** `https://api.stormkit.io`
+
+**Authentication:** At least an environment-level API key passed as the `Authorization` header.
+
+### Path parameters
+
+| Parameter | Type   | Description        |
+| --------- | ------ | ------------------ |
+| `id`      | string | The deployment ID. |
+
+### Response — 200 OK
+
+| Field | Type    | Description               |
+| ----- | ------- | ------------------------- |
+| `ok`  | boolean | Always `true` on success. |
+
+### Error responses
+
+| Status | Condition                                                                               |
+| ------ | --------------------------------------------------------------------------------------- |
+| `403`  | Missing/invalid API key, or token does not have access to the deployment's environment. |
+| `404`  | Deployment not found, or it does not belong to the environment of the API key.          |
+| `500`  | Internal server error.                                                                  |
+
+### Example
+
+```bash
+curl -X DELETE \
+     -H 'Authorization: <api_key>' \
+     'https://api.stormkit.io/v1/deployments/8241'
+```
+
+```json
+{ "ok": true }
+```

--- a/src/ce/api/public/v1/handler_deployment_delete.go
+++ b/src/ce/api/public/v1/handler_deployment_delete.go
@@ -1,0 +1,47 @@
+package publicapiv1
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+func handlerDeploymentDelete(req *RequestContext) *shttp.Response {
+	id := utils.StringToID(req.Vars()["id"])
+
+	if id == 0 {
+		return shttp.NotFound()
+	}
+
+	store := deploy.NewStore()
+
+	depl, err := store.MyDeployment(req.Context(), &deploy.DeploymentsQueryFilters{
+		DeploymentID: id,
+		EnvID:        req.Env.ID,
+	})
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	if depl == nil {
+		return shttp.NotFound()
+	}
+
+	if err := store.MarkDeploymentsAsDeleted(req.Context(), []types.ID{id}); err != nil {
+		return shttp.Error(err)
+	}
+
+	if err := appcache.Service().Reset(depl.EnvID); err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   map[string]any{"ok": true},
+	}
+}

--- a/src/ce/api/public/v1/handler_deployment_delete_test.go
+++ b/src/ce/api/public/v1/handler_deployment_delete_test.go
@@ -1,0 +1,139 @@
+package publicapiv1_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerDeploymentDeleteSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *HandlerDeploymentDeleteSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerDeploymentDeleteSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerDeploymentDeleteSuite) handler() http.Handler {
+	return shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler()
+}
+
+func (s *HandlerDeploymentDeleteSuite) delete(keyValue string, deplID fmt.Stringer) shttptest.Response {
+	return shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodDelete,
+		fmt.Sprintf("/v1/deployments/%s", deplID),
+		nil,
+		map[string]string{"Authorization": keyValue},
+	)
+}
+
+// Test_Success verifies that a valid env-scoped key can delete a deployment.
+func (s *HandlerDeploymentDeleteSuite) Test_Success() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	depl := s.MockDeployment(env)
+	key := s.MockAPIKey(appl, env)
+
+	response := s.delete(key.Value, depl.ID)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.Equal(true, response.Map()["ok"])
+
+	// Verify the deployment is actually deleted.
+	response = s.delete(key.Value, depl.ID)
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
+// Test_NotFound_UnknownID verifies that a non-existent deployment returns 404.
+func (s *HandlerDeploymentDeleteSuite) Test_NotFound_UnknownID() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	key := s.MockAPIKey(appl, env)
+
+	response := s.delete(key.Value, types.ID(999999999))
+
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
+// Test_NotFound_WrongEnv verifies that a deployment belonging to a different env returns 404.
+func (s *HandlerDeploymentDeleteSuite) Test_NotFound_WrongEnv() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env1 := s.MockEnv(appl)
+	env2 := s.MockEnv(appl, map[string]any{"Name": "staging"})
+	depl := s.MockDeployment(env1)
+	key := s.MockAPIKey(appl, env2)
+
+	response := s.delete(key.Value, depl.ID)
+
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
+// Test_Forbidden_NoAPIKey verifies that requests without an API key are rejected.
+func (s *HandlerDeploymentDeleteSuite) Test_Forbidden_NoAPIKey() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	depl := s.MockDeployment(env)
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodDelete,
+		fmt.Sprintf("/v1/deployments/%s", depl.ID),
+		nil,
+		map[string]string{},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
+// Test_Forbidden_UserNotMember verifies that a user-scoped key with no membership is rejected.
+func (s *HandlerDeploymentDeleteSuite) Test_Forbidden_UserNotMember() {
+	usr1 := s.MockUser()
+	appl := s.MockApp(usr1)
+	env := s.MockEnv(appl)
+	depl := s.MockDeployment(env)
+
+	usr2 := s.MockUser()
+	key := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": usr2.ID,
+		"Scope":  apikey.SCOPE_USER,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+		"TeamID": types.ID(0),
+	})
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodDelete,
+		fmt.Sprintf("/v1/deployments/%s?envId=%d", depl.ID, env.ID),
+		nil,
+		map[string]string{"Authorization": key.Value},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
+func TestHandlerDeploymentDelete(t *testing.T) {
+	suite.Run(t, &HandlerDeploymentDeleteSuite{})
+}

--- a/src/ce/api/public/v1/handler_mcp.go
+++ b/src/ce/api/public/v1/handler_mcp.go
@@ -140,6 +140,8 @@ func mcpDispatch(req *RequestContextMCP, id any, params *toolCallParams) *shttp.
 		resp = mcpGetDeployment(req, params.Arguments)
 	case "publish_deployment":
 		resp = mcpPublishDeployment(req, params.Arguments)
+	case "delete_deployment":
+		resp = mcpDeleteDeployment(req, params.Arguments)
 	case "list_apps":
 		resp = mcpListApps(req, params.Arguments)
 	case "list_environments":

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -280,6 +280,7 @@ func (s *HandlerMCPSuite) Test_ToolsList_ReturnsExpectedTools() {
 		"deploy",
 		"get_deployment",
 		"publish_deployment",
+		"delete_deployment",
 		"list_apps",
 		"list_environments",
 		"create_environment",

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -64,6 +64,19 @@ func mcpAllTools() []mcpToolDef {
 			},
 		},
 		{
+			Name:        "delete_deployment",
+			Description: "Delete a deployment and its associated artifacts.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"deploymentId": map[string]any{"type": "string", "description": "Deployment ID to delete."},
+					"envId":        map[string]any{"type": "string", "description": "Environment the deployment belongs to."},
+				},
+				"required":             []string{"deploymentId", "envId"},
+				"additionalProperties": false,
+			},
+		},
+		{
 			Name:        "list_apps",
 			Description: "Return a paginated list of applications scoped to a team. Use hasNextPage and increment 'from' to paginate.",
 			InputSchema: map[string]any{
@@ -312,6 +325,18 @@ func mcpPublishDeployment(req *RequestContextMCP, args map[string]any) *shttp.Re
 	}
 
 	return handlerDeploymentPublish(req.RequestContext)
+}
+
+func mcpDeleteDeployment(req *RequestContextMCP, args map[string]any) *shttp.Response {
+	if resp := req.withEnv(args); resp != nil {
+		return resp
+	}
+
+	if resp := req.withDeploymentID(args); resp != nil {
+		return resp
+	}
+
+	return handlerDeploymentDelete(req.RequestContext)
 }
 
 func mcpListApps(req *RequestContextMCP, args map[string]any) *shttp.Response {

--- a/src/ce/api/public/v1/services.go
+++ b/src/ce/api/public/v1/services.go
@@ -29,7 +29,8 @@ func Services(r *shttp.Router) *shttp.Service {
 	s.NewEndpoint("/v1/deployments/{id:[0-9]+}").
 		Handler(shttp.MethodGet, "", WithAPIKey(handlerDeploymentGet, &Opts{MinimumScope: apikey.SCOPE_ENV})).
 		Handler(shttp.MethodGet, "/poll", WithAPIKey(handlerDeploymentPoll, &Opts{MinimumScope: apikey.SCOPE_ENV})).
-		Handler(shttp.MethodPost, "/publish", WithAPIKey(handlerDeploymentPublish, &Opts{MinimumScope: apikey.SCOPE_ENV}))
+		Handler(shttp.MethodPost, "/publish", WithAPIKey(handlerDeploymentPublish, &Opts{MinimumScope: apikey.SCOPE_ENV})).
+		Handler(shttp.MethodDelete, "", WithAPIKey(handlerDeploymentDelete, &Opts{MinimumScope: apikey.SCOPE_ENV}))
 
 	s.NewEndpoint("/v1/env").
 		Handler(shttp.MethodPost, "", WithAPIKey(handlerEnvAdd, &Opts{MinimumScope: apikey.SCOPE_APP})).

--- a/src/ce/api/public/v1/services_test.go
+++ b/src/ce/api/public/v1/services_test.go
@@ -20,6 +20,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 	s.NotNil(services)
 
 	handlers := []string{
+		"DELETE:/v1/deployments/{id:[0-9]+}",
 		"DELETE:/v1/domains",
 		"DELETE:/v1/domains/cert",
 		"DELETE:/v1/env",
@@ -61,6 +62,7 @@ func (s *ServicesSuite) Test_Services_StormkitCloud() {
 	s.NotNil(services)
 
 	handlers := []string{
+		"DELETE:/v1/deployments/{id:[0-9]+}",
 		"DELETE:/v1/domains",
 		"DELETE:/v1/domains/cert",
 		"DELETE:/v1/env",
@@ -107,6 +109,7 @@ func (s *ServicesSuite) Test_EE() {
 		"GET:/v1/deployments/{id:[0-9]+}":          http.StatusForbidden,
 		"GET:/v1/deployments/{id:[0-9]+}/poll":     http.StatusForbidden,
 		"POST:/v1/deployments/{id:[0-9]+}/publish": http.StatusForbidden,
+		"DELETE:/v1/deployments/{id:[0-9]+}":       http.StatusForbidden,
 		"POST:/v1/deploy":                          http.StatusForbidden,
 		"POST:/v1/env":                             http.StatusForbidden,
 		"PUT:/v1/env":                              http.StatusForbidden,


### PR DESCRIPTION
## Summary

Adds a soft-delete endpoint for deployments via the public API.

## Changes

- **Handler** `handler_deployment_delete.go`: fetches the deployment scoped to the authenticated environment, calls `MarkDeploymentsAsDeleted`, and resets the env cache via `appcache`.
- **Tests** `handler_deployment_delete_test.go`: 5 tests covering success, env isolation, forbidden, and not-found cases.
- **Route**: `DELETE /v1/deployments/{id}` registered with `SCOPE_ENV`.
- **MCP**: `delete_deployment` tool added to manifest and dispatch.
- **Docs**: `GET /v1/deployments/{delete}` section added to `docs/api/7-deployments.md`.

## Test results

```
--- PASS: TestHandlerDeploymentDelete (5 tests)
```