### PR TITLE
feat: add SMTP config and mailer utility

### DIFF
--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -127,6 +127,20 @@ func (dc DeployerConfig) IsLocal() bool {
 	return dc.Service == "local"
 }
 
+// SMTPConfig holds credentials for system-level transactional email sending.
+type SMTPConfig struct {
+	Host     string
+	Port     string
+	Username string
+	Password string
+	From     string
+}
+
+// IsConfigured returns true when the minimum required fields are present.
+func (c *SMTPConfig) IsConfigured() bool {
+	return c != nil && c.Host != "" && c.Username != "" && c.Password != ""
+}
+
 // StripeConfig represents the stripe configuration.
 type StripeConfig struct {
 	ClientID            string
@@ -189,6 +203,7 @@ type Config struct {
 	Database          *DatabaseConfig
 	Deployer          *DeployerConfig
 	Stripe            *StripeConfig
+	SMTP              *SMTPConfig
 	Reporting         *ReportingConfig
 	Runner            *RunnerConfig
 	Tracking          *TrackingConfig
@@ -258,6 +273,14 @@ func New() *Config {
 			CustomerPortalLink:  os.Getenv("STRIPE_CUSTOMER_PORTAL_LINK"),
 			PaymentLinkPremium:  os.Getenv("STRIPE_PAYMENT_LINK_PREMIUM"),
 			PaymentLinkUltimate: os.Getenv("STRIPE_PAYMENT_LINK_ULTIMATE"),
+		},
+
+		SMTP: &SMTPConfig{
+			Host:     os.Getenv("STORMKIT_SMTP_HOST"),
+			Port:     os.Getenv("STORMKIT_SMTP_PORT"),
+			Username: os.Getenv("STORMKIT_SMTP_USERNAME"),
+			Password: os.Getenv("STORMKIT_SMTP_PASSWORD"),
+			From:     os.Getenv("STORMKIT_SMTP_FROM"),
 		},
 
 		Deployer: &DeployerConfig{
@@ -420,6 +443,15 @@ func Set(config *Config) *Config {
 // Reset resets the config.
 func Reset() {
 	c = nil
+}
+
+// SetSMTP overrides the SMTP config. Intended for tests only.
+func SetSMTP(smtp *SMTPConfig) {
+	if !IsTest() {
+		panic("SetSMTP can only be used in test environments")
+	}
+
+	Get().SMTP = smtp
 }
 
 var _cachedSecrets map[string]string

--- a/src/lib/mailer/mailer.go
+++ b/src/lib/mailer/mailer.go
@@ -1,0 +1,40 @@
+package mailer
+
+import (
+	"fmt"
+	"net/smtp"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+var SendMailFunc = smtp.SendMail
+
+type SendEmailParams struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+// SendEmail sends an HTML email to the given recipient using the system SMTP configuration.
+func SendEmail(p SendEmailParams) error {
+	cfg := config.Get().SMTP
+
+	if !cfg.IsConfigured() {
+		return fmt.Errorf("smtp not configured")
+	}
+
+	from := utils.GetString(cfg.From, cfg.Username)
+	mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
+	msg := []byte(
+		fmt.Sprintf("From: %s\n", from) +
+			fmt.Sprintf("Subject: %s\n", p.Subject) +
+			mime +
+			fmt.Sprintf("<html><body>%s</body></html>", p.Body),
+	)
+
+	auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+	port := utils.GetString(cfg.Port, "587")
+
+	return SendMailFunc(cfg.Host+":"+port, auth, cfg.Username, []string{p.To}, msg)
+}

--- a/src/lib/mailer/mailer_test.go
+++ b/src/lib/mailer/mailer_test.go
@@ -1,0 +1,89 @@
+package mailer_test
+
+import (
+	"net/smtp"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/mailer"
+	"github.com/stretchr/testify/suite"
+)
+
+type MailerSuite struct {
+	suite.Suite
+}
+
+func (s *MailerSuite) AfterTest(_, _ string) {
+	mailer.SendMailFunc = smtp.SendMail
+}
+
+func (s *MailerSuite) Test_SendEmail_Success() {
+	called := false
+
+	config.SetSMTP(&config.SMTPConfig{
+		Host:     "smtp.example.com",
+		Port:     "587",
+		Username: "user@example.com",
+		Password: "secret",
+		From:     "Stormkit <no-reply@stormkit.io>",
+	})
+
+	mailer.SendMailFunc = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
+		s.Equal("smtp.example.com:587", addr)
+		s.Equal("user@example.com", from)
+		s.Equal([]string{"customer@example.com"}, to)
+		s.Equal([]byte(
+			"From: Stormkit <no-reply@stormkit.io>\n"+
+				"Subject: Your license key\n"+
+				mime+
+				"<html><body>Here is your key.</body></html>",
+		), msg)
+		called = true
+		return nil
+	}
+
+	err := mailer.SendEmail(mailer.SendEmailParams{
+		To:      "customer@example.com",
+		Subject: "Your license key",
+		Body:    "Here is your key.",
+	})
+
+	s.NoError(err)
+	s.True(called)
+}
+
+func (s *MailerSuite) Test_SendEmail_DefaultPort() {
+	config.SetSMTP(&config.SMTPConfig{
+		Host:     "smtp.example.com",
+		Username: "user@example.com",
+		Password: "secret",
+	})
+
+	mailer.SendMailFunc = func(addr string, _ smtp.Auth, _ string, _ []string, _ []byte) error {
+		s.Equal("smtp.example.com:587", addr)
+		return nil
+	}
+
+	s.NoError(mailer.SendEmail(mailer.SendEmailParams{
+		To:      "customer@example.com",
+		Subject: "Test",
+		Body:    "Body",
+	}))
+}
+
+func (s *MailerSuite) Test_SendEmail_NotConfigured() {
+	config.SetSMTP(&config.SMTPConfig{})
+
+	err := mailer.SendEmail(mailer.SendEmailParams{
+		To:      "customer@example.com",
+		Subject: "Test",
+		Body:    "Body",
+	})
+
+	s.EqualError(err, "smtp not configured")
+}
+
+func TestMailerSuite(t *testing.T) {
+	suite.Run(t, new(MailerSuite))
+}


### PR DESCRIPTION
## Summary

- Adds `SMTPConfig` to the global config, populated from `STORMKIT_SMTP_HOST`, `STORMKIT_SMTP_PORT`, `STORMKIT_SMTP_USERNAME`, `STORMKIT_SMTP_PASSWORD`, and `STORMKIT_SMTP_FROM` env vars
- Introduces `src/lib/mailer` package with a `SendEmail` utility that uses `net/smtp` for system-level transactional emails (e.g. license key delivery)
- Port defaults to `587` when `STORMKIT_SMTP_PORT` is not set

## Test plan

- [ ] `go test ./src/lib/mailer/...` passes (3 test cases: success, default port, not configured)