### PR TITLE
feat: opt-in pprof endpoint on hosting binary

### DIFF
--- a/src/ee/hosting/main.go
+++ b/src/ee/hosting/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"strings"
 
@@ -20,6 +21,34 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/tracking"
 	"github.com/stormkit-io/stormkit-io/src/migrations"
 )
+
+// maybePProfListener exposes net/http/pprof on its own mux when
+// STORMKIT_PPROF_ADDR is set. The mux is dedicated (not DefaultServeMux)
+// so the pprof endpoints are reachable only on the configured address —
+// typically a loopback or admin-only interface (e.g. 127.0.0.1:6060).
+// Leave the env var unset in production unless actively debugging.
+func maybePProfListener() {
+	addr := os.Getenv("STORMKIT_PPROF_ADDR")
+
+	if addr == "" {
+		return
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	go func() {
+		slog.Infof("pprof listening on %s", addr)
+
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			slog.Errorf("pprof server error: %v", err)
+		}
+	}()
+}
 
 // nonMagic starts an http server.
 func nonMagic(handler http.Handler, port string) {
@@ -71,6 +100,8 @@ func main() {
 
 	// Register redis listeners
 	hosting.RegisterListeners()
+
+	maybePProfListener()
 
 	if c.Tracking != nil && c.Tracking.Prometheus {
 		tracking.Prometheus(tracking.PrometheusOpts{


### PR DESCRIPTION
## Summary

Add `net/http/pprof` endpoints on the hosting binary, gated behind a `STORMKIT_PPROF_ADDR` environment variable. The pprof handlers are mounted on a dedicated `*http.ServeMux` — not `http.DefaultServeMux` — so they are reachable only on the configured address and never colocated with the public HTTPS listener or the Prometheus metrics port.

This unblocks CPU / heap / goroutine profiling on a running production host with just `curl`. Analysis happens off-host on a workstation that has the Go toolchain, so the container itself doesn't need Go installed.

## Usage

Set the env var on a host (typically loopback or an admin-only interface):

```
STORMKIT_PPROF_ADDR=127.0.0.1:6060
```

Inside the container:

```
curl -o /tmp/cpu.prof   "http://127.0.0.1:6060/debug/pprof/profile?seconds=30"
curl -o /tmp/heap.prof  "http://127.0.0.1:6060/debug/pprof/heap"
curl -o /tmp/grt.txt    "http://127.0.0.1:6060/debug/pprof/goroutine?debug=2"
```

Copy the binary profiles off the host (`docker cp`, `scp`, …) and analyse on a workstation:

```
go tool pprof -http=:8080 cpu.prof
```

## Notes

- Leave `STORMKIT_PPROF_ADDR` unset by default — there is no behavior change unless the operator opts in.
- Bind to `127.0.0.1` or an admin-only network. The pprof endpoints expose runtime details (goroutine stacks, heap shape) and should never be public.
- CPU profile collection has ~3–5% CPU overhead for the 30-second window. Heap and goroutine dumps are essentially free.

## Test plan

- [x] `go build ./src/ee/hosting/` clean.
- [ ] With `STORMKIT_PPROF_ADDR=127.0.0.1:6060` set, confirm `curl http://127.0.0.1:6060/debug/pprof/` returns the pprof index.
- [ ] With the env var unset, confirm no extra port is listening.
- [ ] Confirm a 30-second CPU profile captured during steady-state load can be analysed locally with `go tool pprof`.