### PR TITLE
test: add prioritize_deployment to MCP tools list test

### DIFF
--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -285,6 +285,7 @@ func (s *HandlerMCPSuite) Test_ToolsList_ReturnsExpectedTools() {
 		"publish_deployment",
 		"delete_deployment",
 		"restart_deployment",
+		"prioritize_deployment",
 		"list_deployments",
 		"stop_deployment",
 		"list_apps",


### PR DESCRIPTION
## Summary

- Adds `prioritize_deployment` to the expected tools list in `Test_ToolsList_ReturnsExpectedTools`
- The tool was introduced in the recent run-next priority queue feature (#244) but the test was not updated