### PR TITLE
fix: stream request body through proxy to avoid buffering large uploads

### DIFF
--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -271,12 +271,13 @@ func (r *RequestServer) Dynamic() *shttp.Response {
 	}
 
 	result, err := integrations.Client().Invoke(integrations.InvokeArgs{
-		URL:          url,
-		ARN:          arn,
-		Body:         r.req.Body,
-		Method:       r.req.Method,
-		Headers:      r.req.Headers(),
-		HostName:     r.req.Host.Name,
+		URL:           url,
+		ARN:           arn,
+		Body:          r.req.Body,
+		ContentLength: r.req.ContentLength,
+		Method:        r.req.Method,
+		Headers:       r.req.Headers(),
+		HostName:      r.req.Host.Name,
 		AppID:        cnf.AppID,
 		EnvID:        cnf.EnvID,
 		DeploymentID: cnf.DeploymentID,

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -438,7 +438,33 @@ func (s *HandlerForwardSuite) Test_Redirects_RedirectingToDifferentDomain_ProxyW
 	s.mockRequest.On("URL", "https://test-api.example.com/api/v2/my-endpoint").Return(s.mockRequest).Once()
 	s.mockRequest.On("Method", "").Return(s.mockRequest).Once()
 	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", req.Body).Return(s.mockRequest).Once()
+	s.mockRequest.On("Stream", req.Body, int64(0)).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("my-response")),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	res := hosting.HandlerForward(req)
+	data, ok := res.Data.([]byte)
+
+	s.Nil(res.Redirect)
+	s.True(ok)
+	s.Equal([]byte("my-response"), data)
+	s.Equal(http.StatusOK, res.Status)
+}
+
+func (s *HandlerForwardSuite) Test_Redirects_RedirectingToDifferentDomain_ProxyWithContentLength() {
+	req := s.newRequest(s.host, "/api/v2/my-endpoint")
+	req.Body = io.NopCloser(strings.NewReader("my-payload"))
+	req.ContentLength = int64(len("my-payload"))
+
+	s.mockRequest.On("URL", "https://test-api.example.com/api/v2/my-endpoint").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Stream", req.Body, int64(10)).Return(s.mockRequest).Once()
 	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
 		Response: &http.Response{
 			StatusCode: http.StatusOK,
@@ -463,7 +489,7 @@ func (s *HandlerForwardSuite) Test_Redirects_RedirectingToDifferentDomain_ProxyW
 	s.mockRequest.On("URL", "https://test-api.example.com/api/v1/my-endpoint/").Return(s.mockRequest).Once()
 	s.mockRequest.On("Method", "").Return(s.mockRequest).Once()
 	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", req.Body).Return(s.mockRequest).Once()
+	s.mockRequest.On("Stream", req.Body, int64(0)).Return(s.mockRequest).Once()
 	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
 		Response: &http.Response{
 			StatusCode: http.StatusOK,

--- a/src/lib/integrations/client.go
+++ b/src/lib/integrations/client.go
@@ -26,21 +26,22 @@ type GetFileResult struct {
 }
 
 type InvokeArgs struct {
-	ARN          string            // Function ARN
-	Body         io.ReadCloser     // Request body
-	Method       string            // Request method
-	HostName     string            // Host Name
-	URL          *url.URL          // Request url
-	Headers      http.Header       // Request headers
-	Command      string            // If provided, this will run as a process manager. This only works on local environments.
-	CaptureLogs  bool              // Whether to tell the handlers to capture logs
-	EnvVariables map[string]string // This is required for server actions
-	IsPublished  bool              // Whether the deployment is published or not
-	AppID        types.ID
-	EnvID        types.ID
-	DeploymentID types.ID
-	Context      map[string]any // Additional context to pass to the function
-	QueueLog     func(*Log)     // Queue logs for later processing
+	ARN           string            // Function ARN
+	Body          io.ReadCloser     // Request body
+	ContentLength int64             // Request body content length; -1 if unknown
+	Method        string            // Request method
+	HostName      string            // Host Name
+	URL           *url.URL          // Request url
+	Headers       http.Header       // Request headers
+	Command       string            // If provided, this will run as a process manager. This only works on local environments.
+	CaptureLogs   bool              // Whether to tell the handlers to capture logs
+	EnvVariables  map[string]string // This is required for server actions
+	IsPublished   bool              // Whether the deployment is published or not
+	AppID         types.ID
+	EnvID         types.ID
+	DeploymentID  types.ID
+	Context       map[string]any // Additional context to pass to the function
+	QueueLog      func(*Log)     // Queue logs for later processing
 }
 
 type Log struct {

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -3,7 +3,6 @@ package integrations
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -649,27 +648,34 @@ func (pm *ProcessManager) addService(service *Service, ARN string) {
 	}
 }
 
-// Request the given URL within the allowed timeout. We're trying every 250ms to fetch the
-// result from the server until allowed timeout is exhausted.
-func (pm *ProcessManager) requestWithRetry(args InvokeArgs, service *Service) (*InvokeResult, error) {
-	timeout := time.After(30 * time.Second)
-	ticker := time.NewTicker(250 * time.Millisecond)
-	defer ticker.Stop()
+// waitForPort polls via TCP dial until the port is accepting connections or the timeout elapses.
+func (pm *ProcessManager) waitForPort(port int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	addr := fmt.Sprintf("localhost:%d", port)
 
-	for {
-		select {
-		case <-timeout:
-			return nil, errors.New("server is not up and running within allowed timeout")
-		case <-ticker.C:
-			res, err := pm.request(args, service)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 250*time.Millisecond)
 
-			if err != nil {
-				continue
-			}
-
-			return res, nil
+		if err == nil {
+			conn.Close()
+			return nil
 		}
+
+		time.Sleep(250 * time.Millisecond)
 	}
+
+	return fmt.Errorf("server on port %d did not become available within the allowed timeout", port)
+}
+
+// requestWithRetry waits for the service port to accept TCP connections, then forwards
+// the request exactly once. Separating port-readiness polling from the HTTP send ensures
+// the streaming body is never consumed on a failed connection attempt.
+func (pm *ProcessManager) requestWithRetry(args InvokeArgs, service *Service) (*InvokeResult, error) {
+	if err := pm.waitForPort(service.port, 30*time.Second); err != nil {
+		return nil, err
+	}
+
+	return pm.request(args, service)
 }
 
 // Request the given resource from the spawned server.
@@ -680,10 +686,11 @@ func (pm *ProcessManager) request(args InvokeArgs, service *Service) (*InvokeRes
 
 	res := shttp.Proxy(&shttp.RequestContext{
 		Request: &http.Request{
-			Header: args.Headers,
-			Method: args.Method,
-			URL:    args.URL,
-			Body:   args.Body,
+			Header:        args.Headers,
+			Method:        args.Method,
+			URL:           args.URL,
+			Body:          args.Body,
+			ContentLength: args.ContentLength,
 		},
 	}, shttp.ProxyArgs{
 		Target:          target.String(),

--- a/src/lib/shttp/request_v2.go
+++ b/src/lib/shttp/request_v2.go
@@ -35,6 +35,7 @@ type RequestInterface interface {
 	URL(url string) RequestInterface
 	Method(method string) RequestInterface
 	Payload(payload any) RequestInterface
+	Stream(body io.Reader, contentLength int64) RequestInterface
 	Headers(headers http.Header) RequestInterface
 	WithExponentialBackoff(maxDelay time.Duration, maxRetries int) RequestInterface
 	WithTimeout(duration time.Duration) RequestInterface
@@ -47,6 +48,8 @@ type RequestV2 struct {
 	timeout               time.Duration
 	method                string
 	payload               []byte
+	bodyStream            io.Reader
+	contentLength         int64
 	headers               http.Header
 	url                   string
 	followRedirects       bool
@@ -66,6 +69,8 @@ func NewRequestV2(method, url string) RequestInterface {
 	client.method = method
 	client.url = url
 	client.payload = nil
+	client.bodyStream = nil
+	client.contentLength = 0
 	client.headers = nil
 	client.followRedirects = true
 	client.timeout = 10 * time.Second
@@ -96,6 +101,13 @@ func (r *RequestV2) Payload(payload any) RequestInterface {
 	return r
 }
 
+// Stream sets a streaming body for the request, bypassing buffering.
+func (r *RequestV2) Stream(body io.Reader, contentLength int64) RequestInterface {
+	r.bodyStream = body
+	r.contentLength = contentLength
+	return r
+}
+
 // Method sets the request method.
 func (r *RequestV2) Method(method string) RequestInterface {
 	r.method = method
@@ -115,10 +127,20 @@ func (r *RequestV2) FollowRedirects(v bool) RequestInterface {
 
 // Do triggers a request.
 func (r *RequestV2) Do() (*HTTPResponse, error) {
-	req, err := http.NewRequest(r.method, r.url, bytes.NewBuffer(r.payload))
+	body := io.Reader(bytes.NewBuffer(r.payload))
+
+	if r.bodyStream != nil {
+		body = r.bodyStream
+	}
+
+	req, err := http.NewRequest(r.method, r.url, body)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if r.bodyStream != nil && r.contentLength > 0 {
+		req.ContentLength = r.contentLength
 	}
 
 	req.Header = r.headers
@@ -168,7 +190,7 @@ type ProxyArgs struct {
 }
 
 func Proxy(req *RequestContext, args ProxyArgs) *Response {
-	headers := req.Header
+	headers := req.Header.Clone()
 
 	// Make sure X-Forwarded-For headers are set
 	if headers.Get("X-Forwarded-For") == "" && headers.Get("X-Real-IP") == "" {
@@ -200,7 +222,7 @@ func Proxy(req *RequestContext, args ProxyArgs) *Response {
 	}
 
 	if req.Body != nil {
-		client.Payload(req.Body)
+		client.Stream(req.Body, req.ContentLength)
 	}
 
 	response, err := client.Do()

--- a/src/mocks/request_interface.go
+++ b/src/mocks/request_interface.go
@@ -3,10 +3,12 @@
 package mocks
 
 import (
+	io "io"
 	http "net/http"
 
-	shttp "github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	mock "github.com/stretchr/testify/mock"
+
+	shttp "github.com/stormkit-io/stormkit-io/src/lib/shttp"
 
 	time "time"
 )
@@ -117,6 +119,26 @@ func (_m *RequestInterface) Payload(payload interface{}) shttp.RequestInterface 
 	var r0 shttp.RequestInterface
 	if rf, ok := ret.Get(0).(func(interface{}) shttp.RequestInterface); ok {
 		r0 = rf(payload)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(shttp.RequestInterface)
+		}
+	}
+
+	return r0
+}
+
+// Stream provides a mock function with given fields: body, contentLength
+func (_m *RequestInterface) Stream(body io.Reader, contentLength int64) shttp.RequestInterface {
+	ret := _m.Called(body, contentLength)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Stream")
+	}
+
+	var r0 shttp.RequestInterface
+	if rf, ok := ret.Get(0).(func(io.Reader, int64) shttp.RequestInterface); ok {
+		r0 = rf(body, contentLength)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(shttp.RequestInterface)


### PR DESCRIPTION
## Problem

Large file uploads (>50MB) through the Stormkit proxy were failing with `failed to parse request: unexpected EOF`. The root cause was twofold:

1. **`shttp.Proxy` buffered the entire request body** via `io.ReadAll` (through `Payload()` → `toByteArray()`) before forwarding it to the hosted app. This meant the Go HTTP timeout handler could interrupt the read mid-stream, causing partial or empty bytes to be forwarded silently.

2. **`requestWithRetry` consumed the body on failed attempts.** The retry loop called `pm.request` (and thus `shttp.Proxy`) repeatedly until the app port was ready. Each failed attempt consumed the `io.ReadCloser` body, so subsequent retries forwarded an empty body.

## Changes

- **`shttp.RequestInterface` / `RequestV2`**: Add `Stream(body io.Reader, contentLength int64)` method that passes the reader directly to `http.NewRequest`, bypassing `io.ReadAll` entirely.
- **`shttp.Proxy`**: Switch from `client.Payload(req.Body)` to `client.Stream(req.Body, req.ContentLength)`. Also clones headers before mutating them to avoid side-effects on the original request.
- **`InvokeArgs`**: Add `ContentLength int64` field and thread it through `handler_forward.go` → `pm.request` so the upstream app receives an accurate `Content-Length` header.
- **`requestWithRetry`**: Replace the HTTP-level retry loop with `waitForPort`, which polls via TCP dial until the app port accepts connections. Once the port is ready, the request is made exactly once — the body stream is never consumed on a failed connection attempt.