### PR TITLE
feat: log all emails and expose GET /mailer endpoint

### DIFF
--- a/src/ce/api/app/buildconf/mailer_store.go
+++ b/src/ce/api/app/buildconf/mailer_store.go
@@ -76,7 +76,7 @@ func (s *mailerStore) UpsertConfig(ctx context.Context, cnf *MailerConf) error {
 
 // InsertMail inserts a sent email to the database. This is mostly for auditing.
 func (s *mailerStore) InsertEmail(ctx context.Context, mail Email) error {
-	_, err := s.Exec(ctx, mstmt.insertEmail, mail.EnvID, mail.To, mail.From, mail.Body, mail.Subject)
+	_, err := s.Exec(ctx, mstmt.insertEmail, mail.EnvID, mail.To, mail.From, mail.Subject, mail.Body)
 	return err
 }
 

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
@@ -45,29 +45,27 @@ func HandlerMail(req *app.RequestContext) *shttp.Response {
 	}
 
 	config := env.MailerConf
+	from := data.From
 
-	if config == nil {
-		return &shttp.Response{
-			Status: http.StatusBadRequest,
-			Data:   map[string]string{"error": "Mailer is not yet configured."},
-		}
-	}
+	if config != nil {
+		from = utils.GetString(data.From, config.Username)
 
-	if err := config.Send(buildconf.SendEmailParams{
-		To:      data.To,
-		From:    data.From,
-		Subject: data.Subject,
-		Body:    data.Body,
-	}); err != nil {
-		return &shttp.Response{
-			Status: http.StatusInternalServerError,
-			Data:   map[string]string{"error": err.Error()},
+		if err := config.Send(buildconf.SendEmailParams{
+			To:      data.To,
+			From:    data.From,
+			Subject: data.Subject,
+			Body:    data.Body,
+		}); err != nil {
+			return &shttp.Response{
+				Status: http.StatusInternalServerError,
+				Data:   map[string]string{"error": err.Error()},
+			}
 		}
 	}
 
 	email := buildconf.Email{
 		EnvID:   req.EnvID,
-		From:    utils.GetString(data.From, config.Username),
+		From:    from,
 		To:      data.To,
 		Body:    data.Body,
 		Subject: data.Subject,

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail_list.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail_list.go
@@ -1,0 +1,22 @@
+package mailerhandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func HandlerMailList(req *app.RequestContext) *shttp.Response {
+	emails, err := buildconf.MailerStore().Emails(req.Context(), req.EnvID)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   map[string]any{"emails": emails},
+	}
+}

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail_list_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail_list_test.go
@@ -1,0 +1,88 @@
+package mailerhandlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/mailerhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+)
+
+type MailListSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *MailListSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *MailListSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *MailListSuite) Test_ReturnsEmails() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	err := buildconf.MailerStore().InsertEmail(context.Background(), buildconf.Email{
+		EnvID:   env.ID,
+		To:      "joe@stormkit.io",
+		From:    "sender@example.com",
+		Subject: "Hello",
+		Body:    "Welcome!",
+	})
+	s.NoError(err)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/mailer?appId=%d&envId=%d", app.ID, env.ID),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	emails, err := buildconf.MailerStore().Emails(context.Background(), env.ID)
+	s.NoError(err)
+	s.Len(emails, 1)
+	s.Equal("Hello", emails[0].Subject)
+	s.Equal("Welcome!", emails[0].Body)
+}
+
+func (s *MailListSuite) Test_EmptyList() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/mailer?appId=%d&envId=%d", app.ID, env.ID),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(`{"emails": []}`, response.String())
+}
+
+func TestMailListSuite(t *testing.T) {
+	suite.Run(t, &MailListSuite{})
+}

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail_test.go
@@ -82,9 +82,11 @@ func (s *MailerSuite) Test_Success() {
 	emails, err := buildconf.MailerStore().Emails(context.Background(), env.ID)
 	s.NoError(err)
 	s.Len(emails, 1)
+	s.Equal("Hello", emails[0].Subject)
+	s.Equal("Welcome to my world!", emails[0].Body)
 }
 
-func (s *MailerSuite) Test_ShouldFail_NoConfig() {
+func (s *MailerSuite) Test_NoConfig_StoresEmail() {
 	called := false
 	usr := s.MockUser()
 	app := s.MockApp(usr)
@@ -102,7 +104,8 @@ func (s *MailerSuite) Test_ShouldFail_NoConfig() {
 		map[string]any{
 			"appId":   app.ID.String(),
 			"envId":   env.ID.String(),
-			"to":      "joe@stormkit.io; jane@stormkit.io",
+			"to":      "joe@stormkit.io",
+			"from":    "sender@example.com",
 			"subject": "Hello",
 			"body":    "Welcome to my world!",
 		},
@@ -111,9 +114,16 @@ func (s *MailerSuite) Test_ShouldFail_NoConfig() {
 		},
 	)
 
-	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(`{ "error": "Mailer is not yet configured." }`, response.String())
+	s.Equal(http.StatusOK, response.Code)
 	s.False(called)
+
+	emails, err := buildconf.MailerStore().Emails(context.Background(), env.ID)
+	s.NoError(err)
+	s.Len(emails, 1)
+	s.Equal("joe@stormkit.io", emails[0].To)
+	s.Equal("sender@example.com", emails[0].From)
+	s.Equal("Hello", emails[0].Subject)
+	s.Equal("Welcome to my world!", emails[0].Body)
 }
 
 func TestMailerSuite(t *testing.T) {

--- a/src/ce/api/app/buildconf/mailerhandlers/services.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/services.go
@@ -10,6 +10,7 @@ func Services(r *shttp.Router) *shttp.Service {
 	s := r.NewService()
 
 	s.NewEndpoint("/mailer").
+		Handler(shttp.MethodGet, "", app.WithApp(HandlerMailList, &app.Opts{Env: true})).
 		Handler(shttp.MethodPost, "", app.WithApp(HandlerMail, &app.Opts{Env: true})).
 		Handler(shttp.MethodGet, "/config", app.WithApp(HandlerMailerConfigGet, &app.Opts{Env: true})).
 		Handler(shttp.MethodPost, "/config", app.WithApp(HandlerMailerConfigSet, &app.Opts{Env: true}))

--- a/src/ce/api/app/buildconf/mailerhandlers/services_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/services_test.go
@@ -17,6 +17,7 @@ func (s *ServicesSuite) Test_Services() {
 	s.NotNil(services)
 
 	handlers := []string{
+		"GET:/mailer",
 		"GET:/mailer/config",
 		"POST:/mailer",
 		"POST:/mailer/config",


### PR DESCRIPTION
## Summary

- Emails are now stored in the `mailer` table unconditionally — whether SMTP is configured or not. This lets teams verify their email integration without setting up an SMTP server first.
- `POST /mailer` skips the SMTP send when no mailer config is set, but still stores the email and returns 200.
- New `GET /mailer` endpoint returns the last 100 stored emails for an environment (accessible to authenticated team members only).
- Fixes a bug in `InsertEmail` where `subject` and `body` were passed in the wrong order to the SQL statement.

## Test plan

- [ ] `POST /mailer` with no SMTP config returns 200 and stores the email
- [ ] `POST /mailer` with SMTP config sends via SMTP and stores the email
- [ ] `GET /mailer` returns stored emails for the environment
- [ ] `GET /mailer` returns `{"emails": []}` when no emails have been sent
- [ ] Run `go test ./src/ce/api/app/buildconf/mailerhandlers/... -v`