### PR TITLE
feat: separate cloud and self-hosted Stripe products

### DIFF
--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout.go
@@ -1,7 +1,6 @@
 package subscriptionhandlers
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -10,15 +9,18 @@ import (
 )
 
 const (
-	planPortal   = "portal"
-	planPremium  = "premium"
-	planUltimate = "ultimate"
+	planPortal        = "portal"
+	planPremium       = "premium"
+	planUltimate      = "ultimate"
+	editionSelfHosted = "self-hosted"
 )
 
-// HandleSelfHostedCheckout redirects self-hosted users to the appropriate Stripe page.
+// HandleSelfHostedCheckout redirects users to the appropriate Stripe page.
+// The edition parameter determines whether to use the self-hosted or cloud payment link.
 func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
 	plan := req.Request.URL.Query().Get("plan")
 	ref := req.Request.URL.Query().Get("ref")
+	edition := req.Request.URL.Query().Get("edition")
 	stripe := config.Get().Stripe
 
 	if stripe == nil {
@@ -31,9 +33,13 @@ func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
 	case planPortal:
 		redirectURL = stripe.CustomerPortalLink
 	case planPremium:
-		redirectURL = withClientReferenceID(stripe.PaymentLinkPremium, ref)
+		if edition == editionSelfHosted {
+			redirectURL = withStripeParams(stripe.PaymentLinkPremiumSH, ref)
+		} else {
+			redirectURL = withStripeParams(stripe.PaymentLinkPremiumCloud, ref)
+		}
 	case planUltimate:
-		redirectURL = withClientReferenceID(stripe.PaymentLinkUltimate, ref)
+		redirectURL = withStripeParams(stripe.PaymentLinkUltimateSH, ref)
 	}
 
 	if redirectURL == "" {
@@ -45,7 +51,7 @@ func HandleSelfHostedCheckout(req *shttp.RequestContext) *shttp.Response {
 	return nil
 }
 
-func withClientReferenceID(baseURL, ref string) string {
+func withStripeParams(baseURL, ref string) string {
 	if ref == "" {
 		return baseURL
 	}
@@ -57,7 +63,7 @@ func withClientReferenceID(baseURL, ref string) string {
 	}
 
 	q := u.Query()
-	q.Set("client_reference_id", fmt.Sprintf("selfhosted:%s", ref))
+	q.Set("client_reference_id", ref)
 	q.Set("prefilled_email", ref)
 	u.RawQuery = q.Encode()
 

--- a/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_selfhosted_checkout_test.go
@@ -34,31 +34,53 @@ func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPortal() {
 	s.Equal("https://billing.stripe.com/p/login/test", response.Header().Get("Location"))
 }
 
-func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPremium() {
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToCloudPremium() {
 	config.Get().Stripe = &config.StripeConfig{
-		PaymentLinkPremium: "https://buy.stripe.com/premium_test",
+		PaymentLinkPremiumCloud: "https://buy.stripe.com/cloud_premium_test",
 	}
 
 	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium", nil)
 
 	s.Equal(http.StatusFound, response.Code)
-	s.Equal("https://buy.stripe.com/premium_test", response.Header().Get("Location"))
+	s.Equal("https://buy.stripe.com/cloud_premium_test", response.Header().Get("Location"))
 }
 
-func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToPremiumWithRef() {
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToCloudPremiumWithRef() {
 	config.Get().Stripe = &config.StripeConfig{
-		PaymentLinkPremium: "https://buy.stripe.com/premium_test",
+		PaymentLinkPremiumCloud: "https://buy.stripe.com/cloud_premium_test",
 	}
 
 	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium&ref=user%40example.com", nil)
 
 	s.Equal(http.StatusFound, response.Code)
-	s.Equal("https://buy.stripe.com/premium_test?client_reference_id=selfhosted%3Auser%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
+	s.Equal("https://buy.stripe.com/cloud_premium_test?client_reference_id=user%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToSelfHostedPremium() {
+	config.Get().Stripe = &config.StripeConfig{
+		PaymentLinkPremiumSH: "https://buy.stripe.com/sh_premium_test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium&edition=self-hosted", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://buy.stripe.com/sh_premium_test", response.Header().Get("Location"))
+}
+
+func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToSelfHostedPremiumWithRef() {
+	config.Get().Stripe = &config.StripeConfig{
+		PaymentLinkPremiumSH: "https://buy.stripe.com/sh_premium_test",
+	}
+
+	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=premium&edition=self-hosted&ref=user%40example.com", nil)
+
+	s.Equal(http.StatusFound, response.Code)
+	s.Equal("https://buy.stripe.com/sh_premium_test?client_reference_id=user%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
 }
 
 func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimate() {
 	config.Get().Stripe = &config.StripeConfig{
-		PaymentLinkUltimate: "https://buy.stripe.com/ultimate_test",
+		PaymentLinkUltimateSH: "https://buy.stripe.com/ultimate_test",
 	}
 
 	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=ultimate", nil)
@@ -69,13 +91,13 @@ func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimate() {
 
 func (s *HandlerSelfHostedCheckoutSuite) Test_RedirectsToUltimateWithRef() {
 	config.Get().Stripe = &config.StripeConfig{
-		PaymentLinkUltimate: "https://buy.stripe.com/ultimate_test",
+		PaymentLinkUltimateSH: "https://buy.stripe.com/ultimate_test",
 	}
 
 	response := shttptest.Request(s.handler(), shttp.MethodGet, "/billing/checkout?plan=ultimate&ref=user%40example.com", nil)
 
 	s.Equal(http.StatusFound, response.Code)
-	s.Equal("https://buy.stripe.com/ultimate_test?client_reference_id=selfhosted%3Auser%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
+	s.Equal("https://buy.stripe.com/ultimate_test?client_reference_id=user%40example.com&prefilled_email=user%40example.com", response.Header().Get("Location"))
 }
 
 func (s *HandlerSelfHostedCheckoutSuite) Test_BadRequestOnInvalidPlan() {

--- a/src/ce/api/user/subscriptionhandlers/handler_subscription_update.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_subscription_update.go
@@ -15,7 +15,11 @@ import (
 	"github.com/stripe/stripe-go/v81/webhook"
 )
 
-var productIDToPackage = map[string]string{
+var cloudProductIDToPackage = map[string]string{
+	"prod_UQ3S5tzO70RHPK": config.PackagePremium,
+}
+
+var selfHostedProductIDToPackage = map[string]string{
 	// test
 	"prod_THDhiOfzmRa6xD_test": config.PackagePremium,
 	"prod_Rw6no7lokoLIVD_test": config.PackageUltimate,
@@ -86,8 +90,8 @@ func handlerSubscriptionUpdate(req *shttp.RequestContext) *shttp.Response {
 }
 
 // UpdateSubscription updates the subscription of the user based on the provided subscription info.
-// For cloud users it updates their account metadata. For self-hosted customers (no cloud account)
-// it generates or updates a license and emails it on first creation.
+// For self-hosted products it generates or updates a license and emails it on first creation.
+// For cloud products it updates the cloud account metadata.
 func UpdateSubscription(req *shttp.RequestContext, subscription stripe.Subscription) *shttp.Response {
 	client := stripeClient()
 	customer, err := client.Customers(subscription.Customer.ID, nil)
@@ -106,6 +110,10 @@ func UpdateSubscription(req *shttp.RequestContext, subscription stripe.Subscript
 		return shttp.NotFound()
 	}
 
+	if isSelfHosted(subscription) {
+		return SendSelfHostedLicense(req, customer, subscription)
+	}
+
 	store := user.NewStore()
 	usr, err := store.UserByEmail(req.Context(), []string{customer.Email})
 
@@ -113,37 +121,37 @@ func UpdateSubscription(req *shttp.RequestContext, subscription stripe.Subscript
 		return shttp.Error(err, fmt.Sprintf("error while retrieving user from stripe email: %s, err: %v", customer.Email, err))
 	}
 
-	if usr != nil {
-		packageName := config.PackageFree
-		quantity := int64(0)
-
-		if subscription.Items != nil {
-			for _, sub := range subscription.Items.Data {
-				if pck := productIDToPackage[sub.Plan.Product.ID]; pck != "" {
-					packageName = pck
-					quantity = sub.Quantity
-				}
-			}
-		}
-
-		meta := usr.Metadata
-		meta.PackageName = packageName
-		meta.StripeCustomerID = customer.ID
-		meta.SeatsPurchased = int(quantity)
-
-		if err := store.UpdateSubscription(req.Context(), usr.ID, meta); err != nil {
-			return shttp.Error(err, fmt.Sprintf("error while updating subscription: %v", err))
-		}
-
+	if usr == nil {
+		slog.Errorf("cloud subscription event for unknown user: %s", customer.Email)
 		return shttp.OK()
 	}
 
-	// No cloud account — self-hosted customer.
-	return SendSelfHostedLicense(req, customer, subscription)
+	packageName := config.PackageFree
+	quantity := int64(0)
+
+	if subscription.Items != nil {
+		for _, sub := range subscription.Items.Data {
+			if pck := cloudProductIDToPackage[sub.Plan.Product.ID]; pck != "" {
+				packageName = pck
+				quantity = sub.Quantity
+			}
+		}
+	}
+
+	meta := usr.Metadata
+	meta.PackageName = packageName
+	meta.StripeCustomerID = customer.ID
+	meta.SeatsPurchased = int(quantity)
+
+	if err := store.UpdateSubscription(req.Context(), usr.ID, meta); err != nil {
+		return shttp.Error(err, fmt.Sprintf("error while updating subscription: %v", err))
+	}
+
+	return shttp.OK()
 }
 
-// CancelSubscription downgrades a cloud user to the free tier and removes any
-// self-hosted license associated with the customer, if they exist.
+// CancelSubscription downgrades a cloud user to the free tier or deletes the
+// self-hosted license, depending on the product associated with the subscription.
 func CancelSubscription(req *shttp.RequestContext, subscription stripe.Subscription) *shttp.Response {
 	client := stripeClient()
 	customer, err := client.Customers(subscription.Customer.ID, nil)
@@ -157,6 +165,16 @@ func CancelSubscription(req *shttp.RequestContext, subscription stripe.Subscript
 		return shttp.NotFound()
 	}
 
+	if isSelfHosted(subscription) {
+		store := user.NewStore()
+
+		if err := store.DeleteSelfHostedLicense(req.Context(), customer.Email); err != nil {
+			return shttp.Error(err, fmt.Sprintf("error while deleting self-hosted license for %s: %v", customer.Email, err))
+		}
+
+		return shttp.OK()
+	}
+
 	store := user.NewStore()
 	usr, err := store.UserByEmail(req.Context(), []string{customer.Email})
 
@@ -164,18 +182,17 @@ func CancelSubscription(req *shttp.RequestContext, subscription stripe.Subscript
 		return shttp.Error(err, fmt.Sprintf("error while retrieving user from stripe email: %s, err: %v", customer.Email, err))
 	}
 
-	if usr != nil {
-		meta := usr.Metadata
-		meta.PackageName = config.PackageFree
-		meta.SeatsPurchased = 0
-
-		if err := store.UpdateSubscription(req.Context(), usr.ID, meta); err != nil {
-			return shttp.Error(err, fmt.Sprintf("error while downgrading subscription: %v", err))
-		}
+	if usr == nil {
+		slog.Errorf("cloud cancellation event for unknown user: %s", customer.Email)
+		return shttp.OK()
 	}
 
-	if err := store.DeleteSelfHostedLicense(req.Context(), customer.Email); err != nil {
-		return shttp.Error(err, fmt.Sprintf("error while deleting self-hosted license for %s: %v", customer.Email, err))
+	meta := usr.Metadata
+	meta.PackageName = config.PackageFree
+	meta.SeatsPurchased = 0
+
+	if err := store.UpdateSubscription(req.Context(), usr.ID, meta); err != nil {
+		return shttp.Error(err, fmt.Sprintf("error while downgrading subscription: %v", err))
 	}
 
 	return shttp.OK()
@@ -243,6 +260,21 @@ func SendSelfHostedLicense(req *shttp.RequestContext, customer *stripe.Customer,
 	return shttp.OK()
 }
 
+// isSelfHosted reports whether the subscription contains a self-hosted product.
+func isSelfHosted(subscription stripe.Subscription) bool {
+	if subscription.Items == nil {
+		return false
+	}
+
+	for _, item := range subscription.Items.Data {
+		if _, ok := selfHostedProductIDToPackage[item.Plan.Product.ID]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
 // selfHostedPlan resolves the package name and seat count from a subscription's items.
 func selfHostedPlan(subscription stripe.Subscription) (packageName string, quantity int64) {
 	packageName = config.PackageFree
@@ -252,7 +284,7 @@ func selfHostedPlan(subscription stripe.Subscription) (packageName string, quant
 	}
 
 	for _, sub := range subscription.Items.Data {
-		if pck := productIDToPackage[sub.Plan.Product.ID]; pck != "" {
+		if pck := selfHostedProductIDToPackage[sub.Plan.Product.ID]; pck != "" {
 			packageName = pck
 			quantity = sub.Quantity
 		}

--- a/src/ce/api/user/subscriptionhandlers/handler_subscription_update_test.go
+++ b/src/ce/api/user/subscriptionhandlers/handler_subscription_update_test.go
@@ -62,7 +62,7 @@ func (s *HandlerUpdateSubscriptionSuite) Test_UpdateSubscription_Success() {
 				{
 					Plan: &stripe.Plan{
 						Product: &stripe.Product{
-							ID: "prod_THDhiOfzmRa6xD", // Premium package
+							ID: "prod_UQ3S5tzO70RHPK", // Cloud premium package
 						},
 					},
 					Quantity: 5,
@@ -86,6 +86,17 @@ func (s *HandlerUpdateSubscriptionSuite) Test_CancelSubscription_DowngradesCloud
 		ID:       "sub_test123",
 		Status:   stripe.SubscriptionStatusCanceled,
 		Customer: s.customer,
+		Items: &stripe.SubscriptionItemList{
+			Data: []*stripe.SubscriptionItem{
+				{
+					Plan: &stripe.Plan{
+						Product: &stripe.Product{
+							ID: "prod_UQ3S5tzO70RHPK", // Cloud premium package
+						},
+					},
+				},
+			},
+		},
 	}
 
 	s.mockClient.On("Customers", s.customer.ID, (*stripe.CustomerParams)(nil)).Return(s.customer, nil)

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -143,12 +143,13 @@ func (c *SMTPConfig) IsConfigured() bool {
 
 // StripeConfig represents the stripe configuration.
 type StripeConfig struct {
-	ClientID            string
-	ClientSecret        string
-	WebhooksSecret      string
-	CustomerPortalLink  string
-	PaymentLinkPremium  string
-	PaymentLinkUltimate string
+	ClientID                string
+	ClientSecret            string
+	WebhooksSecret          string
+	CustomerPortalLink      string
+	PaymentLinkPremiumCloud string
+	PaymentLinkPremiumSH    string
+	PaymentLinkUltimateSH   string
 }
 
 type ReportingConfig struct {
@@ -267,12 +268,13 @@ func New() *Config {
 		},
 
 		Stripe: &StripeConfig{
-			ClientID:            os.Getenv("STRIPE_CLIENT_ID"),
-			ClientSecret:        secrets["STRIPE_SECRET"],
-			WebhooksSecret:      secrets["STRIPE_WH_SECRET"],
-			CustomerPortalLink:  os.Getenv("STRIPE_CUSTOMER_PORTAL_LINK"),
-			PaymentLinkPremium:  os.Getenv("STRIPE_PAYMENT_LINK_PREMIUM"),
-			PaymentLinkUltimate: os.Getenv("STRIPE_PAYMENT_LINK_ULTIMATE"),
+			ClientID:                os.Getenv("STRIPE_CLIENT_ID"),
+			ClientSecret:            secrets["STRIPE_SECRET"],
+			WebhooksSecret:          secrets["STRIPE_WH_SECRET"],
+			CustomerPortalLink:      os.Getenv("STRIPE_CUSTOMER_PORTAL_LINK"),
+			PaymentLinkPremiumCloud: os.Getenv("STRIPE_PAYMENT_LINK_PREMIUM_CLOUD"),
+			PaymentLinkPremiumSH:    os.Getenv("STRIPE_PAYMENT_LINK_PREMIUM_SH"),
+			PaymentLinkUltimateSH:   os.Getenv("STRIPE_PAYMENT_LINK_ULTIMATE_SH"),
 		},
 
 		SMTP: &SMTPConfig{

--- a/src/ui/src/components/UpgradeButton/UpgradeButton.spec.tsx
+++ b/src/ui/src/components/UpgradeButton/UpgradeButton.spec.tsx
@@ -2,42 +2,65 @@ import { describe, expect, beforeEach, it } from "vitest";
 import type { RenderResult } from "@testing-library/react";
 import { render } from "@testing-library/react";
 import { AuthContext } from "~/pages/auth/Auth.context";
+import { RootContext } from "~/pages/Root.context";
 import mockUser from "~/testing/data/mock_user";
 import { subscriptionLink } from "~/utils/billing";
 import UpgradeButton from "./UpgradeButton";
 
 interface Props {
   user: User;
+  edition?: string;
   text?: string;
   variant?: "contained" | "outlined" | "text";
 }
 
+const createWrapper = ({ user, edition, text, variant }: Props): RenderResult =>
+  render(
+    <RootContext.Provider
+      value={{
+        mode: "dark",
+        setMode: () => {},
+        details: { stormkit: { edition: edition as InstanceDetails["stormkit"]["edition"], apiCommit: "", apiVersion: "" } },
+      }}
+    >
+      <AuthContext.Provider value={{ user }}>
+        <UpgradeButton text={text} variant={variant} />
+      </AuthContext.Provider>
+    </RootContext.Provider>,
+  );
+
 describe("~/components/UpgradeButton/UpgradeButton", () => {
   let wrapper: RenderResult;
 
-  const createWrapper = ({ user, text, variant }: Props) => {
-    wrapper = render(
-      <AuthContext.Provider value={{ user }}>
-        <UpgradeButton text={text} variant={variant} />
-      </AuthContext.Provider>,
-    );
-  };
-
-  describe("free user", () => {
+  describe("cloud free user", () => {
     let user: User;
 
     beforeEach(() => {
       user = mockUser({ packageId: "free" });
-      createWrapper({ user });
+      wrapper = createWrapper({ user, edition: "cloud" });
     });
 
     it("should show upgrade text", () => {
       expect(wrapper.getByText("Upgrade to enterprise")).toBeTruthy();
     });
 
-    it("should link to the premium checkout page", () => {
+    it("should link to the cloud premium checkout page", () => {
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email, "cloud"));
+    });
+  });
+
+  describe("self-hosted free user", () => {
+    let user: User;
+
+    beforeEach(() => {
+      user = mockUser({ packageId: "free" });
+      wrapper = createWrapper({ user, edition: "self-hosted" });
+    });
+
+    it("should link to the self-hosted premium checkout page", () => {
+      const link = wrapper.getByRole("link");
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email, "self-hosted"));
     });
   });
 
@@ -46,7 +69,7 @@ describe("~/components/UpgradeButton/UpgradeButton", () => {
 
     beforeEach(() => {
       user = mockUser({ packageId: "premium" });
-      createWrapper({ user, text: "Manage subscription" });
+      wrapper = createWrapper({ user, text: "Manage subscription" });
     });
 
     it("should show manage subscription text", () => {
@@ -55,23 +78,23 @@ describe("~/components/UpgradeButton/UpgradeButton", () => {
 
     it("should link to the billing portal", () => {
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email, undefined));
     });
   });
 
   describe("text variant", () => {
     it("should render as a link element for free user", () => {
       const user = mockUser({ packageId: "free" });
-      createWrapper({ user, variant: "text" });
+      wrapper = createWrapper({ user, variant: "text" });
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email, undefined));
     });
 
     it("should render as a link element for paid user", () => {
       const user = mockUser({ packageId: "premium" });
-      createWrapper({ user, variant: "text" });
+      wrapper = createWrapper({ user, variant: "text" });
       const link = wrapper.getByRole("link");
-      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email));
+      expect(link.getAttribute("href")).toBe(subscriptionLink(user.package.id, user.email, undefined));
     });
   });
 });

--- a/src/ui/src/components/UpgradeButton/UpgradeButton.tsx
+++ b/src/ui/src/components/UpgradeButton/UpgradeButton.tsx
@@ -4,6 +4,7 @@ import LaunchIcon from "@mui/icons-material/Launch";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
 import { AuthContext } from "~/pages/auth/Auth.context";
+import { RootContext } from "~/pages/Root.context";
 import { subscriptionLink } from "~/utils/billing";
 
 interface Props {
@@ -18,8 +19,9 @@ export default function UpgradeButton({
   variant = "contained",
 }: Props) {
   const { user } = useContext(AuthContext);
+  const { details } = useContext(RootContext);
   const Icon = text === "Upgrade to enterprise" ? LockIcon : LaunchIcon;
-  const href = subscriptionLink(user?.package.id, user?.email);
+  const href = subscriptionLink(user?.package.id, user?.email, details?.stormkit?.edition);
 
   if (variant === "text") {
     return (

--- a/src/ui/src/utils/billing.ts
+++ b/src/ui/src/utils/billing.ts
@@ -4,12 +4,16 @@ const apiDomain = isDev
   ? process.env.API_DOMAIN || ""
   : "https://api.stormkit.io";
 
-export const subscriptionLink = (packageId?: string, email?: string): string => {
+export const subscriptionLink = (packageId?: string, email?: string, edition?: string): string => {
   const plan = packageId === "free" || !packageId ? "premium" : "portal";
   const params = new URLSearchParams({ plan });
 
   if (email) {
     params.set("ref", email);
+  }
+
+  if (edition) {
+    params.set("edition", edition);
   }
 
   return `${apiDomain}/billing/checkout?${params}`;


### PR DESCRIPTION
## Summary

- Split `productIDToPackage` into `cloudProductIDToPackage` (new `prod_UQ3S5tzO70RHPK`) and `selfHostedProductIDToPackage` (existing IDs). Subscription events now check product IDs first, so a cloud user and a self-hosted customer sharing the same email are handled correctly.
- `StripeConfig` renamed `PaymentLinkPremium`/`PaymentLinkUltimate` → `PaymentLinkPremiumSH`/`PaymentLinkUltimateSH`; added `PaymentLinkPremium` for the new cloud product (`https://buy.stripe.com/6oU00k3wYfKu70m6iPbAs07`). Env vars renamed accordingly (`STRIPE_PAYMENT_LINK_PREMIUM_SH`, `STRIPE_PAYMENT_LINK_ULTIMATE_SH`).
- Checkout deeplink (`/billing/checkout`) now routes to the SH or cloud payment link based on an `edition` query param (`self-hosted` vs anything else). Removed the `selfhosted:` prefix from `client_reference_id`.
- `UpgradeButton` reads `details?.stormkit?.edition` from `RootContext` and passes it to `subscriptionLink`.

## Env var changes required

| Old | New |
|---|---|
| `STRIPE_PAYMENT_LINK_PREMIUM` | `STRIPE_PAYMENT_LINK_PREMIUM_SH` |
| `STRIPE_PAYMENT_LINK_ULTIMATE` | `STRIPE_PAYMENT_LINK_ULTIMATE_SH` |
| _(new)_ | `STRIPE_PAYMENT_LINK_PREMIUM=https://buy.stripe.com/6oU00k3wYfKu70m6iPbAs07` |

## Test plan

- [ ] Self-hosted free user → link includes `plan=premium&edition=self-hosted` → redirects to `PaymentLinkPremiumSH`
- [ ] Cloud free user → link includes `plan=premium&edition=cloud` → redirects to `PaymentLinkPremium`
- [ ] Paid user → link includes `plan=portal` → redirects to customer portal
- [ ] `customer.subscription.created` with self-hosted product ID → sends license, does not touch cloud account
- [ ] `customer.subscription.created` with cloud product ID → updates cloud account, does not send license
- [ ] All Go and frontend tests pass