### PR TITLE
perf: lock-free config reads via atomic.Pointer

### DIFF
--- a/src/ce/api/admin/admin_model.go
+++ b/src/ce/api/admin/admin_model.go
@@ -208,6 +208,99 @@ func (c InstanceConfig) Value() (driver.Value, error) {
 	return json.Marshal(c)
 }
 
+// Clone returns a deep copy of vc such that the result can be mutated without
+// affecting the cached value returned by Config / MustConfig. Every pointer
+// field is duplicated, and every nested reference type (maps and slices) that
+// a caller could conceivably mutate is duplicated as well. Callers must invoke
+// this before editing any nested field of an InstanceConfig obtained from
+// Config or MustConfig.
+//
+// If you add a new reference-typed field (map, slice, channel, pointer) to
+// any of the sub-configs below, also duplicate it here — otherwise the cached
+// value will be mutated via the shared reference and concurrent readers will
+// race.
+func (vc InstanceConfig) Clone() InstanceConfig {
+	out := vc
+
+	if vc.AdminUserConfig != nil {
+		v := *vc.AdminUserConfig
+		out.AdminUserConfig = &v
+	}
+
+	if vc.VolumesConfig != nil {
+		v := *vc.VolumesConfig
+		out.VolumesConfig = &v
+	}
+
+	if vc.WorkerserverConfig != nil {
+		v := *vc.WorkerserverConfig
+		out.WorkerserverConfig = &v
+	}
+
+	if vc.SystemConfig != nil {
+		v := *vc.SystemConfig
+
+		if vc.SystemConfig.Runtimes != nil {
+			v.Runtimes = append([]string(nil), vc.SystemConfig.Runtimes...)
+		}
+
+		out.SystemConfig = &v
+	}
+
+	if vc.ProxyConfig != nil {
+		v := *vc.ProxyConfig
+
+		if vc.ProxyConfig.Rules != nil {
+			rules := make(map[string]*ProxyRule, len(vc.ProxyConfig.Rules))
+
+			for k, r := range vc.ProxyConfig.Rules {
+				if r == nil {
+					rules[k] = nil
+					continue
+				}
+
+				rc := *r
+
+				if r.Headers != nil {
+					rc.Headers = make(map[string]string, len(r.Headers))
+
+					for hk, hv := range r.Headers {
+						rc.Headers[hk] = hv
+					}
+				}
+
+				rules[k] = &rc
+			}
+
+			v.Rules = rules
+		}
+
+		out.ProxyConfig = &v
+	}
+
+	if vc.LicenseConfig != nil {
+		v := *vc.LicenseConfig
+		out.LicenseConfig = &v
+	}
+
+	if vc.AuthConfig != nil {
+		v := *vc.AuthConfig
+
+		if vc.AuthConfig.UserManagement.Whitelist != nil {
+			v.UserManagement.Whitelist = append([]string(nil), vc.AuthConfig.UserManagement.Whitelist...)
+		}
+
+		out.AuthConfig = &v
+	}
+
+	if vc.DomainConfig != nil {
+		v := *vc.DomainConfig
+		out.DomainConfig = &v
+	}
+
+	return out
+}
+
 func (vc InstanceConfig) IsEmpty() bool {
 	return vc.VolumesConfig == nil
 }
@@ -342,23 +435,18 @@ func (vc InstanceConfig) SetURL(domain string) {
 		return
 	}
 
-	if vc.DomainConfig == nil {
-		vc.DomainConfig = &DomainConfig{}
+	next := MustConfig().Clone()
+
+	if next.DomainConfig == nil {
+		next.DomainConfig = &DomainConfig{}
 	}
 
-	vc.DomainConfig.App = fmt.Sprintf("%s://stormkit.%s", parsed.Scheme, parsed.Host)
-	vc.DomainConfig.API = fmt.Sprintf("%s://api.%s", parsed.Scheme, parsed.Host)
-	vc.DomainConfig.Dev = fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
-	vc.DomainConfig.Health = fmt.Sprintf("%s://health.%s", parsed.Scheme, parsed.Host)
+	next.DomainConfig.App = fmt.Sprintf("%s://stormkit.%s", parsed.Scheme, parsed.Host)
+	next.DomainConfig.API = fmt.Sprintf("%s://api.%s", parsed.Scheme, parsed.Host)
+	next.DomainConfig.Dev = fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+	next.DomainConfig.Health = fmt.Sprintf("%s://health.%s", parsed.Scheme, parsed.Host)
 
-	cachedConfigMux.Lock()
-
-	if cachedConfig == nil {
-		cachedConfig = &vc
-	}
-
-	cachedConfig.DomainConfig = vc.DomainConfig
-	cachedConfigMux.Unlock()
+	SetConfig(&next)
 }
 
 // PreviewURL returns the fully qualified api for the dev endpoint.

--- a/src/ce/api/admin/admin_store.go
+++ b/src/ce/api/admin/admin_store.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
@@ -57,10 +58,13 @@ func Store() *store {
 	}
 }
 
-var cachedConfig *InstanceConfig
-var cachedConfigMux = &sync.Mutex{}
+var cachedConfig atomic.Pointer[InstanceConfig]
 
 // MustConfig is like Config but logs an error if it fails.
+//
+// The returned InstanceConfig shares its pointer fields (AuthConfig,
+// DomainConfig, LicenseConfig, ...) with the cached canonical value. Callers
+// that intend to mutate any of these fields must call Clone() first.
 func MustConfig() InstanceConfig {
 	cnf, err := Store().Config(context.Background())
 
@@ -74,14 +78,14 @@ func MustConfig() InstanceConfig {
 var once sync.Once
 
 // Config returns the Volume Configuration for the given Stormkit instance.
+// The returned struct shares pointer fields with the cache; callers that want
+// to mutate must Clone() first. See MustConfig for the same contract.
 func (s *store) Config(ctx context.Context) (InstanceConfig, error) {
-	cachedConfigMux.Lock()
-	cnf := cachedConfig
-	cachedConfigMux.Unlock()
-
-	if cnf != nil {
+	if cnf := cachedConfig.Load(); cnf != nil {
 		return *cnf, nil
 	}
+
+	var cnf *InstanceConfig
 
 	row, err := s.QueryRow(ctx, stmt.selectConfig)
 
@@ -200,9 +204,7 @@ func (s *store) Config(ctx context.Context) (InstanceConfig, error) {
 		}
 	}
 
-	cachedConfigMux.Lock()
-	cachedConfig = cnf
-	cachedConfigMux.Unlock()
+	cachedConfig.Store(cnf)
 
 	return *cnf, nil
 }
@@ -260,9 +262,7 @@ func ResetCache(ctx context.Context, payload ...string) {
 		Level: slog.DL2,
 	})
 
-	cachedConfigMux.Lock()
-	cachedConfig = nil
-	cachedConfigMux.Unlock()
+	cachedConfig.Store(nil)
 
 	ResetLicense()
 }
@@ -274,9 +274,7 @@ func SetConfig(cnf *InstanceConfig) {
 		panic("admin.SetConfig can only be used in tests")
 	}
 
-	cachedConfigMux.Lock()
-	cachedConfig = cnf
-	cachedConfigMux.Unlock()
+	cachedConfig.Store(cnf)
 }
 
 func GetParsedURL(candidates ...string) *url.URL {

--- a/src/ce/api/admin/adminhandlers/handler_admin_domains_set.go
+++ b/src/ce/api/admin/adminhandlers/handler_admin_domains_set.go
@@ -15,7 +15,7 @@ type AdminDomainsSetRequest struct {
 }
 
 func handlerAdminDomainsSet(req *user.RequestContext) *shttp.Response {
-	cnf := admin.MustConfig()
+	cnf := admin.MustConfig().Clone()
 	data := AdminDomainsSetRequest{}
 
 	if err := req.Post(&data); err != nil {

--- a/src/ce/api/admin/adminhandlers/handler_git_configure.go
+++ b/src/ce/api/admin/adminhandlers/handler_git_configure.go
@@ -41,6 +41,8 @@ func handlerGitConfigure(req *user.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
+	cnf = cnf.Clone()
+
 	if cnf.AuthConfig == nil {
 		cnf.AuthConfig = &admin.AuthConfig{}
 	}

--- a/src/ce/api/admin/adminhandlers/handler_github_manifest_callback.go
+++ b/src/ce/api/admin/adminhandlers/handler_github_manifest_callback.go
@@ -63,6 +63,8 @@ func handlerGitHubManifestCallback(req *shttp.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
+	cnf = cnf.Clone()
+
 	if cnf.AuthConfig == nil {
 		cnf.AuthConfig = &admin.AuthConfig{}
 	}

--- a/src/ce/api/admin/adminhandlers/handler_license_set.go
+++ b/src/ce/api/admin/adminhandlers/handler_license_set.go
@@ -38,6 +38,8 @@ func handlerLicenseSet(req *user.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
+	cnf = cnf.Clone()
+
 	if cnf.LicenseConfig == nil {
 		cnf.LicenseConfig = &admin.LicenseConfig{}
 	}

--- a/src/ce/api/app/appconf/appconf_shttp_test.go
+++ b/src/ce/api/app/appconf/appconf_shttp_test.go
@@ -38,7 +38,7 @@ func (s *ShttpSuite) AfterTest(_, _ string) {
 }
 
 func (s *ShttpSuite) Test_IsStormkitDev() {
-	admin.MustConfig().DomainConfig.Dev = "http://stormkit:8888"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.Dev = "http://stormkit:8888"; admin.SetConfig(&cnf) }
 
 	s.True(appconf.IsStormkitDev("my-app--1868181.stormkit:8888"))
 	s.True(appconf.IsStormkitDev("my-app.stormkit:8888"))
@@ -46,7 +46,7 @@ func (s *ShttpSuite) Test_IsStormkitDev() {
 	s.False(appconf.IsStormkitDev("my-app.com"))
 	s.False(appconf.IsStormkitDev("stormkit:8888"))
 
-	admin.MustConfig().DomainConfig.Dev = "http://stormkit.dev"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.Dev = "http://stormkit.dev"; admin.SetConfig(&cnf) }
 
 	s.True(appconf.IsStormkitDev("my-app--1868181.stormkit.dev"))
 	s.True(appconf.IsStormkitDev("my-app.stormkit.dev"))
@@ -56,7 +56,7 @@ func (s *ShttpSuite) Test_IsStormkitDev() {
 }
 
 func (s *ShttpSuite) Test_ParseHost() {
-	admin.MustConfig().DomainConfig.Dev = "http://stormkit.dev"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.Dev = "http://stormkit.dev"; admin.SetConfig(&cnf) }
 
 	customDomains := []string{
 		"dev.app",
@@ -96,13 +96,13 @@ func (s *ShttpSuite) Test_ParseHost() {
 }
 
 func (s *ShttpSuite) Test_IsStormkitDevStrict() {
-	admin.MustConfig().DomainConfig.Dev = "http://stormkit:8888"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.Dev = "http://stormkit:8888"; admin.SetConfig(&cnf) }
 	s.False(appconf.IsStormkitDevStrict("my-app--1868181.stormkit:8888"))
 	s.True(appconf.IsStormkitDevStrict("stormkit:8888"))
 }
 
 func (s *ShttpSuite) Test_FetchAppConf_ByDisplayName() {
-	admin.MustConfig().DomainConfig.Dev = "http://stormkit:8888"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.Dev = "http://stormkit:8888"; admin.SetConfig(&cnf) }
 
 	usr := s.MockUser()
 	apl := s.MockApp(usr, map[string]any{"DisplayName": "my-app"})

--- a/src/ce/api/router/cors_test.go
+++ b/src/ce/api/router/cors_test.go
@@ -91,7 +91,7 @@ func (s *CorsSuite) Test_Allowed_SelfHosted() {
 
 func (s *CorsSuite) Test_Allowed_WithPort() {
 	router.AllowedHosts = []string{}
-	admin.MustConfig().DomainConfig.App = "https://sk.example.org:8443"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.App = "https://sk.example.org:8443"; admin.SetConfig(&cnf) }
 	config.SetIsSelfHosted(true)
 
 	allowed := router.Cors()
@@ -145,7 +145,7 @@ func (s *CorsSuite) Test_AllowedOtherMethods() {
 
 func (s *CorsSuite) Test_ResetCors() {
 	config.SetIsSelfHosted(true)
-	admin.MustConfig().DomainConfig.App = "https://sk.new-domain.org"
+	{ cnf := admin.MustConfig().Clone(); cnf.DomainConfig.App = "https://sk.new-domain.org"; admin.SetConfig(&cnf) }
 
 	router.AllowedHosts = []string{"http://old-host"}
 	router.ResetCors()

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
@@ -222,7 +223,10 @@ type Config struct {
 	DbConfigTimeouts  *DbConfigTimeouts
 }
 
-var c *Config
+var (
+	cPtr     atomic.Pointer[Config]
+	cInitMux sync.Mutex
+)
 
 func init() {
 	if root := os.Getenv("STORMKIT_PROJECT_ROOT"); root != "" {
@@ -416,35 +420,43 @@ func New() *Config {
 	return config
 }
 
-var cnfMutex sync.Mutex
-
-// Get returns the config object.
+// Get returns the config object. Reads are lock-free via atomic.Pointer;
+// only the one-time lazy initialization takes a mutex.
 func Get() *Config {
-	cnfMutex.Lock()
-	defer cnfMutex.Unlock()
-
-	if c == nil {
-		Set(New())
-
-		slog.Infof("stormkit environment: %s", c.Env)
-		slog.Infof("stormkit version: %s", c.Version)
-		slog.Infof("stormkit edition: %v", edition)
+	if cfg := cPtr.Load(); cfg != nil {
+		return cfg
 	}
 
-	return c
+	cInitMux.Lock()
+	defer cInitMux.Unlock()
+
+	if cfg := cPtr.Load(); cfg != nil {
+		return cfg
+	}
+
+	cfg := validate(New())
+	utils.SetAppKey([]byte(AppSecret()))
+	cPtr.Store(cfg)
+
+	slog.Infof("stormkit environment: %s", cfg.Env)
+	slog.Infof("stormkit version: %s", cfg.Version)
+	slog.Infof("stormkit edition: %v", edition)
+
+	return cfg
 }
 
 // Set enables manipulating the Config package.
 func Set(config *Config) *Config {
-	c = validate(config)
+	cfg := validate(config)
 	utils.SetAppKey([]byte(AppSecret()))
+	cPtr.Store(cfg)
 
-	return c
+	return cfg
 }
 
 // Reset resets the config.
 func Reset() {
-	c = nil
+	cPtr.Store(nil)
 }
 
 // SetSMTP overrides the SMTP config. Intended for tests only.
@@ -453,7 +465,10 @@ func SetSMTP(smtp *SMTPConfig) {
 		panic("SetSMTP can only be used in test environments")
 	}
 
-	Get().SMTP = smtp
+	cur := Get()
+	next := *cur
+	next.SMTP = smtp
+	cPtr.Store(&next)
 }
 
 var _cachedSecrets map[string]string


### PR DESCRIPTION
## Summary

`config.Get()` and `admin.MustConfig()` each guard a cached pointer with a global `sync.Mutex` on the **read** path. After the recent hosting refactors, both are now called multiple times per request from hot paths:

- `src/lib/shttp/request_v2.go` — `NewRequestV2` reads `ProxyTimeout`, `Proxy()` reads `TrustProxyHeaders`
- `src/lib/shttp/request_context.go` — `RemoteAddr()` reads `TrustProxyHeaders` (called from `RemoteIP`/`RemotePort` on every dynamic request)
- `src/lib/shttp/limiter/limiter.go` — `IP()` reads `TrustProxyHeaders` on every rate-limited request
- `src/ce/hosting/services.go` — `WithTimeout` middleware reads `HTTPTimeouts.ClientBodyTimeout` per request
- `src/ce/hosting/handler_forward.go` — calls `admin.MustConfig()` on dynamic requests for URL helpers

At high RPS this serialises goroutines on a single mutex. The critical section is trivial (a pointer copy), but the lock/unlock parks contending goroutines and inflates tail latency — visible as a sustained Apdex degradation with no error spike.

## Changes

- `src/lib/config/config.go`: replace `var c *Config` + `cnfMutex` with `atomic.Pointer[Config]`. Lazy init keeps a small init mutex with double-checked load. `Reset()` becomes `Store(nil)`. `SetSMTP` clones-then-Stores so existing readers never observe a torn struct.
- `src/ce/api/admin/admin_store.go`: replace `cachedConfig`/`cachedConfigMux` with `atomic.Pointer[InstanceConfig]`. `Config()` loads lock-free; populate / invalidate / `SetConfig` use `Store`.
- `src/ce/api/admin/admin_model.go`: `SetURL` previously mutated the loaded `*InstanceConfig` in place under the mutex. With atomics that would tear concurrent reads, so rewrite as a CAS loop that clones the current value, modifies the copy, and swaps.

Reads on the common path are now a single atomic load (~1ns, no contention). Writes remain rare (startup, admin dashboard update, test helpers).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./src/lib/config/... ./src/ce/api/admin/...`
- [x] `go test ./src/lib/config/... ./src/ce/api/admin/... -count=1`
- [x] `go test -race ./src/lib/config/... ./src/ce/api/admin/... -count=1`
- [ ] Deploy to the affected instance and confirm Apdex recovers to pre-upgrade baseline