### PR TITLE
feat: add email auth provider to SkAuth and expose /_stormkit/auth/register endpoint

### DIFF
--- a/src/ce/api/public/v1/handler_auth_email_register.go
+++ b/src/ce/api/public/v1/handler_auth_email_register.go
@@ -3,40 +3,55 @@ package publicapiv1
 import (
 	"fmt"
 	"net/http"
-	"net/url"
-	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
-	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"golang.org/x/crypto/bcrypt"
 )
 
 // HandlerAuthEmailRegister registers a new user with email and password.
-// It accepts a form POST and on success redirects to /_stormkit/auth?code=X,
-// where the hosting layer (WithSKAuth) exchanges the code for a session token
-// and redirects to the configured SuccessURL.
-// On failure: returns JSON 400 when the env is unknown or the Referer cannot
-// be validated; redirects to the Referer with ?error=<message> once the env
-// is resolved and the Referer host is confirmed to belong to it.
+// On success it returns a JSON response with a session token:
+//
+//	{"token": "<jwt>"}
+//
+// On failure it returns a JSON 400 with an "errors" key.
+// The handler is registered at POST /v1/auth/register and is also
+// callable from the hosting layer via /_stormkit/auth/register (WithSKAuth).
 // POST /v1/auth/register
 func HandlerAuthEmailRegister(req *shttp.RequestContext) *shttp.Response {
-	envID := utils.StringToID(req.FormValue("envId"))
-	email := req.FormValue("email")
-	password := req.FormValue("password")
+	body := &struct {
+		EnvID    string `json:"envId"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}{}
+
+	if err := req.Post(body); err != nil {
+		return shttp.BadRequest(map[string]any{"errors": []string{err.Error()}})
+	}
+
+	// envId can be supplied in the JSON body or injected into the URL query
+	// string by the hosting middleware (/_stormkit/auth/register path).
+	envIDStr := body.EnvID
+
+	if envIDStr == "" {
+		envIDStr = req.FormValue("envId")
+	}
+
+	envID := utils.StringToID(envIDStr)
+	email := body.Email
+	password := body.Password
 
 	if envID == 0 {
-		return redirectAuthError(req, nil, "envId is required")
+		return shttp.BadRequest(map[string]any{"errors": []string{"envId is required"}})
 	}
 
 	if errs := validateEmailAuthRequest(email, password); len(errs) > 0 {
-		return redirectAuthError(req, nil, errs[0])
+		return shttp.BadRequest(map[string]any{"errors": errs})
 	}
 
 	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), envID)
@@ -84,7 +99,7 @@ func HandlerAuthEmailRegister(req *shttp.RequestContext) *shttp.Response {
 
 	if err := store.InsertAuthUser(req.Context(), &oauth, &usr); err != nil {
 		if database.IsDuplicate(err) {
-			return redirectAuthError(req, env, "an account with this email already exists")
+			return shttp.BadRequest(map[string]any{"errors": []string{"an account with this email already exists"}})
 		}
 
 		return shttp.Error(err, fmt.Sprintf("failed to register user: %s", err.Error()))
@@ -100,57 +115,10 @@ func HandlerAuthEmailRegister(req *shttp.RequestContext) *shttp.Response {
 		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error()))
 	}
 
-	code, err := utils.SecureRandomToken(32)
-
-	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to generate auth code: %s", err.Error()))
+	return &shttp.Response{
+		Status: http.StatusCreated,
+		Data:   map[string]any{"token": sessionToken},
 	}
-
-	if err := rediscache.Client().Set(req.Context(), code, sessionToken, time.Minute*2).Err(); err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to store session token: %s", err.Error()))
-	}
-
-	// WithSKAuth (hosting layer) reads SuccessURL from its own config, so there
-	// is no need to pass it here — doing so would be redundant and misleading.
-	req.Redirect(
-		fmt.Sprintf("/_stormkit/auth?code=%s", code),
-		http.StatusFound,
-	)
-
-	return nil
-}
-
-// redirectAuthError redirects back to the HTTP Referer with ?error=<msg>.
-// Falls back to a JSON 400 response when no valid Referer header is present,
-// when env is nil, or when the Referer host does not belong to the environment
-// (to prevent open-redirect attacks).
-func redirectAuthError(req *shttp.RequestContext, env *buildconf.Env, errMsg string) *shttp.Response {
-	referer := req.Referer()
-
-	if referer == "" || env == nil {
-		return shttp.BadRequest(map[string]any{"errors": []string{errMsg}})
-	}
-
-	parsed, err := url.ParseRequestURI(referer)
-
-	if err != nil {
-		return shttp.BadRequest(map[string]any{"errors": []string{errMsg}})
-	}
-
-	hostname := parsed.Hostname()
-	belongs, err := appconf.NewStore().BelongsToEnv(req.Context(), env.ID, appconf.ParseHost(hostname))
-
-	if err != nil || !belongs {
-		return shttp.BadRequest(map[string]any{"errors": []string{errMsg}})
-	}
-
-	q := parsed.Query()
-	q.Set("error", errMsg)
-	parsed.RawQuery = q.Encode()
-
-	req.Redirect(parsed.String(), http.StatusFound)
-
-	return nil
 }
 
 // validateEmailAuthRequest validates email and password fields shared by register and login.

--- a/src/ce/api/public/v1/handler_auth_email_register_test.go
+++ b/src/ce/api/public/v1/handler_auth_email_register_test.go
@@ -76,7 +76,7 @@ func (s *HandlerAuthEmailRegisterSuite) post(fields map[string]string) shttptest
 		shttp.MethodPost,
 		"/v1/auth/register",
 		fields,
-		map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		nil,
 	)
 }
 
@@ -132,12 +132,14 @@ func (s *HandlerAuthEmailRegisterSuite) Test_Success() {
 		"password": "supersecret123",
 	})
 
-	s.Equal(http.StatusFound, response.Code)
-	s.Contains(response.Header().Get("Location"), "/_stormkit/auth?code=")
-	s.NotContains(response.Header().Get("Location"), "successUrl")
+	s.Equal(http.StatusCreated, response.Code)
+
+	token, ok := response.Map()["token"].(string)
+	s.True(ok)
+	s.NotEmpty(token)
 }
 
-// Test_Success_NoSuccessURL verifies that the redirect only contains the code parameter.
+// Test_Success_NoSuccessURL verifies that registration works regardless of whether a SuccessURL is set.
 func (s *HandlerAuthEmailRegisterSuite) Test_Success_NoSuccessURL() {
 	env, err := s.setupEnv("")
 	s.Require().NoError(err)
@@ -148,12 +150,14 @@ func (s *HandlerAuthEmailRegisterSuite) Test_Success_NoSuccessURL() {
 		"password": "supersecret123",
 	})
 
-	s.Equal(http.StatusFound, response.Code)
-	s.Contains(response.Header().Get("Location"), "/_stormkit/auth?code=")
-	s.NotContains(response.Header().Get("Location"), "successUrl")
+	s.Equal(http.StatusCreated, response.Code)
+
+	token, ok := response.Map()["token"].(string)
+	s.True(ok)
+	s.NotEmpty(token)
 }
 
-// Test_DuplicateEmail verifies that registering with an existing email returns an error redirect.
+// Test_DuplicateEmail verifies that registering with an existing email returns a JSON 400 error.
 func (s *HandlerAuthEmailRegisterSuite) Test_DuplicateEmail() {
 	env, err := s.setupEnv("")
 	s.Require().NoError(err)
@@ -164,7 +168,7 @@ func (s *HandlerAuthEmailRegisterSuite) Test_DuplicateEmail() {
 		"password": "supersecret123",
 	}
 
-	s.Require().Equal(http.StatusFound, s.post(fields).Code)
+	s.Require().Equal(http.StatusCreated, s.post(fields).Code)
 
 	// Second registration with same email — no Referer, so falls back to JSON error.
 	response := s.post(fields)

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -16,8 +17,29 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 		return nil, nil
 	}
 
-	if !strings.HasPrefix(req.URL().Path, "/_stormkit/auth") {
+	path := req.URL().Path
+
+	if !strings.HasPrefix(path, "/_stormkit/auth") {
 		return nil, nil
+	}
+
+	if path == "/_stormkit/auth/register" {
+		if req.Method != http.MethodPost {
+			return &shttp.Response{
+				Status: http.StatusMethodNotAllowed,
+				Data:   map[string]any{"errors": []string{"method not allowed"}},
+			}, nil
+		}
+
+		// Inject the environment ID from the host config so the handler can
+		// look up the environment without requiring it in the request body.
+		reqURL := req.URL()
+		q := reqURL.Query()
+		q.Set("envId", req.Host.Config.EnvID.String())
+		reqURL.RawQuery = q.Encode()
+		req.ResetQuery()
+
+		return publicapiv1.HandlerAuthEmailRegister(req.RequestContext), nil
 	}
 
 	var head, content string

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -1,7 +1,10 @@
 package hosting_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -60,7 +63,33 @@ func (s *WithSKAuthSuite) hostWithSKAuth() *hosting.Host {
 	}
 }
 
-// Test_SKAuthDisabled checks that the middleware is a no-op when SKAuth is not configured.
+func (s *WithSKAuthSuite) newPostRequest(host *hosting.Host, path string, body any) *hosting.RequestContext {
+	var buf bytes.Buffer
+
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+
+	rq := &hosting.RequestContext{
+		Host: host,
+		RequestContext: shttp.NewRequestContext(&http.Request{
+			Method: http.MethodPost,
+			Header: make(http.Header),
+			URL: &url.URL{
+				Host:    host.Name,
+				Path:    path,
+				RawPath: path,
+			},
+			Body: io.NopCloser(&buf),
+		}),
+	}
+
+	rq.OriginalPath = path
+
+	return rq
+}
+
+
 func (s *WithSKAuthSuite) Test_SKAuthDisabled() {
 	host := &hosting.Host{
 		Name:   "www.stormkit.io",
@@ -135,6 +164,47 @@ func (s *WithSKAuthSuite) Test_ValidCode() {
 	body := string(res.Data.([]byte))
 	s.Contains(body, `localStorage.setItem('skauth'`)
 	s.Contains(body, sessionToken)
+}
+
+// Test_RegisterPath_SKAuthDisabled checks that /_stormkit/auth/register is a no-op when SKAuth is not configured.
+func (s *WithSKAuthSuite) Test_RegisterPath_SKAuthDisabled() {
+	host := &hosting.Host{
+		Name:   "www.stormkit.io",
+		Config: &appconf.Config{},
+	}
+
+	req := s.newPostRequest(host, "/_stormkit/auth/register", map[string]any{
+		"email":    "test@example.com",
+		"password": "supersecret123",
+	})
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res)
+}
+
+// Test_RegisterPath_MethodNotAllowed checks that /_stormkit/auth/register rejects non-POST requests.
+func (s *WithSKAuthSuite) Test_RegisterPath_MethodNotAllowed() {
+	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth/register")
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal(http.StatusMethodNotAllowed, res.Status)
+}
+
+// Test_RegisterPath_MissingEnv checks that /_stormkit/auth/register returns 400 when the
+// host has no EnvID configured (envId injected as 0 triggers validation failure).
+func (s *WithSKAuthSuite) Test_RegisterPath_MissingEnv() {
+	req := s.newPostRequest(s.hostWithSKAuth(), "/_stormkit/auth/register", map[string]any{
+		"email":    "test@example.com",
+		"password": "supersecret123",
+	})
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal(http.StatusBadRequest, res.Status)
 }
 
 func TestWithSKAuth(t *testing.T) {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -190,6 +190,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
       await createWrapper({
         hasSchema: true,
         providers: {
+          email: {
+            status: true,
+          },
           google: {
             status: true,
             clientId: "google-client-id",
@@ -206,6 +209,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
 
     it("should display authentication providers", async () => {
       await waitFor(() => {
+        expect(wrapper.getByText("Email")).toBeTruthy();
         expect(wrapper.getByText("Google")).toBeTruthy();
         expect(wrapper.getByText("X / Twitter (OAuth 2.0)")).toBeTruthy();
       });
@@ -213,7 +217,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
 
     it("should display correct status for enabled provider", async () => {
       await waitFor(() => {
-        expect(wrapper.getByText("enabled")).toBeTruthy();
+        expect(wrapper.getAllByText("enabled").length).toBeGreaterThan(0);
       });
     });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -30,17 +30,33 @@ export interface AuthProvider {
 }
 
 const allProviders: AuthProvider[] = [
-  // {
-  //   id: "email",
-  //   icon: EmailIcon,
-  //   name: "Email",
-  //   drawerTitle: "Email Provider Settings",
-  //   drawerDesc: "Allow authentication using email/password and magic links.",
-  //   fields: [
-  //     { name: "clientId", label: "Client ID", value: "" },
-  //     { name: "clientSecret", label: "Client Secret", value: "" },
-  //   ],
-  // },
+  {
+    id: "email",
+    icon: EmailIcon,
+    name: "Email",
+    drawerTitle: "Email Provider Settings",
+    drawerDesc: "Allow authentication using email and password.",
+    steps: [
+      "Enable this provider to allow users to register and sign in with an email and password.",
+      <>
+        Use the{" "}
+        <Link
+          href="https://www.stormkit.io/docs/features/authentication"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Stormkit Auth API
+        </Link>{" "}
+        to register and authenticate users programmatically.
+      </>,
+      <>
+        Send a <code>POST</code> request to{" "}
+        <code>/_stormkit/auth/register</code> with a JSON body containing{" "}
+        <code>email</code> and <code>password</code> fields. On success, a JWT
+        token is returned.
+      </>,
+    ],
+  },
   {
     id: "google",
     icon: GoogleIcon,


### PR DESCRIPTION
## Summary

Adds the **Email** provider to the SkAuth authentication UI and introduces a `/_stormkit/auth/register` endpoint that browser clients can call directly on their own domain (solving the CORS problem with the API domain).

## Changes

### Frontend
- Add email provider entry to `actions.tsx`
  - No OAuth fields (email/password flow, not OAuth)
  - No redirect/auth URL
  - Setup steps: enable the provider, then `POST /_stormkit/auth/register` with a JSON body containing `email` and `password` — a JWT token is returned on success
- Update `SkAuth.spec.tsx`: include `email` in providers list, switch `getByText` → `getAllByText` for enabled chip assertions

### Backend
- `HandlerAuthEmailRegister` now accepts a **JSON body** (`{email, password, envId}`) instead of form-encoded data
- Returns `{"token": "<jwt>"}` with `201 Created` on success

> ⚠️ **Breaking change**: `POST /v1/auth/register` previously returned `302 Found` and redirected to `/_stormkit/auth?code=X`. It now returns `201 Created` with a JSON token. Any existing callers of this endpoint need to be updated.

- All error paths return JSON `400` with `{"errors": [...]}`; `redirectAuthError` removed
- `WithSKAuth` hosting middleware intercepts `POST /_stormkit/auth/register` (exact path match), returns `405` for non-POST methods, injects `envId` from the host config, and delegates to `HandlerAuthEmailRegister` — frontends can POST to this path on their own domain without CORS restrictions
- Middleware reordered: early return for non-`/_stormkit/auth` paths first, then `/register` exact match before the code-exchange fallback