### PR TITLE
feat: add Sent Emails submenu under Mailer

### DIFF
--- a/src/ui/src/layouts/AppLayout/menu_items.tsx
+++ b/src/ui/src/layouts/AppLayout/menu_items.tsx
@@ -124,6 +124,18 @@ export const envMenuItems = ({
     path: `${envPath}/mailer`,
     icon: Icon(MailIcon),
     isActive: pathname.includes("/mailer"),
+    children: [
+      {
+        text: "Configuration",
+        path: `${envPath}/mailer`,
+        isActive: pathname.endsWith("/mailer"),
+      },
+      {
+        text: "Sent Emails",
+        path: `${envPath}/mailer/emails`,
+        isActive: pathname.endsWith("/mailer/emails"),
+      },
+    ],
   });
 
   if (env.published?.length) {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.spec.tsx
@@ -1,0 +1,109 @@
+import type { Scope } from "nock";
+import type { MockEmail } from "~/testing/nocks/nock_mailer";
+import { describe, expect, it, vi } from "vitest";
+import { RenderResult, waitFor } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
+import { AppContext } from "~/pages/apps/[id]/App.context";
+import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
+import mockApp from "~/testing/data/mock_app";
+import mockEnvironments from "~/testing/data/mock_environments";
+import { mockFetchEmails } from "~/testing/nocks/nock_mailer";
+import SentEmails from "./SentEmails";
+
+interface WrapperProps {
+  emails?: MockEmail[];
+}
+
+describe("~/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx", () => {
+  let wrapper: RenderResult;
+  let fetchScope: Scope;
+  let currentApp: App;
+  let currentEnv: Environment;
+
+  const createWrapper = ({ emails = [] }: WrapperProps) => {
+    currentApp = mockApp();
+    currentApp.id = "1";
+    currentEnv = mockEnvironments({ app: currentApp })[0];
+
+    fetchScope = mockFetchEmails({
+      appId: currentApp.id,
+      envId: currentEnv.id!,
+      response: { emails },
+    });
+
+    wrapper = render(
+      <AppContext.Provider
+        value={{
+          app: currentApp,
+          environments: [currentEnv],
+          setRefreshToken: vi.fn(),
+        }}
+      >
+        <EnvironmentContext.Provider value={{ environment: currentEnv }}>
+          <SentEmails />
+        </EnvironmentContext.Provider>
+      </AppContext.Provider>,
+    );
+  };
+
+  it("should display empty state when no emails", async () => {
+    createWrapper({});
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+    });
+
+    expect(wrapper.getByText("Sent Emails")).toBeTruthy();
+    expect(wrapper.getByText("No emails sent yet.")).toBeTruthy();
+  });
+
+  it("should render list of emails", async () => {
+    const emails: MockEmail[] = [
+      {
+        id: "1",
+        envId: currentEnv?.id || "1",
+        from: "sender@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome aboard",
+        body: "<p>Hello!</p>",
+        sentAt: 1700000000,
+      },
+    ];
+
+    createWrapper({ emails });
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+    });
+
+    expect(wrapper.getByText("Welcome aboard")).toBeTruthy();
+    expect(wrapper.getByText("To: recipient@example.com")).toBeTruthy();
+  });
+
+  it("should open email preview dialog on row click", async () => {
+    const emails: MockEmail[] = [
+      {
+        id: "1",
+        envId: currentEnv?.id || "1",
+        from: "sender@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome aboard",
+        body: "<p>Hello!</p>",
+        sentAt: 1700000000,
+      },
+    ];
+
+    createWrapper({ emails });
+
+    await waitFor(() => {
+      expect(wrapper.getByText("Welcome aboard")).toBeTruthy();
+    });
+
+    fireEvent.click(wrapper.getByText("Welcome aboard"));
+
+    await waitFor(() => {
+      expect(wrapper.getByText("From: sender@example.com")).toBeTruthy();
+      expect(wrapper.getAllByText("To: recipient@example.com")).toHaveLength(2);
+    });
+  });
+});

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx
@@ -1,0 +1,94 @@
+import { useState, useContext } from "react";
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Typography from "@mui/material/Typography";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardRow from "~/components/CardRow";
+import { AppContext } from "~/pages/apps/[id]/App.context";
+import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
+import { formatDate } from "~/utils/helpers/date";
+import { useFetchEmails, type Email } from "./actions";
+
+export default function SentEmails() {
+  const { app } = useContext(AppContext);
+  const { environment: env } = useContext(EnvironmentContext);
+  const [selectedEmail, setSelectedEmail] = useState<Email>();
+  const { loading, error, emails } = useFetchEmails({
+    appId: app.id,
+    envId: env.id!,
+  });
+
+  return (
+    <>
+      <Card id="sent-emails" width="100%" loading={loading} error={error}>
+        <CardHeader
+          title="Sent Emails"
+          subtitle="Last 100 emails sent from this environment."
+        />
+
+        {emails.map(email => (
+          <CardRow
+            key={email.id}
+            sx={{ cursor: "pointer" }}
+            onClick={() => setSelectedEmail(email)}
+          >
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <Box sx={{ flex: 1 }}>
+                <Typography>{email.subject}</Typography>
+                <Typography sx={{ fontSize: 12, color: "text.secondary" }}>
+                  To: {email.to}
+                </Typography>
+              </Box>
+              <Typography
+                sx={{ fontSize: 12, color: "text.secondary", ml: 2 }}
+              >
+                {formatDate(email.sentAt)}
+              </Typography>
+            </Box>
+          </CardRow>
+        ))}
+
+        {!loading && emails.length === 0 && (
+          <Box sx={{ px: 4, py: 2 }}>
+            <Typography sx={{ color: "text.secondary" }}>
+              No emails sent yet.
+            </Typography>
+          </Box>
+        )}
+      </Card>
+
+      {selectedEmail && (
+        <Dialog
+          open
+          onClose={() => setSelectedEmail(undefined)}
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle>{selectedEmail.subject}</DialogTitle>
+          <DialogContent>
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                From: {selectedEmail.from}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                To: {selectedEmail.to}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Sent: {formatDate(selectedEmail.sentAt)}
+              </Typography>
+            </Box>
+            <Box
+              component="iframe"
+              srcDoc={selectedEmail.body}
+              sx={{ width: "100%", minHeight: 400, border: "none" }}
+              title="Email preview"
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
@@ -8,7 +8,23 @@ interface MailerConfig {
   password: string;
 }
 
+export interface Email {
+  id: string;
+  envId: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  sentAt: number;
+}
+
 interface FetchMailerConfigProps {
+  appId: string;
+  envId: string;
+  refreshToken?: number;
+}
+
+interface FetchEmailsProps {
   appId: string;
   envId: string;
   refreshToken?: number;
@@ -43,4 +59,45 @@ export const useFetchMailerConfig = ({
   }, [refreshToken, appId, envId]);
 
   return { config, loading, error };
+};
+
+export const useFetchEmails = ({
+  appId,
+  envId,
+  refreshToken,
+}: FetchEmailsProps) => {
+  const [emails, setEmails] = useState<Email[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoading(true);
+    setError(undefined);
+
+    api
+      .fetch<{ emails: Email[] }>(`/mailer?appId=${appId}&envId=${envId}`)
+      .then(({ emails }) => {
+        if (!unmounted) {
+          setEmails(emails || []);
+        }
+      })
+      .catch(() => {
+        if (!unmounted) {
+          setError("Something went wrong while fetching sent emails.");
+        }
+      })
+      .finally(() => {
+        if (!unmounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, [refreshToken, appId, envId]);
+
+  return { emails, loading, error };
 };

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/routes.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/routes.ts
@@ -46,6 +46,13 @@ const routes: Array<RouteProps> = [
     ),
   },
   {
+    path: "/mailer/emails",
+    element: Async(
+      () =>
+        import("~/pages/apps/[id]/environments/[env-id]/mailer/SentEmails"),
+    ),
+  },
+  {
     path: "/auth",
     element: Async(
       () => import("~/pages/apps/[id]/environments/[env-id]/skauth"),

--- a/src/ui/src/testing/nocks/nock_mailer.ts
+++ b/src/ui/src/testing/nocks/nock_mailer.ts
@@ -61,6 +61,34 @@ export const mockSetMailerConfig = ({
     .reply(status, response);
 };
 
+export interface MockEmail {
+  id: string;
+  envId: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  sentAt: number;
+}
+
+interface MockFetchEmailsProps {
+  appId?: string;
+  envId?: string;
+  status?: number;
+  response?: { emails: MockEmail[] };
+}
+
+export const mockFetchEmails = ({
+  appId = "",
+  envId = "",
+  status = 200,
+  response = { emails: [] },
+}: MockFetchEmailsProps) => {
+  return nock(endpoint)
+    .get(`/mailer?appId=${appId}&envId=${envId}`)
+    .reply(status, response);
+};
+
 interface MockSendTestEmailProps {
   appId: string;
   envId: string;


### PR DESCRIPTION
## Summary

- Adds a **Sent Emails** sub-page under the Mailer nav item (matching the Authentication submenu pattern)
- Mailer nav item now expands to two children: **Configuration** and **Sent Emails**
- Sent Emails page fetches `GET /mailer` and lists the last 100 emails for the environment
- Each row shows subject, recipient, and timestamp — clicking a row opens a dialog with full email details and an HTML preview in a sandboxed iframe
- Empty state shown when no emails have been sent yet
- Adds `useFetchEmails` hook and `mockFetchEmails` nock helper

## Test plan

- [ ] Navigate to Mailer in the sidebar — confirm it expands to Configuration / Sent Emails sub-items
- [ ] Sent Emails page loads and shows an empty state when no emails exist
- [ ] After sending a test email via the Configuration page, navigate to Sent Emails and confirm it appears
- [ ] Click a row to open the preview dialog — verify from, to, subject, and HTML body are displayed
- [ ] Run `npm test -- mailer` in `src/ui`