### PR TITLE
Add headless browser docs for runtimes and status checks

### DIFF
--- a/docs/deployments/7-status-checks.md
+++ b/docs/deployments/7-status-checks.md
@@ -19,6 +19,8 @@ To set up status checks:
 
 The command will execute with the same environment variables available during the build process.
 
+If you are self-hosting Stormkit, you can also use status checks for browser-based workflows with tools such as Playwright and headless Chromium. See [Headless Browsers](/docs/features/headless-browsers) and [Runtime Management](/docs/self-hosting/runtimes).
+
 For an example of a status check script, visit our [sample repository](https://github.com/stormkit-io/sample-project/blob/main/scripts/puppeteer.ts).
 
 ## Modifying an Existing Status Check

--- a/docs/features/15-headless-browsers.md
+++ b/docs/features/15-headless-browsers.md
@@ -1,0 +1,65 @@
+---
+title: Headless Browsers
+description: Use headless Chromium and Playwright in self-hosted Stormkit deployments for testing, scraping, and browser-based workflows.
+---
+
+# Headless Browsers
+
+Stormkit can be used to run browser-based workloads in self-hosted instances.
+
+This is especially useful for:
+
+- End-to-end tests with Playwright
+- Smoke tests against preview deployments
+- Post-deploy checks that verify the application in a real browser before publishing
+- Visiting JavaScript-heavy pages and extracting rendered HTML
+- Running internal scraping, crawling, or snapshot workflows from your application
+
+## How it works
+
+On self-hosted instances, headless browser support is enabled through the runtime manager.
+
+You can install tools such as:
+
+- `nix:chromium` to provide a headless Chromium binary
+- `npm:playwright` to make the Playwright CLI available on the instance
+
+When a tool exposes an executable, Stormkit injects its resolved path as an environment variable using the `MISE_<TOOL>_PATH` format. For Chromium, this becomes `MISE_CHROMIUM_PATH`.
+
+This lets your scripts run a browser without hardcoding system-specific paths.
+
+## Typical setup
+
+1. Go to **Admin** > **System** > **Installed runtimes**
+2. Add `nix:chromium`
+3. Add `npm:playwright`
+4. Save the changes
+5. Configure a deployment status check that runs after each successful deployment
+
+With this setup, your deployment can stay unpublished until the browser-based check passes.
+
+## Using it inside your application
+
+Headless browsers are not limited to deployment checks.
+
+You can also use them from your own application code when you need a real browser context to:
+
+- Load pages that depend on client-side JavaScript before reading the final HTML
+- Access pages that require browser APIs or complex navigation flows
+- Extract content from third-party websites after the page has fully rendered
+
+In these cases, your application can launch Chromium through Playwright and use `process.env.MISE_CHROMIUM_PATH` as the browser `executablePath`.
+
+## Using it with status checks
+
+Status checks are a good fit for browser-based validation because they run after deployment and can decide whether a deploy should be published.
+
+For example, you can run a Playwright-based command that opens the preview deployment, waits for the application to load, and exits with a non-zero status when a critical path fails.
+
+If your script needs the Chromium path explicitly, use `process.env.MISE_CHROMIUM_PATH`.
+
+## Related Documentation
+
+- [Runtime Management](/docs/self-hosting/runtimes)
+- [Deployment Status Checks](/docs/deployments/status-checks)
+- [System environment variables](/docs/deployments/system-variables)

--- a/docs/self-hosting/5-runtimes.md
+++ b/docs/self-hosting/5-runtimes.md
@@ -77,6 +77,21 @@ The following files are recognized automatically:
 
 Stormkit relies on the **[mise](https://mise.jdx.dev/)** open-source tool for runtime management. **Current version** is displayed in the **Mise** section.
 
+### Nix Package Manager
+
+Stormkit enables the `nix` plugin for `mise`, which means you can install Nix packages from the runtimes page in the same way you install language runtimes and development tools.
+
+This is especially useful for browser automation workloads. For example:
+
+- `nix:chromium` installs a headless Chromium binary
+- `npm:playwright` makes the Playwright CLI available on the instance
+
+When a tool exposes an executable, Stormkit injects its resolved path as an environment variable using the `MISE_<TOOL>_PATH` format. For example, `nix:chromium` becomes `MISE_CHROMIUM_PATH`.
+
+This makes it possible to run browser-based workloads in self-hosted instances, including deployment checks, Playwright-based automation, and application code that needs to visit JavaScript-rendered pages and extract HTML. A Playwright-based script can use `process.env.MISE_CHROMIUM_PATH` as the browser `executablePath`.
+
+For a feature overview, see [Headless Browsers](/docs/features/headless-browsers). To learn how to run checks after each deployment, see [Deployment Status Checks](/docs/deployments/status-checks).
+
 ### Upgrading Mise
 
 1. Click **Upgrade to latest**.


### PR DESCRIPTION
## Description

This PR improves the documentation around headless browser support in self-hosted Stormkit.

Changes included:
- Added a new **Headless Browsers** feature page to make the capability easier to discover from the docs menu
- Expanded the self-hosting runtimes documentation with a dedicated section under **Mise / Nix Package Manager**
- Clarified that headless browser support is not only useful for deployment status checks, but also for application workloads such as visiting JavaScript-rendered pages and extracting HTML
- Added cross-links between feature docs, runtime docs, and deployment status checks docs

## Additional Notes

The goal of this PR is to improve discoverability and positioning:
- **Headless Browsers** is now presented as a user-facing feature
- Runtime installation details remain documented in the self-hosting runtimes section
- Status checks are documented as one possible use case, not the only one
