### PR TITLE
fix: invalid SQL in function trigger bulk update

### DIFF
--- a/src/ce/api/app/functiontrigger/function_trigger_store.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_store.go
@@ -74,13 +74,13 @@ var stmts = struct {
 	`,
 	updateNextRunAt: `
 		UPDATE
-			function_triggers AS ft
+			function_triggers
 		SET
 			next_run_at = (v.next_run_at)::timestamp
 		FROM
-			(VALUES {{ generateValues 2 (len .) }}) AS v(trigger_id, next_run_at) 
+			(VALUES {{ generateValues 2 (len .) }}) AS v(trigger_id, next_run_at)
 		WHERE
-			(v.trigger_id)::integer = ft.trigger_id;
+			(v.trigger_id)::integer = function_triggers.trigger_id;
 	`,
 	insertTriggerLogs: `
 		INSERT INTO function_trigger_logs (
@@ -259,6 +259,10 @@ func (s *Store) Update(ctx context.Context, ft *FunctionTrigger) error {
 
 // SetNextRunAt is a batch operation to update the nextRunAt of the given trigger ids.
 func (s *Store) SetNextRunAt(ctx context.Context, values map[types.ID]utils.Unix) error {
+	if len(values) == 0 {
+		return nil
+	}
+
 	var qb strings.Builder
 
 	if err := s.updateBatchStmt.Execute(&qb, values); err != nil {


### PR DESCRIPTION
Related to #134

## Summary

- Remove `AS ft` alias from the `UPDATE function_triggers` target table — PostgreSQL does not support aliasing the target table in an `UPDATE` statement
- Replace the `ft.trigger_id` reference in the `WHERE` clause with the full table name `function_triggers.trigger_id`
- Guard `SetNextRunAt` against an empty values map, which previously generated `(VALUES )` — invalid SQL that occurred whenever all trigger requests failed