### PR TITLE
chore: log slow requests at debug level

### DIFF
--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -120,8 +120,9 @@ type DeployerConfig struct {
 }
 
 type TrackingConfig struct {
-	Prometheus     bool
-	PrometheusPort string
+	Prometheus             bool
+	PrometheusPort         string
+	SlowRequestThresholdMs int
 }
 
 func (dc DeployerConfig) IsLocal() bool {
@@ -327,8 +328,9 @@ func New() *Config {
 		},
 
 		Tracking: &TrackingConfig{
-			Prometheus:     isTrueString(os.Getenv("PROMETHEUS_METRICS")),
-			PrometheusPort: get(os.Getenv("PROMETHEUS_PORT"), "2112"),
+			Prometheus:             isTrueString(os.Getenv("PROMETHEUS_METRICS")),
+			PrometheusPort:         get(os.Getenv("PROMETHEUS_PORT"), "2112"),
+			SlowRequestThresholdMs: getInt(os.Getenv("STORMKIT_SLOW_REQUEST_THRESHOLD_MS"), 1000),
 		},
 
 		Env:       Env(),

--- a/src/lib/shttp/service.go
+++ b/src/lib/shttp/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/tracking"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -135,16 +136,41 @@ func (se *ServiceEndpoint) CatchAll(handler RequestFunc, devDomain string) *Serv
 	cnf := config.Get()
 	trackingEnabled := cnf.Tracking != nil && cnf.Tracking.Prometheus
 
+	slowThresholdMs := 0
+
+	if cnf.Tracking != nil {
+		slowThresholdMs = cnf.Tracking.SlowRequestThresholdMs
+	}
+
 	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		req := requestContext(w, r)
 		res := handler(req)
 		se.Send(w, req, res)
 
+		elapsed := time.Since(start)
+		isDevHost := devDomain != "" && strings.HasSuffix(req.HostName(), devDomain)
+
 		// Record the response time if tracking is enabled
 		// and the request is not for the dev domain.
-		if trackingEnabled && devDomain != "" && !strings.HasSuffix(req.HostName(), devDomain) {
-			tracking.RecordResponseTime(r, res.Status, time.Since(start))
+		if trackingEnabled && !isDevHost {
+			tracking.RecordResponseTime(r, res.Status, elapsed)
+		}
+
+		if slowThresholdMs > 0 && !isDevHost && elapsed.Milliseconds() >= int64(slowThresholdMs) {
+			slog.Debug(slog.LogOpts{
+				Msg:   "slow request",
+				Level: slog.DL2,
+				Payload: []zap.Field{
+					zap.String("method", r.Method),
+					zap.String("host", req.HostName()),
+					zap.String("path", r.URL.Path),
+					zap.Int("status", res.Status),
+					zap.Int64("duration_ms", elapsed.Milliseconds()),
+					zap.String("remote", r.RemoteAddr),
+					zap.String("ua", r.UserAgent()),
+				},
+			})
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Add `STORMKIT_SLOW_REQUEST_THRESHOLD_MS` env var (default `1000`) on `TrackingConfig`.
- In `shttp.CatchAll`, log requests slower than the threshold via `slog.Debug` at `DL2` with structured fields (method, host, path, status, duration_ms, remote, ua).
- Skips the dev domain, mirroring the existing metric-recording guard.

Intended as a diagnostic for the recent apdex flakiness — silent by default, opt-in by raising the debug level on the affected host.

## Test plan

- [ ] Set `STORMKIT_DEBUG_LEVEL=2` and `STORMKIT_SLOW_REQUEST_THRESHOLD_MS=400` on a host, send a slow request, and confirm a single `slow request` log line with the expected fields.
- [ ] Confirm no log line emitted with default debug level (off).
- [ ] Confirm no log line for the dev domain.