### PR TITLE
feat: add PROXY protocol support for L4 load balancers

### DIFF
--- a/docs/self-hosting/6-advanced-configuration.md
+++ b/docs/self-hosting/6-advanced-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: "Advanced Configuration"
-description: Advanced configuration options for self-hosted Stormkit instances, including HTTP timeout tuning and queue configuration.
+description: Advanced configuration options for self-hosted Stormkit instances, including HTTP timeout tuning, load balancer setup, and queue configuration.
 ---
 
 # Advanced Configuration
@@ -15,21 +15,43 @@ The hosting queue is a Redis list used to buffer incoming analytics, logs, and u
 
 ## Reverse Proxy / Load Balancer
 
-By default Stormkit assumes it is the public edge: `X-Forwarded-For` is always overwritten with the real socket address, and `X-Real-IP` is overwritten if the client supplied one. This prevents clients from spoofing their IP for rate-limiting or access-control purposes.
+By default Stormkit assumes it is the public edge: `X-Forwarded-For` is always overwritten with the real socket address, and `X-Real-IP` is overwritten if the client supplied one.
 
-If Stormkit sits behind a trusted reverse proxy or load balancer that already sets these headers correctly, enable the following variable so that they are passed through unchanged:
+Choose the right mode based on the type of load balancer in front of Stormkit:
 
-| Variable                          | Default | Description                                                                                                                                                      |
-| --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STORMKIT_TRUST_PROXY_HEADERS`    | `false` | Set to `true` when Stormkit runs behind a trusted upstream proxy. `X-Forwarded-For` and `X-Real-IP` are passed through unchanged. When `false` (default), `X-Forwarded-For` is always overwritten with the real socket address and `X-Real-IP` is overwritten if present. |
+| Setup                                                    | Variable to enable                  |
+| -------------------------------------------------------- | ----------------------------------- |
+| No load balancer (Stormkit is the public edge)           | neither (default)                   |
+| L7 HTTP load balancer (e.g. nginx, AWS ALB, Cloudflare)  | `STORMKIT_TRUST_PROXY_HEADERS=true` |
+| L4 TCP load balancer (e.g. AWS NLB, HAProxy in TCP mode) | `STORMKIT_PROXY_PROTOCOL=true`      |
+
+### L7 HTTP load balancer
+
+If Stormkit sits behind a trusted HTTP reverse proxy that sets `X-Forwarded-For` / `X-Real-IP` correctly, enable the following variable so that those headers are passed through unchanged:
+
+| Variable                       | Default | Description                                                                                                                                                                                                                          |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `STORMKIT_TRUST_PROXY_HEADERS` | `false` | Set to `true` when Stormkit runs behind a trusted upstream HTTP proxy. `X-Forwarded-For` and `X-Real-IP` are passed through unchanged. When `false` (default), `X-Forwarded-For` is always overwritten with the real socket address. |
+
+### L4 TCP load balancer (PROXY protocol)
+
+TCP load balancers forward connections at the network level and cannot inject HTTP headers, so `X-Forwarded-For` will never be set. Instead, configure the load balancer to emit a [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) header (v1 or v2) at the start of each TCP connection, and enable the corresponding Stormkit flag:
+
+| Variable                  | Default | Description                                                                                                                                                        |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `STORMKIT_PROXY_PROTOCOL` | `false` | Set to `true` when Stormkit runs behind a TCP load balancer that emits PROXY protocol headers. The real client IP is read from the TCP layer before TLS handshake. |
+
+> **Security note:** PROXY protocol headers are only trustworthy when Stormkit can be reached **only** through the trusted L4 load balancer. If the Stormkit port is directly reachable, a client can send a forged PROXY header and spoof the source IP. When `STORMKIT_PROXY_PROTOCOL=true`, restrict inbound traffic to the Stormkit origin so that only the load balancer can connect (for example with security groups, firewall rules, or equivalent network controls).
+
+> **Security note:** It is not advised to enable `STORMKIT_PROXY_PROTOCOL` and `STORMKIT_TRUST_PROXY_HEADERS` at the same time as it will allow a client to spoof its source IP by injecting arbitrary `X-Forwarded-For` headers alongside a PROXY protocol header.
 
 ## HTTP Timeouts
 
 The following environment variables control the HTTP server timeouts. Values are parsed as Go duration strings; you should include a unit suffix (e.g. `30s`, `1m`, `500ms`). Bare integers without a unit (e.g. `30`) are interpreted as nanoseconds (e.g. `30` → `30ns`), which results in an extremely short timeout and is almost never desired. When unset, the defaults shown below are used.
 
-| Variable                             | Default | Description                                                                                                                                                                                                                    |
-| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `STORMKIT_HTTP_READ_TIMEOUT`         | `30s`   | Maximum time to read an entire request, including the body. Used only for the API server; the hosting server uses `STORMKIT_HTTP_CLIENT_BODY_TIMEOUT` instead.                                                                 |
-| `STORMKIT_HTTP_IDLE_TIMEOUT`         | `60s`   | Maximum time to wait for the next request on a keep-alive connection.                                                                                                                                                          |
-| `STORMKIT_HTTP_CLIENT_BODY_TIMEOUT`  | `60s`   | Maximum idle time between successive reads of an incoming request body. Equivalent to nginx's `client_body_timeout`. If no bytes arrive within this window, body reads time out. Set to `0` to disable.                       |
-| `STORMKIT_HTTP_PROXY_TIMEOUT`        | `30s`   | Maximum time the upstream server has to start sending response headers after the proxy finishes sending the request. Does not cap total upload duration or idle time while reading the response body. Set to `0` to disable.  |
+| Variable                            | Default | Description                                                                                                                                                                                                                  |
+| ----------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STORMKIT_HTTP_READ_TIMEOUT`        | `30s`   | Maximum time to read an entire request, including the body. Used only for the API server; the hosting server uses `STORMKIT_HTTP_CLIENT_BODY_TIMEOUT` instead.                                                               |
+| `STORMKIT_HTTP_IDLE_TIMEOUT`        | `60s`   | Maximum time to wait for the next request on a keep-alive connection.                                                                                                                                                        |
+| `STORMKIT_HTTP_CLIENT_BODY_TIMEOUT` | `60s`   | Maximum idle time between successive reads of an incoming request body. Equivalent to nginx's `client_body_timeout`. If no bytes arrive within this window, body reads time out. Set to `0` to disable.                      |
+| `STORMKIT_HTTP_PROXY_TIMEOUT`       | `30s`   | Maximum time the upstream server has to start sending response headers after the proxy finishes sending the request. Does not cap total upload duration or idle time while reading the response body. Set to `0` to disable. |

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9
 	github.com/libdns/route53 v1.6.0
+	github.com/pires/go-proxyproto v0.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.16.0
@@ -51,6 +52,7 @@ require (
 	golang.org/x/crypto v0.43.0
 	golang.org/x/net v0.46.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sync v0.17.0
 	golang.org/x/time v0.14.0
 	gopkg.in/go-playground/webhooks.v5 v5.17.0
 	gopkg.in/guregu/null.v3 v3.5.0
@@ -122,7 +124,6 @@ require (
 	go.uber.org/zap/exp v0.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/pires/go-proxyproto v0.12.0 h1:TTCxD66dU898tahivkqc3hoceZp7P44FnorWyo9d5vM=
+github.com/pires/go-proxyproto v0.12.0/go.mod h1:qUvfqUMEoX7T8g0q7TQLDnhMjdTrxnG0hvpMn+7ePNI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/ce/hosting/certmagic_server.go
+++ b/src/ce/hosting/certmagic_server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/caddyserver/certmagic"
 	"github.com/libdns/route53"
+	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -129,21 +130,25 @@ func Magic(opts MagicOpts) {
 func httpsServe(cfg *certmagic.Config, handler http.Handler) error {
 	ctx := context.Background()
 
-	httpLn, err := net.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPPort))
+	httpTCPLn, err := net.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPPort))
 
 	if err != nil {
 		return err
 	}
 
+	httpLn := maybeProxyProto(httpTCPLn)
+
 	tlsConfig := cfg.TLSConfig()
 	tlsConfig.NextProtos = append([]string{"h2", "http/1.1"}, tlsConfig.NextProtos...)
 
-	httpsLn, err := tls.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPSPort), tlsConfig)
+	httpsTCPLn, err := net.Listen("tcp", fmt.Sprintf(":%d", certmagic.HTTPSPort))
 
 	if err != nil {
 		httpLn.Close()
 		return err
 	}
+
+	httpsLn := tls.NewListener(maybeProxyProto(httpsTCPLn), tlsConfig)
 
 	// Ensure both listeners are closed when the HTTPS server stops, which
 	// also causes the HTTP goroutine below to exit cleanly.
@@ -181,6 +186,16 @@ func httpsServe(cfg *certmagic.Config, handler http.Handler) error {
 	go httpServer.Serve(httpLn)
 
 	return httpsServer.Serve(httpsLn)
+}
+
+// maybeProxyProto wraps ln with a PROXY protocol listener when
+// STORMKIT_PROXY_PROTOCOL is enabled, otherwise returns ln unchanged.
+func maybeProxyProto(ln net.Listener) net.Listener {
+	if !config.Get().ProxyProtocol {
+		return ln
+	}
+
+	return &proxyproto.Listener{Listener: ln}
 }
 
 // httpRedirectHandler redirects plain HTTP requests to HTTPS.

--- a/src/ee/hosting/main.go
+++ b/src/ee/hosting/main.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strings"
 
+	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -24,12 +26,19 @@ func nonMagic(handler http.Handler, port string) {
 	addr := fmt.Sprintf(":%s", port)
 	slog.Info(fmt.Sprintf("external server listening on %s", addr))
 
-	srv := &http.Server{
-		Addr:    addr,
-		Handler: handler,
+	ln, err := net.Listen("tcp", addr)
+
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	log.Fatal(srv.ListenAndServe())
+	if config.Get().ProxyProtocol {
+		ln = &proxyproto.Listener{Listener: ln}
+	}
+
+	srv := &http.Server{Handler: handler}
+
+	log.Fatal(srv.Serve(ln))
 }
 
 func handler() http.Handler {

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -181,25 +181,26 @@ var Limits = map[string]limits{
 
 // Config is the root object for the configuration.
 type Config struct {
-	AWS              *AwsConfig
-	Alibaba          *AlibabaConfig
-	Database         *DatabaseConfig
-	Deployer         *DeployerConfig
-	Stripe           *StripeConfig
-	Reporting        *ReportingConfig
-	Runner           *RunnerConfig
-	Tracking         *TrackingConfig
-	InstanceID       string // The ID of the instance that is randomly assigned during start time
-	AppSecret        string
-	APIKey           string // The API key used to access several endpoints (for dedicated instances)
-	Env              string
-	Version          VersionConfig
-	Hash             string
-	RedisAddr        string
-	Secrets          map[string]string
+	AWS               *AwsConfig
+	Alibaba           *AlibabaConfig
+	Database          *DatabaseConfig
+	Deployer          *DeployerConfig
+	Stripe            *StripeConfig
+	Reporting         *ReportingConfig
+	Runner            *RunnerConfig
+	Tracking          *TrackingConfig
+	InstanceID        string // The ID of the instance that is randomly assigned during start time
+	AppSecret         string
+	APIKey            string // The API key used to access several endpoints (for dedicated instances)
+	Env               string
+	Version           VersionConfig
+	Hash              string
+	RedisAddr         string
+	Secrets           map[string]string
 	TrustProxyHeaders bool
+	ProxyProtocol     bool
 	HTTPTimeouts      *HttpTimeoutsConfig
-	DbConfigTimeouts *DbConfigTimeouts
+	DbConfigTimeouts  *DbConfigTimeouts
 }
 
 var c *Config
@@ -268,6 +269,7 @@ func New() *Config {
 		},
 
 		TrustProxyHeaders: isTrueString(os.Getenv("STORMKIT_TRUST_PROXY_HEADERS")),
+		ProxyProtocol:     isTrueString(os.Getenv("STORMKIT_PROXY_PROTOCOL")),
 
 		HTTPTimeouts: &HttpTimeoutsConfig{
 			ReadTimeout:       getDuration(os.Getenv("STORMKIT_HTTP_READ_TIMEOUT"), 30*time.Second),


### PR DESCRIPTION
## Summary

- Adds `STORMKIT_PROXY_PROTOCOL=true` config flag to enable PROXY protocol (v1/v2) support
- Wraps TCP listeners with `go-proxyproto` before TLS negotiation in the HTTPS path, so the real client IP is recovered at the TCP layer without relying on HTTP headers
- Converts `nonMagic` (plain HTTP path) from `ListenAndServe` to `net.Listen` + `Serve` to apply the same wrapping

When enabled, `r.RemoteAddr` automatically reflects the client IP from the PROXY protocol header — no changes to `RemoteAddr()` are needed and no header spoofing is possible.

| Setup | Config |
|---|---|
| No load balancer (direct) | neither (default) |
| L7 HTTP load balancer | `STORMKIT_TRUST_PROXY_HEADERS=true` |
| L4 TCP load balancer | `STORMKIT_PROXY_PROTOCOL=true` |

## Test plan

- [ ] Deploy with `STORMKIT_PROXY_PROTOCOL=true` behind an L4 LB (e.g. AWS NLB or HAProxy in TCP mode) configured to emit PROXY protocol headers — verify `r.RemoteAddr` returns the real client IP
- [ ] Deploy without the flag set — verify existing behaviour is unchanged
- [ ] Deploy with `STORMKIT_TRUST_PROXY_HEADERS=true` — verify XFF-based path still works independently