### PR TITLE
feat: add flake.nix support and fix mise trust for subdirectories

### DIFF
--- a/src/ce/runner/builder.go
+++ b/src/ce/runner/builder.go
@@ -67,16 +67,22 @@ func (bm Builder) ExecCommands(ctx context.Context) error {
 
 	bm.reporter.AddStep(bm.cmd)
 
-	cmd := sys.Command(ctx, sys.CommandOpts{
-		Name:   "sh",
-		Args:   []string{"-c", bm.cmd},
+	opts := sys.CommandOpts{
 		Env:    PrepareEnvVars(bm.envVars),
 		Dir:    bm.workDir,
 		Stdout: bm.reporter.File(),
 		Stderr: bm.reporter.File(),
-	})
+	}
 
-	return cmd.Run()
+	if file.Exists(filepath.Join(bm.workDir, "flake.nix")) {
+		opts.Name = "nix"
+		opts.Args = []string{"--extra-experimental-features", "nix-command flakes", "develop", "--command", "sh", "-c", bm.cmd}
+	} else {
+		opts.Name = "sh"
+		opts.Args = []string{"-c", bm.cmd}
+	}
+
+	return sys.Command(ctx, opts).Run()
 }
 
 func (bm Builder) BuildApiIfNecessary(ctx context.Context) (bool, error) {

--- a/src/ce/runner/builder.go
+++ b/src/ce/runner/builder.go
@@ -10,6 +10,19 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
 )
 
+// nixFlakeDir returns the directory that contains flake.nix, or an empty string
+// if no flake.nix is found. It checks workDir first (covers SK_CWD subdirectory
+// builds), then repoDir (repo root).
+func nixFlakeDir(workDir, repoDir string) string {
+	for _, dir := range []string{workDir, repoDir} {
+		if dir != "" && file.Exists(filepath.Join(dir, "flake.nix")) {
+			return dir
+		}
+	}
+
+	return ""
+}
+
 type BuilderInterface interface {
 	ExecCommands(context.Context) error
 	BuildApiIfNecessary(context.Context) (bool, error)
@@ -74,8 +87,9 @@ func (bm Builder) ExecCommands(ctx context.Context) error {
 		Stderr: bm.reporter.File(),
 	}
 
-	if file.Exists(filepath.Join(bm.workDir, "flake.nix")) {
+	if flakeDir := nixFlakeDir(bm.workDir, bm.repoDir); flakeDir != "" {
 		opts.Name = "nix"
+		opts.Dir = flakeDir
 		opts.Args = []string{"--extra-experimental-features", "nix-command flakes", "develop", "--command", "sh", "-c", bm.cmd}
 	} else {
 		opts.Name = "sh"

--- a/src/ce/runner/builder_test.go
+++ b/src/ce/runner/builder_test.go
@@ -98,6 +98,37 @@ func (s *BuildManagerSuite) Test_Build_WithFlake() {
 	mockCmd.AssertExpectations(s.T())
 }
 
+func (s *BuildManagerSuite) Test_Build_WithFlake_InRepoRoot() {
+	subDir := path.Join(s.config.Repo.Dir, "subdir")
+	s.NoError(os.MkdirAll(subDir, 0776))
+
+	s.config.WorkDir = subDir
+	s.config.Build.BuildCmd = "npm run build"
+	s.config.Build.EnvVars = map[string]string{}
+
+	// flake.nix is at repo root, not workDir
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0776))
+
+	mockCmd := &mocks.CommandInterface{}
+	sys.DefaultCommand = mockCmd
+	defer func() { sys.DefaultCommand = nil }()
+
+	mockCmd.On("SetOpts", sys.CommandOpts{
+		Name:   "nix",
+		Args:   []string{"--extra-experimental-features", "nix-command flakes", "develop", "--command", "sh", "-c", "npm run build"},
+		Env:    runner.PrepareEnvVars(s.config.Build.EnvVars),
+		Dir:    s.config.Repo.Dir,
+		Stdout: s.config.Reporter.File(),
+		Stderr: s.config.Reporter.File(),
+	}).Return(mockCmd).Once()
+
+	mockCmd.On("Run").Return(nil, nil).Once()
+
+	bm := runner.NewBuilder(s.config)
+	s.NoError(bm.ExecCommands(context.Background()))
+	mockCmd.AssertExpectations(s.T())
+}
+
 func TestBuildManagerSuite(t *testing.T) {
 	suite.Run(t, &BuildManagerSuite{})
 }

--- a/src/ce/runner/builder_test.go
+++ b/src/ce/runner/builder_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/runner"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -66,6 +68,34 @@ func (s *BuildManagerSuite) Test_Build_StaticRepo() {
 
 	logs := s.config.Reporter.Logs()
 	s.Equal("", logs)
+}
+
+func (s *BuildManagerSuite) Test_Build_WithFlake() {
+	s.config.WorkDir = s.config.Repo.Dir
+	s.config.Build.BuildCmd = "npm run build"
+	s.config.Build.EnvVars = map[string]string{}
+
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0776))
+
+	mockCmd := &mocks.CommandInterface{}
+	sys.DefaultCommand = mockCmd
+	defer func() { sys.DefaultCommand = nil }()
+
+	mockCmd.On("SetOpts", sys.CommandOpts{
+		Name:   "nix",
+		Args:   []string{"--extra-experimental-features", "nix-command flakes", "develop", "--command", "sh", "-c", "npm run build"},
+		Env:    runner.PrepareEnvVars(s.config.Build.EnvVars),
+		Dir:    s.config.Repo.Dir,
+		Stdout: s.config.Reporter.File(),
+		Stderr: s.config.Reporter.File(),
+	}).Return(mockCmd).Once()
+
+	mockCmd.On("Run").Return(nil, nil).Once()
+
+	bm := runner.NewBuilder(s.config)
+	s.NoError(bm.ExecCommands(context.Background()))
+	s.Contains(s.config.Reporter.Logs(), "[sk-step] npm run build")
+	mockCmd.AssertExpectations(s.T())
 }
 
 func TestBuildManagerSuite(t *testing.T) {

--- a/src/ce/runner/installer.go
+++ b/src/ce/runner/installer.go
@@ -144,31 +144,18 @@ func (p *Installer) hasFlakeNix() bool {
 	return err == nil
 }
 
-// installFlake runs the flake's dev shell and applies its PATH to the current process
-// so that packages defined in flake.nix are available to subsequent build commands.
+// installFlake pre-builds the nix dev shell so its packages are in the store
+// before the build command runs. The build command itself is wrapped by the
+// builder using `nix develop --command` to get the full shell environment.
 func (p *Installer) installFlake(ctx context.Context) error {
-	cmd := sys.Command(ctx, sys.CommandOpts{
+	return sys.Command(ctx, sys.CommandOpts{
 		Name:   "sh",
-		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command env`},
+		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command true`},
 		Dir:    p.workDir,
 		Env:    PrepareEnvVars(p.envVars),
+		Stdout: p.reporter.File(),
 		Stderr: p.reporter.File(),
-	})
-
-	output, err := cmd.Output()
-
-	if err != nil {
-		return err
-	}
-
-	for line := range strings.SplitSeq(string(output), "\n") {
-		if v, ok := strings.CutPrefix(line, "PATH="); ok {
-			os.Setenv("PATH", v)
-			break
-		}
-	}
-
-	return nil
+	}).Run()
 }
 
 // InstallRuntimeDependencies installs runtime dependencies using mise and flake.nix (if present).

--- a/src/ce/runner/installer.go
+++ b/src/ce/runner/installer.go
@@ -71,6 +71,7 @@ type Installer struct {
 	isYarn             bool
 	isPnpm             bool
 	workDir            string
+	repoDir            string
 	buildCmd           string
 	hasPackageLockFile bool
 	runtime            string // The runtime that is going to be used to build the project
@@ -87,6 +88,7 @@ func NewInstaller(opts RunnerOpts) InstallerInterface {
 
 	p := &Installer{
 		workDir:            opts.WorkDir,
+		repoDir:            opts.Repo.Dir,
 		buildCmd:           opts.Build.BuildCmd,
 		installCmd:         opts.Build.InstallCmd,
 		envVars:            opts.Build.EnvVars,
@@ -139,19 +141,14 @@ func (p Installer) RuntimeVersion(ctx context.Context) error {
 	}).Run()
 }
 
-func (p *Installer) hasFlakeNix() bool {
-	_, err := os.Stat(path.Join(p.workDir, "flake.nix"))
-	return err == nil
-}
-
 // installFlake pre-builds the nix dev shell so its packages are in the store
 // before the build command runs. The build command itself is wrapped by the
 // builder using `nix develop --command` to get the full shell environment.
-func (p *Installer) installFlake(ctx context.Context) error {
+func (p *Installer) installFlake(ctx context.Context, flakeDir string) error {
 	return sys.Command(ctx, sys.CommandOpts{
 		Name:   "sh",
 		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command true`},
-		Dir:    p.workDir,
+		Dir:    flakeDir,
 		Env:    PrepareEnvVars(p.envVars),
 		Stdout: p.reporter.File(),
 		Stderr: p.reporter.File(),
@@ -179,8 +176,8 @@ func (p *Installer) InstallRuntimeDependencies(ctx context.Context) ([]string, e
 		return nil, err
 	}
 
-	if p.hasFlakeNix() {
-		if err := p.installFlake(ctx); err != nil {
+	if flakeDir := nixFlakeDir(p.workDir, p.repoDir); flakeDir != "" {
+		if err := p.installFlake(ctx, flakeDir); err != nil {
 			return nil, err
 		}
 	}

--- a/src/ce/runner/installer_test.go
+++ b/src/ce/runner/installer_test.go
@@ -468,13 +468,14 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps_WithFlake() {
 
 	s.mockCmd.On("SetOpts", sys.CommandOpts{
 		Name:   "sh",
-		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command env`},
+		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command true`},
 		Dir:    workDir,
 		Env:    runner.PrepareEnvVars(s.config.Build.EnvVars),
+		Stdout: stdout,
 		Stderr: stdout,
 	}).Return(s.mockCmd).Once()
 
-	s.mockCmd.On("Output").Return([]byte("HOME=/home/stormkit\nPATH=/nix/store/abc/bin:/usr/bin\nTERM=xterm\n"), nil).Once()
+	s.mockCmd.On("Run").Return(nil, nil).Once()
 
 	s.config.WorkDir = workDir
 	s.config.Repo.Runtime = "go"
@@ -484,7 +485,6 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps_WithFlake() {
 	installed, err := p.InstallRuntimeDependencies(ctx)
 	s.NoError(err)
 	s.Equal([]string{"go@1.24"}, installed)
-	s.Equal("/nix/store/abc/bin:/usr/bin", os.Getenv("PATH"))
 }
 
 func TestInstallerSuite(t *testing.T) {

--- a/src/lib/utils/mise/mise.go
+++ b/src/lib/utils/mise/mise.go
@@ -131,19 +131,6 @@ func (m *Mise) InstallMise(ctx context.Context) error {
 		slog.Errorf("error adding mise experimental setting: %v", err)
 	}
 
-	// Enable plugin for using nix:* packages
-	cmd = sys.Command(ctx, sys.CommandOpts{
-		String: "mise plugin install nix https://github.com/jbadeau/mise-nix.git",
-		Env: []string{
-			"PATH=" + os.Getenv("PATH"),
-			"HOME=" + os.Getenv("HOME"),
-		},
-	})
-
-	if err = cmd.Run(); err != nil {
-		slog.Errorf("error installing mise nix plugin: %v", err)
-	}
-
 	return nil
 }
 
@@ -258,7 +245,7 @@ func (m *Mise) BinPaths(ctx context.Context) (map[string]string, error) {
 		pieces := strings.Split(tool, "@")
 		toolName := pieces[0]
 
-		// nix:chromium for example should return just "chromium" as the tool name
+		// npm:ng for example should return just "ng" as the tool name
 		if strings.Contains(toolName, ":") {
 			toolName = strings.Split(toolName, ":")[1]
 		}

--- a/src/lib/utils/mise/mise.go
+++ b/src/lib/utils/mise/mise.go
@@ -185,7 +185,7 @@ func (m *Mise) InstallLocal(ctx context.Context, opts LocalOpts) error {
 	if opts.Runtime != "" {
 		args = fmt.Sprintf("mise use -y %s", opts.Runtime)
 	} else {
-		args = "mise trust --yes -q && mise install"
+		args = "mise trust --yes --all -q && mise install"
 	}
 
 	// Install the runtime using mise


### PR DESCRIPTION
## Summary

- **flake.nix support**: If a repo contains a `flake.nix`, Stormkit now pre-builds the nix dev shell during the **install runtimes** step and wraps the build command with `nix develop --command sh -c <cmd>`, giving it the full nix shell environment (PATH, LD_LIBRARY_PATH, PKG_CONFIG_PATH, etc.)
- **mise trust fix**: Changed `mise trust --yes --all -q` so trust is applied to the current directory and all parent directories — fixes deployments where `mise.toml` lives at the repo root but the build runs from a subdirectory
- **Renamed** the deployment log step from `mise install` to `install runtimes`

## Test plan

- [ ] All existing tests pass
- [ ] `Test_InstallingRuntimeDeps_WithFlake` verifies nix dev shell is pre-built
- [ ] `Test_Build_WithFlake` verifies build command is wrapped with `nix develop --command`
- [ ] Deploy a repo with a `flake.nix` and confirm tools are available and the build runs inside the nix shell
- [ ] Deploy a repo where `mise.toml` is at the root but `SK_CWD` points to a subdirectory — confirm no trust error