### PR TITLE
fix: wire auth config form submission to API

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -258,6 +258,50 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
     });
   });
 
+  describe("auth config form", () => {
+    beforeEach(async () => {
+      await createWrapper({ hasSchema: true });
+    });
+
+    it("should explain how success callback can access skauth", async () => {
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(
+            "Relative URL to redirect to after successful authentication. At this URL, browser code can read the skauth item from localStorage.",
+          ),
+        ).toBeTruthy();
+      });
+    });
+
+    it("should save config successfully", async () => {
+      const scope = nock(apiDomain)
+        .post("/skauth/config", {
+          envId: currentEnv.id,
+          successUrl: "",
+          tokenTtl: 0,
+          status: true,
+        })
+        .reply(200);
+
+      fireEvent.submit(wrapper.getByRole("button", { name: "Save" }).closest("form")!);
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
+        expect(wrapper.getByText("Settings saved successfully")).toBeTruthy();
+      });
+    });
+
+    it("should display error when save fails", async () => {
+      nock(apiDomain).post("/skauth/config").reply(500);
+
+      fireEvent.submit(wrapper.getByRole("button", { name: "Save" }).closest("form")!);
+
+      await waitFor(() => {
+        expect(wrapper.getByText("Failed to save settings")).toBeTruthy();
+      });
+    });
+  });
+
   describe("when fetch providers fails", () => {
     beforeEach(async () => {
       currentApp = mockApp();

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -16,7 +16,7 @@ import CardFooter from "~/components/CardFooter";
 import { RootContext } from "~/pages/Root.context";
 import Drawer from "./ProviderSettings";
 import { useFetchSchema } from "../database/actions";
-import { AuthProvider, useFetchProviders } from "./actions";
+import { AuthProvider, saveConfig, useFetchProviders } from "./actions";
 
 interface EmptyViewProps {
   isCloud?: boolean;
@@ -155,6 +155,8 @@ export default function SkAuth() {
   const result = useFetchSchema({ envId: env.id!, isCloud });
   const [refreshToken, setRefreshToken] = useState<number>();
   const [success, setSuccess] = useState<string>();
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string>();
   const { providers, loading, error, config } = useFetchProviders({
     envId: env.id!,
     refreshToken,
@@ -166,7 +168,7 @@ export default function SkAuth() {
 
   if (!hasSchema && !result.loading) {
     return (
-      <Card>
+      <Card sx={{ width: "100%" }}>
         <CardHeader title={title} subtitle={subtitle} />
         <EmptyView isCloud={isCloud} env={env} />
       </Card>
@@ -179,10 +181,39 @@ export default function SkAuth() {
         success={success}
         successTitle={false}
         onSuccessClose={() => setSuccess(undefined)}
-        error={result.error || error}
+        error={result.error || error || saveError}
         loading={result.loading || loading}
         component="form"
         sx={{ width: "100%" }}
+        onSubmit={e => {
+          e.preventDefault();
+          const form = e.target;
+
+          if (!(form instanceof HTMLFormElement)) {
+            throw new TypeError("Expected form submit target");
+          }
+
+          const data = new FormData(form);
+
+          setSaving(true);
+          setSaveError(undefined);
+
+          saveConfig({
+            envId: env.id!,
+            successUrl: (data.get("successUrl") as string) || "",
+            tokenTtl: Number(data.get("tokenTtl") || 0),
+            status: true,
+          })
+            .then(() => {
+              setSuccess("Settings saved successfully");
+            })
+            .catch(() => {
+              setSaveError("Failed to save settings");
+            })
+            .finally(() => {
+              setSaving(false);
+            });
+        }}
       >
         <CardHeader title={title} subtitle={subtitle} />
 
@@ -195,7 +226,7 @@ export default function SkAuth() {
             defaultValue={config?.successUrl || ""}
             variant="filled"
             autoComplete="off"
-            helperText="Relative URL to redirect to after successful authentication"
+            helperText="Relative URL to redirect to after successful authentication. At this URL, browser code can read the skauth item from localStorage."
             slotProps={{
               inputLabel: {
                 shrink: true,
@@ -228,11 +259,7 @@ export default function SkAuth() {
             type="submit"
             variant="contained"
             color="secondary"
-            disabled={result.loading || loading}
-            onClick={e => {
-              e.preventDefault();
-              setSuccess("Settings saved successfully");
-            }}
+            disabled={result.loading || loading || saving}
           >
             Save
           </Button>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -135,6 +135,21 @@ interface AuthConfig {
   successUrl?: string;
 }
 
+interface SaveConfigParams {
+  envId: string;
+  successUrl: string;
+  tokenTtl: number;
+  status: boolean;
+}
+
+export const saveConfig = ({
+  envId,
+  successUrl,
+  tokenTtl,
+  status,
+}: SaveConfigParams): Promise<void> =>
+  api.post("/skauth/config", { envId, successUrl, tokenTtl, status });
+
 export const useFetchProviders = ({
   envId,
   refreshToken,


### PR DESCRIPTION
## Problem

The "Save" button in the Stormkit Auth config form was calling `e.preventDefault()` and immediately showing a success toast without ever calling the API (`POST /skauth/config`).

## Changes

- Add `saveConfig()` to `actions.tsx` calling `POST /skauth/config`
- Wire `SkAuth.tsx` form `onSubmit` to `saveConfig`, with loading and error state
- Remove the fake `onClick` that showed success without calling the API
- Add spec tests for save success and failure