### PR TITLE
feat: return email and userId in auth register response

### DIFF
--- a/src/ce/api/public/v1/handler_auth_email_register.go
+++ b/src/ce/api/public/v1/handler_auth_email_register.go
@@ -117,7 +117,7 @@ func HandlerAuthEmailRegister(req *shttp.RequestContext) *shttp.Response {
 
 	return &shttp.Response{
 		Status: http.StatusCreated,
-		Data:   map[string]any{"token": sessionToken},
+		Data:   map[string]any{"token": sessionToken, "email": email, "userId": usr.ID},
 	}
 }
 

--- a/src/ce/api/public/v1/handler_auth_email_register_test.go
+++ b/src/ce/api/public/v1/handler_auth_email_register_test.go
@@ -112,9 +112,12 @@ func (s *HandlerAuthEmailRegisterSuite) Test_Success() {
 
 	s.Equal(http.StatusCreated, response.Code)
 
-	token, ok := response.Map()["token"].(string)
+	body := response.Map()
+	token, ok := body["token"].(string)
 	s.True(ok)
 	s.NotEmpty(token)
+	s.Equal("jane@example.com", body["email"])
+	s.NotEmpty(body["userId"])
 }
 
 // Test_Success_NoSuccessURL verifies that registration works regardless of whether a SuccessURL is set.
@@ -130,9 +133,12 @@ func (s *HandlerAuthEmailRegisterSuite) Test_Success_NoSuccessURL() {
 
 	s.Equal(http.StatusCreated, response.Code)
 
-	token, ok := response.Map()["token"].(string)
+	body := response.Map()
+	token, ok := body["token"].(string)
 	s.True(ok)
 	s.NotEmpty(token)
+	s.Equal("jane@example-2.com", body["email"])
+	s.NotEmpty(body["userId"])
 }
 
 // Test_DuplicateEmail verifies that registering with an existing email returns a JSON 400 error.


### PR DESCRIPTION
## Summary

- The `/_stormkit/auth/register` endpoint now returns `email` and `userId` alongside the existing `token` in the 201 response, allowing consumers to associate the registered user with their own systems.

## Test plan

- [ ] `Test_Success` and `Test_Success_NoSuccessURL` assert that `email` and `userId` are present and non-empty in the response