### PR TITLE
feat: drop Postgres schemas for soft-deleted envs

### DIFF
--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"regexp"
+	"strings"
 	"text/template"
 	"time"
 
@@ -480,6 +481,19 @@ func (s *schemaStore) DropSchema(ctx context.Context, schemaName string) error {
 	if _, err := s.Exec(ctx, buf.String()); err != nil {
 		return fmt.Errorf("failed to drop schema: %w", err)
 	}
+
+	// Close any cached per-schema connections — DROP terminated their backends.
+	suffix := "/" + schemaName
+
+	schemaStoreCache.Range(func(key, value any) bool {
+		if k, ok := key.(string); ok && strings.HasSuffix(k, suffix) {
+			if store, ok := value.(*schemaStore); ok {
+				_ = store.Close()
+			}
+		}
+
+		return true
+	})
 
 	return nil
 }

--- a/src/ce/workerserver/job_environments.go
+++ b/src/ce/workerserver/job_environments.go
@@ -3,11 +3,20 @@ package jobs
 import (
 	"context"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"go.uber.org/zap"
 )
 
+type staleSchema struct {
+	EnvID      types.ID
+	SchemaName string
+}
+
 // RemoveStaleEnvironments marks soft deleted environment's deployments soft deleted and
-// removes environment if deployments of environment is deleted
+// drops the per-environment Postgres schema (and its roles) when one was provisioned.
 func RemoveStaleEnvironments(ctx context.Context) error {
 	store := NewStore()
 
@@ -18,6 +27,79 @@ func RemoveStaleEnvironments(ctx context.Context) error {
 	if err != nil {
 		slog.Errorf("error while marking deployments soft deleted %v", err)
 		return err
+	}
+
+	if err := dropStaleSchemas(ctx, store); err != nil {
+		slog.Errorf("error while dropping stale schemas: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// dropStaleSchemas finds soft-deleted environments that still have a schema
+// provisioned and drops the schema along with its app/migration roles.
+// Per-env failures are logged and skipped so a single broken schema does not
+// block the rest of the batch; schema_conf is cleared only after the drop
+// succeeds, so transient failures retry on the next run.
+func dropStaleSchemas(ctx context.Context, store *Store) error {
+	rows, err := store.Query(ctx, stmt.selectStaleSchemas)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	var stale []staleSchema
+
+	for rows.Next() {
+		var (
+			envID   types.ID
+			appID   types.ID
+			rawConf []byte
+		)
+
+		if err := rows.Scan(&envID, &appID, &rawConf); err != nil {
+			return err
+		}
+
+		schemaName := buildconf.SchemaName(appID, envID)
+
+		var conf buildconf.SchemaConf
+
+		if err := utils.ByteaScan(rawConf, &conf); err != nil {
+			slog.Errorf("failed to decode schema_conf for env %d, falling back to derived name: %v", envID, err)
+		} else if conf.SchemaName != "" {
+			schemaName = conf.SchemaName
+		}
+
+		stale = append(stale, staleSchema{EnvID: envID, SchemaName: schemaName})
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, s := range stale {
+		if err := buildconf.SchemaStore().DropSchema(ctx, s.SchemaName); err != nil {
+			slog.Errorf("failed to drop schema %s for env %d: %v", s.SchemaName, s.EnvID, err)
+			continue
+		}
+
+		if _, err := store.Exec(ctx, stmt.clearSchemaConf, s.EnvID); err != nil {
+			slog.Errorf("failed to clear schema_conf for env %d: %v", s.EnvID, err)
+			continue
+		}
+
+		slog.Debug(slog.LogOpts{
+			Msg:   "dropped stale schema",
+			Level: slog.DL1,
+			Payload: []zap.Field{
+				zap.String("schema", s.SchemaName),
+				zap.Int64("env_id", int64(s.EnvID)),
+			},
+		})
 	}
 
 	return nil

--- a/src/ce/workerserver/job_environments_test.go
+++ b/src/ce/workerserver/job_environments_test.go
@@ -2,9 +2,11 @@ package jobs_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -61,6 +63,62 @@ func (s *JobEnvironmentsSuite) Test_RemoveStateEnvironments() {
 		s.NoError(err)
 		s.NotEmpty(deletedAt)
 	}
+}
+
+func (s *JobEnvironmentsSuite) Test_RemoveStaleEnvironments_DropsSchemas() {
+	app := s.MockApp(nil)
+
+	envWithSchema := s.MockEnv(app, map[string]any{
+		"DeletedAt": utils.Unix{Time: time.Now(), Valid: true},
+	})
+
+	schemaName := buildconf.SchemaName(app.ID, envWithSchema.ID)
+
+	_, err := s.conn.Exec(
+		"UPDATE apps_build_conf SET schema_conf = $1 WHERE env_id = $2",
+		&buildconf.SchemaConf{SchemaName: schemaName},
+		envWithSchema.ID,
+	)
+	s.NoError(err)
+
+	_, err = s.conn.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schemaName))
+	s.NoError(err)
+
+	defer func() {
+		_, _ = s.conn.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaName))
+	}()
+
+	// A live environment with a schema must not be touched.
+	envLive := s.MockEnv(app, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			SchemaName: "should_not_be_touched",
+		},
+	})
+
+	s.NoError(jobs.RemoveStaleEnvironments(context.TODO()))
+
+	var exists bool
+
+	s.NoError(s.conn.
+		QueryRow(`SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)`, schemaName).
+		Scan(&exists),
+	)
+
+	s.False(exists, "schema for deleted env should be dropped")
+
+	var staleConf []byte
+	s.NoError(s.conn.
+		QueryRow("SELECT schema_conf FROM apps_build_conf WHERE env_id = $1", envWithSchema.ID).
+		Scan(&staleConf),
+	)
+	s.Nil(staleConf, "schema_conf should be cleared on the deleted env")
+
+	var liveConf []byte
+	s.NoError(s.conn.
+		QueryRow("SELECT schema_conf FROM apps_build_conf WHERE env_id = $1", envLive.ID).
+		Scan(&liveConf),
+	)
+	s.NotEmpty(liveConf, "schema_conf on live env must be preserved")
 }
 
 func TestJobEnvironmentsSuite(t *testing.T) {

--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -20,6 +20,8 @@ type statement struct {
 	syncAnalyticsReferrers          string
 	syncAnalyticsCountries          string
 	selectUserIDsWithoutAPIKeys     string
+	selectStaleSchemas              string
+	clearSchemaConf                 string
 }
 
 var stmt = &statement{
@@ -200,6 +202,23 @@ var stmt = &statement{
 			(aggregate_date, country_iso_code, domain_id)
 		DO UPDATE SET
 			visit_count = EXCLUDED.visit_count;
+	`,
+
+	selectStaleSchemas: `
+		SELECT
+			env_id, app_id, schema_conf
+		FROM
+			apps_build_conf
+		WHERE
+			deleted_at IS NOT NULL AND
+			schema_conf IS NOT NULL
+		ORDER BY
+			deleted_at ASC, env_id ASC
+		LIMIT 50;
+	`,
+
+	clearSchemaConf: `
+		UPDATE apps_build_conf SET schema_conf = NULL WHERE env_id = $1;
 	`,
 
 	selectUserIDsWithoutAPIKeys: `


### PR DESCRIPTION
## Summary
- Soft-deleting an environment (or its parent app) used to leave the per-env Postgres schema, the app role, and the migration role orphaned forever — no worker job touched them.
- Extends the existing `RemoveStaleEnvironments` cleanup (already runs every 6h on the master node) to also drop the schema and clear `schema_conf` for any environment whose `deleted_at IS NOT NULL` and that still has `schema_conf` populated.
- Per-env failures are logged and skipped so a single broken schema doesn't block the rest of the batch; `schema_conf` is cleared only after a successful drop, so transient failures retry next run.

Follow-up to #250 (public schema API).

## Test plan
- [x] `go test ./src/ce/workerserver/... -run JobEnvironments` — new `Test_RemoveStaleEnvironments_DropsSchemas` covers drop + clear, and asserts live envs are untouched
- [ ] On a self-hosted instance: attach a database to an env, delete the env, run the worker, verify the schema and both roles are gone in Postgres