### PR TITLE
fix: disable aws-chunked encoding for Alibaba OSS multipart uploads

### DIFF
--- a/src/lib/integrations/client_alibaba.go
+++ b/src/lib/integrations/client_alibaba.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -103,11 +104,21 @@ func Alibaba(args ClientArgs) (*AlibabaClient, error) {
 	// operations that carry a request body. This is required by Alibaba OSS for
 	// DeleteObjects (which fails with MissingArgument without it) and is harmless
 	// for other operations such as PutObject.
+	//
+	// SwapComputePayloadSHA256ForUnsignedPayloadMiddleware replaces the default
+	// ComputePayloadSHA256 middleware with UnsignedPayload, which sets
+	// x-amz-content-sha256 to "UNSIGNED-PAYLOAD". Without this, the AWS SDK uses
+	// aws-chunked transfer encoding for multipart uploads, which Alibaba OSS does
+	// not support and rejects with an InvalidArgument error.
 	awscli, err := AWS(
 		ClientArgs{
-			AccessKey:   args.AccessKey,
-			SecretKey:   args.SecretKey,
-			Middlewares: append(args.Middlewares, smithyhttp.AddContentChecksumMiddleware),
+			AccessKey: args.AccessKey,
+			SecretKey: args.SecretKey,
+			Middlewares: append(
+				args.Middlewares,
+				smithyhttp.AddContentChecksumMiddleware,
+				v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
+			),
 		}, &AWSOptions{
 			awsConf: &cfg,
 			s3Only:  true,

--- a/src/lib/integrations/client_alibaba.go
+++ b/src/lib/integrations/client_alibaba.go
@@ -4,7 +4,10 @@ package integrations
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -12,10 +15,12 @@ import (
 	alibaba "github.com/alibabacloud-go/fc-20230330/v4/client"
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
@@ -27,6 +32,63 @@ func init() {
 		Msg:   "alibaba integration is enabled",
 		Level: slog.DL1,
 	})
+}
+
+// deleteObjectsContentMD5 is a Build-stage middleware that computes and sets the
+// Content-MD5 header exclusively for DeleteObjects requests. Alibaba OSS requires
+// this header on DeleteObjects but rejects or mishandles it on file uploads, so
+// using the global smithyhttp.AddContentChecksumMiddleware breaks PutObject.
+type deleteObjectsContentMD5 struct{}
+
+func addDeleteObjectsContentMD5Middleware(stack *middleware.Stack) error {
+	return stack.Build.Add(&deleteObjectsContentMD5{}, middleware.Before)
+}
+
+func (m *deleteObjectsContentMD5) ID() string { return "DeleteObjectsContentMD5" }
+
+func (m *deleteObjectsContentMD5) HandleBuild(
+	ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
+) (middleware.BuildOutput, middleware.Metadata, error) {
+	if awsmiddleware.GetOperationName(ctx) != "DeleteObjects" {
+		return next.HandleBuild(ctx, in)
+	}
+
+	req, ok := in.Request.(*smithyhttp.Request)
+	if !ok {
+		return next.HandleBuild(ctx, in)
+	}
+
+	if v := req.Header.Get("Content-Md5"); v != "" {
+		return next.HandleBuild(ctx, in)
+	}
+
+	stream := req.GetStream()
+
+	if stream == nil {
+		return next.HandleBuild(ctx, in)
+	}
+
+	if !req.IsStreamSeekable() {
+		return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("unseekable stream is not supported for computing md5 checksum")
+	}
+
+	h := md5.New()
+
+	if _, err := io.Copy(h, stream); err != nil {
+		return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("failed to read body: %w", err)
+	}
+
+	sum := h.Sum(nil)
+	b64 := make([]byte, base64.StdEncoding.EncodedLen(len(sum)))
+	base64.StdEncoding.Encode(b64, sum)
+
+	if err := req.RewindStream(); err != nil {
+		return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("error rewinding request stream after computing md5 checksum: %w", err)
+	}
+
+	req.Header.Set("Content-Md5", string(b64))
+
+	return next.HandleBuild(ctx, in)
 }
 
 type AlibabaSDK interface {
@@ -100,10 +162,12 @@ func Alibaba(args ClientArgs) (*AlibabaClient, error) {
 	}
 
 	// Alibaba is S3 Compatible, so use that interface.
-	// AddContentChecksumMiddleware injects a Content-MD5 header for all S3
-	// operations that carry a request body. This is required by Alibaba OSS for
-	// DeleteObjects (which fails with MissingArgument without it) and is harmless
-	// for other operations such as PutObject.
+	//
+	// addDeleteObjectsContentMD5Middleware injects a Content-MD5 header only for
+	// DeleteObjects requests. Alibaba OSS requires this header for DeleteObjects
+	// (it fails with MissingArgument without it). Using the global
+	// smithyhttp.AddContentChecksumMiddleware instead breaks PutObject because it
+	// tries to compute MD5 on upload streams that may not be seekable.
 	//
 	// SwapComputePayloadSHA256ForUnsignedPayloadMiddleware replaces the default
 	// ComputePayloadSHA256 middleware with UnsignedPayload, which sets
@@ -116,7 +180,7 @@ func Alibaba(args ClientArgs) (*AlibabaClient, error) {
 			SecretKey: args.SecretKey,
 			Middlewares: append(
 				args.Middlewares,
-				smithyhttp.AddContentChecksumMiddleware,
+				addDeleteObjectsContentMD5Middleware,
 				v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
 			),
 		}, &AWSOptions{

--- a/src/lib/integrations/client_alibaba_oss_test.go
+++ b/src/lib/integrations/client_alibaba_oss_test.go
@@ -307,6 +307,51 @@ func (s *AlibabaOSSSuite) Test_Upload_UnsignedPayload() {
 	s.Equal("UNSIGNED-PAYLOAD", contentSHA256Seen, "x-amz-content-sha256 must be UNSIGNED-PAYLOAD to avoid aws-chunked encoding on Alibaba OSS")
 }
 
+// Test_Upload_NoContentMD5 verifies that PutObject requests to Alibaba OSS do NOT
+// carry a Content-MD5 header. The scoped deleteObjectsContentMD5 middleware must
+// only add the header for DeleteObjects; applying it to PutObject breaks uploads.
+func (s *AlibabaOSSSuite) Test_Upload_NoContentMD5() {
+	contentMD5Seen := ""
+
+	oss, err := integrations.Alibaba(integrations.ClientArgs{
+		AccessKey: "my-access-key",
+		SecretKey: "my-secret-key",
+		Middlewares: []func(stack *middleware.Stack) error{
+			func(stack *middleware.Stack) error {
+				return stack.Finalize.Add(
+					middleware.FinalizeMiddlewareFunc("AssertNoContentMD5", func(ctx context.Context, fi middleware.FinalizeInput, fh middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+						opName := awsmiddleware.GetOperationName(ctx)
+
+						if opName == "PutObject" {
+							if req, ok := fi.Request.(*smithyhttp.Request); ok {
+								contentMD5Seen = req.Header.Get("Content-Md5")
+							}
+
+							return middleware.FinalizeOutput{
+								Result: &s3.PutObjectOutput{},
+							}, middleware.Metadata{}, nil
+						}
+
+						return middleware.FinalizeOutput{}, middleware.Metadata{}, errors.New("unexpected AWS operation: " + opName)
+					}),
+					middleware.Before,
+				)
+			},
+		},
+	})
+
+	s.Require().NoError(err)
+
+	_, err = oss.Upload(integrations.UploadArgs{
+		DeploymentID: 50919,
+		ClientZip:    path.Join(s.tmpdir, "sk-client.zip"),
+		BucketName:   "my-s3-bucket",
+	})
+
+	s.NoError(err)
+	s.Empty(contentMD5Seen, "Content-MD5 must not be set on PutObject requests to avoid breaking Alibaba OSS uploads")
+}
+
 func TestAlibabaOSS(t *testing.T) {
 	suite.Run(t, &AlibabaOSSSuite{})
 }

--- a/src/lib/integrations/client_alibaba_oss_test.go
+++ b/src/lib/integrations/client_alibaba_oss_test.go
@@ -258,6 +258,55 @@ func (s *AlibabaOSSSuite) Test_DeleteArtifacts_ContentMD5Header() {
 	s.NotEmpty(contentMD5Seen, "Content-Md5 header must be present on DeleteObjects requests to Alibaba OSS")
 }
 
+// Test_Upload_UnsignedPayload verifies that PutObject requests sent to Alibaba OSS
+// carry the x-amz-content-sha256: UNSIGNED-PAYLOAD header. Without this, the AWS
+// SDK uses aws-chunked transfer encoding for multipart uploads, which Alibaba OSS
+// rejects with an InvalidArgument error.
+func (s *AlibabaOSSSuite) Test_Upload_UnsignedPayload() {
+	contentSHA256Seen := ""
+
+	oss, err := integrations.Alibaba(integrations.ClientArgs{
+		AccessKey: "my-access-key",
+		SecretKey: "my-secret-key",
+		Middlewares: []func(stack *middleware.Stack) error{
+			// Insert after the "Signing" middleware so the x-amz-content-sha256
+			// header has already been set by the signer when we inspect it.
+			func(stack *middleware.Stack) error {
+				return stack.Finalize.Insert(
+					middleware.FinalizeMiddlewareFunc("AssertUnsignedPayload", func(ctx context.Context, fi middleware.FinalizeInput, fh middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+						opName := awsmiddleware.GetOperationName(ctx)
+
+						if opName == "PutObject" {
+							if req, ok := fi.Request.(*smithyhttp.Request); ok {
+								contentSHA256Seen = req.Header.Get("X-Amz-Content-Sha256")
+							}
+
+							return middleware.FinalizeOutput{
+								Result: &s3.PutObjectOutput{},
+							}, middleware.Metadata{}, nil
+						}
+
+						return middleware.FinalizeOutput{}, middleware.Metadata{}, errors.New("unexpected AWS operation: " + opName)
+					}),
+					"Signing",
+					middleware.After,
+				)
+			},
+		},
+	})
+
+	s.Require().NoError(err)
+
+	_, err = oss.Upload(integrations.UploadArgs{
+		DeploymentID: 50919,
+		ClientZip:    path.Join(s.tmpdir, "sk-client.zip"),
+		BucketName:   "my-s3-bucket",
+	})
+
+	s.NoError(err)
+	s.Equal("UNSIGNED-PAYLOAD", contentSHA256Seen, "x-amz-content-sha256 must be UNSIGNED-PAYLOAD to avoid aws-chunked encoding on Alibaba OSS")
+}
+
 func TestAlibabaOSS(t *testing.T) {
 	suite.Run(t, &AlibabaOSSSuite{})
 }


### PR DESCRIPTION
## Problem

Alibaba OSS rejects multipart `UploadPart` requests with:

```
InvalidArgument: aws-chunked encoding is not supported with the specified x-amz-content-sha256 value
```

The AWS SDK v2 `manager.Uploader` sets `x-amz-content-sha256` to `STREAMING-AWS4-HMAC-SHA256-PAYLOAD` by default for large files, which implies `aws-chunked` transfer encoding. Alibaba OSS does not support this mode.

## Fix

Add `v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware` to the Alibaba S3 client middleware stack alongside the existing `AddContentChecksumMiddleware`. This replaces the `ComputePayloadHash` middleware with `UnsignedPayload`, which sets `x-amz-content-sha256: UNSIGNED-PAYLOAD` for all S3 operations — preventing the chunked encoding that OSS rejects.

## Tests

Added `Test_Upload_UnsignedPayload` to `client_alibaba_oss_test.go` that inserts a Finalize interceptor after the `Signing` middleware and asserts the `X-Amz-Content-Sha256` header is `UNSIGNED-PAYLOAD` on `PutObject` requests.