### PR TITLE
feat: copy flake.nix to server output and wrap runtime command with nix develop

### DIFF
--- a/src/ce/runner/bundler.go
+++ b/src/ce/runner/bundler.go
@@ -444,6 +444,35 @@ func (b Bundler) bundleServerSideStormkitSubfolder() ([]string, string, error) {
 	return []string{StormkitServerFolder}, fmt.Sprintf("%s:%s", serverEntry, functionHandler), nil
 }
 
+// copyNixFlake copies flake.nix and flake.lock from the detected flake directory
+// into destDir so the files are included in the server zip and available at runtime
+// for nix develop wrapping.
+func (b Bundler) copyNixFlake(destDir string) {
+	flakeDir := nixFlakeDir(b.workDir, b.repoDir)
+
+	if flakeDir == "" {
+		return
+	}
+
+	for _, name := range []string{"flake.nix", "flake.lock"} {
+		src := filepath.Join(flakeDir, name)
+
+		if !file.Exists(src) {
+			continue
+		}
+
+		dst := filepath.Join(destDir, name)
+
+		if src == dst {
+			continue
+		}
+
+		if err := file.Copy(src, dst, 0664); err != nil {
+			slog.Errorf("error copying %s to server output: %s", name, err.Error())
+		}
+	}
+}
+
 // bundleServerSide returns the necessary information to bundle the server side code.
 func (b Bundler) bundleServerSide() ([]string, string, error) {
 	if b.serverCmd == "" && len(b.serverDirs) == 0 {
@@ -454,6 +483,7 @@ func (b Bundler) bundleServerSide() ([]string, string, error) {
 
 	// Handle bundling the whole folder case (go, python, ruby, etc...)
 	if len(b.serverDirs) == 1 && b.serverDirs[0] == "" {
+		b.copyNixFlake(b.workDir)
 		return []string{"."}, functionHandler, nil
 	}
 
@@ -507,6 +537,8 @@ func (b Bundler) bundleServerSide() ([]string, string, error) {
 		if dir == "" || !file.Exists(absolutePath) {
 			continue
 		}
+
+		b.copyNixFlake(absolutePath)
 
 		deps, err := b.bundleDependencies(absolutePath, additionalDeps...)
 

--- a/src/ce/runner/bundler_test.go
+++ b/src/ce/runner/bundler_test.go
@@ -175,6 +175,61 @@ func (s *BundlerSuite) Test_Bundle_AllRepo() {
 	s.Equal([]string{"."}, artifacts.ServerDirs)
 }
 
+func (s *BundlerSuite) Test_Bundle_CopiesFlakeNix_WholeDir() {
+	// flake.nix in repoDir, whole workDir bundled
+	s.config.Build.ServerCmd = "npm run start"
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0664))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.lock"), []byte("{}"), 0664))
+
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.Equal([]string{"."}, artifacts.ServerDirs)
+
+	// flake.nix was already in workDir — no copy needed, but it must be present
+	s.FileExists(path.Join(s.config.Repo.Dir, "flake.nix"))
+	s.FileExists(path.Join(s.config.Repo.Dir, "flake.lock"))
+}
+
+func (s *BundlerSuite) Test_Bundle_CopiesFlakeNix_ToServerDir() {
+	// flake.nix in workDir, server output is a dist subdirectory.
+	// findDistDir auto-detects "dist", so flake.nix is copied there.
+	distDir := path.Join(s.config.Repo.Dir, "dist")
+	s.NoError(os.MkdirAll(distDir, 0774))
+	s.NoError(os.WriteFile(path.Join(distDir, "server"), []byte("binary"), 0775))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0664))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.lock"), []byte("{}"), 0664))
+
+	s.config.Build.ServerCmd = "./dist/server"
+
+	bundler := runner.NewBundler(s.config)
+	_, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.FileExists(path.Join(distDir, "flake.nix"))
+	s.FileExists(path.Join(distDir, "flake.lock"))
+}
+
+func (s *BundlerSuite) Test_Bundle_CopiesFlakeNix_FromRepoDirToServerDir() {
+	// flake.nix is in repoDir but workDir is a subdirectory (SK_CWD case)
+	subDir := path.Join(s.config.Repo.Dir, "app")
+	serverDir := path.Join(subDir, "dist")
+	s.NoError(os.MkdirAll(serverDir, 0774))
+	s.NoError(os.WriteFile(path.Join(serverDir, "server"), []byte("binary"), 0775))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0664))
+
+	s.config.WorkDir = subDir
+	s.config.Build.ServerFolder = "dist"
+	s.config.Build.ServerCmd = "./dist/server"
+
+	bundler := runner.NewBundler(s.config)
+	_, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.FileExists(path.Join(serverDir, "flake.nix"))
+}
+
 func (s *BundlerSuite) Test_Bundle_NextServer_AlternativeSyntax() {
 	s.config.Build.ServerCmd = "npm run start"
 	s.config.Build.ServerFolder = ".next"

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -272,6 +272,16 @@ func (pm *ProcessManager) runSetupScript(ctx context.Context, args RunSetupScrip
 	return nil
 }
 
+// BuildServerCommand wraps command with nix develop when flake.nix is present in workDir,
+// so that all nix-provided libraries are available at runtime.
+func (pm *ProcessManager) BuildServerCommand(command, workDir string) string {
+	if file.Exists(path.Join(workDir, "flake.nix")) {
+		return `nix --extra-experimental-features "nix-command flakes" develop --command sh -c ` + command
+	}
+
+	return command
+}
+
 // Start starts a new service with the given arguments and working directory.
 // It creates a new command with the given command string, working directory, and environment variables.
 // It also creates a log file in the temporary directory to capture the output of the command.
@@ -404,7 +414,7 @@ func (pm *ProcessManager) Start(ctx context.Context, args *InvokeArgs, workDir s
 		s.isSettingUp = false
 
 		service.cmd = sys.Command(ctx, sys.CommandOpts{
-			String:      args.Command,
+			String:      pm.BuildServerCommand(args.Command, workDir),
 			Dir:         workDir,
 			Env:         vars,
 			Stdout:      outfile,

--- a/src/lib/integrations/client_process_manager_test.go
+++ b/src/lib/integrations/client_process_manager_test.go
@@ -361,6 +361,21 @@ func (s *ProcessManagerSuite) Test_StormkitServerConfig() {
 	s.True(file.Exists(path.Join(s.tmpdir, "my_workdir", "example.txt")), "example.txt should exist in the workdir")
 }
 
+func (s *ProcessManagerSuite) Test_BuildServerCommand_WithoutFlake() {
+	cmd := s.pm.BuildServerCommand("node index.js", s.tmpdir)
+	s.Equal("node index.js", cmd)
+}
+
+func (s *ProcessManagerSuite) Test_BuildServerCommand_WithFlake() {
+	flakePath := path.Join(s.tmpdir, "flake.nix")
+	s.NoError(os.WriteFile(flakePath, []byte("{}"), 0664))
+
+	defer os.Remove(flakePath)
+
+	cmd := s.pm.BuildServerCommand("node index.js", s.tmpdir)
+	s.Equal(`nix --extra-experimental-features "nix-command flakes" develop --command sh -c node index.js`, cmd)
+}
+
 func TestProcessManager(t *testing.T) {
 	suite.Run(t, &ProcessManagerSuite{})
 }


### PR DESCRIPTION
## Summary

- Bundler copies `flake.nix` and `flake.lock` from the detected flake directory into the server output folder before zipping, so they travel with the deployment artifact
- `ProcessManager` detects `flake.nix` in the deployment `workDir` at runtime and wraps the server command with `nix develop --command` — ensures the binary runs with all nix-provided libraries available
- Covers both the "whole workDir" bundle case and specific server dir cases (e.g. `dist/server`)

## Test plan

- [ ] Deploy a Go server built with CGO against nix-provided OpenCV — confirm `./dist/server` starts correctly via the process manager
- [ ] Confirm `flake.nix` and `flake.lock` appear in the server zip artifact
- [ ] Confirm deployments without `flake.nix` are unaffected