### PR TITLE
feat: add billing checkout redirect endpoint

### DIFF
--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
@@ -1,0 +1,43 @@
+package subscriptionhandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+const (
+	planPortal   = "portal"
+	planPremium  = "premium"
+	planUltimate = "ultimate"
+)
+
+// HandleSelfHostedCheckout redirects self-hosted users to the appropriate Stripe page.
+func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
+	plan := req.Request.URL.Query().Get("plan")
+	stripe := config.Get().Stripe
+
+	if stripe == nil {
+		return &shttp.Response{Status: http.StatusServiceUnavailable}
+	}
+
+	var redirectURL string
+
+	switch plan {
+	case planPortal:
+		redirectURL = stripe.CustomerPortalLink
+	case planPremium:
+		redirectURL = stripe.PaymentLinkPremium
+	case planUltimate:
+		redirectURL = stripe.PaymentLinkUltimate
+	}
+
+	if redirectURL == "" {
+		return shttp.BadRequest()
+	}
+
+	req.Redirect(redirectURL, http.StatusFound)
+
+	return nil
+}

--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
@@ -1,0 +1,73 @@
+package subscriptionhandlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/subscriptionhandlers"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerSelfHostedCheckoutSuite struct {
+	suite.Suite
+}
+
+func (f *HandlerSelfHostedCheckoutSuite) AfterTest(_, _ string) {
+	config.Get().Stripe = nil
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) handler() http.Handler {
+	return shttp.NewRouter().RegisterService(subscriptionhandlers.Services).Router().Handler()
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPortal() {
+	config.Get().Stripe = &config.StripeConfig{
+		CustomerPortalLink: "https://billing.stripe.com/p/login/test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=portal", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://billing.stripe.com/p/login/test", response.Header().Get("Location"))
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPremium() {
+	config.Get().Stripe = &config.StripeConfig{
+		PaymentLinkPremium: "https://buy.stripe.com/premium_test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://buy.stripe.com/premium_test", response.Header().Get("Location"))
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimate() {
+	config.Get().Stripe = &config.StripeConfig{
+		PaymentLinkUltimate: "https://buy.stripe.com/ultimate_test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=ultimate", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://buy.stripe.com/ultimate_test", response.Header().Get("Location"))
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_BadRequestOnInvalidPlan() {
+	config.Get().Stripe = &config.StripeConfig{}
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=unknown", nil)
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_ServiceUnavailableWhenStripeNotConfigured() {
+	config.Get().Stripe = nil
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium", nil)
+	s.Equal(http.StatusServiceUnavailable, response.Code)
+}
+
+func TestHandlerSelfHostedCheckoutSuite(t *testing.T) {
+	suite.Run(t, new(HandlerSelfHostedCheckoutSuite))
+}

--- a/src/ce/api/user/subscriptionhandlers/services.go
+++ b/src/ce/api/user/subscriptionhandlers/services.go
@@ -11,5 +11,8 @@ func Services(r *shttp.Router) *shttp.Service {
 	s.NewEndpoint("/user/subscription").
 		Handler(shttp.MethodPost, "/update", shttp.WithRateLimit(handlerSubscriptionUpdate))
 
+	s.NewEndpoint("/billing").
+		Handler(shttp.MethodGet, "/checkout", HandleSelfHostedCheckout)
+
 	return s
 }

--- a/src/ce/api/user/subscriptionhandlers/services_test.go
+++ b/src/ce/api/user/subscriptionhandlers/services_test.go
@@ -1,26 +1,30 @@
 package subscriptionhandlers_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user/subscriptionhandlers"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestServices(t *testing.T) {
-	r := shttp.NewRouter()
-	s := r.RegisterService(subscriptionhandlers.Services)
+type ServicesSuite struct {
+	suite.Suite
+}
 
-	if s == nil {
-		t.Fatalf("Was expecting service not to be nil")
-	}
+func (s *ServicesSuite) Test_Services_SelfHosted() {
+	services := shttp.NewRouter().RegisterService(subscriptionhandlers.Services)
+
+	s.NotNil(services)
 
 	handlers := []string{
+		"GET:/billing/checkout",
 		"POST:/user/subscription/update",
 	}
 
-	if reflect.DeepEqual(s.Handlers(), handlers) == false {
-		t.Fatalf("Handlers are not registered correctly")
-	}
+	s.Equal(handlers, services.HandlerKeys())
+}
+
+func TestServicesSuite(t *testing.T) {
+	suite.Run(t, new(ServicesSuite))
 }

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -129,9 +129,12 @@ func (dc DeployerConfig) IsLocal() bool {
 
 // StripeConfig represents the stripe configuration.
 type StripeConfig struct {
-	ClientID       string
-	ClientSecret   string
-	WebhooksSecret string
+	ClientID            string
+	ClientSecret        string
+	WebhooksSecret      string
+	CustomerPortalLink  string
+	PaymentLinkPremium  string
+	PaymentLinkUltimate string
 }
 
 type ReportingConfig struct {
@@ -249,9 +252,12 @@ func New() *Config {
 		},
 
 		Stripe: &StripeConfig{
-			ClientID:       os.Getenv("STRIPE_CLIENT_ID"),
-			ClientSecret:   secrets["STRIPE_SECRET"],
-			WebhooksSecret: secrets["STRIPE_WH_SECRET"],
+			ClientID:            os.Getenv("STRIPE_CLIENT_ID"),
+			ClientSecret:        secrets["STRIPE_SECRET"],
+			WebhooksSecret:      secrets["STRIPE_WH_SECRET"],
+			CustomerPortalLink:  os.Getenv("STRIPE_CUSTOMER_PORTAL_LINK"),
+			PaymentLinkPremium:  os.Getenv("STRIPE_PAYMENT_LINK_PREMIUM"),
+			PaymentLinkUltimate: os.Getenv("STRIPE_PAYMENT_LINK_ULTIMATE"),
 		},
 
 		Deployer: &DeployerConfig{


### PR DESCRIPTION
## Summary

- Adds `GET /billing/checkout?plan=<portal|premium|ultimate>` endpoint that redirects self-hosted users to the appropriate Stripe page
- Free users are sent to a Stripe payment link (premium or ultimate); existing subscribers are sent to the customer portal
- Adds `CustomerPortalLink`, `PaymentLinkPremium`, and `PaymentLinkUltimate` to `StripeConfig`, loaded from env vars

## Test plan

- [ ] `go test ./src/ce/api/user/subscriptionhandlers/...` passes
- [ ] `GET /billing/checkout?plan=portal` redirects to the customer portal URL
- [ ] `GET /billing/checkout?plan=premium` redirects to the premium payment link
- [ ] `GET /billing/checkout?plan=ultimate` redirects to the ultimate payment link
- [ ] Missing or unknown `plan` param returns 400
- [ ] Missing Stripe config returns 503