### PR TITLE
feat: support flake.nix and persist nix store

### DIFF
--- a/docs/self-hosting/5-runtimes.md
+++ b/docs/self-hosting/5-runtimes.md
@@ -84,6 +84,28 @@ Stormkit relies on the **[mise](https://mise.jdx.dev/)** open-source tool for ru
 
 > **Note:** Upgrading `mise` does not automatically upgrade installed runtimes. You’ll need to update those manually.
 
+## Persisting the Nix Store
+
+Stormkit uses [Nix](https://nixos.org/) as a backend for certain runtimes (e.g. `nix:ffmpeg`, `nix:playwright`). By default, the Nix store lives at `/nix` inside the container. Without a persistent volume at that path, packages are re-downloaded every time the container restarts.
+
+As of **April 2026**, the official `docker-compose.yaml` mounts a named `nix` volume at `/nix` for both the `workerserver` and `hosting` services. If you set up Stormkit before this date, add the following to your `docker-compose.yaml` to benefit from cached Nix packages:
+
+**1. Declare the volume** at the top-level `volumes` section:
+
+```yaml
+volumes:
+  nix:
+```
+
+**2. Mount it** in both the `workerserver` and `hosting` service definitions:
+
+```yaml
+volumes:
+  - nix:/nix
+```
+
+After updating, run `docker compose up -d` to recreate the containers with the new mount. The Nix store will be populated on first use and reused on subsequent restarts.
+
 ## Best Practices
 
 - **Pin versions** for production apps to ensure predictable builds.

--- a/docs/self-hosting/5-runtimes.md
+++ b/docs/self-hosting/5-runtimes.md
@@ -16,6 +16,7 @@ You can:
 - Install and manage multiple runtimes (Node.js, Go, npm, Angular CLI, etc.)
 - Specify exact versions or use `latest`
 - Enable or disable automatic runtime installation
+- Use a `flake.nix` file to provide system-level tools via Nix
 - Upgrade the underlying runtime manager (**mise**)
 
 ## Accessing the Runtime Management Page
@@ -72,6 +73,29 @@ The following files are recognized automatically:
 | node    | `.nvmrc`, `.node-version`             |
 | python  | `.python-version`, `.python-versions` |
 | ruby    | `.ruby-version`, `Gemfile`            |
+
+## Nix Flakes
+
+If your repository contains a `flake.nix` file, Stormkit will automatically run `nix develop` during the **install runtimes** step to bootstrap the Nix development shell. The packages defined in the flake are then available for all subsequent build commands — no additional configuration required.
+
+A typical `flake.nix` that provides `ffmpeg` and `imagemagick` during builds:
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      packages = [ pkgs.ffmpeg pkgs.imagemagick ];
+    };
+  };
+}
+```
+
+`flake.nix` and `mise.toml` can coexist — mise handles language runtimes while the flake covers system-level tools.
 
 ## Mise Runtime Manager
 

--- a/src/ce/runner/installer.go
+++ b/src/ce/runner/installer.go
@@ -139,9 +139,41 @@ func (p Installer) RuntimeVersion(ctx context.Context) error {
 	}).Run()
 }
 
-// InstallRuntimeDependencies installs runtime dependencies using mise.
+func (p *Installer) hasFlakeNix() bool {
+	_, err := os.Stat(path.Join(p.workDir, "flake.nix"))
+	return err == nil
+}
+
+// installFlake runs the flake's dev shell and applies its PATH to the current process
+// so that packages defined in flake.nix are available to subsequent build commands.
+func (p *Installer) installFlake(ctx context.Context) error {
+	cmd := sys.Command(ctx, sys.CommandOpts{
+		Name:   "sh",
+		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command env`},
+		Dir:    p.workDir,
+		Env:    PrepareEnvVars(p.envVars),
+		Stderr: p.reporter.File(),
+	})
+
+	output, err := cmd.Output()
+
+	if err != nil {
+		return err
+	}
+
+	for line := range strings.SplitSeq(string(output), "\n") {
+		if v, ok := strings.CutPrefix(line, "PATH="); ok {
+			os.Setenv("PATH", v)
+			break
+		}
+	}
+
+	return nil
+}
+
+// InstallRuntimeDependencies installs runtime dependencies using mise and flake.nix (if present).
 func (p *Installer) InstallRuntimeDependencies(ctx context.Context) ([]string, error) {
-	p.reporter.AddStep("mise install")
+	p.reporter.AddStep("install runtimes")
 
 	m := mise.Client()
 
@@ -156,10 +188,14 @@ func (p *Installer) InstallRuntimeDependencies(ctx context.Context) ([]string, e
 		Stderr: p.reporter.File(),
 	}
 
-	err := m.InstallLocal(ctx, opts)
-
-	if err != nil {
+	if err := m.InstallLocal(ctx, opts); err != nil {
 		return nil, err
+	}
+
+	if p.hasFlakeNix() {
+		if err := p.installFlake(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	runtimes, err := m.ListLocal(ctx, mise.LocalOpts{

--- a/src/ce/runner/installer_test.go
+++ b/src/ce/runner/installer_test.go
@@ -433,7 +433,7 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps() {
 	installed, err := p.InstallRuntimeDependencies(ctx)
 	s.Equal([]string{"go@1.24"}, installed)
 	s.NoError(err)
-	s.Contains(s.config.Reporter.Logs(), "[sk-step] mise install")
+	s.Contains(s.config.Reporter.Logs(), "[sk-step] install runtimes")
 
 	// Now let's try returning no runtimes installed
 	s.mockMise.On("InstallMise", ctx).Return(nil).Once()
@@ -449,7 +449,42 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps() {
 	installed, err = p.InstallRuntimeDependencies(ctx)
 	s.Equal([]string{"go"}, installed)
 	s.NoError(err)
-	s.Contains(s.config.Reporter.Logs(), "[sk-step] mise install")
+	s.Contains(s.config.Reporter.Logs(), "[sk-step] install runtimes")
+}
+
+func (s *InstallerSuite) Test_InstallingRuntimeDeps_WithFlake() {
+	ctx := context.Background()
+	workDir := path.Join(s.config.Repo.Dir, "my-dir")
+	stdout := s.config.Reporter.File()
+
+	s.NoError(os.Mkdir(workDir, 0776))
+	s.NoError(os.WriteFile(path.Join(workDir, "mise.toml"), []byte(`[tools]\ngo = "1.24"`), 0776))
+	s.NoError(os.WriteFile(path.Join(workDir, "flake.nix"), []byte(`{}`), 0776))
+
+	s.mockMise.On("InstallMise", ctx).Return(nil).Once()
+	s.mockMise.On("InstallLocal", ctx, mise.LocalOpts{Dir: workDir, Stdout: stdout, Stderr: stdout}).Return(nil).Once()
+	s.mockMise.On("ListLocal", ctx, mise.LocalOpts{Dir: workDir}).Return([]string{"go@1.24"}, nil).Once()
+	s.mockMise.On("BinPaths", ctx).Return(map[string]string{}, nil).Once()
+
+	s.mockCmd.On("SetOpts", sys.CommandOpts{
+		Name:   "sh",
+		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command env`},
+		Dir:    workDir,
+		Env:    runner.PrepareEnvVars(s.config.Build.EnvVars),
+		Stderr: stdout,
+	}).Return(s.mockCmd).Once()
+
+	s.mockCmd.On("Output").Return([]byte("HOME=/home/stormkit\nPATH=/nix/store/abc/bin:/usr/bin\nTERM=xterm\n"), nil).Once()
+
+	s.config.WorkDir = workDir
+	s.config.Repo.Runtime = "go"
+
+	p := runner.NewInstaller(s.config)
+
+	installed, err := p.InstallRuntimeDependencies(ctx)
+	s.NoError(err)
+	s.Equal([]string{"go@1.24"}, installed)
+	s.Equal("/nix/store/abc/bin:/usr/bin", os.Getenv("PATH"))
 }
 
 func TestInstallerSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `flake.nix` support to the **install runtimes** step: if a `flake.nix` is detected in the repo, Stormkit runs `nix develop` and applies the dev shell's `PATH` so all flake-provided tools are available during the build
- Renames the deployment log step from `mise install` to `install runtimes` to reflect that both mise and Nix flakes are now handled here
- Documents the `flake.nix` support and the `nix` volume migration for existing self-hosted users (pre-April 2026)

## Test plan

- [ ] Existing `Test_InstallingRuntimeDeps` passes with updated step label
- [ ] New `Test_InstallingRuntimeDeps_WithFlake` verifies flake PATH extraction
- [ ] Deploy a repo with a `flake.nix` and confirm tools are available during build
- [ ] Existing users: add `nix` volume to `docker-compose.yaml` and confirm Nix packages persist across restarts