### PR TITLE
fix: add --yes to mise trust to prevent silent no-op in non-interactive shells

### DIFF
--- a/src/lib/utils/mise/mise.go
+++ b/src/lib/utils/mise/mise.go
@@ -185,7 +185,7 @@ func (m *Mise) InstallLocal(ctx context.Context, opts LocalOpts) error {
 	if opts.Runtime != "" {
 		args = fmt.Sprintf("mise use -y %s", opts.Runtime)
 	} else {
-		args = "mise trust -q && mise install"
+		args = "mise trust --yes -q && mise install"
 	}
 
 	// Install the runtime using mise


### PR DESCRIPTION
## Summary

- `mise trust -q` only suppresses output but does not skip the confirmation prompt in newer mise versions
- In non-interactive shells (like the runner), this causes the trust to be silently skipped, leaving the config file untrusted
- `mise install` then fails with "Config files are not trusted" and "error parsing config file"
- Adding `--yes` ensures the trust is actually written before `mise install` runs

## Test plan

- [ ] Existing mise package tests pass (`go test ./src/lib/utils/mise/...`)
- [ ] Trigger a deployment with a `mise.toml` in the repo and verify `mise install` succeeds