### PR TITLE
feat: configurable artifact retention days

### DIFF
--- a/src/ce/api/admin/admin_model.go
+++ b/src/ce/api/admin/admin_model.go
@@ -49,8 +49,9 @@ type AdminUserConfig struct {
 }
 
 type SystemConfig struct {
-	AutoInstall bool     `json:"autoInstall"` // Whether to install runtimes automatically or not. Default is true.
-	Runtimes    []string `json:"runtimes"`    // The list of runtimes to install in format <name>@<version>
+	AutoInstall          bool     `json:"autoInstall"`          // Whether to install runtimes automatically or not. Default is true.
+	Runtimes             []string `json:"runtimes"`             // The list of runtimes to install in format <name>@<version>
+	ArtifactRetentionDays int     `json:"artifactRetentionDays"` // Number of days to retain deployment artifacts. Default is 30.
 }
 
 type ProxyRule struct {
@@ -468,8 +469,9 @@ func AddRuntimes(ctx context.Context, runtimes []string) error {
 
 func defaultSystemConfig() *SystemConfig {
 	cfg := &SystemConfig{
-		AutoInstall: true,
-		Runtimes:    []string{},
+		AutoInstall:           true,
+		Runtimes:              []string{},
+		ArtifactRetentionDays: 30,
 	}
 
 	// Backwards compatibility: if the NODE_VERSION environment variable is set, we assume

--- a/src/ce/api/admin/adminhandlers/handler_jobs_remove_old_artifacts.go
+++ b/src/ce/api/admin/adminhandlers/handler_jobs_remove_old_artifacts.go
@@ -4,14 +4,27 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
 
 func handlerJobsRemoveOldArtifacts(req *user.RequestContext) *shttp.Response {
+	vc, err := admin.Store().Config(req.Context())
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	retentionDays := 30
+
+	if vc.SystemConfig != nil && vc.SystemConfig.ArtifactRetentionDays > 0 {
+		retentionDays = vc.SystemConfig.ArtifactRetentionDays
+	}
+
 	ctx := context.WithValue(req.Context(), jobs.KeyContextNumberOfDeploymentsToDelete{}, 50)
-	ids, err := jobs.RemoveDeploymentArtifactsManually(ctx, 30)
+	ids, err := jobs.RemoveDeploymentArtifactsManually(ctx, retentionDays)
 
 	if err != nil {
 		return &shttp.Response{

--- a/src/ce/api/admin/adminhandlers/handler_system_settings.go
+++ b/src/ce/api/admin/adminhandlers/handler_system_settings.go
@@ -1,0 +1,30 @@
+package adminhandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func handlerSystemSettings(req *user.RequestContext) *shttp.Response {
+	vc, err := admin.Store().Config(req.Context())
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	artifactRetentionDays := 30
+
+	if vc.SystemConfig != nil && vc.SystemConfig.ArtifactRetentionDays > 0 {
+		artifactRetentionDays = vc.SystemConfig.ArtifactRetentionDays
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"artifactRetentionDays": artifactRetentionDays,
+		},
+	}
+}

--- a/src/ce/api/admin/adminhandlers/handler_system_settings_test.go
+++ b/src/ce/api/admin/adminhandlers/handler_system_settings_test.go
@@ -1,0 +1,71 @@
+package adminhandlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin/adminhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+)
+
+type HandlerSystemSettingsSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *HandlerSystemSettingsSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerSystemSettingsSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerSystemSettingsSuite) Test_Get_Success() {
+	usr := s.MockUser(map[string]any{"IsAdmin": true})
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/admin/system/settings",
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	data := map[string]any{}
+
+	s.Equal(http.StatusOK, resp.Code)
+	s.NoError(json.Unmarshal(resp.Byte(), &data))
+	s.Equal(float64(30), data["artifactRetentionDays"])
+}
+
+func (s *HandlerSystemSettingsSuite) Test_Get_Unauthorized_NonAdmin() {
+	usr := s.MockUser(map[string]any{"IsAdmin": false})
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/admin/system/settings",
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusUnauthorized, resp.Code)
+}
+
+func TestHandlerSystemSettingsSuite(t *testing.T) {
+	suite.Run(t, &HandlerSystemSettingsSuite{})
+}

--- a/src/ce/api/admin/adminhandlers/handler_system_settings_update.go
+++ b/src/ce/api/admin/adminhandlers/handler_system_settings_update.go
@@ -1,0 +1,50 @@
+package adminhandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+type systemSettingsUpdateRequest struct {
+	ArtifactRetentionDays int `json:"artifactRetentionDays"`
+}
+
+func handlerSystemSettingsUpdate(req *user.RequestContext) *shttp.Response {
+	data := systemSettingsUpdateRequest{}
+
+	if err := req.Post(&data); err != nil {
+		return shttp.Error(err)
+	}
+
+	if data.ArtifactRetentionDays <= 0 {
+		return shttp.BadRequest(map[string]any{
+			"error": "artifactRetentionDays must be a positive number",
+		})
+	}
+
+	vc, err := admin.Store().Config(req.Context())
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	if vc.SystemConfig == nil {
+		vc.SystemConfig = &admin.SystemConfig{}
+	}
+
+	vc.SystemConfig.ArtifactRetentionDays = data.ArtifactRetentionDays
+
+	if err := admin.Store().UpsertConfig(req.Context(), vc); err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"artifactRetentionDays": data.ArtifactRetentionDays,
+		},
+	}
+}

--- a/src/ce/api/admin/adminhandlers/handler_system_settings_update_test.go
+++ b/src/ce/api/admin/adminhandlers/handler_system_settings_update_test.go
@@ -1,0 +1,97 @@
+package adminhandlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin/adminhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+)
+
+type HandlerSystemSettingsUpdateSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *HandlerSystemSettingsUpdateSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerSystemSettingsUpdateSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerSystemSettingsUpdateSuite) Test_Update_Success() {
+	usr := s.MockUser(map[string]any{"IsAdmin": true})
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPut,
+		"/admin/system/settings",
+		map[string]any{
+			"artifactRetentionDays": 60,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	data := map[string]any{}
+
+	s.Equal(http.StatusOK, resp.Code)
+	s.NoError(json.Unmarshal(resp.Byte(), &data))
+	s.Equal(float64(60), data["artifactRetentionDays"])
+}
+
+func (s *HandlerSystemSettingsUpdateSuite) Test_Update_InvalidRetentionDays() {
+	usr := s.MockUser(map[string]any{"IsAdmin": true})
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPut,
+		"/admin/system/settings",
+		map[string]any{
+			"artifactRetentionDays": 0,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	data := map[string]any{}
+
+	s.Equal(http.StatusBadRequest, resp.Code)
+	s.NoError(json.Unmarshal(resp.Byte(), &data))
+	s.Contains(data, "error")
+}
+
+func (s *HandlerSystemSettingsUpdateSuite) Test_Update_Unauthorized_NonAdmin() {
+	usr := s.MockUser(map[string]any{"IsAdmin": false})
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodPut,
+		"/admin/system/settings",
+		map[string]any{
+			"artifactRetentionDays": 60,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusUnauthorized, resp.Code)
+}
+
+func TestHandlerSystemSettingsUpdateSuite(t *testing.T) {
+	suite.Run(t, &HandlerSystemSettingsUpdateSuite{})
+}

--- a/src/ce/api/admin/adminhandlers/services.go
+++ b/src/ce/api/admin/adminhandlers/services.go
@@ -20,7 +20,9 @@ func Services(r *shttp.Router) *shttp.Service {
 		Handler(shttp.MethodGet, "/mise", user.WithAdmin(handlerMise)).
 		Handler(shttp.MethodPost, "/mise", user.WithAdmin(handlerMiseUpdate)).
 		Handler(shttp.MethodGet, "/proxies", user.WithAdmin(handlerProxies)).
-		Handler(shttp.MethodPut, "/proxies", user.WithAdmin(handlerProxiesUpdate))
+		Handler(shttp.MethodPut, "/proxies", user.WithAdmin(handlerProxiesUpdate)).
+		Handler(shttp.MethodGet, "/settings", user.WithAdmin(handlerSystemSettings)).
+		Handler(shttp.MethodPut, "/settings", user.WithAdmin(handlerSystemSettingsUpdate))
 
 	s.NewEndpoint("/admin/license").
 		Handler(shttp.MethodPost, "", user.WithAdmin(handlerLicenseSet))

--- a/src/ce/api/admin/adminhandlers/services_test.go
+++ b/src/ce/api/admin/adminhandlers/services_test.go
@@ -26,6 +26,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 		"GET:/admin/system/mise",
 		"GET:/admin/system/proxies",
 		"GET:/admin/system/runtimes",
+		"GET:/admin/system/settings",
 		"GET:/admin/users/pending",
 		"GET:/admin/users/sign-up-mode",
 		"POST:/admin/domains",
@@ -39,6 +40,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 		"POST:/admin/users/manage",
 		"POST:/admin/users/sign-up-mode",
 		"PUT:/admin/system/proxies",
+		"PUT:/admin/system/settings",
 	}
 
 	s.Equal(handlers, services.HandlerKeys())
@@ -59,6 +61,7 @@ func (s *ServicesSuite) Test_Services_Cloud() {
 		"GET:/admin/system/mise",
 		"GET:/admin/system/proxies",
 		"GET:/admin/system/runtimes",
+		"GET:/admin/system/settings",
 		"GET:/admin/users/pending",
 		"GET:/admin/users/sign-up-mode",
 		"POST:/admin/cloud/impersonate",
@@ -73,6 +76,7 @@ func (s *ServicesSuite) Test_Services_Cloud() {
 		"POST:/admin/users/manage",
 		"POST:/admin/users/sign-up-mode",
 		"PUT:/admin/system/proxies",
+		"PUT:/admin/system/settings",
 	}
 
 	s.Equal(handlers, services.HandlerKeys())

--- a/src/ce/workerserver/job_deployments.go
+++ b/src/ce/workerserver/job_deployments.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
@@ -14,7 +15,7 @@ import (
 
 type KeyContextNumberOfDeploymentsToDelete struct{}
 
-// RemoveDeploymentArtifactsManually removes the artifacts of expired deployments.
+// RemoveDeploymentArtifactsManually removes the artifacts of expired, non-published deployments.
 // An expired deployment is a deployment that has not been used for more than 30 days.
 // Overwrite the numberOfDays to set a custom expiration time.
 func RemoveDeploymentArtifactsManually(ctx context.Context, numberOfDays int) ([]string, error) {
@@ -71,7 +72,15 @@ func RemoveDeploymentArtifactsManually(ctx context.Context, numberOfDays int) ([
 
 // RemoveDeploymentArtifacts is a job to remove the artifacts of expired deployments.
 func RemoveDeploymentArtifacts(ctx context.Context) error {
-	idsToBeMarked, err := RemoveDeploymentArtifactsManually(ctx, 30)
+	retentionDays := 30
+
+	vc, err := admin.Store().Config(ctx)
+
+	if err == nil && vc.SystemConfig != nil && vc.SystemConfig.ArtifactRetentionDays > 0 {
+		retentionDays = vc.SystemConfig.ArtifactRetentionDays
+	}
+
+	idsToBeMarked, err := RemoveDeploymentArtifactsManually(ctx, retentionDays)
 
 	if err != nil {
 		return err

--- a/src/ui/src/pages/admin/System.spec.tsx
+++ b/src/ui/src/pages/admin/System.spec.tsx
@@ -62,10 +62,17 @@ describe("~/pages/admin/System.tsx", () => {
       });
   };
 
+  const fetchSystemSettingsScope = (artifactRetentionDays = 30) => {
+    return nock(process.env.API_DOMAIN || "")
+      .get("/admin/system/settings")
+      .reply(200, { artifactRetentionDays });
+  };
+
   beforeEach(async () => {
     const scope = fetchRuntimesScope(["node@24", "python@3"]);
     const scopeVersion = fetchMiseVersionScope();
     const scopeDomains = fetchDomainsScope();
+    const scopeSettings = fetchSystemSettingsScope();
 
     createWrapper();
 
@@ -73,6 +80,7 @@ describe("~/pages/admin/System.tsx", () => {
       expect(scopeVersion.isDone()).toBe(true);
       expect(scope.isDone()).toBe(true);
       expect(scopeDomains.isDone()).toBe(true);
+      expect(scopeSettings.isDone()).toBe(true);
     });
   });
 
@@ -433,12 +441,17 @@ describe("~/pages/admin/System.tsx", () => {
         .get("/admin/domains")
         .reply(500, { error: "Internal server error" });
 
+      const errorSettingsScope = nock(process.env.API_DOMAIN || "")
+        .get("/admin/system/settings")
+        .reply(200, { artifactRetentionDays: 30 });
+
       const errorWrapper = render(<AdminSystem />);
 
       await waitFor(() => {
         expect(errorScope.isDone()).toBe(true);
         expect(errorMiseScope.isDone()).toBe(true);
         expect(errorDomainsScope.isDone()).toBe(true);
+        expect(errorSettingsScope.isDone()).toBe(true);
       });
 
       await waitFor(() => {
@@ -501,6 +514,89 @@ describe("~/pages/admin/System.tsx", () => {
         expect(
           wrapper.getByText(
             "An error occurred while updating domains. Make sure specified domains are valid.",
+          ),
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("SystemSettings", () => {
+    it("should render system settings form", async () => {
+      await waitFor(() => {
+        expect(wrapper.getByText("System settings")).toBeTruthy();
+        expect(
+          wrapper.getByText(
+            "Configure system-wide settings for your Stormkit instance",
+          ),
+        ).toBeTruthy();
+        expect(wrapper.getByLabelText("Artifact retention days")).toBeTruthy();
+        expect(
+          wrapper.getByText(
+            "Number of days to retain unpublished deployment artifacts before they are deleted",
+          ),
+        ).toBeTruthy();
+      });
+    });
+
+    it("should display fetched artifact retention days", async () => {
+      await waitFor(() => {
+        const field = wrapper.getByDisplayValue("30");
+        expect(field).toBeTruthy();
+      });
+    });
+
+    it("should submit system settings successfully", async () => {
+      const putScope = nock(process.env.API_DOMAIN || "")
+        .put("/admin/system/settings", { artifactRetentionDays: 60 })
+        .reply(200, { artifactRetentionDays: 60 });
+
+      await waitFor(() => {
+        const field = wrapper.getByLabelText("Artifact retention days");
+        fireEvent.change(field, { target: { value: "60" } });
+      });
+
+      const saveButtons = wrapper.getAllByText("Save");
+      fireEvent.click(saveButtons[2]); // Third save button is for system settings
+
+      await waitFor(() => {
+        expect(putScope.isDone()).toBe(true);
+        expect(
+          wrapper.getByText("System settings saved successfully."),
+        ).toBeTruthy();
+      });
+    });
+
+    it("should show validation error for invalid retention days", async () => {
+      await waitFor(() => {
+        const field = wrapper.getByLabelText("Artifact retention days");
+        fireEvent.change(field, { target: { value: "abc" } });
+      });
+
+      const saveButtons = wrapper.getAllByText("Save");
+      fireEvent.click(saveButtons[2]); // Third save button is for system settings
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByText(
+            "Artifact retention days must be a positive number.",
+          ),
+        ).toBeTruthy();
+      });
+    });
+
+    it("should handle system settings update error", async () => {
+      const putScope = nock(process.env.API_DOMAIN || "")
+        .put("/admin/system/settings")
+        .reply(500, { error: "Internal server error" });
+
+      const saveButtons = wrapper.getAllByText("Save");
+      fireEvent.click(saveButtons[2]); // Third save button is for system settings
+
+      await waitFor(() => {
+        expect(putScope.isDone()).toBe(true);
+        expect(
+          wrapper.getByText(
+            "An error occurred while updating system settings.",
           ),
         ).toBeTruthy();
       });

--- a/src/ui/src/pages/admin/System.tsx
+++ b/src/ui/src/pages/admin/System.tsx
@@ -509,12 +509,113 @@ function Domains() {
   );
 }
 
+const useFetchSystemSettings = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [artifactRetentionDays, setArtifactRetentionDays] = useState(30);
+
+  useEffect(() => {
+    Api.fetch<{ artifactRetentionDays: number }>("/admin/system/settings")
+      .then(({ artifactRetentionDays }) => {
+        setArtifactRetentionDays(artifactRetentionDays);
+      })
+      .catch(() => {
+        setError("Something went wrong while fetching system settings");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return { loading, error, artifactRetentionDays };
+};
+
+function SystemSettings() {
+  const { error, loading, artifactRetentionDays: days } = useFetchSystemSettings();
+  const [updateError, setUpdateError] = useState<string>();
+  const [updateSuccess, setUpdateSuccess] = useState<string>();
+  const [updateLoading, setUpdateLoading] = useState(false);
+  const [artifactRetentionDays, setArtifactRetentionDays] = useState(String(days));
+
+  useEffect(() => {
+    setArtifactRetentionDays(String(days));
+  }, [days]);
+
+  return (
+    <Card
+      error={error || updateError}
+      success={updateSuccess}
+      loading={loading}
+      sx={{ mt: 4, backgroundColor: "container.transparent" }}
+      contentPadding={false}
+      component="form"
+    >
+      <CardHeader
+        title="System settings"
+        subtitle="Configure system-wide settings for your Stormkit instance"
+      />
+      <CardRow>
+        <TextField
+          label="Artifact retention days"
+          variant="filled"
+          name="artifactRetentionDays"
+          value={artifactRetentionDays}
+          slotProps={{ inputLabel: { shrink: true } }}
+          helperText="Number of days to retain unpublished deployment artifacts before they are deleted"
+          fullWidth
+          onChange={e => {
+            setArtifactRetentionDays(e.target.value);
+            setUpdateError(undefined);
+            setUpdateSuccess(undefined);
+          }}
+        />
+      </CardRow>
+      <CardFooter>
+        <Button
+          variant="contained"
+          color="secondary"
+          type="submit"
+          loading={updateLoading}
+          onClick={e => {
+            e.preventDefault();
+
+            const days = parseInt(artifactRetentionDays, 10);
+
+            if (!days || days <= 0) {
+              setUpdateError("Artifact retention days must be a positive number.");
+              return;
+            }
+
+            setUpdateLoading(true);
+
+            Api.put("/admin/system/settings", { artifactRetentionDays: days })
+              .then(() => {
+                setUpdateSuccess("System settings saved successfully.");
+              })
+              .catch(() => {
+                setUpdateError(
+                  "An error occurred while updating system settings.",
+                );
+              })
+              .finally(() => {
+                setUpdateLoading(false);
+              });
+          }}
+        >
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
 export default function System() {
   return (
     <Box>
       <Runtimes />
       <Mise />
       <Domains />
+      <SystemSettings />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `ArtifactRetentionDays` field to `SystemConfig` (default: 30)
- New `GET /admin/system/settings` and `PUT /admin/system/settings` endpoints to read/write the setting
- Both the manual job handler and the scheduled `RemoveDeploymentArtifacts` cron job now read the value from config
- New **System settings** card in the Admin → System tab with a text input, client-side validation, and a success message on save
- Helper text clarifies that only **unpublished** deployment artifacts are affected

## Test plan

- [ ] Go: `go test ./src/ce/api/admin/adminhandlers/... -run TestHandlerSystemSettings`
- [ ] Frontend: `npm test -- src/pages/admin/System.spec.tsx`
- [ ] In the Admin panel, navigate to System tab and confirm the new "System settings" card appears with the default value of 30
- [ ] Save a new value and confirm the success message appears
- [ ] Enter a non-numeric value and confirm the validation error appears without making a network request