### PR TITLE
fix: prevent X-Forwarded-For spoofing at the edge

### DIFF
--- a/docs/self-hosting/6-advanced-configuration.md
+++ b/docs/self-hosting/6-advanced-configuration.md
@@ -13,6 +13,16 @@ The hosting queue is a Redis list used to buffer incoming analytics, logs, and u
 | ----------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `STORMKIT_HOSTING_QUEUE_BATCH_SIZE` | `1000`  | Number of items consumed from the hosting queue per worker run. Increase this value if the queue grows faster than it is being drained. |
 
+## Reverse Proxy / Load Balancer
+
+By default Stormkit assumes it is the public edge and rewrites `X-Forwarded-For` and `X-Real-IP` with the real socket address on every proxied request, preventing clients from spoofing those headers.
+
+If Stormkit sits behind a trusted reverse proxy or load balancer that already sets `X-Forwarded-For` correctly, enable the following variable so that the upstream chain is preserved and the real socket address is appended rather than replaced:
+
+| Variable                          | Default | Description                                                                                                                                                      |
+| --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STORMKIT_TRUST_PROXY_HEADERS`    | `false` | Set to `true` when Stormkit runs behind a trusted upstream proxy. The existing `X-Forwarded-For` header is preserved and the connecting address is appended to it. When `false` (default), `X-Forwarded-For` and `X-Real-IP` are always overwritten with the real socket address. |
+
 ## HTTP Timeouts
 
 The following environment variables control the HTTP server timeouts. Values are parsed as Go duration strings; you should include a unit suffix (e.g. `30s`, `1m`, `500ms`). Bare integers without a unit (e.g. `30`) are interpreted as nanoseconds (e.g. `30` → `30ns`), which results in an extremely short timeout and is almost never desired. When unset, the defaults shown below are used.

--- a/docs/self-hosting/6-advanced-configuration.md
+++ b/docs/self-hosting/6-advanced-configuration.md
@@ -15,13 +15,13 @@ The hosting queue is a Redis list used to buffer incoming analytics, logs, and u
 
 ## Reverse Proxy / Load Balancer
 
-By default Stormkit assumes it is the public edge and rewrites `X-Forwarded-For` and `X-Real-IP` with the real socket address on every proxied request, preventing clients from spoofing those headers.
+By default Stormkit assumes it is the public edge: `X-Forwarded-For` is always overwritten with the real socket address, and `X-Real-IP` is overwritten if the client supplied one. This prevents clients from spoofing their IP for rate-limiting or access-control purposes.
 
-If Stormkit sits behind a trusted reverse proxy or load balancer that already sets `X-Forwarded-For` correctly, enable the following variable so that the upstream chain is preserved and the real socket address is appended rather than replaced:
+If Stormkit sits behind a trusted reverse proxy or load balancer that already sets these headers correctly, enable the following variable so that they are passed through unchanged:
 
 | Variable                          | Default | Description                                                                                                                                                      |
 | --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STORMKIT_TRUST_PROXY_HEADERS`    | `false` | Set to `true` when Stormkit runs behind a trusted upstream proxy. The existing `X-Forwarded-For` header is preserved and the connecting address is appended to it. When `false` (default), `X-Forwarded-For` and `X-Real-IP` are always overwritten with the real socket address. |
+| `STORMKIT_TRUST_PROXY_HEADERS`    | `false` | Set to `true` when Stormkit runs behind a trusted upstream proxy. `X-Forwarded-For` and `X-Real-IP` are passed through unchanged. When `false` (default), `X-Forwarded-For` is always overwritten with the real socket address and `X-Real-IP` is overwritten if present. |
 
 ## HTTP Timeouts
 

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
 	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
 	"github.com/stormkit-io/stormkit-io/src/lib/pool"
@@ -108,6 +109,7 @@ func (s *HandlerForwardSuite) BeforeTest(_, _ string) {
 func (s *HandlerForwardSuite) AfterTest(_, _ string) {
 	admin.ResetMockLicense()
 	hosting.QueueName = jobs.HostingQueueName
+	config.Get().TrustProxyHeaders = false
 }
 
 func (s *HandlerForwardSuite) TearDownSuite() {
@@ -527,6 +529,8 @@ func (s *HandlerForwardSuite) Test_Redirects_UI_Defined_Redirects() {
 }
 
 func (s *HandlerForwardSuite) Test_Analytics() {
+	config.Get().TrustProxyHeaders = true
+
 	s.mockClient.On("GetFile", integrations.GetFileArgs{
 		Location:     "aws:my-bucket/my-key-prefix",
 		FileName:     "/analytics/index.html",

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -197,7 +197,8 @@ type Config struct {
 	Hash             string
 	RedisAddr        string
 	Secrets          map[string]string
-	HTTPTimeouts     *HttpTimeoutsConfig
+	TrustProxyHeaders bool
+	HTTPTimeouts      *HttpTimeoutsConfig
 	DbConfigTimeouts *DbConfigTimeouts
 }
 
@@ -265,6 +266,8 @@ func New() *Config {
 			DiscordDeploymentsSuccessChannel: os.Getenv("DISCORD_DEPLOYMENTS_SUCCESS_CHANNEL"),
 			DiscordProductionChannel:         os.Getenv("DISCORD_PRODUCTION_CHANNEL"),
 		},
+
+		TrustProxyHeaders: isTrueString(os.Getenv("STORMKIT_TRUST_PROXY_HEADERS")),
 
 		HTTPTimeouts: &HttpTimeoutsConfig{
 			ReadTimeout:       getDuration(os.Getenv("STORMKIT_HTTP_READ_TIMEOUT"), 30*time.Second),

--- a/src/lib/shttp/limiter/limiter.go
+++ b/src/lib/shttp/limiter/limiter.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 )
 
 // Options represents the rate limit options.
@@ -34,15 +36,16 @@ func IP(r *http.Request) string {
 		return ""
 	}
 
-	// Check the X-Forwarded-For header first (commonly used by proxies)
-	if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
-		return forwardedFor
+	if config.Get().TrustProxyHeaders {
+		if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+			return forwardedFor
+		}
+
+		if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+			return realIP
+		}
 	}
 
-	// If X-Forwarded-For is empty, check the X-Real-IP header
-	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
-		return realIP
-	}
 	return getRemoteAddr(r)
 }
 

--- a/src/lib/shttp/limiter/limiter_test.go
+++ b/src/lib/shttp/limiter/limiter_test.go
@@ -4,46 +4,78 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/limiter"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestIP_XForwardedFor(t *testing.T) {
-	req := &http.Request{
-		Header: http.Header{
-			"X-Forwarded-For": []string{"1.1.1.1"},
-		},
-	}
-
-	ip := limiter.IP(req)
-
-	if ip != "1.1.1.1" {
-		t.Fatalf("Was expecting ip to be 1.1.1.1 but received: %s", ip)
-	}
+type IPSuite struct {
+	suite.Suite
 }
 
-func TestIP_XRealIP(t *testing.T) {
+func (s *IPSuite) TearDownTest() {
+	config.Get().TrustProxyHeaders = false
+}
+
+func (s *IPSuite) Test_EdgeMode_UsesRemoteAddr() {
 	hdr := http.Header{}
+	hdr.Set("X-Forwarded-For", "9.9.9.9")
+	hdr.Set("X-Real-IP", "8.8.8.8")
+
 	req := &http.Request{
-		Header: hdr,
+		RemoteAddr: "1.2.3.4:1234",
+		Header:     hdr,
 	}
 
-	hdr.Set("X-Real-IP", "127.0.0.1")
-
-	ip := limiter.IP(req)
-
-	if ip != "127.0.0.1" {
-		t.Fatalf("Was expecting ip to be 127.0.0.1 but received: %s", ip)
-	}
+	s.Equal("1.2.3.4", limiter.IP(req))
 }
 
-func TestIP_RemoteAddr(t *testing.T) {
+func (s *IPSuite) Test_EdgeMode_FallsBackToRemoteAddrWithoutPort() {
 	req := &http.Request{
 		RemoteAddr: "127.0.0.1",
 	}
 
-	ip := limiter.IP(req)
+	s.Equal("127.0.0.1", limiter.IP(req))
+}
 
-	if ip != "127.0.0.1" {
-		t.Fatalf("Was expecting ip to be 127.0.0.1 but received: %s", ip)
+func (s *IPSuite) Test_TrustProxy_UsesXForwardedFor() {
+	config.Get().TrustProxyHeaders = true
+
+	hdr := http.Header{}
+	hdr.Set("X-Forwarded-For", "1.1.1.1")
+
+	req := &http.Request{
+		RemoteAddr: "10.0.0.1:1234",
+		Header:     hdr,
 	}
+
+	s.Equal("1.1.1.1", limiter.IP(req))
+}
+
+func (s *IPSuite) Test_TrustProxy_FallsBackToXRealIP() {
+	config.Get().TrustProxyHeaders = true
+
+	hdr := http.Header{}
+	hdr.Set("X-Real-IP", "127.0.0.1")
+
+	req := &http.Request{
+		RemoteAddr: "10.0.0.1:1234",
+		Header:     hdr,
+	}
+
+	s.Equal("127.0.0.1", limiter.IP(req))
+}
+
+func (s *IPSuite) Test_TrustProxy_FallsBackToRemoteAddr() {
+	config.Get().TrustProxyHeaders = true
+
+	req := &http.Request{
+		RemoteAddr: "10.0.0.1:5000",
+	}
+
+	s.Equal("10.0.0.1", limiter.IP(req))
+}
+
+func TestIPSuite(t *testing.T) {
+	suite.Run(t, new(IPSuite))
 }

--- a/src/lib/shttp/request_context.go
+++ b/src/lib/shttp/request_context.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/model"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttperr"
 )
@@ -215,14 +216,17 @@ func (r *RequestContext) Redirect(url string, status int) {
 	http.Redirect(r.writer, r.Request, url, status)
 }
 
-// RemoteAddr returns the remote address. It first checks for X-Fowarded-*
-// headers and if either the ip or the port is missing returns the request.RemoteAddr.
+// RemoteAddr returns the remote address. When STORMKIT_TRUST_PROXY_HEADERS is
+// true it reads from X-Forwarded-For / X-Real-IP set by an upstream proxy.
+// Otherwise it always uses the real socket address so clients cannot spoof it.
 func RemoteAddr(r *http.Request) string {
-	// Check the X-Forwarded-For header first (commonly used by proxies)
+	if !config.Get().TrustProxyHeaders {
+		return r.RemoteAddr
+	}
+
 	addr := r.Header.Get("X-Forwarded-For")
 	port := r.Header.Get("X-Forwarded-Port")
 
-	// If X-Forwarded-For is empty, check the X-Real-IP header
 	if addr == "" {
 		addr = r.Header.Get("X-Real-IP")
 	}

--- a/src/lib/shttp/request_v2.go
+++ b/src/lib/shttp/request_v2.go
@@ -213,37 +213,31 @@ type ProxyArgs struct {
 func Proxy(req *RequestContext, args ProxyArgs) *Response {
 	headers := req.Header.Clone()
 
-	// When Stormkit is the public edge (default), always overwrite X-Forwarded-For
-	// and X-Real-IP with the real socket address so clients cannot spoof them.
+	// When Stormkit is the public edge (default), overwrite X-Forwarded-For with
+	// the real socket address and overwrite X-Real-IP if the client supplied one,
+	// so clients cannot spoof their IP for rate-limiting or access-control.
 	// When STORMKIT_TRUST_PROXY_HEADERS=true a trusted upstream proxy (e.g. a
-	// load balancer) has already set these headers; preserve them and only append
-	// the real socket address to the X-Forwarded-For chain.
-	trustProxy := config.Get().TrustProxyHeaders
+	// load balancer) has already set these headers correctly; pass them through
+	// unchanged.
+	if !config.Get().TrustProxyHeaders {
+		if remoteAddr := req.RemoteAddr(); remoteAddr != "" {
+			addr, port, err := net.SplitHostPort(remoteAddr)
 
-	if remoteAddr := req.RemoteAddr(); remoteAddr != "" {
-		addr, port, err := net.SplitHostPort(remoteAddr)
-
-		if err != nil {
-			slog.Errorf("error splitting remote address: %s", remoteAddr)
-		}
-
-		if addr != "" {
-			if trustProxy {
-				prior := headers.Get("X-Forwarded-For")
-
-				if prior != "" {
-					headers.Set("X-Forwarded-For", prior+", "+addr)
-				} else {
-					headers.Set("X-Forwarded-For", addr)
-				}
-			} else {
-				headers.Set("X-Forwarded-For", addr)
-				headers.Del("X-Real-IP")
+			if err != nil {
+				slog.Errorf("error splitting remote address: %s", remoteAddr)
 			}
-		}
 
-		if port != "" {
-			headers.Set("X-Forwarded-Port", port)
+			if addr != "" {
+				headers.Set("X-Forwarded-For", addr)
+
+				if headers.Get("X-Real-IP") != "" {
+					headers.Set("X-Real-IP", addr)
+				}
+			}
+
+			if port != "" {
+				headers.Set("X-Forwarded-Port", port)
+			}
 		}
 	}
 

--- a/src/lib/shttp/request_v2.go
+++ b/src/lib/shttp/request_v2.go
@@ -213,22 +213,37 @@ type ProxyArgs struct {
 func Proxy(req *RequestContext, args ProxyArgs) *Response {
 	headers := req.Header.Clone()
 
-	// Make sure X-Forwarded-For headers are set
-	if headers.Get("X-Forwarded-For") == "" && headers.Get("X-Real-IP") == "" {
-		if remoteAddr := req.RemoteAddr(); remoteAddr != "" {
-			addr, port, err := net.SplitHostPort(remoteAddr)
+	// When Stormkit is the public edge (default), always overwrite X-Forwarded-For
+	// and X-Real-IP with the real socket address so clients cannot spoof them.
+	// When STORMKIT_TRUST_PROXY_HEADERS=true a trusted upstream proxy (e.g. a
+	// load balancer) has already set these headers; preserve them and only append
+	// the real socket address to the X-Forwarded-For chain.
+	trustProxy := config.Get().TrustProxyHeaders
 
-			if err != nil {
-				slog.Infof("error splitting remote address: %s", remoteAddr)
-			}
+	if remoteAddr := req.RemoteAddr(); remoteAddr != "" {
+		addr, port, err := net.SplitHostPort(remoteAddr)
 
-			if addr != "" {
+		if err != nil {
+			slog.Errorf("error splitting remote address: %s", remoteAddr)
+		}
+
+		if addr != "" {
+			if trustProxy {
+				prior := headers.Get("X-Forwarded-For")
+
+				if prior != "" {
+					headers.Set("X-Forwarded-For", prior+", "+addr)
+				} else {
+					headers.Set("X-Forwarded-For", addr)
+				}
+			} else {
 				headers.Set("X-Forwarded-For", addr)
+				headers.Del("X-Real-IP")
 			}
+		}
 
-			if port != "" {
-				headers.Set("X-Forwarded-Port", port)
-			}
+		if port != "" {
+			headers.Set("X-Forwarded-Port", port)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- By default Stormkit treats itself as the public edge: \`X-Forwarded-For\` is always overwritten with the real socket address, and \`X-Real-IP\` is overwritten if the client supplied one. This prevents clients from spoofing their IP for rate-limiting or access-control bypass.
- Set \`STORMKIT_TRUST_PROXY_HEADERS=true\` when running behind a trusted upstream load balancer — \`X-Forwarded-For\` and \`X-Real-IP\` are passed through unchanged.
- The flag is respected consistently across all three IP-resolution sites: outgoing proxy requests (\`shttp.Proxy\`), remote address resolution (\`shttp.RemoteAddr\`), and rate-limiter key extraction (\`limiter.IP\`).

## Breaking change

Deployments behind a load balancer that rely on forwarded headers must set \`STORMKIT_TRUST_PROXY_HEADERS=true\`. See the updated [Advanced Configuration](docs/self-hosting/6-advanced-configuration.md) docs.

## Test plan

- [ ] Direct client connection: backend receives \`X-Forwarded-For\` equal to the real socket IP, not a client-supplied value
- [ ] Direct client connection with \`X-Real-IP\` set: header is overwritten with the real socket IP
- [ ] With \`STORMKIT_TRUST_PROXY_HEADERS=true\`: \`X-Forwarded-For\` and \`X-Real-IP\` are passed through unchanged
- [ ] Rate limiter keys are based on real socket IP in edge mode and on forwarded headers in proxy mode