### PR TITLE
chore: update changelog for v2026.04.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v2026.04.25.1...v2026.04.25.2
+
+[compare changes](https://github.com/stormkit-io/stormkit-io/compare/v2026.04.25.1...v2026.04.25.2)
+
+### 🚀 Enhancements
+
+- Add flake.nix support and fix mise trust for subdirectories ([#203](https://github.com/stormkit-io/stormkit-io/pull/203))
+
+### 📖 Documentation
+
+- Clarify separate nix volumes to avoid startup race ([1795976](https://github.com/stormkit-io/stormkit-io/commit/1795976))
+
+### 🏡 Chore
+
+- Update changelog for v2026.04.25.1 ([#202](https://github.com/stormkit-io/stormkit-io/pull/202))
+
+### ❤️ Contributors
+
+- Savas Vedova <savas@stormkit.io>
+
 ## v2026.04.24.3...v2026.04.25.1
 
 [compare changes](https://github.com/stormkit-io/stormkit-io/compare/v2026.04.24.3...v2026.04.25.1)


### PR DESCRIPTION
Automated changelog update for release v2026.04.25.2.