### PR TITLE
feat: add magic link authentication provider for SKAuth

### DIFF
--- a/src/ce/api/app/buildconf/mailer_store.go
+++ b/src/ce/api/app/buildconf/mailer_store.go
@@ -25,7 +25,7 @@ var mstmt = struct {
 	`,
 
 	upsertConfig: `
-		UPDATE apps_build_conf SET mailer_conf = $1 WHERE env_id = $2;	
+		UPDATE apps_build_conf SET mailer_conf = $1 WHERE env_id = $2;
 	`,
 
 	selectEmails: `
@@ -74,7 +74,7 @@ func (s *mailerStore) UpsertConfig(ctx context.Context, cnf *MailerConf) error {
 	return err
 }
 
-// InsertMail inserts a sent email to the database. This is mostly for auditing.
+// InsertEmail inserts a sent email to the database.
 func (s *mailerStore) InsertEmail(ctx context.Context, mail Email) error {
 	_, err := s.Exec(ctx, mstmt.insertEmail, mail.EnvID, mail.To, mail.From, mail.Subject, mail.Body)
 	return err

--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -17,14 +17,16 @@ import (
 )
 
 var schemaStmt = struct {
-	selectSchema          string
-	selectTables          string
-	createAuthTable       string
-	createMigrationsTable string
-	selectMigrations      string
-	insertOAuth           string
-	insertAuthUser        string
-	verifyEmailUser       string
+	selectSchema           string
+	selectTables           string
+	createAuthTable        string
+	createMigrationsTable  string
+	selectMigrations       string
+	insertOAuth            string
+	insertAuthUser         string
+	verifyEmailUser        string
+	updateMagicLinkToken   string
+	consumeMagicLinkToken  string
 }{
 	createAuthTable: `
 		CREATE TABLE IF NOT EXISTS stormkit_auth_users (
@@ -41,8 +43,8 @@ var schemaStmt = struct {
 			auth_id SERIAL PRIMARY KEY NOT NULL,
 			user_id BIGINT NOT NULL REFERENCES stormkit_auth_users(user_id) ON DELETE CASCADE,
 			account_id TEXT,
-			access_token TEXT NOT NULL,
-			refresh_token TEXT NOT NULL,
+			access_token TEXT,
+			refresh_token TEXT,
 			token_type TEXT NOT NULL,
 			provider_name TEXT NOT NULL,
 			expiry TIMESTAMPTZ NULL,
@@ -118,6 +120,19 @@ var schemaStmt = struct {
 		WHERE verification_token = $1 AND provider_name = 'email'
 		RETURNING user_id;
 	`,
+
+	updateMagicLinkToken: `
+		UPDATE stormkit_auth_providers
+		SET verification_token = $1
+		WHERE user_id = $2 AND provider_name = 'magiclink';
+	`,
+
+	consumeMagicLinkToken: `
+		UPDATE stormkit_auth_providers
+		SET verified_at = NOW(), verification_token = NULL
+		WHERE verification_token = $1 AND provider_name = 'magiclink'
+		RETURNING user_id;
+	`,
 }
 
 var sqlTemplates = struct {
@@ -130,10 +145,10 @@ var sqlTemplates = struct {
 	selectAuthUsers: template.Must(template.New("selectAuthUsers").Parse(`
 		SELECT
 			u.user_id,
-			u.first_name,
-			u.last_name,
+			COALESCE(u.first_name, '') AS first_name,
+			COALESCE(u.last_name, '') AS last_name,
 			u.email,
-			u.avatar,
+			COALESCE(u.avatar, '') AS avatar,
 			u.created_at,
 			u.last_login_at
 			{{- if .WithHash}}, p.access_token AS password_hash, p.verified_at{{end}}
@@ -611,8 +626,8 @@ func (s *schemaStore) InsertAuthUser(ctx context.Context, oauth *skauth.OAuth, u
 	_, err = tx.ExecContext(ctx, schemaStmt.insertOAuth,
 		user.ID,
 		oauth.AccountID,
-		utils.EncryptToString(oauth.AccessToken),
-		utils.EncryptToString(oauth.RefreshToken),
+		null.NewString(utils.EncryptToString(oauth.AccessToken), oauth.AccessToken != ""),
+		null.NewString(utils.EncryptToString(oauth.RefreshToken), oauth.RefreshToken != ""),
 		oauth.TokenType,
 		oauth.ProviderName,
 		oauth.Expiry,
@@ -755,7 +770,7 @@ func (s *schemaStore) AuthUserByEmail(ctx context.Context, p AuthUserByEmailPara
 
 	authUser := &skauth.User{}
 
-	var encryptedHash string
+	var encryptedHash null.String
 
 	err = row.Scan(
 		&authUser.ID,
@@ -777,7 +792,7 @@ func (s *schemaStore) AuthUserByEmail(ctx context.Context, p AuthUserByEmailPara
 		return nil, err
 	}
 
-	authUser.PasswordHash = utils.DecryptToString(encryptedHash)
+	authUser.PasswordHash = utils.DecryptToString(encryptedHash.String)
 
 	return authUser, nil
 }
@@ -792,6 +807,57 @@ func (s *schemaStore) VerifyEmailUser(ctx context.Context, token string) (types.
 	var userID types.ID
 
 	err := s.Conn.QueryRowContext(ctx, schemaStmt.verifyEmailUser, token).Scan(&userID)
+
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+
+	return userID, err
+}
+
+// UpsertMagicLinkUser finds or creates a user by email and sets a new magic link token
+// on their magiclink provider record. Returns the user ID.
+func (s *schemaStore) UpsertMagicLinkUser(ctx context.Context, email, token string) (types.ID, error) {
+	if s.conf == nil {
+		return 0, fmt.Errorf("schema configuration is required to upsert magic link user")
+	}
+
+	existing, err := s.AuthUserByEmail(ctx, AuthUserByEmailParams{
+		Email:    email,
+		Provider: skauth.ProviderMagicLink,
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	if existing != nil {
+		_, err = s.Exec(ctx, schemaStmt.updateMagicLinkToken, token, existing.ID)
+		return existing.ID, err
+	}
+
+	user := &skauth.User{Email: email}
+
+	err = s.InsertAuthUser(ctx, &skauth.OAuth{
+		AccountID:         email,
+		ProviderName:      skauth.ProviderMagicLink,
+		TokenType:         skauth.ProviderMagicLink,
+		VerificationToken: token,
+	}, user)
+
+	return user.ID, err
+}
+
+// ConsumeMagicLinkToken validates and consumes a magic link token. On success it stamps
+// verified_at, clears the token, and returns the user ID. Returns 0 if not found.
+func (s *schemaStore) ConsumeMagicLinkToken(ctx context.Context, token string) (types.ID, error) {
+	if s.conf == nil {
+		return 0, fmt.Errorf("schema configuration is required to consume magic link token")
+	}
+
+	var userID types.ID
+
+	err := s.Conn.QueryRowContext(ctx, schemaStmt.consumeMagicLinkToken, token).Scan(&userID)
 
 	if err == sql.ErrNoRows {
 		return 0, nil

--- a/src/ce/api/app/skauth/client_magiclink.go
+++ b/src/ce/api/app/skauth/client_magiclink.go
@@ -1,0 +1,30 @@
+package skauth
+
+import (
+	"context"
+	"errors"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"golang.org/x/oauth2"
+)
+
+type magicLinkClient struct{}
+
+// NewMagicLinkClient returns a Client implementation for the magic link provider.
+// Magic link login does not use OAuth redirects; this client is used only to satisfy
+// the Client interface and to signal that the provider is valid.
+func NewMagicLinkClient() Client {
+	return &magicLinkClient{}
+}
+
+func (c *magicLinkClient) AuthCodeURL(_ AuthCodeURLParams) (string, error) {
+	return "", errors.New("magiclink provider does not support OAuth redirect flow")
+}
+
+func (c *magicLinkClient) Exchange(_ context.Context, _ *shttp.RequestContext) (*oauth2.Token, error) {
+	return nil, errors.New("magiclink provider does not support OAuth token exchange")
+}
+
+func (c *magicLinkClient) UserInfo(_ context.Context, _ *oauth2.Token) (*UserInfo, error) {
+	return nil, errors.New("magiclink provider does not support UserInfo via OAuth token")
+}

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -14,11 +14,13 @@ import (
 const ProviderGoogle = "google"
 const ProviderX = "x"
 const ProviderEmail = "email"
+const ProviderMagicLink = "magiclink"
 
 var Providers = []string{
 	ProviderGoogle,
 	ProviderX,
 	ProviderEmail,
+	ProviderMagicLink,
 }
 
 type OAuthToken struct {
@@ -79,6 +81,8 @@ func (p *Provider) Client() Client {
 		p.cachedClient = NewXClient(p.Data.ClientID, p.Data.ClientSecret)
 	case ProviderEmail:
 		p.cachedClient = NewEmailClient()
+	case ProviderMagicLink:
+		p.cachedClient = NewMagicLinkClient()
 	}
 
 	return p.cachedClient

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
@@ -63,7 +63,7 @@ func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 	data.ProviderName = strings.TrimSpace(strings.ToLower(data.ProviderName))
 
 	switch data.ProviderName {
-	case skauth.ProviderEmail:
+	case skauth.ProviderEmail, skauth.ProviderMagicLink:
 		return handleEmailProvider(req, data, env)
 	default:
 		return handleOAuthProvider(req, data, env)

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
@@ -275,6 +275,30 @@ func (s *HandlerAuthUpsertSuite) Test_Success_EmailProvider_NoClientCredentials(
 	s.Equal(skauth.ProviderData{}, provider.Data, "Email provider should store no OAuth credentials")
 }
 
+func (s *HandlerAuthUpsertSuite) Test_Success_MagicLinkProvider() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth",
+		map[string]any{
+			"envId":        s.env.ID,
+			"providerName": skauth.ProviderMagicLink,
+			"status":       true,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	provider, err := skauth.NewStore().Provider(context.Background(), s.env.ID, skauth.ProviderMagicLink)
+	s.NoError(err)
+	s.NotNil(provider, "Magic link provider should be saved")
+	s.True(provider.Status)
+	s.Equal(skauth.ProviderData{}, provider.Data, "Magic link provider should have no OAuth credentials")
+}
+
 func TestHandlerUpsertSuite(t *testing.T) {
 	suite.Run(t, &HandlerAuthUpsertSuite{})
 }

--- a/src/ce/api/public/v1/handler_auth_magiclink.go
+++ b/src/ce/api/public/v1/handler_auth_magiclink.go
@@ -1,0 +1,200 @@
+package publicapiv1
+
+import (
+	"fmt"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+func generateMagicLinkToken(env *buildconf.Env) (string, error) {
+	jti, err := utils.SecureRandomToken(16)
+
+	if err != nil {
+		return "", err
+	}
+
+	return user.JWT(jwt.MapClaims{
+		"exp": time.Now().Add(15 * time.Minute).Unix(),
+		"prv": skauth.ProviderMagicLink,
+		"jti": jti,
+	}, env.AuthConf.Secret)
+}
+
+func sendMagicLinkEmail(req *shttp.RequestContext, env *buildconf.Env, email, token string) error {
+	u := req.URL()
+	link := fmt.Sprintf("%s://%s/_stormkit/auth/magic?token=%s", u.Scheme, u.Host, token)
+
+	params := buildconf.SendEmailParams{
+		To:      email,
+		Subject: "Your magic link",
+		Body:    fmt.Sprintf(`<p>Click the link below to sign in. The link expires in 15 minutes.</p><p><a href="%s">%s</a></p>`, link, link),
+	}
+
+	if err := buildconf.MailerStore().InsertEmail(req.Context(), buildconf.Email{
+		EnvID:   env.ID,
+		To:      email,
+		Subject: params.Subject,
+		Body:    params.Body,
+	}); err != nil {
+		return err
+	}
+
+	if env.MailerConf != nil {
+		return env.MailerConf.Send(params)
+	}
+
+	return nil
+}
+
+// HandlerAuthMagicLinkRequest handles a magic link sign-in request.
+// It finds or creates the user, stores a short-lived token, and emails the link.
+// POST /v1/auth/magiclink
+func HandlerAuthMagicLinkRequest(req *shttp.RequestContext) *shttp.Response {
+	body := &struct {
+		EnvID string `json:"envId"`
+		Email string `json:"email"`
+	}{}
+
+	// Ignore parse errors — the fields may arrive as query params instead of a JSON body.
+	_ = req.Post(body)
+
+	envID := utils.StringToID(utils.GetString(body.EnvID, req.FormValue("envId"), req.Query().Get("envId")))
+	email := utils.GetString(body.Email, req.Query().Get("email"))
+
+	if envID == 0 {
+		return shttp.BadRequest(map[string]any{"errors": []string{"envId is required"}})
+	}
+
+	if !utils.IsValidEmail(email) {
+		return shttp.BadRequest(map[string]any{"errors": []string{"email is invalid"}})
+	}
+
+	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), envID)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to get environment by ID %d", envID))
+	}
+
+	if env == nil || env.AuthConf == nil || !env.AuthConf.Status || env.SchemaConf == nil {
+		return shttp.NotFound()
+	}
+
+	prv, err := skauth.NewStore().Provider(req.Context(), envID, skauth.ProviderMagicLink)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to get provider: %s", err.Error()))
+	}
+
+	if prv == nil || !prv.Status {
+		return shttp.NotFound()
+	}
+
+	token, err := generateMagicLinkToken(env)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to generate magic link token: %s", err.Error()))
+	}
+
+	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to get schema store: %s", err.Error()))
+	}
+
+	if _, err := store.UpsertMagicLinkUser(req.Context(), email, token); err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to upsert magic link user: %s", err.Error()))
+	}
+
+	if err := sendMagicLinkEmail(req, env, email, token); err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to send magic link email: %s", err.Error()))
+	}
+
+	return shttp.OK()
+}
+
+// HandlerAuthMagicLinkVerify validates a magic link token and returns a session.
+// GET /v1/auth/magiclink?token=&envId=
+func HandlerAuthMagicLinkVerify(req *shttp.RequestContext) *shttp.Response {
+	token := req.Query().Get("token")
+	envIDStr := req.Query().Get("envId")
+
+	if token == "" {
+		return shttp.BadRequest(map[string]any{"errors": []string{"token is required"}})
+	}
+
+	envID := utils.StringToID(envIDStr)
+
+	if envID == 0 {
+		return shttp.BadRequest(map[string]any{"errors": []string{"envId is required"}})
+	}
+
+	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), envID)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to get environment by ID %d", envID))
+	}
+
+	if env == nil || env.AuthConf == nil || !env.AuthConf.Status || env.SchemaConf == nil {
+		return shttp.NotFound()
+	}
+
+	prv, err := skauth.NewStore().Provider(req.Context(), envID, skauth.ProviderMagicLink)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to get provider: %s", err.Error()))
+	}
+
+	if prv == nil || !prv.Status {
+		return shttp.NotFound()
+	}
+
+	if claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: token, Secret: env.AuthConf.Secret}); claims == nil {
+		return shttp.BadRequest(map[string]any{"errors": []string{"invalid or expired magic link token"}})
+	}
+
+	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to get schema store: %s", err.Error()))
+	}
+
+	userID, err := store.ConsumeMagicLinkToken(req.Context(), token)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to consume magic link token: %s", err.Error()))
+	}
+
+	if userID == 0 {
+		return shttp.BadRequest(map[string]any{"errors": []string{"invalid or expired magic link token"}})
+	}
+
+	authUser, err := store.AuthUser(req.Context(), userID)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to fetch user: %s", err.Error()))
+	}
+
+	if authUser == nil {
+		return shttp.Error(fmt.Errorf("user %d not found after consuming magic link", userID), "internal error")
+	}
+
+	sessionToken, err := user.JWT(jwt.MapClaims{
+		"uid": authUser.ID,
+		"eid": fmt.Sprintf("%d", envID),
+		"prv": skauth.ProviderMagicLink,
+	}, env.AuthConf.Secret)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error()))
+	}
+
+	return &shttp.Response{
+		Data: map[string]any{"token": sessionToken, "email": authUser.Email, "userId": authUser.ID},
+	}
+}

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -81,6 +81,50 @@ func (m *skAuthMiddleware) handleVerify() (*shttp.Response, error) {
 	return m.renderVerifyPage(http.StatusOK, head, ""), nil
 }
 
+func (m *skAuthMiddleware) handleMagicLinkRequest() (*shttp.Response, error) {
+	m.injectEnvID()
+
+	resp := publicapiv1.HandlerAuthMagicLinkRequest(m.req.RequestContext)
+
+	if resp.Status != 0 && resp.Status != http.StatusOK {
+		return resp, nil
+	}
+
+	return &shttp.Response{Status: http.StatusCreated}, nil
+}
+
+func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
+	m.injectEnvID()
+
+	resp := publicapiv1.HandlerAuthMagicLinkVerify(m.req.RequestContext)
+
+	if resp.Status != 0 && resp.Status != http.StatusOK {
+		errMsg := "magic link verification failed"
+
+		if d, ok := resp.Data.(map[string]any); ok {
+			if errs, ok := d["errors"].([]string); ok && len(errs) > 0 {
+				errMsg = errs[0]
+			}
+		}
+
+		return m.renderVerifyPage(resp.Status, "", errMsg), nil
+	}
+
+	data, ok := resp.Data.(map[string]any)
+
+	if !ok {
+		return m.renderVerifyPage(http.StatusInternalServerError, "", "magic link verification failed"), nil
+	}
+
+	head := fmt.Sprintf(
+		`<script>localStorage.setItem('skauth', JSON.stringify('%s'));window.location.href="%s?verified=true";</script>`,
+		data["token"],
+		m.req.Host.Config.SKAuth.SuccessURL,
+	)
+
+	return m.renderVerifyPage(http.StatusOK, head, ""), nil
+}
+
 func (m *skAuthMiddleware) handleCallback() (*shttp.Response, error) {
 	var head, content string
 
@@ -148,6 +192,14 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 
 	if path == "/_stormkit/auth/verify" {
 		return m.handleVerify()
+	}
+
+	if path == "/_stormkit/auth/magic" {
+		if m.req.Query().Get("token") != "" {
+			return m.handleMagicLinkVerify()
+		}
+
+		return m.handleMagicLinkRequest()
 	}
 
 	return m.handleCallback()

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -1,0 +1,270 @@
+package hosting_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
+	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/database"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type WithSKAuthMagicLinkSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+	app  *factory.MockApp
+}
+
+func (s *WithSKAuthMagicLinkSuite) BeforeTest(suiteName, _ string) {
+	truncateMagicLinkAuthTables()
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+	s.app = s.MockApp(s.MockUser(nil), nil)
+}
+
+func (s *WithSKAuthMagicLinkSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *WithSKAuthMagicLinkSuite) setupEnv() (*factory.MockEnv, error) {
+	env := s.MockEnv(s.app, map[string]any{
+		"AuthConf": &buildconf.SKAuthConf{
+			Secret: "test-secret",
+			Status: true,
+		},
+		"SchemaConf": &buildconf.SchemaConf{
+			SchemaName:        s.conn.Cfg.Schema,
+			DBName:            s.conn.Cfg.DBName,
+			Port:              s.conn.Cfg.Port,
+			Host:              s.conn.Cfg.Host,
+			MigrationUserName: s.conn.Cfg.User,
+			MigrationPassword: s.conn.Cfg.Password,
+			AppUserName:       s.conn.Cfg.User,
+			AppPassword:       s.conn.Cfg.Password,
+			DriverName:        s.conn.Cfg.DriverName,
+		},
+	})
+
+	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeMigrations)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := store.CreateAuthTable(context.Background()); err != nil {
+		return nil, err
+	}
+
+	err = skauth.NewStore().SaveProvider(context.Background(), skauth.SaveProviderArgs{
+		EnvID: env.ID,
+		AppID: s.app.ID,
+		Provider: &skauth.Provider{
+			Name:   skauth.ProviderMagicLink,
+			Status: true,
+		},
+	})
+
+	return env, err
+}
+
+func (s *WithSKAuthMagicLinkSuite) hostFor(envID types.ID) *hosting.Host {
+	return &hosting.Host{
+		Name: "my.example.com",
+		Config: &appconf.Config{
+			EnvID: envID,
+			SKAuth: &buildconf.SKAuthConf{
+				Secret:     "test-secret",
+				SuccessURL: "/dashboard",
+			},
+		},
+	}
+}
+
+func (s *WithSKAuthMagicLinkSuite) magicRequest(host *hosting.Host, path string) *hosting.RequestContext {
+	pieces := strings.SplitN(path, "?", 2)
+	rawPath := pieces[0]
+	query := ""
+
+	if len(pieces) > 1 {
+		query = pieces[1]
+	}
+
+	rq := &hosting.RequestContext{
+		Host: host,
+		RequestContext: shttp.NewRequestContext(&http.Request{
+			Method: http.MethodGet,
+			Header: make(http.Header),
+			URL: &url.URL{
+				Scheme:   "https",
+				Host:     host.Name,
+				Path:     rawPath,
+				RawQuery: query,
+				RawPath:  rawPath,
+			},
+		}),
+	}
+
+	rq.OriginalPath = rawPath
+
+	return rq
+}
+
+func (s *WithSKAuthMagicLinkSuite) captureToken(envID types.ID) string {
+	emails, err := buildconf.MailerStore().Emails(context.Background(), envID)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(emails, "expected at least one stored email")
+
+	body := emails[len(emails)-1].Body
+	needle := "token="
+	idx := strings.Index(body, needle)
+	s.Require().GreaterOrEqual(idx, 0, "token not found in email body")
+
+	start := idx + len(needle)
+	end := start
+
+	for end < len(body) && body[end] != '"' && body[end] != '<' && body[end] != '>' && body[end] != ' ' {
+		end++
+	}
+
+	return body[start:end]
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_InvalidEmail() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=not-an-email"))
+
+	s.NoError(err)
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_ProviderNotEnabled() {
+	env := s.MockEnv(s.app, nil)
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com"))
+
+	s.NoError(err)
+	s.Equal(http.StatusNotFound, res.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_Success() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com"))
+
+	s.NoError(err)
+	s.Equal(http.StatusCreated, res.Status)
+
+	emails, err := buildconf.MailerStore().Emails(context.Background(), env.ID)
+	s.Require().NoError(err)
+	s.Require().Len(emails, 1)
+	s.Equal("user@example.com", emails[0].To)
+	s.Contains(emails[0].Body, "_stormkit/auth/magic?token=")
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_CreatesNewUser() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=newuser@example.com"))
+	s.Require().NoError(err)
+
+	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
+	s.Require().NoError(err)
+
+	authUser, err := store.AuthUserByEmail(context.Background(), buildconf.AuthUserByEmailParams{
+		Email:    "newuser@example.com",
+		Provider: skauth.ProviderMagicLink,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(authUser)
+	s.Equal("newuser@example.com", authUser.Email)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_InvalidToken() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?token=bad-token"))
+
+	s.NoError(err)
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_Success() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=verify@example.com"))
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, res.Status)
+	s.Contains(string(res.Data.([]byte)), "localStorage.setItem('skauth'")
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_TokenConsumedOnce() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=once@example.com"))
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	path := fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)
+
+	first, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	s.NoError(err)
+	s.Equal(http.StatusOK, first.Status)
+
+	second, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	s.NoError(err)
+	s.Equal(http.StatusBadRequest, second.Status)
+}
+
+func truncateMagicLinkAuthTables() {
+	db, err := sql.Open("postgres", database.ConnectionString(database.Config))
+
+	if err != nil {
+		return
+	}
+
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		DO $$
+		BEGIN
+			IF EXISTS (SELECT FROM pg_tables WHERE schemaname = current_schema() AND tablename = 'stormkit_auth_users') THEN
+				TRUNCATE stormkit_auth_users, stormkit_auth_providers RESTART IDENTITY CASCADE;
+			END IF;
+		END $$;
+	`); err != nil {
+		panic("truncateMagicLinkAuthTables: " + err.Error())
+	}
+}
+
+func TestWithSKAuthMagicLink(t *testing.T) {
+	suite.Run(t, new(WithSKAuthMagicLinkSuite))
+}

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -285,6 +285,37 @@ func (s *WithSKAuthSuite) Test_VerifyPath_MissingEnv() {
 	s.Equal(http.StatusBadRequest, res.Status)
 }
 
+// Test_MagicPath_RequestMissingEmail checks that GET /_stormkit/auth/magic without
+// an email param returns 400.
+func (s *WithSKAuthSuite) Test_MagicPath_RequestMissingEmail() {
+	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic")
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+// Test_MagicPath_RequestInvalidEmail checks that a malformed email returns 400.
+func (s *WithSKAuthSuite) Test_MagicPath_RequestInvalidEmail() {
+	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic?email=not-an-email")
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+// Test_MagicPath_VerifyInvalidToken checks that an invalid token returns 400.
+func (s *WithSKAuthSuite) Test_MagicPath_VerifyInvalidToken() {
+	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic?token=bad-token")
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
 func TestWithSKAuth(t *testing.T) {
 	suite.Run(t, new(WithSKAuthSuite))
 }

--- a/src/ui/src/components/MenuLink/MenuLink.tsx
+++ b/src/ui/src/components/MenuLink/MenuLink.tsx
@@ -16,10 +16,17 @@ interface Props {
   item: Path;
   inline?: boolean;
   dot?: boolean;
+  borderRadius?: number;
   sx?: SxProps;
 }
 
-export default function MenuLink({ item, sx, inline, dot = false }: Props) {
+export default function MenuLink({
+  item,
+  sx,
+  inline,
+  borderRadius = 1,
+  dot = false,
+}: Props) {
   return (
     <Typography
       component="div"
@@ -35,8 +42,8 @@ export default function MenuLink({ item, sx, inline, dot = false }: Props) {
           display: "inline-flex",
           position: "relative",
           alignItems: "center",
+          borderRadius,
           justifyContent: "space-between",
-          borderRadius: 1,
           transition: "background-color 0.2s ease, color 0.2s ease",
           bgcolor:
             item.isActive && !item.children?.length
@@ -51,7 +58,7 @@ export default function MenuLink({ item, sx, inline, dot = false }: Props) {
         }}
       >
         <span>
-          {item.icon ?? (dot ? <Dot sx={{ mr: 2 }} /> : null)}
+          {item.icon ?? (dot ? <Dot sx={{ pl: 0.25, mr: 2.75 }} /> : null)}
           {item.text}
         </span>
         {item.children && (

--- a/src/ui/src/layouts/AppLayout/EnvMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/EnvMenu.tsx
@@ -103,12 +103,14 @@ export default function EnvMenu() {
             <Box key={item.path}>
               <Box
                 sx={{
-                  borderBottom: item.children ? undefined : "1px solid",
+                  borderBottom:
+                    item.children && item.isActive ? undefined : "1px solid",
                   borderColor: "container.border",
                 }}
               >
                 <MenuLink
                   item={item}
+                  borderRadius={0}
                   sx={{
                     flex: 1,
                     mx: 2,
@@ -133,6 +135,7 @@ export default function EnvMenu() {
                       dot
                       key={child.path}
                       item={child}
+                      borderRadius={0}
                       sx={{
                         mx: 2,
                         py: 1,
@@ -140,6 +143,9 @@ export default function EnvMenu() {
                         borderColor: "container.border",
                         display: "flex",
                         alignItems: "center",
+                        "&:last-child": {
+                          borderBottom: "none",
+                        },
                       }}
                     />
                   ))}

--- a/src/ui/src/layouts/AppLayout/menu_items.tsx
+++ b/src/ui/src/layouts/AppLayout/menu_items.tsx
@@ -124,6 +124,18 @@ export const envMenuItems = ({
     path: `${envPath}/mailer`,
     icon: Icon(MailIcon),
     isActive: pathname.includes("/mailer"),
+    children: [
+      {
+        text: "Configuration",
+        path: `${envPath}/mailer`,
+        isActive: pathname.endsWith("/mailer"),
+      },
+      {
+        text: "Sent Emails",
+        path: `${envPath}/mailer/emails`,
+        isActive: pathname.endsWith("/mailer/emails"),
+      },
+    ],
   });
 
   if (env.published?.length) {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.spec.tsx
@@ -1,0 +1,109 @@
+import type { Scope } from "nock";
+import type { MockEmail } from "~/testing/nocks/nock_mailer";
+import { describe, expect, it, vi } from "vitest";
+import { RenderResult, waitFor } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
+import { AppContext } from "~/pages/apps/[id]/App.context";
+import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
+import mockApp from "~/testing/data/mock_app";
+import mockEnvironments from "~/testing/data/mock_environments";
+import { mockFetchEmails } from "~/testing/nocks/nock_mailer";
+import SentEmails from "./SentEmails";
+
+interface WrapperProps {
+  emails?: MockEmail[];
+}
+
+describe("~/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx", () => {
+  let wrapper: RenderResult;
+  let fetchScope: Scope;
+  let currentApp: App;
+  let currentEnv: Environment;
+
+  const createWrapper = ({ emails = [] }: WrapperProps) => {
+    currentApp = mockApp();
+    currentApp.id = "1";
+    currentEnv = mockEnvironments({ app: currentApp })[0];
+
+    fetchScope = mockFetchEmails({
+      appId: currentApp.id,
+      envId: currentEnv.id!,
+      response: { emails },
+    });
+
+    wrapper = render(
+      <AppContext.Provider
+        value={{
+          app: currentApp,
+          environments: [currentEnv],
+          setRefreshToken: vi.fn(),
+        }}
+      >
+        <EnvironmentContext.Provider value={{ environment: currentEnv }}>
+          <SentEmails />
+        </EnvironmentContext.Provider>
+      </AppContext.Provider>,
+    );
+  };
+
+  it("should display empty state when no emails", async () => {
+    createWrapper({});
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+    });
+
+    expect(wrapper.getByText("Sent Emails")).toBeTruthy();
+    expect(wrapper.getByText("No emails sent yet.")).toBeTruthy();
+  });
+
+  it("should render list of emails", async () => {
+    const emails: MockEmail[] = [
+      {
+        id: "1",
+        envId: currentEnv?.id || "1",
+        from: "sender@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome aboard",
+        body: "<p>Hello!</p>",
+        sentAt: 1700000000,
+      },
+    ];
+
+    createWrapper({ emails });
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+    });
+
+    expect(wrapper.getByText("Welcome aboard")).toBeTruthy();
+    expect(wrapper.getByText("To: recipient@example.com")).toBeTruthy();
+  });
+
+  it("should open email preview dialog on row click", async () => {
+    const emails: MockEmail[] = [
+      {
+        id: "1",
+        envId: currentEnv?.id || "1",
+        from: "sender@example.com",
+        to: "recipient@example.com",
+        subject: "Welcome aboard",
+        body: "<p>Hello!</p>",
+        sentAt: 1700000000,
+      },
+    ];
+
+    createWrapper({ emails });
+
+    await waitFor(() => {
+      expect(wrapper.getByText("Welcome aboard")).toBeTruthy();
+    });
+
+    fireEvent.click(wrapper.getByText("Welcome aboard"));
+
+    await waitFor(() => {
+      expect(wrapper.getByText("From: sender@example.com")).toBeTruthy();
+      expect(wrapper.getAllByText("To: recipient@example.com")).toHaveLength(2);
+    });
+  });
+});

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx
@@ -1,0 +1,99 @@
+import { useState, useContext } from "react";
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Typography from "@mui/material/Typography";
+import Link from "@mui/material/Link";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardRow from "~/components/CardRow";
+import { AppContext } from "~/pages/apps/[id]/App.context";
+import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
+import { formatDate } from "~/utils/helpers/date";
+import { useFetchEmails, type Email } from "./actions";
+
+export default function SentEmails() {
+  const { app } = useContext(AppContext);
+  const { environment: env } = useContext(EnvironmentContext);
+  const [selectedEmail, setSelectedEmail] = useState<Email>();
+  const { loading, error, emails } = useFetchEmails({
+    appId: app.id,
+    envId: env.id!,
+  });
+
+  return (
+    <>
+      <Card
+        id="sent-emails"
+        width="100%"
+        loading={loading}
+        error={error}
+        sx={{ pb: 4 }}
+        contentPadding={false}
+        info={emails.length === 0 ? "No emails sent yet." : undefined}
+      >
+        <CardHeader
+          title="Sent Emails"
+          subtitle="Last 100 emails sent from this environment."
+        />
+
+        {emails.map(email => (
+          <CardRow key={email.id}>
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <Box sx={{ flex: 1 }}>
+                <Link href="#" onClick={() => setSelectedEmail(email)}>
+                  {email.subject}
+                </Link>
+                <Typography sx={{ fontSize: 12, color: "text.secondary" }}>
+                  To: {email.to}
+                </Typography>
+              </Box>
+              <Typography sx={{ fontSize: 12, color: "text.secondary", ml: 2 }}>
+                {formatDate(email.sentAt)}
+              </Typography>
+            </Box>
+          </CardRow>
+        ))}
+      </Card>
+
+      {selectedEmail && (
+        <Dialog
+          open
+          onClose={() => setSelectedEmail(undefined)}
+          maxWidth="md"
+          fullWidth
+        >
+          <DialogTitle>{selectedEmail.subject}</DialogTitle>
+          <DialogContent>
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                From: {selectedEmail.from || "-"}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                To: {selectedEmail.to}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Sent: {formatDate(selectedEmail.sentAt)}
+              </Typography>
+            </Box>
+            <Box
+              component="iframe"
+              bgcolor="container.paper"
+              border="1px solid"
+              borderColor="container.border"
+              srcDoc={`<style>*,a{color:#fff!important}</style>${selectedEmail.body}`}
+              sx={{
+                p: 2,
+                borderRadius: 1,
+                width: "100%",
+                minHeight: 400,
+              }}
+              title="Email preview"
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
@@ -8,7 +8,23 @@ interface MailerConfig {
   password: string;
 }
 
+export interface Email {
+  id: string;
+  envId: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  sentAt: number;
+}
+
 interface FetchMailerConfigProps {
+  appId: string;
+  envId: string;
+  refreshToken?: number;
+}
+
+interface FetchEmailsProps {
   appId: string;
   envId: string;
   refreshToken?: number;
@@ -43,4 +59,45 @@ export const useFetchMailerConfig = ({
   }, [refreshToken, appId, envId]);
 
   return { config, loading, error };
+};
+
+export const useFetchEmails = ({
+  appId,
+  envId,
+  refreshToken,
+}: FetchEmailsProps) => {
+  const [emails, setEmails] = useState<Email[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoading(true);
+    setError(undefined);
+
+    api
+      .fetch<{ emails: Email[] }>(`/mailer?appId=${appId}&envId=${envId}`)
+      .then(({ emails }) => {
+        if (!unmounted) {
+          setEmails(emails || []);
+        }
+      })
+      .catch(() => {
+        if (!unmounted) {
+          setError("Something went wrong while fetching sent emails.");
+        }
+      })
+      .finally(() => {
+        if (!unmounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, [refreshToken, appId, envId]);
+
+  return { emails, loading, error };
 };

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/routes.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/routes.ts
@@ -46,6 +46,13 @@ const routes: Array<RouteProps> = [
     ),
   },
   {
+    path: "/mailer/emails",
+    element: Async(
+      () =>
+        import("~/pages/apps/[id]/environments/[env-id]/mailer/SentEmails"),
+    ),
+  },
+  {
     path: "/auth",
     element: Async(
       () => import("~/pages/apps/[id]/environments/[env-id]/skauth"),

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -210,6 +210,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
     it("should display authentication providers", async () => {
       await waitFor(() => {
         expect(wrapper.getByText("Email")).toBeTruthy();
+        expect(wrapper.getByText("Magic Link")).toBeTruthy();
         expect(wrapper.getByText("Google")).toBeTruthy();
         expect(wrapper.getByText("X / Twitter (OAuth 2.0)")).toBeTruthy();
       });
@@ -223,7 +224,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
 
     it("should display correct status for disabled provider", async () => {
       await waitFor(() => {
-        expect(wrapper.getByText("disabled")).toBeTruthy();
+        expect(wrapper.getAllByText("disabled").length).toBeGreaterThan(0);
       });
     });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import XIcon from "@mui/icons-material/X";
 import GoogleIcon from "@mui/icons-material/Google";
 import EmailIcon from "@mui/icons-material/Email";
-import Link from "@mui/material/Link";
+import LinkIcon from "@mui/icons-material/Link";
+import MuiLink from "@mui/material/Link";
 import api from "~/utils/api/Api";
 
 export interface Field {
@@ -12,7 +13,7 @@ export interface Field {
   helperText?: string;
 }
 
-type AuthProviderID = "email" | "google" | "x";
+type AuthProviderID = "email" | "magiclink" | "google" | "x";
 
 export interface AuthProvider {
   id: AuthProviderID;
@@ -40,13 +41,13 @@ const allProviders: AuthProvider[] = [
       "Enable this provider to allow users to register and sign in with an email and password.",
       <>
         Use the{" "}
-        <Link
+        <MuiLink
           href="https://www.stormkit.io/docs/features/authentication"
           target="_blank"
           rel="noreferrer noopener"
         >
           Stormkit Auth API
-        </Link>{" "}
+        </MuiLink>{" "}
         to register and authenticate users programmatically.
       </>,
       <>
@@ -54,6 +55,27 @@ const allProviders: AuthProvider[] = [
         <code>/_stormkit/auth/register</code> with a JSON body containing{" "}
         <code>email</code> and <code>password</code> fields. On success, a JWT
         token is returned.
+      </>,
+    ],
+  },
+  {
+    id: "magiclink",
+    icon: LinkIcon,
+    name: "Magic Link",
+    drawerTitle: "Magic Link Settings",
+    drawerDesc: "Allow passwordless sign-in via a one-time link sent by email.",
+    steps: [
+      "Enable this provider to allow users to sign in with a magic link sent to their email address.",
+      <>
+        Send a <code>GET</code> request to{" "}
+        <code>/_stormkit/auth/magic?email=user@example.com</code>. A one-time
+        sign-in link will be sent to that address. The endpoint returns{" "}
+        <code>201</code> with no content.
+      </>,
+      <>
+        The link redirects the user to{" "}
+        <code>/_stormkit/auth/magic?token=&lt;token&gt;</code>, which exchanges
+        the token for a session JWT stored in <code>localStorage</code>.
       </>,
     ],
   },
@@ -72,14 +94,14 @@ const allProviders: AuthProvider[] = [
     steps: [
       <>
         Go to{" "}
-        <Link
+        <MuiLink
           type="button"
           href="https://console.developers.google.com/apis/credentials"
           target="_blank"
           rel="noreferrer noopener"
         >
           https://console.developers.google.com/apis/credentials
-        </Link>
+        </MuiLink>
       </>,
       "Create a new OAuth 2.0 Client ID credential.",
       "Select 'Web application' as the Application type.",
@@ -103,14 +125,14 @@ const allProviders: AuthProvider[] = [
     steps: [
       <>
         Go to{" "}
-        <Link
+        <MuiLink
           type="button"
           href="https://developer.x.com/en/portal/dashboard"
           target="_blank"
           rel="noreferrer noopener"
         >
           https://developer.x.com/en/portal/dashboard
-        </Link>{" "}
+        </MuiLink>{" "}
         and create a new project.
       </>,
       "Click 'Set up' under 'User authentication settings' section.",

--- a/src/ui/src/testing/nocks/nock_mailer.ts
+++ b/src/ui/src/testing/nocks/nock_mailer.ts
@@ -61,6 +61,34 @@ export const mockSetMailerConfig = ({
     .reply(status, response);
 };
 
+export interface MockEmail {
+  id: string;
+  envId: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  sentAt: number;
+}
+
+interface MockFetchEmailsProps {
+  appId?: string;
+  envId?: string;
+  status?: number;
+  response?: { emails: MockEmail[] };
+}
+
+export const mockFetchEmails = ({
+  appId = "",
+  envId = "",
+  status = 200,
+  response = { emails: [] },
+}: MockFetchEmailsProps) => {
+  return nock(endpoint)
+    .get(`/mailer?appId=${appId}&envId=${envId}`)
+    .reply(status, response);
+};
+
 interface MockSendTestEmailProps {
   appId: string;
   envId: string;


### PR DESCRIPTION
## Summary

- Adds `magiclink` as a new SKAuth provider (`ProviderMagicLink` constant, `magicLinkClient` struct)
- `POST /v1/auth/magiclink`: validates email, checks provider is enabled, generates a short-lived JWT, upserts the user in the per-app schema, and emails the magic link
- `GET /v1/auth/magiclink?token=&envId=`: validates and consumes the one-time token, returns a session JWT
- Fixes NULL scan issue in `selectAuthUsers` SQL template — `first_name`, `last_name`, `avatar` are now wrapped in `COALESCE` to handle users inserted without profile fields (magic link users are email-only)
- Adds `UpsertMagicLinkUser` and `ConsumeMagicLinkToken` to the schema store; token consumption is one-shot (verified_at set, token cleared)

## Test plan

- [ ] `go test ./src/ce/api/public/v1/... -run "TestHandlerAuthMagicLink|TestServices"` — all pass
- [ ] Invalid email → 400
- [ ] Provider not enabled → 404
- [ ] Successful request → 200, email sent via `SendMailFunc`
- [ ] New user created in per-app schema on first magic link request
- [ ] Invalid/bad JWT token → 400
- [ ] Successful verify → 200, returns `token` + `email` + `userId`
- [ ] Token consumed once — second verify with same token → 400