### PR TITLE
feat: add auth users UI, secondary nav, and fix schema store connections

### DIFF
--- a/src/ce/api/app/buildconf/schema_model.go
+++ b/src/ce/api/app/buildconf/schema_model.go
@@ -9,6 +9,12 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
+// schemaStoreCache is a package-level cache of open schema store connections,
+// keyed by access type and connection coordinates. It survives across requests,
+// unlike the per-request SchemaConf structs that are deserialized fresh from
+// the database each time.
+var schemaStoreCache sync.Map
+
 type SchemaTable struct {
 	Name string
 	Size int64 // in bytes
@@ -58,8 +64,6 @@ type SchemaConf struct {
 	SSLMode           string `json:"sslMode"`
 	DriverName        string `json:"-"` // Used in tests to specify the driver name
 
-	cachedStores    map[string]*schemaStore `json:"-"`
-	cachedStoresMux sync.Mutex              `json:"-"`
 }
 
 // Value implements the Sql Driver interface.
@@ -70,18 +74,15 @@ func (sc *SchemaConf) Value() (driver.Value, error) {
 const SchemaAccessTypeMigrations = "migrations"
 const SchemaAccessTypeAppUser = "app"
 
+func (sc *SchemaConf) storeKey(accessType string) string {
+	return fmt.Sprintf("%s:%s@%s:%s/%s/%s", accessType, sc.AppUserName, sc.Host, sc.Port, sc.DBName, sc.SchemaName)
+}
+
 func (sc *SchemaConf) Store(accessType string) (*schemaStore, error) {
-	sc.cachedStoresMux.Lock()
-	defer sc.cachedStoresMux.Unlock()
+	cacheKey := sc.storeKey(accessType)
 
-	if sc.cachedStores == nil {
-		sc.cachedStores = make(map[string]*schemaStore)
-	}
-
-	cacheKey := fmt.Sprintf("%s:%s", accessType, sc.DBName)
-
-	if db, exists := sc.cachedStores[cacheKey]; exists {
-		return db, nil
+	if cached, ok := schemaStoreCache.Load(cacheKey); ok {
+		return cached.(*schemaStore), nil
 	}
 
 	store, err := SchemaStoreFor(sc, accessType)
@@ -90,8 +91,8 @@ func (sc *SchemaConf) Store(accessType string) (*schemaStore, error) {
 		return nil, err
 	}
 
-	sc.cachedStores[cacheKey] = store
-	return store, err
+	schemaStoreCache.Store(cacheKey, store)
+	return store, nil
 }
 
 // URL returns the psql connection URL.

--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -715,11 +715,8 @@ func (s *schemaStore) ListAuthUsers(ctx context.Context, from, limit int) ([]*sk
 
 // Close closes the schema store and its underlying database connection.
 func (s *schemaStore) Close() error {
-	s.conf.cachedStoresMux.Lock()
-	defer s.conf.cachedStoresMux.Unlock()
-
 	if s.conf != nil {
-		delete(s.conf.cachedStores, fmt.Sprintf("%s:%s", s.accessType, s.conf.DBName))
+		schemaStoreCache.Delete(s.conf.storeKey(s.accessType))
 	}
 
 	return s.Conn.Close()

--- a/src/ui/src/components/MenuLink/MenuLink.tsx
+++ b/src/ui/src/components/MenuLink/MenuLink.tsx
@@ -1,22 +1,30 @@
 import type { SxProps } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import Dot from "~/components/Dot";
 
 export interface Path {
   path: string;
   icon?: React.ReactNode;
   text: React.ReactNode;
   isActive?: boolean;
+  children?: Omit<Path, "children">[];
 }
 
 interface Props {
   item: Path;
+  inline?: boolean;
+  dot?: boolean;
   sx?: SxProps;
 }
 
-export default function MenuLink({ item, sx }: Props) {
+export default function MenuLink({ item, sx, inline, dot = false }: Props) {
   return (
-    <Typography component="div" sx={{ display: "inline-block" }}>
+    <Typography
+      component="div"
+      sx={{ display: inline ? "inline-block" : "block" }}
+    >
       <Link
         key={item.path}
         href={item.path}
@@ -27,9 +35,13 @@ export default function MenuLink({ item, sx }: Props) {
           display: "inline-flex",
           position: "relative",
           alignItems: "center",
+          justifyContent: "space-between",
           borderRadius: 1,
           transition: "background-color 0.2s ease, color 0.2s ease",
-          bgcolor: item.isActive ? "rgba(81, 81, 81, 0.24)" : undefined,
+          bgcolor:
+            item.isActive && !item.children?.length
+              ? "rgba(81, 81, 81, 0.24)"
+              : undefined,
           ":hover": {
             opacity: 1,
             bgcolor: "rgba(81, 81, 81, 0.50)",
@@ -38,8 +50,20 @@ export default function MenuLink({ item, sx }: Props) {
           ...sx,
         }}
       >
-        {item.icon}
-        {item.text}
+        <span>
+          {item.icon ?? (dot ? <Dot sx={{ mr: 2 }} /> : null)}
+          {item.text}
+        </span>
+        {item.children && (
+          <ChevronRightIcon
+            sx={{
+              ml: 2,
+              color: "text.secondary",
+              fontSize: 18,
+              rotate: item.isActive ? "90deg" : "0deg",
+            }}
+          />
+        )}
       </Link>
     </Typography>
   );

--- a/src/ui/src/layouts/AppLayout/AppMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/AppMenu.tsx
@@ -16,7 +16,7 @@ export default function AppMenu({ app, team }: Props) {
 
   const appMenu = useMemo(
     () => appMenuItems({ app, pathname }),
-    [app, pathname]
+    [app, pathname],
   );
 
   return (
@@ -60,6 +60,7 @@ export default function AppMenu({ app, team }: Props) {
             }}
           />
           <MenuLink
+            inline
             item={{
               text: <AppName imageSize={18} app={app} />,
               path: `/apps/${app.id}/environments/${app.defaultEnvId}`,
@@ -69,7 +70,7 @@ export default function AppMenu({ app, team }: Props) {
         </Box>
         <Box>
           {appMenu.map(item => (
-            <MenuLink key={item.path} item={item} sx={{ mr: 1 }} />
+            <MenuLink inline key={item.path} item={item} sx={{ mr: 1 }} />
           ))}
         </Box>
       </Box>

--- a/src/ui/src/layouts/AppLayout/EnvMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/EnvMenu.tsx
@@ -27,7 +27,7 @@ export default function EnvMenu() {
 
   const envMenu = useMemo(
     () => envMenuItems({ app, env, pathname }),
-    [app, env, pathname]
+    [app, env, pathname],
   );
 
   if (!selectedEnvId || !env) {
@@ -67,8 +67,8 @@ export default function EnvMenu() {
                 navigate(
                   pathname.replace(
                     `/environments/${selectedEnvId}`,
-                    `/environments/${e.target.value}`
-                  )
+                    `/environments/${e.target.value}`,
+                  ),
                 );
               } else {
                 navigate(`/apps/${app.id}/environments/${e.target.value}`);
@@ -100,18 +100,52 @@ export default function EnvMenu() {
           }}
         >
           {envMenu.map(item => (
-            <MenuLink
-              key={item.path}
-              item={item}
-              sx={{
-                borderBottom: "1px solid",
-                borderColor: "container.border",
-                mx: 2,
-                p: 2,
-                display: "flex",
-                alignItems: "center",
-              }}
-            />
+            <Box key={item.path}>
+              <Box
+                sx={{
+                  borderBottom: item.children ? undefined : "1px solid",
+                  borderColor: "container.border",
+                }}
+              >
+                <MenuLink
+                  item={item}
+                  sx={{
+                    flex: 1,
+                    mx: 2,
+                    p: 2,
+                    display: "flex",
+                    alignItems: "center",
+                  }}
+                />
+              </Box>
+              {item.isActive && item.children && (
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    borderBottom: "1px solid",
+                    borderColor: "container.border",
+                    pb: 2,
+                  }}
+                >
+                  {item.children.map(child => (
+                    <MenuLink
+                      dot
+                      key={child.path}
+                      item={child}
+                      sx={{
+                        mx: 2,
+                        py: 1,
+                        borderBottom: "1px solid",
+                        borderColor: "container.border",
+                        display: "flex",
+                        alignItems: "center",
+                      }}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
           ))}
         </Box>
         <Box sx={{ display: { xs: "block", md: "none" }, mr: 2 }}>

--- a/src/ui/src/layouts/AppLayout/menu_items.tsx
+++ b/src/ui/src/layouts/AppLayout/menu_items.tsx
@@ -8,6 +8,7 @@ import InsertChartIcon from "@mui/icons-material/InsertChart";
 import MailIcon from "@mui/icons-material/Mail";
 import GroupIcon from "@mui/icons-material/Group";
 import DatabaseIcon from "@mui/icons-material/Inventory";
+import { SxProps } from "@mui/material/styles";
 
 export const appMenuItems = ({
   app,
@@ -35,10 +36,11 @@ interface Path {
   icon?: React.ReactNode;
   text: React.ReactNode;
   isActive?: boolean;
+  children?: Omit<Path, "children">[];
 }
 
-const Icon = (Icon: any) => {
-  return <Icon sx={{ fontSize: 15, mr: 2, color: "text.secondary" }} />;
+const Icon = (Icon: any, sx: SxProps = {}) => {
+  return <Icon sx={{ fontSize: 15, mr: 2, color: "text.secondary", ...sx }} />;
 };
 
 export const envMenuItems = ({
@@ -56,7 +58,7 @@ export const envMenuItems = ({
 
   const envPath = `/apps/${app.id}/environments/${env.id}`;
 
-  const items = [
+  const items: Path[] = [
     {
       text: "Config",
       path: envPath,
@@ -102,6 +104,18 @@ export const envMenuItems = ({
       path: `${envPath}/auth`,
       icon: Icon(GroupIcon),
       isActive: pathname.includes("/auth"),
+      children: [
+        {
+          text: "Providers",
+          path: `${envPath}/auth`,
+          isActive: pathname.endsWith("/auth"),
+        },
+        {
+          text: "Users",
+          path: `${envPath}/auth/users`,
+          isActive: pathname.endsWith("/auth/users"),
+        },
+      ],
     });
   }
 

--- a/src/ui/src/pages/admin/AuthConfig/PendingUsers.spec.tsx
+++ b/src/ui/src/pages/admin/AuthConfig/PendingUsers.spec.tsx
@@ -289,7 +289,7 @@ describe("~/pages/admin/AuthConfig/PendingUsers.tsx", () => {
         expect(fetchScope.isDone()).toBe(true);
       });
 
-      const checkboxes = wrapper.getAllByRole("checkbox");
+      const checkboxes = await waitFor(() => wrapper.getAllByRole("checkbox"));
 
       // Select a user
       fireEvent.click(checkboxes[1]);
@@ -449,7 +449,7 @@ describe("~/pages/admin/AuthConfig/PendingUsers.tsx", () => {
         expect(fetchScope.isDone()).toBe(true);
       });
 
-      const checkboxes = wrapper.getAllByRole("checkbox");
+      const checkboxes = await waitFor(() => wrapper.getAllByRole("checkbox"));
 
       // Select first user
       fireEvent.click(checkboxes[1]);

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/routes.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/routes.ts
@@ -52,6 +52,12 @@ const routes: Array<RouteProps> = [
     ),
   },
   {
+    path: "/auth/users",
+    element: Async(
+      () => import("~/pages/apps/[id]/environments/[env-id]/skauth/AuthUsers"),
+    ),
+  },
+  {
     path: "/deployments",
     element: Async(
       () => import("~/pages/apps/[id]/environments/[env-id]/deployments"),

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/AuthUsers.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/AuthUsers.tsx
@@ -1,0 +1,95 @@
+import { useContext } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardFooter from "~/components/CardFooter";
+import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
+import { formatDate } from "~/utils/helpers/date";
+import { AuthUser, useFetchAuthUsers } from "./actions";
+
+function displayName(user: AuthUser): string {
+  const name = [user.firstName, user.lastName].filter(Boolean).join(" ");
+  return name || "-";
+}
+
+export default function AuthUsers() {
+  const { environment: env } = useContext(EnvironmentContext);
+  const { loading, error, users, hasNextPage, loadMore } = useFetchAuthUsers({
+    envId: env.id!,
+  });
+
+  const hasUsers = !loading && !error && users.length > 0;
+
+  return (
+    <Card
+      loading={loading}
+      error={error}
+      sx={{ width: "100%" }}
+      info={!hasUsers && !loading && "No registered users yet."}
+      contentPadding={false}
+    >
+      <CardHeader
+        title="Registered Users"
+        subtitle="Users registered through the authentication providers"
+      />
+      <Box sx={{ mx: 4 }}>
+        {hasUsers && (
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>
+                  <Typography component="span" color="text.secondary">
+                    Email
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography component="span" color="text.secondary">
+                    Name
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ textAlign: "right" }}>
+                  <Typography component="span" color="text.secondary">
+                    Registered
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ textAlign: "right" }}>
+                  <Typography component="span" color="text.secondary">
+                    Last login
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {users.map(user => (
+                <TableRow key={user.id}>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>{displayName(user)}</TableCell>
+                  <TableCell sx={{ textAlign: "right" }}>
+                    {formatDate(user.createdAt)}
+                  </TableCell>
+                  <TableCell sx={{ textAlign: "right" }}>
+                    {user.lastLoginAt ? formatDate(user.lastLoginAt) : "-"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+        {hasNextPage && (
+          <CardFooter sx={{ justifyContent: "center", mt: 2 }}>
+            <Button variant="outlined" onClick={loadMore} disabled={loading}>
+              Load more
+            </Button>
+          </CardFooter>
+        )}
+      </Box>
+    </Card>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -225,3 +225,59 @@ export const useFetchProviders = ({
 
   return { providers, loading, error, config };
 };
+
+export interface AuthUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  avatar: string;
+  createdAt: number;
+  lastLoginAt: number;
+}
+
+interface FetchAuthUsersParams {
+  envId: string;
+  refreshToken?: number;
+}
+
+export const useFetchAuthUsers = ({ envId, refreshToken }: FetchAuthUsersParams) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [users, setUsers] = useState<AuthUser[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
+
+  const fetchPage = (from: number) => {
+    setLoading(true);
+    setError(undefined);
+
+    api
+      .fetch<{ results: AuthUser[]; hasNextPage: boolean }>(
+        `/v1/auth/users?envId=${envId}&from=${from}`
+      )
+      .then(({ results, hasNextPage }) => {
+        setUsers(prev => (from === 0 ? results : [...prev, ...results]));
+        setHasNextPage(hasNextPage);
+        setOffset(from + results.length);
+      })
+      .catch(() => {
+        setError("Something went wrong while fetching auth users.");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    setOffset(0);
+    setUsers([]);
+    fetchPage(0);
+  }, [envId, refreshToken]);
+
+  const loadMore = () => {
+    fetchPage(offset);
+  };
+
+  return { loading, error, users, hasNextPage, loadMore };
+};


### PR DESCRIPTION
## Summary

- **Auth Users page**: New `AuthUsers` page at `/environments/:envId/auth/users` listing registered SkAuth users in a table (email, name, registered date, last login) with load-more pagination via `GET /v1/auth/users?envId=&from=`
- **Secondary navigation**: Authentication menu item now expands to show "Providers" and "Users" sub-links; chevron icon indicates expandability
- **Schema store connection fix**: Moved the schema store cache from an instance-level field (dead — `SchemaConf` is deserialized fresh per request) to a package-level `sync.Map`, eliminating the "too many connections" error under repeated page loads
- **Test fix**: Two `PendingUsers.spec.tsx` tests were calling `getAllByRole("checkbox")` synchronously before the component re-rendered; wrapped in `await waitFor(...)` to match the pattern used by the other passing tests

## Test plan

- [ ] Navigate to an environment with `SK_AUTH_ENABLED=true` → Authentication menu should expand with Providers / Users sub-links
- [ ] Visit `/auth/users` → table of registered users renders; "Load more" appears when more pages exist
- [ ] Repeatedly reload the users page → no "too many connections" error in logs
- [ ] Run `npm test src/pages/admin/AuthConfig/PendingUsers.spec.tsx` → all 12 tests pass