### PR TITLE
feat: local file:// repo provider (dev only)

### DIFF
--- a/docs/api/2-apps.md
+++ b/docs/api/2-apps.md
@@ -24,8 +24,8 @@ Creates a new application and links it to a source-code repository.
 | Field         | Type   | Required | Description                                                                                                                                                       |
 | ------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `teamId`      | string | No       | ID of the team to create the application under. Required when using a user-level API key; ignored when using a team-level key (the team is derived from the key). |
-| `repo`        | string | No       | Repository path in `owner/slug` format (e.g. `acme/my-app`). Omit to create a bare application.                                                                   |
-| `provider`    | string | No       | Source-code provider. One of `github`, `gitlab`, `bitbucket`. Required when `repo` is set.                                                                        |
+| `repo`        | string | No       | Repository reference. Accepts a full URL (e.g. `https://github.com/acme/my-app`, `file:///srv/repos/my-app`), a Stormkit-style path (e.g. `github/acme/my-app`, `local/srv/repos/my-app`), or a bare `owner/slug` (paired with `provider`). Omit to create a bare application. |
+| `provider`    | string | No       | Source-code provider. One of `github`, `gitlab`, `bitbucket`, `local`. Only required when `repo` is a bare `owner/slug` — when `repo` is a full URL or carries a provider prefix, this field is ignored. |
 | `displayName` | string | No       | Human-readable application name. Must contain only alphanumeric characters, hyphens, and underscores, with no consecutive hyphens. Auto-generated when omitted.   |
 
 ### Response — 200 OK
@@ -40,7 +40,7 @@ Creates a new application and links it to a source-code repository.
 | -------------- | ------- | ----------------------------------------------------------------------------------- |
 | `id`           | string  | Unique application ID.                                                              |
 | `displayName`  | string  | Human-readable name of the application.                                             |
-| `repo`         | string  | Repository path (e.g. `github/acme/my-app`). Empty when `isBare` is `true`.         |
+| `repo`         | string  | Repository reference (e.g. `github/acme/my-app`, or `file:///srv/repos/my-app` for local repos). Empty when `isBare` is `true`. |
 | `isBare`       | boolean | `true` when no repository is linked.                                                |
 | `userId`       | string  | ID of the user who owns the application.                                            |
 | `teamId`       | string  | ID of the team the application belongs to.                                          |
@@ -58,7 +58,25 @@ Creates a new application and links it to a source-code repository.
 ### Examples
 
 ```bash
-# Create an app linked to a GitHub repository
+# Create an app linked to a GitHub repository (full URL — provider derived)
+curl -X POST \
+     -H 'Authorization: <team_api_key>' \
+     -H 'Content-Type: application/json' \
+     -d '{"repo":"https://github.com/acme/my-app"}' \
+     'https://api.stormkit.io/v1/app'
+```
+
+```bash
+# Create an app from a local repository on the deployment host
+curl -X POST \
+     -H 'Authorization: <team_api_key>' \
+     -H 'Content-Type: application/json' \
+     -d '{"repo":"file:///srv/repos/my-app"}' \
+     'https://api.stormkit.io/v1/app'
+```
+
+```bash
+# Bare owner/slug — provider must be supplied explicitly
 curl -X POST \
      -H 'Authorization: <team_api_key>' \
      -H 'Content-Type: application/json' \
@@ -96,6 +114,7 @@ curl -X POST \
 - After creating the app, use `GET /v1/app` with the returned `id` to poll for the `defaultEnvId` once the first environment has been provisioned.
 - For **GitHub**, the GitHub App must be installed on the target account/organisation before deployments can access the repository. If the repository does not appear when deploying, go to **Home → Create New App → Import From GitHub → Connect more repositories** to grant Stormkit access to additional repos.
 - For **GitLab** and **Bitbucket**, an OAuth token for the account must be connected via the Stormkit UI before deployments can clone the repository.
+- For **local** repositories (`file://`), the absolute path must exist on the **deployment host**'s filesystem and be readable by the Stormkit runner. No OAuth or credentials are required. Intended for self-hosted and development setups.
 
 ---
 
@@ -113,7 +132,7 @@ Returns a paginated list of applications belonging to the authenticated user.
 | ------------- | ------ | -------- | ------- | ----------------------------------------------------------------------------- |
 | `teamId`      | number | **Yes**  | —       | ID of the team to scope results to. The API key owner must be a member.       |
 | `from`        | number | No       | `0`     | Pagination offset. Must be ≥ 0.                                               |
-| `repo`        | string | No       | —       | Exact case-insensitive match on the repository path (e.g. `github/org/repo`). |
+| `repo`        | string | No       | —       | Exact case-insensitive match on the repository path. Accepts the same forms as `POST /v1/app` — e.g. `github/org/repo`, `https://github.com/org/repo`, or `file:///abs/path` for local repos. |
 | `displayName` | string | No       | —       | Exact case-insensitive match on the application display name.                 |
 
 > `repo` and `displayName` can be combined and are applied as AND conditions.
@@ -131,7 +150,7 @@ Returns a paginated list of applications belonging to the authenticated user.
 | -------------- | ------- | ----------------------------------------------------------------------------------- |
 | `id`           | string  | Unique application ID. Use this as `appId` in other endpoints.                      |
 | `displayName`  | string  | Human-readable name of the application.                                             |
-| `repo`         | string  | Repository path (e.g. `github/org/repo`). Empty when `isBare` is `true`.            |
+| `repo`         | string  | Repository reference (e.g. `github/org/repo`, or `file:///abs/path` for local repos). Empty when `isBare` is `true`. |
 | `isBare`       | boolean | `true` when no repository is linked.                                                |
 | `userId`       | string  | ID of the user who owns the application.                                            |
 | `teamId`       | string  | ID of the team the application belongs to.                                          |
@@ -225,7 +244,7 @@ Returns a single application. This is also an alias for `GET /v1/app` with an ap
 | -------------- | ------- | ----------------------------------------------------------------------------------- |
 | `id`           | string  | Unique application ID.                                                              |
 | `displayName`  | string  | Human-readable name of the application.                                             |
-| `repo`         | string  | Repository path (e.g. `github/org/repo`). Empty when `isBare` is `true`.            |
+| `repo`         | string  | Repository reference (e.g. `github/org/repo`, or `file:///abs/path` for local repos). Empty when `isBare` is `true`. |
 | `isBare`       | boolean | `true` when no repository is linked.                                                |
 | `userId`       | string  | ID of the user who owns the application.                                            |
 | `teamId`       | string  | ID of the team the application belongs to.                                          |

--- a/src/ce/api/app/app_model.go
+++ b/src/ce/api/app/app_model.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/bitbucket"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/github"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/gitlab"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/local"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/model"
@@ -100,21 +100,6 @@ type MyApp struct {
 	*App
 }
 
-// MyAppJSON is a wrapper around myapp to avoid recursion.
-type MyAppJSON MyApp
-
-// MarshalJSON implements the marshaler interface.
-func (ma MyApp) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		MyAppJSON
-		Endpoint   string `json:"endpoint"`
-		AutoDeploy string `json:"autoDeploy,omitempty"`
-	}{
-		MyAppJSON:  MyAppJSON(ma),
-		AutoDeploy: ma.AutoDeploy.ValueOrZero(),
-	})
-}
-
 // New creates a new app instance.
 func New(uid types.ID) *App {
 	secret, _ := utils.Encrypt([]byte(utils.RandomToken(32)))
@@ -158,11 +143,20 @@ func (a *App) PrivateKey(ctx context.Context) *utils.PrivateKey {
 
 // JSON returns a map that is ready to be sent to the frontend.
 func (a *App) JSON() map[string]any {
+	repo := a.Repo
+
+	// Local repos are stored as "local/<path>" internally; expose them
+	// as their `file://` URL form on the API so callers see a value they
+	// can round-trip back into POST /v1/app.
+	if a.IsLocal() {
+		repo = local.CloneURL(a.Repo)
+	}
+
 	return map[string]any{
 		"id":           a.ID.String(),
 		"userId":       a.UserID.String(),
 		"teamId":       a.TeamID.String(),
-		"repo":         a.Repo,
+		"repo":         repo,
 		"isBare":       a.Repo == "",
 		"displayName":  a.DisplayName,
 		"defaultEnvId": a.DefaultEnvID.String(),
@@ -175,6 +169,11 @@ func (a *App) IsGithub() bool {
 	return strings.HasPrefix(a.Repo, "github")
 }
 
+// IsLocal returns true if the application repository is a local file:// path.
+func (a *App) IsLocal() bool {
+	return local.IsLocal(a.Repo)
+}
+
 // DefaultBranch returns the default branch of the repository.
 func (a *App) DefaultBranch() (db string) {
 	if a.defaultBranch != "" {
@@ -182,6 +181,11 @@ func (a *App) DefaultBranch() (db string) {
 	}
 
 	var err error
+
+	if a.IsLocal() {
+		db, _ = local.DefaultBranch(a.Repo)
+		return db
+	}
 
 	if strings.HasPrefix(a.Repo, "github/") {
 		db, err = github.DefaultBranch(a.Repo)
@@ -213,6 +217,11 @@ func (a *App) GitCreds(ctx context.Context) (string, error) {
 	// TODO: mock these
 	if config.IsTest() {
 		return "some-token", nil
+	}
+
+	// Local file:// repos need no credentials.
+	if a.IsLocal() {
+		return "", nil
 	}
 
 	// For bitbucket we're gonna use the access key
@@ -292,8 +301,11 @@ func (a *App) Validate() *shttperr.ValidationError {
 		isBitbucket := strings.HasPrefix(a.Repo, "bitbucket/")
 		isGithub := strings.HasPrefix(a.Repo, "github/")
 		isGitlab := strings.HasPrefix(a.Repo, "gitlab/")
+		isLocal := local.IsLocal(a.Repo)
 
-		if !isBitbucket && !isGithub && !isGitlab {
+		if isLocal && !config.IsDevelopment() {
+			err.SetError("repo", ErrRepoInvalidProvider.Error())
+		} else if !isBitbucket && !isGithub && !isGitlab && !isLocal {
 			err.SetError("repo", ErrRepoInvalidProvider.Error())
 		}
 	}
@@ -362,8 +374,12 @@ func Validate(a *App) []string {
 			rest = strings.TrimPrefix(a.Repo, "gitlab/")
 		case strings.HasPrefix(a.Repo, "bitbucket/"):
 			rest = strings.TrimPrefix(a.Repo, "bitbucket/")
+		case a.IsLocal():
+			if local.Path(a.Repo) == "/" {
+				errs = append(errs, "Repo is invalid. Local repo path is empty.")
+			}
 		default:
-			errs = append(errs, "Provider is not supported. Supported providers are Github, Bitbucket and Gitlab.")
+			errs = append(errs, "Provider is not supported. Supported providers are Github, Bitbucket, Gitlab and Local.")
 		}
 
 		if rest != "" {

--- a/src/ce/api/app/app_model_test.go
+++ b/src/ce/api/app/app_model_test.go
@@ -53,6 +53,20 @@ func (s *AppModelSuite) Test_Validate_InvalidRepoProvider() {
 	s.Equal(err.Errors["domain"], "")
 }
 
+func (s *AppModelSuite) Test_JSON_LocalRepo_ExposesFileURL() {
+	a := app.New(1)
+	a.Repo = "local/srv/repos/foo"
+
+	s.Equal("file:///srv/repos/foo", a.JSON()["repo"])
+}
+
+func (s *AppModelSuite) Test_JSON_GithubRepo_PreservesStorageForm() {
+	a := app.New(1)
+	a.Repo = "github/owner/my-repo"
+
+	s.Equal("github/owner/my-repo", a.JSON()["repo"])
+}
+
 func (s *AppModelSuite) Test_Cache_PrivateKey() {
 	a := app.New(1)
 	pk := a.PrivateKey(context.Background())

--- a/src/ce/api/app/app_shttp.go
+++ b/src/ce/api/app/app_shttp.go
@@ -39,21 +39,6 @@ type RequestContext struct {
 	Token *apikey.Token
 }
 
-// Response returns a new app response.
-type Response struct {
-	App *MyApp `json:"app"`
-}
-
-// NewResponse returns a new App response.
-func NewResponse(app *MyApp) *shttp.Response {
-	return &shttp.Response{
-		Status: http.StatusOK,
-		Data: &Response{
-			App: app,
-		},
-	}
-}
-
 type Opts struct {
 	Env   bool // Require environment
 	App   bool // Require app

--- a/src/ce/api/app/apphandlers/handler_app_insert.go
+++ b/src/ce/api/app/apphandlers/handler_app_insert.go
@@ -9,9 +9,11 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/bitbucket"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/github"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/gitlab"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/local"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/model"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttperr"
@@ -44,8 +46,16 @@ func (a *appInsertPost) Validate() *shttperr.ValidationError {
 			bitbucket.ProviderName,
 		}
 
+		if config.IsDevelopment() {
+			providers = append(providers, local.ProviderName)
+		}
+
 		if !utils.InSliceString(providers, a.Provider) {
-			err.SetError("provider", "The provider can only be github, gitlab or bitbucket.")
+			if config.IsDevelopment() {
+				err.SetError("provider", "The provider can only be github, gitlab, bitbucket or local.")
+			} else {
+				err.SetError("provider", "The provider can only be github, gitlab or bitbucket.")
+			}
 		}
 	}
 
@@ -116,5 +126,10 @@ func handlerAppInsert(req *user.RequestContext) *shttp.Response {
 		}
 	}
 
-	return app.NewResponse(&app.MyApp{App: myApp})
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"app": myApp.JSON(),
+		},
+	}
 }

--- a/src/ce/api/app/apphandlers/handler_app_insert_test.go
+++ b/src/ce/api/app/apphandlers/handler_app_insert_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -31,6 +32,8 @@ func (s *HandleAppInsertSuite) BeforeTest(suiteName, _ string) {
 	s.conn = databasetest.InitTx(suiteName)
 	s.Factory = factory.New(s.conn)
 	admin.SetMockLicense()
+	// Local-repo provider is dev-only; the suite asserts it is offered.
+	config.SetIsStormkitCloud(false)
 }
 
 func (s *HandleAppInsertSuite) AfterTest(_, _ string) {
@@ -186,7 +189,7 @@ func (s *HandleAppInsertSuite) Test_InvalidRepoProvider() {
 		},
 	)
 
-	expected := `{"errors":{"provider":"The provider can only be github, gitlab or bitbucket."}}`
+	expected := `{"errors":{"provider":"The provider can only be github, gitlab, bitbucket or local."}}`
 	s.Equal(http.StatusBadRequest, response.Code)
 	s.Equal(expected, response.String())
 

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/local"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
@@ -348,6 +349,10 @@ func (d *Deployment) Status() string {
 
 // RepoCloneURL returns the fully qualified repository name to clone the repository.
 func (d *Deployment) RepoCloneURL() string {
+	if local.IsLocal(d.CheckoutRepo) {
+		return local.CloneURL(d.CheckoutRepo)
+	}
+
 	pieces := strings.Split(d.CheckoutRepo, "/")
 
 	if len(pieces) >= 3 {

--- a/src/ce/api/app/deploy/deployment_model_test.go
+++ b/src/ce/api/app/deploy/deployment_model_test.go
@@ -81,6 +81,9 @@ func (s *DeploymentModelSuite) Test_RepoCloneURL() {
 
 	d.CheckoutRepo = "github/stormkit-js/test.github.io"
 	s.Equal("https://github.com/stormkit-js/test.github.io.git", d.RepoCloneURL())
+
+	d.CheckoutRepo = "local/srv/repos/foo"
+	s.Equal("file:///srv/repos/foo", d.RepoCloneURL())
 }
 
 func (s *DeploymentModelSuite) Test_DeploymentLogs_StillRunningButLogsFinished() {

--- a/src/ce/api/oauth/local/local.go
+++ b/src/ce/api/oauth/local/local.go
@@ -1,0 +1,70 @@
+// Package local provides support for apps imported from a local
+// filesystem path (file:// git URLs). Unlike the GitHub/GitLab/Bitbucket
+// providers there is no OAuth or API client — the repo is cloned from
+// disk during deployment.
+package local
+
+import (
+	"os/exec"
+	"strings"
+)
+
+const ProviderName = "local"
+
+const repoPrefix = ProviderName + "/"
+
+// IsLocal reports whether the given App.Repo string refers to a local repo.
+func IsLocal(repo string) bool {
+	return strings.HasPrefix(repo, repoPrefix)
+}
+
+// Path returns the absolute filesystem path encoded in an App.Repo string.
+// The stored format is "local/<path-without-leading-slash>", so a leading
+// slash is prepended on the way out.
+func Path(repo string) string {
+	if !IsLocal(repo) {
+		return ""
+	}
+
+	return "/" + strings.TrimPrefix(repo, repoPrefix)
+}
+
+// CloneURL returns the file:// URL that `git clone` can consume.
+func CloneURL(repo string) string {
+	if !IsLocal(repo) {
+		return ""
+	}
+
+	return "file://" + Path(repo)
+}
+
+// FromURL converts a `file://<absolute-path>` URL into the stored App.Repo
+// representation. Returns "" if the input is not a file:// URL.
+func FromURL(fileURL string) string {
+	const prefix = "file://"
+
+	if !strings.HasPrefix(fileURL, prefix) {
+		return ""
+	}
+
+	path := strings.TrimPrefix(fileURL, prefix)
+	path = strings.TrimPrefix(path, "/")
+
+	if path == "" {
+		return ""
+	}
+
+	return repoPrefix + path
+}
+
+// DefaultBranch returns the local repo's current branch via `git symbolic-ref`.
+// Falls back to "main" when the path is not a valid git repo.
+func DefaultBranch(repo string) (string, error) {
+	out, err := exec.Command("git", "-C", Path(repo), "symbolic-ref", "--short", "HEAD").Output()
+
+	if err != nil {
+		return "main", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}

--- a/src/ce/api/oauth/local/local_test.go
+++ b/src/ce/api/oauth/local/local_test.go
@@ -1,0 +1,39 @@
+package local_test
+
+import (
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/local"
+	"github.com/stretchr/testify/suite"
+)
+
+type LocalSuite struct {
+	suite.Suite
+}
+
+func (s *LocalSuite) Test_IsLocal() {
+	s.True(local.IsLocal("local/srv/repos/foo"))
+	s.False(local.IsLocal("github/stormkit-io/foo"))
+	s.False(local.IsLocal(""))
+}
+
+func (s *LocalSuite) Test_Path() {
+	s.Equal("/srv/repos/foo", local.Path("local/srv/repos/foo"))
+	s.Equal("", local.Path("github/stormkit-io/foo"))
+}
+
+func (s *LocalSuite) Test_CloneURL() {
+	s.Equal("file:///srv/repos/foo", local.CloneURL("local/srv/repos/foo"))
+	s.Equal("", local.CloneURL("github/stormkit-io/foo"))
+}
+
+func (s *LocalSuite) Test_FromURL() {
+	s.Equal("local/srv/repos/foo", local.FromURL("file:///srv/repos/foo"))
+	s.Equal("", local.FromURL("https://github.com/foo/bar"))
+	s.Equal("", local.FromURL("file://"))
+	s.Equal("", local.FromURL("file:///"))
+}
+
+func TestLocalSuite(t *testing.T) {
+	suite.Run(t, new(LocalSuite))
+}

--- a/src/ce/api/public/v1/handler_app_create.go
+++ b/src/ce/api/public/v1/handler_app_create.go
@@ -2,17 +2,26 @@ package publicapiv1
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 type appCreatePost struct {
-	Repo        string `json:"repo"`     // owner/slug
-	Provider    string `json:"provider"` // github|gitlab|bitbucket
+	// Repo accepts any of:
+	//   - a full URL: https://github.com/owner/repo, file:///abs/path
+	//   - Stormkit style: github/owner/repo, local/abs/path
+	//   - bare owner/repo (provider must be set, or defaults to github)
+	Repo string `json:"repo"`
+
+	// Provider is optional when Repo carries its own scheme/prefix.
+	// One of github|gitlab|bitbucket|local.
+	Provider    string `json:"provider,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
 }
 
@@ -46,7 +55,21 @@ func handlerAppCreate(req *RequestContext) *shttp.Response {
 	myApp.TeamID = req.TeamID
 
 	if data.Repo != "" {
-		myApp.Repo = fmt.Sprintf("%s/%s", strings.ToLower(strings.TrimSpace(data.Provider)), strings.TrimSpace(data.Repo))
+		repo := strings.TrimSpace(data.Repo)
+		provider := strings.ToLower(strings.TrimSpace(data.Provider))
+
+		// When the repo string carries its own provider hint (URL scheme or
+		// known prefix), derive provider from it and ignore an explicit
+		// `provider` field. Otherwise fall back to concatenating with the
+		// explicit provider — preserving the legacy two-field form.
+		if repoHasProviderHint(repo) {
+			if p, slug := utils.ParseRepoWithProvider(repo); slug != "" && p != "" {
+				provider = p
+				repo = slug
+			}
+		}
+
+		myApp.Repo = fmt.Sprintf("%s/%s", provider, repo)
 	}
 
 	if trimmed := strings.TrimSpace(data.DisplayName); trimmed != "" {
@@ -79,5 +102,24 @@ func handlerAppCreate(req *RequestContext) *shttp.Response {
 		}
 	}
 
-	return app.NewResponse(&app.MyApp{App: myApp})
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"app": myApp.JSON(),
+		},
+	}
+}
+
+// repoHasProviderHint reports whether the input carries enough information
+// to derive a provider on its own (URL scheme or known Stormkit prefix).
+func repoHasProviderHint(repo string) bool {
+	lower := strings.ToLower(repo)
+
+	for _, prefix := range []string{"http://", "https://", "file://", "github/", "gitlab/", "bitbucket/", "local/"} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/src/ce/api/public/v1/handler_app_create_test.go
+++ b/src/ce/api/public/v1/handler_app_create_test.go
@@ -308,6 +308,54 @@ func (s *HandlerAppCreateSuite) Test_Forbidden_LowScopeKey() {
 	s.Equal(http.StatusForbidden, response.Code)
 }
 
+// Test_Success_RepoURL verifies that a full URL in `repo` derives the provider
+// and the `provider` field can be omitted.
+func (s *HandlerAppCreateSuite) Test_Success_RepoURL() {
+	keyValue, _ := s.teamKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodPost,
+		"/v1/app",
+		map[string]any{
+			"repo": "https://github.com/owner/my-repo",
+		},
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	body := response.Map()
+	appData, _ := body["app"].(map[string]any)
+	s.Equal("github/owner/my-repo", appData["repo"])
+}
+
+// Test_Success_LocalRepo verifies that a file:// URL is accepted with no
+// `provider` field and stored under the local provider.
+func (s *HandlerAppCreateSuite) Test_Success_LocalRepo() {
+	keyValue, _ := s.teamKey()
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodPost,
+		"/v1/app",
+		map[string]any{
+			"repo": "file:///srv/repos/foo",
+		},
+		map[string]string{
+			"Authorization": keyValue,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	body := response.Map()
+	appData, _ := body["app"].(map[string]any)
+	s.Equal("file:///srv/repos/foo", appData["repo"])
+}
+
 func TestHandlerAppCreate(t *testing.T) {
 	suite.Run(t, &HandlerAppCreateSuite{})
 }

--- a/src/ce/api/public/v1/handler_app_list.go
+++ b/src/ce/api/public/v1/handler_app_list.go
@@ -44,7 +44,7 @@ func handlerAppList(req *RequestContext) *shttp.Response {
 
 	if !repoValid {
 		return shttp.BadRequest(map[string]any{
-			"errors": []string{"The 'repo' parameter must be in the format 'github/org/repo', 'gitlab/org/repo', or 'bitbucket/org/repo'"},
+			"errors": []string{"The 'repo' parameter must be in the format 'github/org/repo', 'gitlab/org/repo', 'bitbucket/org/repo', or 'file:///abs/path' for local repos"},
 		})
 	}
 

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/redirects"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -146,7 +145,7 @@ func mcpAllTools() []mcpToolDef {
 					"teamId": map[string]any{"type": "string", "description": "Team ID to create the app under. Required."},
 					"repo": map[string]any{
 						"type":        "string",
-						"description": "Repository reference. Accepted formats: full URL (https://github.com/org/repo), Stormkit style (github/org/repo), or bare owner/repo.",
+						"description": "Repository reference. Accepted formats: full URL (https://github.com/org/repo), Stormkit style (github/org/repo), local repo (file:///abs/path or local/abs/path), or bare owner/repo.",
 					},
 					"displayName": map[string]any{"type": "string", "description": "Human-readable name for the app. Auto-generated if omitted."},
 				},
@@ -502,11 +501,8 @@ func mcpCreateApp(req *RequestContextMCP, id any, args map[string]any) *shttp.Re
 		return resp
 	}
 
-	provider, ownerSlug := utils.ParseRepoWithProvider(stringArg(args, "repo"))
-
 	body := appCreatePost{
-		Repo:        ownerSlug,
-		Provider:    provider,
+		Repo:        stringArg(args, "repo"),
 		DisplayName: stringArg(args, "displayName"),
 	}
 

--- a/src/ce/api/public/v1/validators.go
+++ b/src/ce/api/public/v1/validators.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 type Validators struct{}
@@ -33,6 +36,18 @@ func (v *Validators) ToInt(raw, paramName string) (int, error) {
 func (v *Validators) NormalizeRepo(repo string) (string, bool) {
 	if repo == "" {
 		return "", true
+	}
+
+	// Accept `file://` URLs and stormkit-style references uniformly:
+	// derive the canonical "<provider>/<path>" storage form. Only enabled
+	// in development — `local` repos are a dev convenience and must not be
+	// reachable on Cloud or self-hosted deployments.
+	if config.IsDevelopment() {
+		if provider, slug := utils.ParseRepoWithProvider(repo); provider != "" && slug != "" {
+			if provider == "local" {
+				return provider + "/" + slug, true
+			}
+		}
 	}
 
 	normalized := strings.ToLower(repo)

--- a/src/ce/api/public/v1/validators_test.go
+++ b/src/ce/api/public/v1/validators_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -14,6 +15,8 @@ type ValidatorsSuite struct {
 
 func (s *ValidatorsSuite) SetupTest() {
 	s.v = &publicapiv1.Validators{}
+	// Ensure local repos are accepted by NormalizeRepo (dev-only feature).
+	config.SetIsStormkitCloud(false)
 }
 
 func (s *ValidatorsSuite) Test_ToInt_Empty_ReturnsZero() {
@@ -96,6 +99,26 @@ func (s *ValidatorsSuite) Test_NormalizeRepo_InvalidPrefix() {
 
 func (s *ValidatorsSuite) Test_NormalizeRepo_NoSlash() {
 	_, ok := s.v.NormalizeRepo("myrepo")
+	s.False(ok)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_FileURL() {
+	normalized, ok := s.v.NormalizeRepo("file:///srv/repos/foo")
+	s.True(ok)
+	s.Equal("local/srv/repos/foo", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_LocalPrefix() {
+	normalized, ok := s.v.NormalizeRepo("local/srv/repos/foo")
+	s.True(ok)
+	s.Equal("local/srv/repos/foo", normalized)
+}
+
+func (s *ValidatorsSuite) Test_NormalizeRepo_FileURL_RejectedOutsideDev() {
+	config.SetIsStormkitCloud(true)
+	defer config.SetIsStormkitCloud(false)
+
+	_, ok := s.v.NormalizeRepo("file:///srv/repos/foo")
 	s.False(ok)
 }
 

--- a/src/lib/utils/string.go
+++ b/src/lib/utils/string.go
@@ -103,10 +103,35 @@ func ParseSemver(version string) (major, minor, patch string) {
 //
 //   - https://github.com/owner/repo  (full URL, optional .git suffix)
 //   - github/owner/repo              (Stormkit style)
-//   - owner/repo                     (bare, provider will be empty)
+//   - file:///abs/path               (local repo on disk)
+//   - local/abs/path                 (Stormkit-style local repo)
+//   - owner/repo                     (bare, defaults to github)
 func ParseRepoWithProvider(raw string) (provider, ownerSlug string) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimSuffix(raw, ".git")
+
+	if strings.HasPrefix(raw, "file://") {
+		path := strings.TrimPrefix(raw, "file://")
+		path = strings.TrimPrefix(path, "/")
+		path = strings.TrimRight(path, "/")
+
+		if path == "" {
+			return "", ""
+		}
+
+		return "local", path
+	}
+
+	if strings.HasPrefix(strings.ToLower(raw), "local/") {
+		path := strings.TrimLeft(raw[len("local/"):], "/")
+		path = strings.TrimRight(path, "/")
+
+		if path == "" {
+			return "", ""
+		}
+
+		return "local", path
+	}
 
 	if strings.HasPrefix(raw, "https://") || strings.HasPrefix(raw, "http://") {
 		withoutScheme := strings.SplitN(raw, "://", 2)[1]

--- a/src/lib/utils/string_test.go
+++ b/src/lib/utils/string_test.go
@@ -72,6 +72,10 @@ func (s *StringSuite) Test_ParseRepoWithProvider() {
 		{"gitlab/my-org/my-repo", "gitlab", "my-org/my-repo"},
 		{"bitbucket/my-org/my-repo", "bitbucket", "my-org/my-repo"},
 		{"my-org/my-repo", "github", "my-org/my-repo"},
+		{"file:///srv/repos/foo", "local", "srv/repos/foo"},
+		{"file:///srv/repos/foo/", "local", "srv/repos/foo"},
+		{"local/srv/repos/foo", "local", "srv/repos/foo"},
+		{"local//srv/repos/foo", "local", "srv/repos/foo"},
 	}
 
 	for _, tc := range cases {

--- a/src/ui/src/pages/apps/new/url/ImportURL.tsx
+++ b/src/ui/src/pages/apps/new/url/ImportURL.tsx
@@ -30,19 +30,29 @@ export default function ImportURL() {
 
     try {
       const parsed = new URL(importUrl);
-      repoName = parsed.pathname.replace(/^\/+/, "").replace(".git", "");
-      provider = parsed.hostname.includes("github")
-        ? "github"
-        : parsed.hostname.includes("gitlab")
-          ? "gitlab"
-          : parsed.hostname.includes("bitbucket")
-            ? "bitbucket"
-            : undefined;
+
+      if (parsed.protocol === "file:") {
+        const path = parsed.pathname.replace(/^\/+/, "").replace(/\/$/, "");
+
+        if (path) {
+          provider = "local";
+          repoName = path;
+        }
+      } else {
+        repoName = parsed.pathname.replace(/^\/+/, "").replace(".git", "");
+        provider = parsed.hostname.includes("github")
+          ? "github"
+          : parsed.hostname.includes("gitlab")
+            ? "gitlab"
+            : parsed.hostname.includes("bitbucket")
+              ? "bitbucket"
+              : undefined;
+      }
     } catch {}
 
     if (!provider || !repoName) {
       return setError(
-        "Make sure to import the repository from one these providers: GitLab, GitHub, Bitbucket.",
+        "Make sure to import the repository from one these providers: GitLab, GitHub, Bitbucket, or a local file:// path.",
       );
     }
 
@@ -50,7 +60,7 @@ export default function ImportURL() {
     setError(undefined);
 
     insertRepo({
-      provider: "github",
+      provider,
       repo: repoName,
       teamId: team?.id,
     })
@@ -80,7 +90,7 @@ export default function ImportURL() {
           color="info"
           variant="filled"
           label="Where can we find the repository?"
-          placeholder="https://github.com/stormkit-io/marketplace-feedback-form"
+          placeholder="https://github.com/stormkit-io/marketplace-feedback-form or file:///path/to/repo"
           fullWidth
           autoComplete="off"
           value={importUrl}

--- a/src/ui/src/types/provider.d.ts
+++ b/src/ui/src/types/provider.d.ts
@@ -1,2 +1,2 @@
-declare type Provider = "github" | "gitlab" | "bitbucket";
-declare type ProviderText = "GitHub" | "GitLab" | "Bitbucket";
+declare type Provider = "github" | "gitlab" | "bitbucket" | "local";
+declare type ProviderText = "GitHub" | "GitLab" | "Bitbucket" | "Local";


### PR DESCRIPTION
## Summary
- Adds a `local` provider so apps can be created from a `file://<abs-path>` repository on the deployment host. No OAuth/credentials needed; `git clone` reads straight from disk.
- The public v1 `POST /v1/app` endpoint now accepts a single `repo` field in any of: full URL (`https://github.com/...`, `file:///abs/path`), Stormkit style (`github/org/repo`, `local/abs/path`), or bare `owner/repo`. `provider` is derived when the input carries a hint, kept as an explicit field only for bare `owner/repo`. App JSON exposes `local/...` repos as their `file://` URL form so callers can round-trip.
- UI `Import from URL` flow recognises `file://` URLs and submits them as the `local` provider.
- **Dev gate**: `local`/`file://` is rejected unless `config.IsDevelopment()` is true (gated in `app.Validate`, `apphandlers.appInsertPost.Validate`, and `publicapiv1.NormalizeRepo`). It will not be reachable on Cloud or self-hosted builds — local repos are a developer-loop convenience, not an end-user feature.

## Test plan
- [x] `go test ./src/ce/api/oauth/local/... ./src/ce/api/app/ ./src/ce/api/app/apphandlers/ ./src/ce/api/app/deploy/ ./src/ce/api/public/v1/ ./src/lib/utils/` — all green
- [x] Negative test asserts `file://...` is rejected when `IsStormkitCloud(true)`
- [ ] Manually: in `mise dev`, create an app via `POST /v1/app` with `{"repo":"file:///path/to/local/git/repo"}` and trigger a deploy; verify `git clone` succeeds.
- [ ] Manually: in a cloud/self-hosted build, confirm `file://` and `local/...` are both rejected by both `POST /v1/app` and `GET /v1/app?repo=...`.