### PR TITLE
feat: add shared session endpoint for admin access

### DIFF
--- a/src/ce/api/user/user_model.go
+++ b/src/ce/api/user/user_model.go
@@ -150,7 +150,7 @@ func (u User) JSON() map[string]any {
 	packageName := utils.GetString(u.Metadata.PackageName, config.PackageFree)
 	seats := utils.GetInt(u.Metadata.SeatsPurchased, 1)
 
-	if config.IsSelfHosted() {
+	if config.IsSelfHosted() || config.IsDevelopment() {
 		license := admin.CurrentLicense()
 		seats = utils.GetInt(license.Seats, 1)
 

--- a/src/ce/api/user/userhandlers/handler_user_shared_session.go
+++ b/src/ce/api/user/userhandlers/handler_user_shared_session.go
@@ -1,0 +1,51 @@
+package userhandlers
+
+import (
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+type userSharedSessionArgs struct {
+	Hours int `json:"hours"`
+}
+
+// handlerUserSharedSession generates a short-lived session token for the
+// authenticated user. The token can be shared over a private channel to allow
+// admin access to the instance without creating a new user account.
+//
+// An optional `hours` field (1–24) controls the token lifetime; it defaults
+// to 1. Non-Enterprise users are clamped to 1h regardless of the requested value.
+func handlerUserSharedSession(req *user.RequestContext) *shttp.Response {
+	body := userSharedSessionArgs{}
+
+	if err := req.Post(&body); err != nil {
+		return shttp.Error(err)
+	}
+
+	hours := body.Hours
+
+	if hours < 1 || hours > 24 {
+		hours = 1
+	}
+
+	// Limit the token lifetime to 1 hour for non-Enterprise users, regardless of the requested duration.
+	if hours > 1 && !req.License().IsEnterprise() {
+		hours = 1
+	}
+
+	token, err := user.JWT(jwt.MapClaims{
+		"uid": req.User.ID,
+		"exp": time.Now().Add(time.Duration(hours) * time.Hour).Unix(),
+	})
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Data: map[string]any{"token": token},
+	}
+}

--- a/src/ce/api/user/userhandlers/handler_user_shared_session_test.go
+++ b/src/ce/api/user/userhandlers/handler_user_shared_session_test.go
@@ -1,0 +1,196 @@
+package userhandlers_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/userhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+)
+
+type UserSharedSessionSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *UserSharedSessionSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *UserSharedSessionSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *UserSharedSessionSuite) Test_Success_DefaultsToOneHour() {
+	usr := s.MockUser()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/user/shared-session",
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	body := response.Map()
+	token, ok := body["token"].(string)
+	s.True(ok)
+	s.NotEmpty(token)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: token})
+	s.NotNil(claims)
+	s.Equal(usr.ID.String(), claims["uid"])
+
+	exp, _ := claims["exp"].(float64)
+	s.InDelta(time.Now().Add(time.Hour).Unix(), int64(exp), 5)
+}
+
+func (s *UserSharedSessionSuite) Test_Success_CustomHours() {
+	admin.SetMockLicense()
+	defer admin.ResetMockLicense()
+
+	usr := s.MockUser()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/user/shared-session",
+		map[string]any{"hours": 6},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: response.Map()["token"].(string)})
+	s.NotNil(claims)
+
+	exp, _ := claims["exp"].(float64)
+	s.InDelta(time.Now().Add(6*time.Hour).Unix(), int64(exp), 5)
+}
+
+func (s *UserSharedSessionSuite) Test_OutOfRangeHoursClampsToOne() {
+	usr := s.MockUser()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/user/shared-session",
+		map[string]any{"hours": 99},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: response.Map()["token"].(string)})
+	s.NotNil(claims)
+
+	exp, _ := claims["exp"].(float64)
+	s.InDelta(time.Now().Add(time.Hour).Unix(), int64(exp), 5)
+}
+
+func (s *UserSharedSessionSuite) Test_TokenExpiresAfterOneHour() {
+	usr := s.MockUser()
+
+	// Generate a shared session token with exp set 1h in the past.
+	expired, err := user.JWT(jwt.MapClaims{
+		"uid": usr.ID,
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	s.NoError(err)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/user",
+		nil,
+		map[string]string{
+			"Authorization": "Bearer " + expired,
+		},
+	)
+
+	s.Equal(http.StatusUnauthorized, response.Code)
+}
+
+func (s *UserSharedSessionSuite) Test_EnterpriseLicenseClampsTo24h() {
+	admin.SetMockLicense()
+	defer admin.ResetMockLicense()
+
+	usr := s.MockUser()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/user/shared-session",
+		map[string]any{"hours": 24},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: response.Map()["token"].(string)})
+	s.NotNil(claims)
+
+	exp, _ := claims["exp"].(float64)
+	s.InDelta(time.Now().Add(24*time.Hour).Unix(), int64(exp), 5)
+}
+
+func (s *UserSharedSessionSuite) Test_NonEnterpriseIgnoresHoursAndClampsToOne() {
+	admin.CachedLicense = &admin.License{}
+	defer func() { admin.CachedLicense = nil }()
+
+	usr := s.MockUser()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/user/shared-session",
+		map[string]any{"hours": 6},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: response.Map()["token"].(string)})
+	s.NotNil(claims)
+
+	exp, _ := claims["exp"].(float64)
+	s.InDelta(time.Now().Add(time.Hour).Unix(), int64(exp), 5)
+}
+
+func (s *UserSharedSessionSuite) Test_NotAllowedWithoutAuth() {
+	response := shttptest.Request(
+		shttp.NewRouter().RegisterService(userhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/user/shared-session",
+		nil,
+	)
+
+	s.Equal(http.StatusUnauthorized, response.Code)
+}
+
+func TestUserSharedSession(t *testing.T) {
+	suite.Run(t, &UserSharedSessionSuite{})
+}

--- a/src/ce/api/user/userhandlers/services.go
+++ b/src/ce/api/user/userhandlers/services.go
@@ -14,6 +14,7 @@ func Services(r *shttp.Router) *shttp.Service {
 		Handler(shttp.MethodGet, "", user.WithAuth(handlerUserSession)).
 		Handler(shttp.MethodGet, "/emails", user.WithAuth(handlerUserEmails)).
 		Handler(shttp.MethodPut, "/access-token", user.WithAuth(handlerUpdatePersonalAccessToken)).
+		Handler(shttp.MethodPost, "/shared-session", user.WithAuth(handlerUserSharedSession)).
 		Handler(shttp.MethodDelete, "", user.WithAuth(handlerUserDelete))
 
 	return s

--- a/src/ce/api/user/userhandlers/services_test.go
+++ b/src/ce/api/user/userhandlers/services_test.go
@@ -25,6 +25,7 @@ func (s *ServicesSuite) TestServices_SelfHosted() {
 		"DELETE:/user",
 		"GET:/user",
 		"GET:/user/emails",
+		"POST:/user/shared-session",
 		"PUT:/user/access-token",
 	}
 
@@ -43,6 +44,7 @@ func (s *ServicesSuite) TestServices_StormkitCloud() {
 		"DELETE:/user",
 		"GET:/user",
 		"GET:/user/emails",
+		"POST:/user/shared-session",
 		"PUT:/user/access-token",
 	}
 

--- a/src/ui/src/pages/routes.tsx
+++ b/src/ui/src/pages/routes.tsx
@@ -113,6 +113,10 @@ const routes: Array<ExtendedRouterProps> = [
     element: Async(() => import("~/pages/user/account"), centerLayout),
   },
   {
+    path: "/user/account/share",
+    element: Async(() => import("~/pages/user/account"), centerLayout),
+  },
+  {
     path: "/user/payment/success",
     element: <RedirectPaymentSuccess />,
   },

--- a/src/ui/src/pages/user/account/Account.tsx
+++ b/src/ui/src/pages/user/account/Account.tsx
@@ -1,13 +1,17 @@
 import { useContext } from "react";
+import { useNavigate, useMatch } from "react-router-dom";
 import Box from "@mui/material/Box";
 import { AuthContext } from "~/pages/auth/Auth.context";
 import Error404 from "~/components/Errors/Error404";
 import UserProfile from "./_components/UserProfile";
 import ConnectedAccounts from "./_components/ConnectedAccounts";
 import APIKeys from "./_components/APIKeys";
+import ShareSessionModal from "./_components/ShareSessionModal";
 
 export default function Account() {
   const { user, accounts, metrics } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const isShareRoute = useMatch("/user/account/share");
 
   if (!user) {
     return <Error404 />;
@@ -18,6 +22,9 @@ export default function Account() {
       <UserProfile user={user} metrics={metrics} />
       <ConnectedAccounts accounts={accounts!} />
       <APIKeys user={user} />
+      {isShareRoute && (
+        <ShareSessionModal onClose={() => navigate("/user/account")} />
+      )}
     </Box>
   );
 }

--- a/src/ui/src/pages/user/account/_components/ShareSessionModal.spec.tsx
+++ b/src/ui/src/pages/user/account/_components/ShareSessionModal.spec.tsx
@@ -1,0 +1,113 @@
+import type { RenderResult } from "@testing-library/react";
+import { describe, expect, beforeEach, it, vi, type Mock } from "vitest";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { RootContext } from "~/pages/Root.context";
+import { mockCreateSharedSession } from "~/testing/nocks/nock_user";
+import ShareSessionModal from "./ShareSessionModal";
+
+interface Props {
+  isEnterprise?: boolean;
+}
+
+describe("~/pages/user/account/_components/ShareSessionModal", () => {
+  let onClose: Mock;
+  let wrapper: RenderResult;
+
+  const createWrapper = ({ isEnterprise = false }: Props = {}) => {
+    onClose = vi.fn();
+
+    const details: InstanceDetails | undefined = isEnterprise
+      ? { license: { seats: 10, remaining: 10, edition: "enterprise" } }
+      : undefined;
+
+    wrapper = render(
+      <RootContext.Provider value={{ mode: "dark", setMode: () => {}, details }}>
+        <ShareSessionModal onClose={onClose} />
+      </RootContext.Provider>
+    );
+  };
+
+  describe("non-enterprise user", () => {
+    beforeEach(() => {
+      createWrapper({ isEnterprise: false });
+    });
+
+    it("should not show the duration selector", () => {
+      expect(wrapper.queryByLabelText("Session duration")).toBeNull();
+    });
+
+    it("should create a session with 1h and display the CopyBox snippet", async () => {
+      const scope = mockCreateSharedSession({ payload: { hours: 1 } });
+
+      fireEvent.click(wrapper.getByText("Create session"));
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
+        expect(
+          wrapper.getByText(
+            "Copy this snippet and run it in the browser console of the target instance. This token expires in 1h:"
+          )
+        ).toBeTruthy();
+        expect(
+          wrapper.getByDisplayValue(
+            "localStorage.setItem('skit_token', JSON.stringify('mock-session-token'))"
+          )
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("enterprise user", () => {
+    beforeEach(() => {
+      createWrapper({ isEnterprise: true });
+    });
+
+    it("should show the duration selector", () => {
+      expect(wrapper.getByLabelText("Session duration")).toBeTruthy();
+    });
+
+    it("should create a session with the selected duration", async () => {
+      const scope = mockCreateSharedSession({ payload: { hours: 6 } });
+
+      fireEvent.mouseDown(wrapper.getByLabelText("Session duration"));
+      const option = await waitFor(() => wrapper.getByText("6h"));
+      fireEvent.click(option);
+
+      fireEvent.click(wrapper.getByText("Create session"));
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
+        expect(
+          wrapper.getByText(
+            "Copy this snippet and run it in the browser console of the target instance. This token expires in 6h:"
+          )
+        ).toBeTruthy();
+      });
+    });
+
+    it("should use the skit_token localStorage key in the snippet", async () => {
+      mockCreateSharedSession({ payload: { hours: 1 } });
+
+      fireEvent.click(wrapper.getByText("Create session"));
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByDisplayValue(
+            "localStorage.setItem('skit_token', JSON.stringify('mock-session-token'))"
+          )
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("cancel button", () => {
+    beforeEach(() => {
+      createWrapper();
+    });
+
+    it("should call onClose when cancel is clicked", () => {
+      fireEvent.click(wrapper.getByText("Cancel"));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/ui/src/pages/user/account/_components/ShareSessionModal.tsx
+++ b/src/ui/src/pages/user/account/_components/ShareSessionModal.tsx
@@ -1,0 +1,101 @@
+import { useContext, useState } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import MenuItem from "@mui/material/MenuItem";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Modal from "~/components/Modal";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardFooter from "~/components/CardFooter";
+import CopyBox from "~/components/CopyBox";
+import { RootContext } from "~/pages/Root.context";
+import { createSharedSession } from "../actions";
+
+const ENTERPRISE_DURATIONS = [1, 3, 6, 12, 24];
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function ShareSessionModal({ onClose }: Props) {
+  const { details } = useContext(RootContext);
+  const isEnterprise = details?.license?.edition === "enterprise";
+
+  const [hours, setHours] = useState(1);
+  const [token, setToken] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleCreate = () => {
+    setLoading(true);
+    setError("");
+
+    createSharedSession(hours)
+      .then(({ token }) => {
+        setToken(token);
+      })
+      .catch(() => {
+        setError(
+          "Something went wrong while creating the session. Please try again.",
+        );
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return (
+    <Modal open onClose={onClose}>
+      <Card error={error} contentPadding={false}>
+        <CardHeader
+          title="Share session"
+          subtitle="Generate a temporary token that can be shared over a private channel to grant access on your behalf."
+        />
+        {isEnterprise && !token && (
+          <Box sx={{ px: 4, pb: 2 }}>
+            <TextField
+              select
+              fullWidth
+              label="Session duration"
+              value={hours}
+              onChange={e => setHours(Number(e.target.value))}
+              variant="filled"
+            >
+              {ENTERPRISE_DURATIONS.map(h => (
+                <MenuItem key={h} value={h}>
+                  {h}h
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+        )}
+        {token ? (
+          <Box sx={{ px: 4, pb: 4 }}>
+            <Typography sx={{ mb: 2, color: "text.secondary" }}>
+              Copy this snippet and run it in the browser console of the target
+              instance. This token expires in {hours}h:
+            </Typography>
+            <CopyBox
+              value={`localStorage.setItem('skit_token', JSON.stringify('${token}'))`}
+            />
+          </Box>
+        ) : (
+          <CardFooter>
+            <Button variant="outlined" onClick={onClose} sx={{ mr: 2 }}>
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleCreate}
+              loading={loading}
+            >
+              Create session
+            </Button>
+          </CardFooter>
+        )}
+      </Card>
+    </Modal>
+  );
+}

--- a/src/ui/src/pages/user/account/actions.ts
+++ b/src/ui/src/pages/user/account/actions.ts
@@ -158,3 +158,7 @@ export const usePersonalAccessTokenState = ({
 export const deleteUser = async () => {
   return await api.delete(`/user`);
 };
+
+export const createSharedSession = async (hours: number) => {
+  return await api.post<{ token: string }>("/user/shared-session", { hours });
+};

--- a/src/ui/src/testing/nocks/nock_user.ts
+++ b/src/ui/src/testing/nocks/nock_user.ts
@@ -96,3 +96,16 @@ export const mockAdminRegister = ({
   payload,
 }: MockAdminRegisterProps) =>
   nock(endpoint).post("/auth/admin/register", payload).reply(status, response);
+
+interface MockCreateSharedSessionProps {
+  status?: number;
+  payload?: { hours: number };
+  response?: { token: string };
+}
+
+export const mockCreateSharedSession = ({
+  status = 200,
+  payload = { hours: 1 },
+  response = { token: "mock-session-token" },
+}: MockCreateSharedSessionProps) =>
+  nock(endpoint).post("/user/shared-session", payload).reply(status, response);


### PR DESCRIPTION
## Summary

- Adds `POST /user/shared-session` endpoint (authenticated) that generates a 1-hour JWT for the current user
- Token follows the same structure as a normal login token — can be pasted into `localStorage` to log in as that user
- Expiry is enforced via the standard `exp` claim, which jwt/v5 validates automatically — no Redis or manual revocation needed
- Intended for the Account page so admins can share a temporary session token over a private channel for debugging

## Test plan

- `Test_Success` — authenticated user receives a valid token with the correct `uid` claim
- `Test_TokenExpiresAfterOneHour` — a token with `exp` in the past is rejected by the auth middleware
- `Test_NotAllowedWithoutAuth` — unauthenticated request returns 401