### PR TITLE
fix: install runtimes before pruning to avoid binary availability gap

### DIFF
--- a/src/ce/api/admin/admin_model.go
+++ b/src/ce/api/admin/admin_model.go
@@ -510,10 +510,6 @@ func installDependencies(ctx context.Context) error {
 		return err
 	}
 
-	if err := m.Prune(ctx); err != nil {
-		slog.Errorf("error pruning mise: %v", err)
-	}
-
 	var output string
 
 	for _, runtime := range vc.SystemConfig.Runtimes {
@@ -531,6 +527,12 @@ func installDependencies(ctx context.Context) error {
 				zap.String("runtime", runtime),
 			},
 		})
+	}
+
+	// Remove any runtimes that are not in the config anymore to clean up the environment
+	// and avoid filling up the disk with unused runtimes.
+	if err := m.Prune(ctx, vc.SystemConfig.Runtimes); err != nil {
+		slog.Errorf("error pruning mise: %v", err)
 	}
 
 	slog.Debug(slog.LogOpts{

--- a/src/ce/api/admin/admin_model_test.go
+++ b/src/ce/api/admin/admin_model_test.go
@@ -91,11 +91,12 @@ func (s *AdminModelSuite) Test_InstallDependencies() {
 	s.NoError(admin.Store().UpsertConfig(ctx, vc))
 
 	s.mockMise.On("InstallMise", ctx).Return(nil).Once()
-	s.mockMise.On("Prune", ctx).Return(nil).Once()
 
 	for _, runtime := range vc.SystemConfig.Runtimes {
 		s.mockMise.On("InstallGlobal", ctx, runtime).Return(fmt.Sprintf("runtime installed: %s", runtime), nil).Once()
 	}
+
+	s.mockMise.On("Prune", ctx, vc.SystemConfig.Runtimes).Return(nil).Once()
 
 	admin.InstallDependencies(ctx)
 }
@@ -105,10 +106,11 @@ func (s *AdminModelSuite) Test_InstallDependencies_WithBackwardsCompatibility() 
 	os.Setenv("NODE_VERSION", "18")
 	defer os.Unsetenv("NODE_VERSION")
 
+	runtimes := []string{"go@1.24"}
 	ctx := context.Background()
 	vc := admin.InstanceConfig{
 		SystemConfig: &admin.SystemConfig{
-			Runtimes: []string{"go@1.24"},
+			Runtimes: runtimes,
 		},
 	}
 
@@ -117,16 +119,13 @@ func (s *AdminModelSuite) Test_InstallDependencies_WithBackwardsCompatibility() 
 
 	s.NoError(admin.Store().UpsertConfig(ctx, vc))
 
-	runtimes := []string{"go@1.24", "node@18", "yarn@1.22", "pnpm@latest"}
-
 	s.mockMise.On("InstallMise", ctx).Return(nil).Once()
-	s.mockMise.On("Prune", ctx).Return(nil).Once()
-
-	for _, runtime := range runtimes {
-		s.mockMise.On("InstallGlobal", ctx, runtime).Return(fmt.Sprintf("runtime installed: %s", runtime), nil).Once()
-	}
+	s.mockMise.On("InstallGlobal", ctx, "go@1.24").Return("runtime installed: go@1.24", nil).Once()
+	s.mockMise.On("Prune", ctx, runtimes).Return(nil).Once()
 
 	admin.InstallDependencies(ctx)
+
+	s.mockMise.AssertExpectations(s.T())
 }
 
 func (s *AdminModelSuite) Test_Store() {

--- a/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback_test.go
@@ -373,7 +373,7 @@ func (s *HandlerDeployCallbackSuite) Test_ExitCode_InstallRuntimes() {
 	mockMise.On("InstallMise", mock.Anything).Return(nil).Once()
 	mockMise.On("InstallGlobal", mock.Anything, "go@1.24").Return("", nil).Once()
 	mockMise.On("InstallGlobal", mock.Anything, "node@22").Return("", nil).Once()
-	mockMise.On("Prune", mock.Anything).Return(nil).Once()
+	mockMise.On("Prune", mock.Anything, mock.Anything).Return(nil).Once()
 
 	manifest := &deploy.BuildManifest{
 		Runtimes: []string{"go@1.24", "node@22"},

--- a/src/ce/api/app/deployservice/deployer_local_test.go
+++ b/src/ce/api/app/deployservice/deployer_local_test.go
@@ -62,7 +62,7 @@ func (s *DeployerLocalSuite) Test_StartDeployment() {
 	s.NoError(err)
 
 	s.mockMise.On("InstallMise", mock.Anything).Return(nil).Once()
-	s.mockMise.On("Prune", mock.Anything).Return(nil).Once()
+	s.mockMise.On("Prune", mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockExec.On("SetOpts", sys.CommandOpts{
 		Name: s.mockExecutable,
 		Args: []string{

--- a/src/ce/api/public/v1/handler_app_conf_test.go
+++ b/src/ce/api/public/v1/handler_app_conf_test.go
@@ -8,28 +8,35 @@ import (
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/mise"
 )
 
 type HandlerAppConfSuite struct {
 	suite.Suite
 	*factory.Factory
 
-	conn databasetest.TestDB
+	conn     databasetest.TestDB
+	mockMise *mocks.MiseInterface
 }
 
 func (s *HandlerAppConfSuite) BeforeTest(suiteName, _ string) {
 	s.conn = databasetest.InitTx(suiteName)
 	s.Factory = factory.New(s.conn)
+	s.mockMise = &mocks.MiseInterface{}
+	mise.DefaultMise = s.mockMise
 }
 
 func (s *HandlerAppConfSuite) AfterTest(_, _ string) {
 	s.conn.CloseTx()
+	mise.DefaultMise = nil
 }
 
 func (s *HandlerAppConfSuite) Test_Success() {
@@ -44,6 +51,8 @@ func (s *HandlerAppConfSuite) Test_Success() {
 			{EnvID: env.ID, Percentage: 100},
 		},
 	})
+
+	s.mockMise.On("BinPaths", mock.Anything).Return(map[string]string{"MISE_GO_PATH": "my-path"}, nil).Once()
 
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
@@ -72,6 +81,7 @@ func (s *HandlerAppConfSuite) Test_Success() {
 			"billingUserId": "1",
 			"envVariables": {
 				"NODE_ENV": "production",
+				"MISE_GO_PATH": "my-path",
 				"SK_APP_ID": "{{ .AppID }}",
 				"SK_DEPLOYMENT_ID": "{{ .DeploymentID }}",
 				"SK_DEPLOYMENT_URL": "http://sample-project--{{ .DeploymentID }}.stormkit:8888",

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -415,6 +415,7 @@ func (pm *ProcessManager) Start(ctx context.Context, args *InvokeArgs, workDir s
 
 		if err := s.cmd.Start(); err != nil {
 			pm.QueueLog(args, err.Error())
+			s.Kill()
 			return
 		}
 

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -415,7 +415,7 @@ func (pm *ProcessManager) Start(ctx context.Context, args *InvokeArgs, workDir s
 
 		if err := s.cmd.Start(); err != nil {
 			pm.QueueLog(args, err.Error())
-			s.Kill()
+			s.killed = true
 			return
 		}
 

--- a/src/lib/utils/mise/mise.go
+++ b/src/lib/utils/mise/mise.go
@@ -37,7 +37,7 @@ type MiseInterface interface {
 	BinPaths(context.Context) (map[string]string, error) // Returns { "MISE_<TOOL>_PATH": <path> }
 	Version() (string, error)
 	SelfUpdate(ctx context.Context) error
-	Prune(ctx context.Context) error
+	Prune(ctx context.Context, exceptRuntimes []string) error
 }
 
 var DefaultMise MiseInterface
@@ -387,15 +387,39 @@ func (m *Mise) SelfUpdate(ctx context.Context) error {
 	return nil
 }
 
-// Prune removes unused mise installations and cleans up the environment.
-func (m *Mise) Prune(ctx context.Context) error {
-	cmd := sys.Command(ctx, sys.CommandOpts{
-		Name: "sh",
-		Args: []string{"-c", "mise ls --global | xargs -n1 -r mise unuse --global --yes"},
-		Dir:  os.Getenv("HOME"),
-	})
+// Prune removes globally installed tools that are not present in exceptRuntimes.
+// exceptRuntimes entries are matched by tool name, ignoring the version (e.g. "node@22" matches tool "node").
+func (m *Mise) Prune(ctx context.Context, exceptRuntimes []string) error {
+	keep := make(map[string]bool, len(exceptRuntimes))
 
-	return cmd.Run()
+	for _, r := range exceptRuntimes {
+		name := strings.SplitN(r, "@", 2)[0]
+		keep[name] = true
+	}
+
+	installed, err := m.ListGlobal(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	for tool := range installed {
+		if keep[tool] {
+			continue
+		}
+
+		cmd := sys.Command(ctx, sys.CommandOpts{
+			Name: "mise",
+			Args: []string{"unuse", "--global", "--yes", tool},
+			Dir:  os.Getenv("HOME"),
+		})
+
+		if err := cmd.Run(); err != nil {
+			slog.Errorf("error pruning mise tool %s: %v", tool, err)
+		}
+	}
+
+	return nil
 }
 
 // AutoUpdate is a job that triggers the automatic update of mise.

--- a/src/mocks/mise_interface.go
+++ b/src/mocks/mise_interface.go
@@ -168,17 +168,17 @@ func (_m *MiseInterface) ListLocal(_a0 context.Context, _a1 mise.LocalOpts) ([]s
 	return r0, r1
 }
 
-// Prune provides a mock function with given fields: ctx
-func (_m *MiseInterface) Prune(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// Prune provides a mock function with given fields: ctx, exceptRuntimes
+func (_m *MiseInterface) Prune(ctx context.Context, exceptRuntimes []string) error {
+	ret := _m.Called(ctx, exceptRuntimes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Prune")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, []string) error); ok {
+		r0 = rf(ctx, exceptRuntimes)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
## Problem

`installDependencies` called `Prune` before installing runtimes. `Prune` was implemented as `mise unuse --global --yes` on every globally installed tool, which made **all** binaries temporarily unavailable. Any hosted service that tried to start during this window received a binary-not-found error.

## Changes

**`mise.Prune(ctx, exceptRuntimes []string)`**
- Now accepts the list of runtimes that should be kept
- Calls `ListGlobal` to get currently installed tools
- Only unuses tools whose name is not in `exceptRuntimes` — active runtimes are never touched

**`installDependencies`**
- Runs the full install loop first, then calls `Prune` — tools are always available during the install process
- Stale tools (removed from the runtimes config) are still cleaned up, just after the new ones are confirmed installed