### PR TITLE
feat: fail build when schema migration path is invalid

### DIFF
--- a/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback.go
@@ -183,12 +183,14 @@ func UpdateExit(req *shttp.RequestContext, data deployCallbackRequest) *shttp.Re
 		logs := []string{}
 		logs = append(logs, deploy.LogStep("database migrations"))
 
-		results, err := RunMigrations(req.Context(), RunMigrationsArgs{
+		messages, results, err := RunMigrations(req.Context(), RunMigrationsArgs{
 			DeploymentID:   data.deployment.ID,
 			EnvID:          data.deployment.EnvID,
 			Branch:         data.deployment.Branch,
 			MigrationsFile: data.Result.Migrations.Location,
 		})
+
+		logs = append(logs, messages...)
 
 		// If there was an error and no migrations were applied, set the deployment error
 		if err != nil && len(results) == 0 {
@@ -212,7 +214,7 @@ func UpdateExit(req *shttp.RequestContext, data deployCallbackRequest) *shttp.Re
 			logs = append(logs, fmt.Sprintf("%s (%dms) %s%s", result.FileName, result.Duration.Milliseconds(), tickOrCross, errorMsg))
 		}
 
-		if len(results) == 0 {
+		if len(results) == 0 && len(messages) == 0 {
 			logs = append(logs, "No new migrations to apply.")
 		}
 
@@ -257,25 +259,27 @@ type RunMigrationsArgs struct {
 }
 
 // RunMigrations runs database migrations for the given environment.
-func RunMigrations(ctx context.Context, args RunMigrationsArgs) ([]*buildconf.MigrationResult, error) {
+func RunMigrations(ctx context.Context, args RunMigrationsArgs) ([]string, []*buildconf.MigrationResult, error) {
 	env, err := buildconf.NewStore().EnvironmentByID(ctx, args.EnvID)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if env == nil {
-		return nil, fmt.Errorf("deployment environment not found: %d", args.EnvID)
+		return nil, nil, fmt.Errorf("deployment environment not found: %d", args.EnvID)
 	}
 
 	// Migrations not enabled
 	if env.SchemaConf == nil || !env.SchemaConf.MigrationsEnabled {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Skip migrations as we're not on the default branch
 	if env.Branch != args.Branch {
-		return nil, nil
+		msg := fmt.Sprintf("Migrations skipped: branch %q is not the default branch %q.", args.Branch, env.Branch)
+
+		return []string{msg}, nil, nil
 	}
 
 	migrationsZip, err := integrations.Client().GetFile(integrations.GetFileArgs{
@@ -283,27 +287,27 @@ func RunMigrations(ctx context.Context, args RunMigrationsArgs) ([]*buildconf.Mi
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("error while fetching migrations file: %s", err.Error())
+		return nil, nil, fmt.Errorf("error while fetching migrations file: %s", err.Error())
 	}
 
 	if migrationsZip == nil {
-		return nil, fmt.Errorf("migrations file not found at location: %s", args.MigrationsFile)
+		return nil, nil, fmt.Errorf("migrations file not found at location: %s", args.MigrationsFile)
 	}
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeMigrations)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	defer store.Close()
 
 	if err := store.EnsureMigrationsTable(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := store.AdvisoryLock(int64(env.ID)); err != nil {
-		return nil, errors.New("failed to acquire advisory lock for running migrations; this may be caused by simultaneous deployments")
+		return nil, nil, errors.New("failed to acquire advisory lock for running migrations; this may be caused by simultaneous deployments")
 	}
 
 	defer store.AdvisoryUnlock(int64(env.ID))
@@ -311,7 +315,7 @@ func RunMigrations(ctx context.Context, args RunMigrationsArgs) ([]*buildconf.Mi
 	migrations, err := store.Migrations(ctx)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	results := []*buildconf.MigrationResult{}
@@ -347,7 +351,7 @@ func RunMigrations(ctx context.Context, args RunMigrationsArgs) ([]*buildconf.Mi
 		return nil
 	})
 
-	return results, err
+	return nil, results, err
 }
 
 // LockDeployment is called when the deployment is complete. A deployment is complete

--- a/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback_test.go
@@ -561,7 +561,7 @@ func (s *HandlerDeployCallbackSuite) Test_RunMigrations() {
 		Content: zipContent,
 	}, nil).Once()
 
-	results, err := deployhandlers.RunMigrations(context.Background(), deployhandlers.RunMigrationsArgs{
+	messages, results, err := deployhandlers.RunMigrations(context.Background(), deployhandlers.RunMigrationsArgs{
 		DeploymentID:   6,
 		EnvID:          env.ID,
 		Branch:         env.Branch,
@@ -570,6 +570,7 @@ func (s *HandlerDeployCallbackSuite) Test_RunMigrations() {
 
 	s.Error(err, "pq: relation \"test_users\" does not exist")
 	s.NotEmpty(results)
+	s.Empty(messages)
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeMigrations)
 	s.NoError(err)
@@ -634,6 +635,29 @@ func (s *HandlerDeployCallbackSuite) Test_RunMigrations_Failed_FileDoesNotExist(
 	d, err := deploy.NewStore().DeploymentByID(context.Background(), depl.ID)
 	s.NoError(err)
 	s.Equal("migrations file not found at location: local:/path/to/migrations.zip", d.Error.ValueOrZero())
+}
+
+func (s *HandlerDeployCallbackSuite) Test_RunMigrations_NonDefaultBranch() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			MigrationsEnabled: true,
+		},
+	})
+
+	messages, results, err := deployhandlers.RunMigrations(context.Background(), deployhandlers.RunMigrationsArgs{
+		DeploymentID:   6,
+		EnvID:          env.ID,
+		Branch:         "feature/some-branch",
+		MigrationsFile: "local:/path/to/migrations.zip",
+	})
+
+	s.NoError(err)
+	s.Empty(results)
+	s.Len(messages, 1)
+	s.Contains(messages[0], "feature/some-branch")
+	s.Contains(messages[0], env.Branch)
 }
 
 func TestCallbackHandler(t *testing.T) {

--- a/src/ce/runner/bundler.go
+++ b/src/ce/runner/bundler.go
@@ -805,7 +805,14 @@ func (b Bundler) Zip(artifacts *Artifacts) error {
 	apiZip := filepath.Join(b.distDir, "sk-api.zip")
 	migrationsZip := filepath.Join(b.distDir, "sk-migrations.zip")
 
-	if b.migrationsDir != "" && file.Exists(filepath.Join(b.workDir, b.migrationsDir)) {
+	if b.migrationsDir != "" {
+		if !file.Exists(filepath.Join(b.workDir, b.migrationsDir)) {
+			b.reporter.AddStep("database migrations")
+			b.reporter.AddLine(fmt.Sprintf(`Schema migration path "%s" does not exist or is not accessible relative to the working directory. Please verify the path in your configuration.`, b.migrationsDir))
+
+			return fmt.Errorf("schema migration path %q not found", b.migrationsDir)
+		}
+
 		if err := zip(migrationsZip, []string{b.migrationsDir}, false, "*.sql"); err != nil {
 			return err
 		}

--- a/src/ce/runner/bundler_test.go
+++ b/src/ce/runner/bundler_test.go
@@ -480,6 +480,18 @@ func (s *BundlerSuite) Test_Zip() {
 	}
 }
 
+func (s *BundlerSuite) Test_Zip_MigrationPathDoesNotExist() {
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+
+	err = bundler.Zip(artifacts)
+
+	s.Error(err)
+	s.Contains(err.Error(), "migrations")
+}
+
 func (s *BundlerSuite) Test_ParseHeaders() {
 	headers := `
 		# a path:


### PR DESCRIPTION
## Summary

Closes #181

- Fail the build immediately with a clear error when `migrationsDir` is configured but the path does not exist in the repo, logging under the existing `database migrations` step
- Return a warning log message (instead of silently skipping) when migrations are skipped because the deployment branch is not the default branch

## Test plan

- [ ] `Test_Zip_MigrationPathDoesNotExist` — build fails with an error containing "migrations" when the configured migration path is missing
- [ ] `Test_RunMigrations_NonDefaultBranch` — `RunMigrations` returns a warning message containing both the current and default branch names when the branch does not match