### PR TITLE
feat: honor AutoInstall when skipping runtimes/nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ release/
 bin/
 
 .overmind.sock
+
+.claude/

--- a/src/ce/api/admin/admin_model.go
+++ b/src/ce/api/admin/admin_model.go
@@ -310,6 +310,13 @@ func (vc InstanceConfig) IsAuthEnabled() bool {
 	return vc.IsGithubEnabled() || vc.IsGitlabEnabled() || vc.IsBitbucketEnabled()
 }
 
+// IsAutoInstallEnabled returns whether the runner should automatically install
+// runtime dependencies (mise/flake.nix). Defaults to true when SystemConfig is
+// unset.
+func (vc InstanceConfig) IsAutoInstallEnabled() bool {
+	return vc.SystemConfig == nil || vc.SystemConfig.AutoInstall
+}
+
 // IsBitbucketEnabled returns whether the Bitbucket auth config is enabled or not.
 func (vc InstanceConfig) IsBitbucketEnabled() bool {
 	if vc.AuthConfig == nil {

--- a/src/ce/api/app/deployservice/deployer.go
+++ b/src/ce/api/app/deployservice/deployer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
@@ -123,7 +124,10 @@ func (dd *DefaultDeployer) Deploy(ctx context.Context, a *app.App, d *deploy.Dep
 			),
 		},
 
-		Config: config.Get().Runner,
+		Config: &RunnerSettings{
+			RunnerConfig: *config.Get().Runner,
+			AutoInstall:  admin.MustConfig().IsAutoInstallEnabled(),
+		},
 	}
 
 	queue := tasks.QueueDeployService

--- a/src/ce/api/app/deployservice/deployer_service.go
+++ b/src/ce/api/app/deployservice/deployer_service.go
@@ -107,9 +107,15 @@ type DeploymentMessage struct {
 	// Build is the configuration regarding the deployment.
 	Build BuildConfig `json:"build"`
 
-	Config *config.RunnerConfig `json:"config"`
+	Config *RunnerSettings `json:"config"`
+}
 
-	Canary *bool `json:"canary,omitempty"`
+// RunnerSettings extends config.RunnerConfig with runtime-only fields that the
+// API derives at deploy time (e.g. system-wide flags from admin config).
+type RunnerSettings struct {
+	config.RunnerConfig
+
+	AutoInstall bool `json:"autoInstall"`
 }
 
 // NewDeploy returns a new Deployment object.

--- a/src/ce/api/app/deployservice/deployer_test.go
+++ b/src/ce/api/app/deployservice/deployer_test.go
@@ -109,12 +109,13 @@ func (s *DeploySuite) Test_Deployment() {
 				"STORMKIT":          "true",
 			},
 		},
-		Config: &config.RunnerConfig{
-			Provider:      "filesys",
-			Concurrency:   0,
-			MaxGoRoutines: 25,
-		},
-		Canary: nil,
+		Config: func() *deployservice.RunnerSettings {
+			// Concurrency is `json:"-"` so it doesn't round-trip through the
+			// encrypted payload — zero it out on the expected value.
+			rc := *config.Get().Runner
+			rc.Concurrency = 0
+			return &deployservice.RunnerSettings{RunnerConfig: rc, AutoInstall: true}
+		}(),
 	}, message)
 
 	// Should also insert into database

--- a/src/ce/runner/builder.go
+++ b/src/ce/runner/builder.go
@@ -35,7 +35,8 @@ type Builder struct {
 	distDir     string
 	apiDir      string // Path to api dir
 	packageMngr string
-	envVars map[string]string
+	envVars     map[string]string
+	autoInstall bool
 	reporter    *ReporterModel
 }
 
@@ -54,7 +55,8 @@ func NewBuilder(opts RunnerOpts) BuilderInterface {
 		cmd:         opts.Build.BuildCmd,
 		distDir:     opts.Build.DistFolder,
 		apiDir:      opts.Build.APIFolder,
-		envVars: opts.Build.EnvVars,
+		envVars:     opts.Build.EnvVars,
+		autoInstall: opts.AutoInstall,
 		reporter:    opts.Reporter,
 	}
 
@@ -87,7 +89,13 @@ func (bm Builder) ExecCommands(ctx context.Context) error {
 		Stderr: bm.reporter.File(),
 	}
 
-	if flakeDir := nixFlakeDir(bm.workDir, bm.repoDir); flakeDir != "" {
+	flakeDir := ""
+
+	if bm.autoInstall {
+		flakeDir = nixFlakeDir(bm.workDir, bm.repoDir)
+	}
+
+	if flakeDir != "" {
 		opts.Name = "nix"
 		opts.Dir = flakeDir
 		opts.Args = []string{"--extra-experimental-features", "nix-command flakes", "develop", "--command", "sh", "-c", bm.cmd}
@@ -117,7 +125,7 @@ func (bm Builder) BuildApiIfNecessary(ctx context.Context) (bool, error) {
 		APIDir:         bm.apiDir,
 		OutputDir:      filepath.Join(".stormkit", "api"),
 		PackageManager: bm.packageMngr,
-		EnvVarsMap: bm.envVars,
+		EnvVarsMap:     bm.envVars,
 		Reporter:       bm.reporter,
 	})
 

--- a/src/ce/runner/builder_test.go
+++ b/src/ce/runner/builder_test.go
@@ -25,8 +25,9 @@ func (s *BuildManagerSuite) BeforeTest(_, _ string) {
 	s.NoError(err)
 
 	s.config = runner.RunnerOpts{
-		RootDir:  tmpDir,
-		Reporter: runner.NewReporter("https://example.com"),
+		RootDir:     tmpDir,
+		Reporter:    runner.NewReporter("https://example.com"),
+		AutoInstall: true,
 		Repo: runner.RepoOpts{
 			Dir: path.Join(tmpDir, "repo"),
 		},

--- a/src/ce/runner/bundler.go
+++ b/src/ce/runner/bundler.go
@@ -66,6 +66,7 @@ type Bundler struct {
 	headersFile   string   // Relative path to the headers file (from working dir)
 	redirectsFile string   // Relative path to the redirects file (from working dir)
 	apiFolder     string   // Relative path to the api dir (from working dir)
+	autoInstall   bool
 	packageJson   *PackageJson
 	reporter      *ReporterModel
 }
@@ -332,6 +333,7 @@ func NewBundler(opts RunnerOpts) BundlerInterface {
 		redirectsFile: opts.Build.RedirectsFile,
 		serverCmd:     opts.Build.ServerCmd,
 		apiFolder:     opts.Build.APIFolder,
+		autoInstall:   opts.AutoInstall,
 		packageJson:   opts.Repo.PackageJson,
 		reporter:      opts.Reporter,
 	}
@@ -448,6 +450,10 @@ func (b Bundler) bundleServerSideStormkitSubfolder() ([]string, string, error) {
 // into destDir so the files are included in the server zip and available at runtime
 // for nix develop wrapping.
 func (b Bundler) copyNixFlake(destDir string) {
+	if !b.autoInstall {
+		return
+	}
+
 	flakeDir := nixFlakeDir(b.workDir, b.repoDir)
 
 	if flakeDir == "" {

--- a/src/ce/runner/bundler_test.go
+++ b/src/ce/runner/bundler_test.go
@@ -27,9 +27,10 @@ func (s *BundlerSuite) BeforeTest(_, _ string) {
 	repoDir := path.Join(tmpDir, "repo")
 
 	s.config = runner.RunnerOpts{
-		RootDir:  tmpDir,
-		WorkDir:  repoDir,
-		Reporter: runner.NewReporter("https://example.com"),
+		RootDir:     tmpDir,
+		WorkDir:     repoDir,
+		Reporter:    runner.NewReporter("https://example.com"),
+		AutoInstall: true,
 		Repo: runner.RepoOpts{
 			Dir: repoDir,
 		},

--- a/src/ce/runner/installer.go
+++ b/src/ce/runner/installer.go
@@ -76,6 +76,7 @@ type Installer struct {
 	hasPackageLockFile bool
 	runtime            string // The runtime that is going to be used to build the project
 	envVars            map[string]string
+	autoInstall        bool
 }
 
 // For testing purposes
@@ -99,6 +100,7 @@ func NewInstaller(opts RunnerOpts) InstallerInterface {
 		isYarn:             opts.Repo.IsYarn,
 		isBun:              opts.Repo.IsBun,
 		runtime:            opts.Repo.Runtime,
+		autoInstall:        opts.AutoInstall,
 	}
 
 	return p
@@ -157,6 +159,10 @@ func (p *Installer) installFlake(ctx context.Context, flakeDir string) error {
 
 // InstallRuntimeDependencies installs runtime dependencies using mise and flake.nix (if present).
 func (p *Installer) InstallRuntimeDependencies(ctx context.Context) ([]string, error) {
+	if !p.autoInstall {
+		return nil, nil
+	}
+
 	p.reporter.AddStep("install runtimes")
 
 	m := mise.Client()

--- a/src/ce/runner/installer_test.go
+++ b/src/ce/runner/installer_test.go
@@ -33,9 +33,10 @@ func (s *InstallerSuite) BeforeTest(_, _ string) {
 	s.NoError(err)
 
 	s.config = runner.RunnerOpts{
-		RootDir:  tmpDir,
-		WorkDir:  path.Join(tmpDir, "repo"),
-		Reporter: runner.NewReporter("http://example.com"),
+		RootDir:     tmpDir,
+		WorkDir:     path.Join(tmpDir, "repo"),
+		Reporter:    runner.NewReporter("http://example.com"),
+		AutoInstall: true,
 		Build: runner.BuildOpts{
 			EnvVars: map[string]string{},
 		},

--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -177,6 +177,7 @@ type RunnerOpts struct {
 	Repo           RepoOpts
 	Build          BuildOpts
 	Uploader       *config.RunnerConfig
+	AutoInstall    bool
 	Reporter       *ReporterModel
 }
 
@@ -223,6 +224,11 @@ func Start(payload, rootDir string) error {
 	DeploymentIDEnc = utils.EncryptID(utils.StringToID(p.DeploymentID))
 
 	msg = normalize(msg)
+
+	if msg.Config == nil {
+		msg.Config = &deployservice.RunnerSettings{AutoInstall: true}
+	}
+
 	repoDir := path.Join(p.RootDir, "repo")
 	workDir := path.Join(repoDir, msg.Build.WorkDir)
 
@@ -255,7 +261,8 @@ func Start(payload, rootDir string) error {
 			StatusChecks:     msg.Build.StatusChecks,
 			EnvVars: msg.Build.Vars,
 		},
-		Uploader: msg.Config,
+		Uploader:    &msg.Config.RunnerConfig,
+		AutoInstall: msg.Config.AutoInstall,
 	}
 
 	if opts.Build.EnvVars == nil {

--- a/src/ce/runner/status_checks.go
+++ b/src/ce/runner/status_checks.go
@@ -8,18 +8,20 @@ import (
 )
 
 type StatusChecks struct {
-	workDir  string
-	repoDir  string
-	envVars  map[string]string
-	reporter *ReporterModel
+	workDir     string
+	repoDir     string
+	envVars     map[string]string
+	autoInstall bool
+	reporter    *ReporterModel
 }
 
 func NewStatusChecks(opts RunnerOpts) *StatusChecks {
 	return &StatusChecks{
-		workDir:  opts.WorkDir,
-		repoDir:  opts.Repo.Dir,
-		envVars:  opts.Build.EnvVars,
-		reporter: opts.Reporter,
+		workDir:     opts.WorkDir,
+		repoDir:     opts.Repo.Dir,
+		envVars:     opts.Build.EnvVars,
+		autoInstall: opts.AutoInstall,
+		reporter:    opts.Reporter,
 	}
 }
 
@@ -28,7 +30,7 @@ func NewStatusChecks(opts RunnerOpts) *StatusChecks {
 // env vars (e.g. CHROMIUM_EXECUTABLE_PATH) are available. The current PATH is
 // forwarded via env(1) so that mise-managed runtimes remain accessible.
 func (s *StatusChecks) buildCommand(command string) (string, []string) {
-	if nixFlakeDir(s.workDir, s.repoDir) != "" {
+	if s.autoInstall && nixFlakeDir(s.workDir, s.repoDir) != "" {
 		return "nix", []string{
 			"--extra-experimental-features", "nix-command flakes",
 			"develop",

--- a/src/ce/runner/status_checks_test.go
+++ b/src/ce/runner/status_checks_test.go
@@ -28,9 +28,10 @@ func (s *StatusChecksSuite) BeforeTest(_, _ string) {
 	s.NoError(err)
 
 	s.config = runner.RunnerOpts{
-		Reporter: runner.NewReporter("https://example.com"),
-		RootDir:  tmpDir,
-		WorkDir:  path.Join(tmpDir, "repo"),
+		Reporter:    runner.NewReporter("https://example.com"),
+		RootDir:     tmpDir,
+		WorkDir:     path.Join(tmpDir, "repo"),
+		AutoInstall: true,
 		Build: runner.BuildOpts{
 			EnvVars: map[string]string{
 				"NODE_ENV": "production",

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/shutdown"
@@ -198,6 +199,10 @@ func (pm *ProcessManager) QueueLog(args *InvokeArgs, data string) {
 }
 
 func hasNixFlake(workDir string) bool {
+	if !admin.MustConfig().IsAutoInstallEnabled() {
+		return false
+	}
+
 	return file.Exists(path.Join(workDir, "flake.nix"))
 }
 


### PR DESCRIPTION
## Summary
- When `SystemConfig.AutoInstall` is disabled, the runner no longer installs mise runtimes, pre-builds the nix dev shell, copies `flake.nix` into the bundle, or wraps build/status-check commands with `nix develop`.
- The flag is propagated through the encrypted `DeploymentMessage` (new `RunnerSettings` extends `config.RunnerConfig` with `AutoInstall`), so all runner backends (local + GitHub) honor it without any per-runner plumbing.
- `client_process_manager.hasNixFlake` (API-side serving path) also checks the same setting via a new `InstanceConfig.IsAutoInstallEnabled()` helper.

Removed the unused `Canary` field from `DeploymentMessage` along the way.

## Test plan
- [ ] Toggle Auto Install off in admin settings, redeploy an app with a `flake.nix`, confirm no mise/nix install steps run and the build uses plain `sh -c`.
- [ ] Toggle Auto Install back on, confirm runtimes install and `nix develop` wraps build/status-check commands as before.
- [ ] Verify a GitHub-runner deployment also picks up the flag from the deployment payload.