### PR TITLE
feat: add email provider foundation for SkAuth

### DIFF
--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -22,7 +22,6 @@ var schemaStmt = struct {
 	createAuthTable       string
 	createMigrationsTable string
 	selectMigrations      string
-	selectAuthUser        string
 	insertOAuth           string
 	insertAuthUser        string
 }{
@@ -93,21 +92,6 @@ var schemaStmt = struct {
 		ORDER BY 3;
 	`,
 
-	selectAuthUser: `
-		SELECT
-			user_id,
-			first_name,
-			last_name,
-			email,
-			avatar,
-			created_at,
-			last_login_at
-		FROM
-			stormkit_auth_users
-		WHERE
-			user_id = $1;
-	`,
-
 	insertOAuth: `
 		INSERT INTO stormkit_auth_providers (
 			user_id, account_id, access_token, refresh_token, token_type, provider_name, expiry
@@ -131,7 +115,26 @@ var sqlTemplates = struct {
 	createMigrationUser *template.Template
 	createAppUser       *template.Template
 	dropSchema          *template.Template
+	selectAuthUser      *template.Template
 }{
+	selectAuthUser: template.Must(template.New("selectAuthUser").Parse(`
+		SELECT
+			u.user_id,
+			u.first_name,
+			u.last_name,
+			u.email,
+			u.avatar,
+			u.created_at,
+			u.last_login_at
+			{{- if .WithHash}}, p.access_token AS password_hash{{end}}
+		FROM
+			stormkit_auth_users u
+			{{- if .WithHash}}
+			JOIN stormkit_auth_providers p ON u.user_id = p.user_id AND p.provider_name = $2
+			{{- end}}
+		WHERE
+			u.{{.WhereField}} = $1;
+	`)),
 	createSchema: template.Must(template.New("createSchema").Parse(`CREATE SCHEMA IF NOT EXISTS {{.SchemaName}}`)),
 
 	createMigrationUser: template.Must(template.New("createMigrationUser").Parse(`
@@ -613,7 +616,18 @@ func (s *schemaStore) AuthUser(ctx context.Context, authID types.ID) (*skauth.Us
 		return nil, fmt.Errorf("schema configuration is required to retrieve auth user")
 	}
 
-	row, err := s.QueryRow(ctx, schemaStmt.selectAuthUser, authID)
+	buf := bytes.Buffer{}
+
+	err := sqlTemplates.selectAuthUser.Execute(&buf, map[string]any{
+		"WhereField": "user_id",
+		"WithHash":   false,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to render selectAuthUser template: %w", err)
+	}
+
+	row, err := s.QueryRow(ctx, buf.String(), authID)
 
 	if err != nil {
 		return nil, err

--- a/src/ce/api/app/skauth/client_email.go
+++ b/src/ce/api/app/skauth/client_email.go
@@ -1,0 +1,30 @@
+package skauth
+
+import (
+	"context"
+	"errors"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"golang.org/x/oauth2"
+)
+
+type emailClient struct{}
+
+// NewEmailClient returns a Client implementation for the email/password provider.
+// Email login does not use OAuth redirects; this client is used only to satisfy
+// the Client interface and to signal that the provider is valid.
+func NewEmailClient() Client {
+	return &emailClient{}
+}
+
+func (c *emailClient) AuthCodeURL(_ AuthCodeURLParams) (string, error) {
+	return "", errors.New("email provider does not support OAuth redirect flow")
+}
+
+func (c *emailClient) Exchange(_ context.Context, _ *shttp.RequestContext) (*oauth2.Token, error) {
+	return nil, errors.New("email provider does not support OAuth token exchange")
+}
+
+func (c *emailClient) UserInfo(_ context.Context, _ *oauth2.Token) (*UserInfo, error) {
+	return nil, errors.New("email provider does not support UserInfo via OAuth token")
+}

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -13,10 +13,12 @@ import (
 
 const ProviderGoogle = "google"
 const ProviderX = "x"
+const ProviderEmail = "email"
 
 var Providers = []string{
 	ProviderGoogle,
 	ProviderX,
+	ProviderEmail,
 }
 
 type OAuthToken struct {
@@ -60,7 +62,7 @@ type Provider struct {
 
 var DefaultClient Client
 
-// Client returns the OAuth client for the provider.
+// Client returns the provider client (OAuth or non-OAuth) for the provider.
 func (p *Provider) Client() Client {
 	if DefaultClient != nil {
 		return DefaultClient
@@ -75,6 +77,8 @@ func (p *Provider) Client() Client {
 		p.cachedClient = NewGoogleClient(p.Data.ClientID, p.Data.ClientSecret)
 	case ProviderX:
 		p.cachedClient = NewXClient(p.Data.ClientID, p.Data.ClientSecret)
+	case ProviderEmail:
+		p.cachedClient = NewEmailClient()
 	}
 
 	return p.cachedClient

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
@@ -20,6 +20,7 @@ type AuthUpsertRequest struct {
 }
 
 // handlerAuthUpsert handles the upsert of an authentication provider configuration.
+// It delegates to a provider-specific helper based on the provider name.
 func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 	data := &AuthUpsertRequest{}
 
@@ -61,7 +62,20 @@ func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 
 	data.ProviderName = strings.TrimSpace(strings.ToLower(data.ProviderName))
 
-	// If updating an existing provider and client secret is not provided, retain the existing secret
+	switch data.ProviderName {
+	case skauth.ProviderEmail:
+		return handleEmailProvider(req, data, env)
+	default:
+		return handleOAuthProvider(req, data, env)
+	}
+}
+
+// handleOAuthProvider validates OAuth-specific fields (clientId, clientSecret) and saves
+// the provider configuration.
+func handleOAuthProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env) *shttp.Response {
+	ctx := req.Context()
+
+	// If updating an existing provider and client secret is not provided, retain the existing secret.
 	if data.ClientSecret == "" || data.ClientSecret == ClientSecretPlaceholder {
 		existingProvider, err := skauth.NewStore().Provider(ctx, req.EnvID, data.ProviderName)
 
@@ -86,6 +100,22 @@ func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 		})
 	}
 
+	return saveProvider(req, data, env, skauth.ProviderData{
+		ClientID:     data.ClientID,
+		ClientSecret: data.ClientSecret,
+	})
+}
+
+// handleEmailProvider saves the email/password provider configuration.
+// Email providers do not require OAuth credentials.
+func handleEmailProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env) *shttp.Response {
+	return saveProvider(req, data, env, skauth.ProviderData{})
+}
+
+// saveProvider creates the auth table (idempotent) and upserts the provider record.
+func saveProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env, providerData skauth.ProviderData) *shttp.Response {
+	ctx := req.Context()
+
 	migrationStore, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeMigrations)
 
 	if err != nil {
@@ -102,10 +132,7 @@ func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 	provider := &skauth.Provider{
 		Name:   data.ProviderName,
 		Status: data.Status,
-		Data: skauth.ProviderData{
-			ClientID:     data.ClientID,
-			ClientSecret: data.ClientSecret,
-		},
+		Data:   providerData,
 	}
 
 	if provider.Client() == nil {

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
@@ -223,6 +223,58 @@ func (s *HandlerAuthUpsertSuite) Test_Idempotent() {
 	}, provider.Data)
 }
 
+func (s *HandlerAuthUpsertSuite) Test_Success_EmailProvider() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth",
+		map[string]any{
+			"envId":        s.env.ID,
+			"providerName": skauth.ProviderEmail,
+			"status":       true,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	provider, err := skauth.NewStore().Provider(context.Background(), s.env.ID, skauth.ProviderEmail)
+	s.NoError(err)
+	s.NotNil(provider, "Email provider should be saved")
+	s.True(provider.Status)
+	s.Equal(skauth.ProviderData{}, provider.Data, "Email provider should have no OAuth credentials")
+}
+
+// Test_Success_EmailProvider_NoClientCredentials verifies that the email provider
+// can be enabled without supplying clientId or clientSecret.
+func (s *HandlerAuthUpsertSuite) Test_Success_EmailProvider_NoClientCredentials() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth",
+		map[string]any{
+			"envId":        s.env.ID,
+			"providerName": skauth.ProviderEmail,
+			"clientId":     "should-be-ignored",
+			"clientSecret": "should-be-ignored",
+			"status":       false,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	provider, err := skauth.NewStore().Provider(context.Background(), s.env.ID, skauth.ProviderEmail)
+	s.NoError(err)
+	s.NotNil(provider)
+	s.False(provider.Status)
+	s.Equal(skauth.ProviderData{}, provider.Data, "Email provider should store no OAuth credentials")
+}
+
 func TestHandlerUpsertSuite(t *testing.T) {
 	suite.Run(t, &HandlerAuthUpsertSuite{})
 }


### PR DESCRIPTION
## Summary

Lays the groundwork for email/password authentication in SkAuth.

### Changes

- **`sk_auth_model.go`** — Add `ProviderEmail` constant, register in `Providers` slice, wire up `NewEmailClient()` in the `Client()` switch; update `Client()` doc comment to reflect non-OAuth providers
- **`client_email.go`** *(new)* — Implements the `Client` interface for the email provider; all OAuth methods return errors (email uses no redirect flow)
- **`handler_auth_upsert.go`** — Refactor into `handleOAuthProvider`, `handleEmailProvider`, and `saveProvider` helpers; email provider stores empty `ProviderData{}` (no clientId/clientSecret)
- **`schema_store.go`** — Add `selectAuthUser` SQL template with `{{.WhereField}}` and `{{.WithHash}}` support; drop old string literal; wire `AuthUser` to use the template (`WithHash: false`, `WhereField: "user_id"`). When `WithHash` is true, the query joins `stormkit_auth_providers` and returns `access_token AS password_hash`.
- **`handler_auth_upsert_test.go`** — Tests for email provider upsert path

### What's next (follow-up PR)

- `AuthUserByEmail` DB method (template already in place)
- `POST /v1/auth/register` and `POST /v1/auth/login` handlers + tests
- Frontend: enable email provider in `actions.tsx` / `ProviderSettings.tsx`