### PR TITLE
feat: route self-hosted billing through api.stormkit.io deeplink

### DIFF
--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
@@ -58,6 +58,7 @@ func withClientReferenceID(baseURL, ref string) string {
 
 	q := u.Query()
 	q.Set("client_reference_id", fmt.Sprintf("selfhosted:%s", ref))
+	q.Set("prefilled_email", ref)
 	u.RawQuery = q.Encode()
 
 	return u.String()

--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
@@ -53,7 +53,7 @@ func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPremiumWithRef() {
 	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium&ref=user%40example.com", nil)
 
 	s.Equal(http.StatusFound, response.Code)
-	s.Equal("https://buy.stripe.com/premium_test?client_reference_id=selfhosted%3Auser%40example.com", response.Header().Get("Location"))
+	s.Equal("https://buy.stripe.com/premium_test?client_reference_id=selfhosted%3Auser%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
 }
 
 func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimate() {
@@ -75,7 +75,7 @@ func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimateWithRef() {
 	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=ultimate&ref=user%40example.com", nil)
 
 	s.Equal(http.StatusFound, response.Code)
-	s.Equal("https://buy.stripe.com/ultimate_test?client_reference_id=selfhosted%3Auser%40example.com", response.Header().Get("Location"))
+	s.Equal("https://buy.stripe.com/ultimate_test?client_reference_id=selfhosted%3Auser%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
 }
 
 func (s *HandlerSelfHostedCheckoutSuite) Test_BadRequestOnInvalidPlan() {

--- a/src/ui/src/components/UpgradeButton/UpgradeButton.spec.tsx
+++ b/src/ui/src/components/UpgradeButton/UpgradeButton.spec.tsx
@@ -3,7 +3,7 @@ import type { RenderResult } from "@testing-library/react";
 import { render } from "@testing-library/react";
 import { AuthContext } from "~/pages/auth/Auth.context";
 import mockUser from "~/testing/data/mock_user";
-import { portalLink, paymentLink } from "~/utils/billing";
+import { subscriptionLink } from "~/utils/billing";
 import UpgradeButton from "./UpgradeButton";
 
 interface Props {
@@ -24,26 +24,29 @@ describe("~/components/UpgradeButton/UpgradeButton", () => {
   };
 
   describe("free user", () => {
+    let user: User;
+
     beforeEach(() => {
-      createWrapper({ user: mockUser({ packageId: "free" }) });
+      user = mockUser({ packageId: "free" });
+      createWrapper({ user });
     });
 
     it("should show upgrade text", () => {
       expect(wrapper.getByText("Upgrade to enterprise")).toBeTruthy();
     });
 
-    it("should link to the premium payment page", () => {
+    it("should link to the premium checkout page", () => {
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(paymentLink.premium);
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
     });
   });
 
   describe("paid user", () => {
+    let user: User;
+
     beforeEach(() => {
-      createWrapper({
-        user: mockUser({ packageId: "premium" }),
-        text: "Manage subscription",
-      });
+      user = mockUser({ packageId: "premium" });
+      createWrapper({ user, text: "Manage subscription" });
     });
 
     it("should show manage subscription text", () => {
@@ -52,24 +55,23 @@ describe("~/components/UpgradeButton/UpgradeButton", () => {
 
     it("should link to the billing portal", () => {
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(portalLink);
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
     });
   });
 
   describe("text variant", () => {
     it("should render as a link element for free user", () => {
-      createWrapper({ user: mockUser({ packageId: "free" }), variant: "text" });
+      const user = mockUser({ packageId: "free" });
+      createWrapper({ user, variant: "text" });
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(paymentLink.premium);
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
     });
 
     it("should render as a link element for paid user", () => {
-      createWrapper({
-        user: mockUser({ packageId: "premium" }),
-        variant: "text",
-      });
+      const user = mockUser({ packageId: "premium" });
+      createWrapper({ user, variant: "text" });
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(portalLink);
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
     });
   });
 });

--- a/src/ui/src/components/UpgradeButton/UpgradeButton.tsx
+++ b/src/ui/src/components/UpgradeButton/UpgradeButton.tsx
@@ -19,7 +19,7 @@ export default function UpgradeButton({
 }: Props) {
   const { user } = useContext(AuthContext);
   const Icon = text === "Upgrade to enterprise" ? LockIcon : LaunchIcon;
-  const href = subscriptionLink(user?.package.id);
+  const href = subscriptionLink(user?.package.id, user?.email);
 
   if (variant === "text") {
     return (

--- a/src/ui/src/utils/billing.ts
+++ b/src/ui/src/utils/billing.ts
@@ -1,13 +1,16 @@
 const isDev = process.env.NODE_ENV === "development";
 
-export const portalLink = isDev
-  ? "https://billing.stripe.com/p/login/test_4gw9CvdOF3eabhSeUU"
-  : "https://billing.stripe.com/p/login/9AQ7sKfcx2Or41ibII";
+const apiDomain = isDev
+  ? process.env.API_DOMAIN || ""
+  : "https://api.stormkit.io";
 
-export const paymentLink = {
-  premium: "https://buy.stripe.com/7sY3cwebC1TEesO8qXbAs06",
-  ultimate: "https://buy.stripe.com/eVacOwbDc3dW2IgdQU",
+export const subscriptionLink = (packageId?: string, email?: string): string => {
+  const plan = packageId === "free" || !packageId ? "premium" : "portal";
+  const params = new URLSearchParams({ plan });
+
+  if (email) {
+    params.set("ref", email);
+  }
+
+  return `${apiDomain}/billing/checkout?${params}`;
 };
-
-export const subscriptionLink = (packageId?: string) =>
-  packageId === "free" || !packageId ? paymentLink.premium : portalLink;


### PR DESCRIPTION
## Summary

- Frontend (`billing.ts`) now builds checkout URLs pointing to `https://api.stormkit.io/billing/checkout?plan=...&ref=<email>` instead of hardcoded Stripe links; uses `API_DOMAIN` in development
- `UpgradeButton` passes the user's email as the `ref` query parameter
- Backend (`handler_selfhosted_checkout.go`) now appends `prefilled_email` alongside `client_reference_id` to Stripe payment links for premium and ultimate plans

## Test plan

- [ ] Free user clicking upgrade redirects to `api.stormkit.io/billing/checkout?plan=premium&ref=<email>`
- [ ] Paid user clicking manage subscription redirects to `api.stormkit.io/billing/checkout?plan=portal&ref=<email>`
- [ ] Stripe payment link includes both `client_reference_id=selfhosted:<email>` and `prefilled_email=<email>`
- [ ] All Go and frontend tests pass