### PR TITLE
feat: pass client_reference_id in self-hosted checkout

### DIFF
--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
@@ -1,7 +1,9 @@
 package subscriptionhandlers
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -16,6 +18,7 @@ const (
 // HandleSelfHostedCheckout redirects self-hosted users to the appropriate Stripe page.
 func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
 	plan := req.Request.URL.Query().Get("plan")
+	ref := req.Request.URL.Query().Get("ref")
 	stripe := config.Get().Stripe
 
 	if stripe == nil {
@@ -28,9 +31,9 @@ func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
 	case planPortal:
 		redirectURL = stripe.CustomerPortalLink
 	case planPremium:
-		redirectURL = stripe.PaymentLinkPremium
+		redirectURL = withClientReferenceID(stripe.PaymentLinkPremium, ref)
 	case planUltimate:
-		redirectURL = stripe.PaymentLinkUltimate
+		redirectURL = withClientReferenceID(stripe.PaymentLinkUltimate, ref)
 	}
 
 	if redirectURL == "" {
@@ -40,4 +43,22 @@ func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
 	req.Redirect(redirectURL, http.StatusFound)
 
 	return nil
+}
+
+func withClientReferenceID(baseURL, ref string) string {
+	if ref == "" {
+		return baseURL
+	}
+
+	u, err := url.Parse(baseURL)
+
+	if err != nil {
+		return baseURL
+	}
+
+	q := u.Query()
+	q.Set("client_reference_id", fmt.Sprintf("selfhosted:%s", ref))
+	u.RawQuery = q.Encode()
+
+	return u.String()
 }

--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
@@ -45,6 +45,17 @@ func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPremium() {
 	s.Equal("https://buy.stripe.com/premium_test", response.Header().Get("Location"))
 }
 
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPremiumWithRef() {
+	config.Get().Stripe = &config.StripeConfig{
+		PaymentLinkPremium: "https://buy.stripe.com/premium_test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium&ref=user%40example.com", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://buy.stripe.com/premium_test?client_reference_id=selfhosted%3Auser%40example.com", response.Header().Get("Location"))
+}
+
 func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimate() {
 	config.Get().Stripe = &config.StripeConfig{
 		PaymentLinkUltimate: "https://buy.stripe.com/ultimate_test",
@@ -54,6 +65,17 @@ func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimate() {
 
 	s.Equal(http.StatusFound, response.Code)
 	s.Equal("https://buy.stripe.com/ultimate_test", response.Header().Get("Location"))
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimateWithRef() {
+	config.Get().Stripe = &config.StripeConfig{
+		PaymentLinkUltimate: "https://buy.stripe.com/ultimate_test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=ultimate&ref=user%40example.com", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://buy.stripe.com/ultimate_test?client_reference_id=selfhosted%3Auser%40example.com", response.Header().Get("Location"))
 }
 
 func (s *HandlerSelfHostedCheckoutSuite) Test_BadRequestOnInvalidPlan() {


### PR DESCRIPTION
## Summary

- Reads a `ref` query parameter (user email) from the self-hosted checkout request
- Appends `client_reference_id=selfhosted:<email>` to Stripe payment link URLs for premium and ultimate plans
- Portal links are unchanged (Stripe Customer Portal does not support `client_reference_id`)
- If `ref` is omitted the redirect URL is passed through unmodified

## Test plan

- [ ] `Test_RedirectsToPremiumWithRef` — verifies `client_reference_id` is appended for premium plan
- [ ] `Test_RedirectsToUltimateWithRef` — verifies `client_reference_id` is appended for ultimate plan
- [ ] Existing tests confirm no regression when `ref` is absent or Stripe is not configured