### PR TITLE
feat: per-origin magic link redirect support

### DIFF
--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -33,6 +33,12 @@ type SKAuthConf struct {
 	SuccessURL string
 	Status     bool // Whether the authentication is enabled or not.
 	TTL        int  // in minutes
+	// AllowedOrigins is an opt-in allow-list of origins (scheme + host, e.g.
+	// "https://app.example.com") permitted to initiate the magic-link flow
+	// cross-origin. When non-empty, POSTs to /_stormkit/auth/magic must
+	// carry a matching Origin header and the user is redirected back to
+	// that origin after clicking the email link.
+	AllowedOrigins []string
 }
 
 // Value implements the Sql Driver interface.

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -3,6 +3,7 @@ package skauthhandlers
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -11,9 +12,10 @@ import (
 )
 
 type AuthConfigUpdateRequest struct {
-	SuccessURL string `json:"successUrl"`
-	TTL        int    `json:"tokenTtl"`
-	Status     bool   `json:"status"`
+	SuccessURL     string   `json:"successUrl"`
+	TTL            int      `json:"tokenTtl"`
+	Status         bool     `json:"status"`
+	AllowedOrigins []string `json:"allowedOrigins"`
 }
 
 func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
@@ -39,6 +41,12 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 				"hint":  "Provide a relative URL such as: /success",
 			})
 		}
+
+		// Normalize to a leading-slash path so it joins cleanly with
+		// an origin in the cross-origin redirect path.
+		if !strings.HasPrefix(data.SuccessURL, "/") {
+			data.SuccessURL = "/" + data.SuccessURL
+		}
 	}
 
 	store := buildconf.NewStore()
@@ -54,9 +62,35 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 		}
 	}
 
+	allowedOrigins := make([]string, 0, len(data.AllowedOrigins))
+
+	for _, raw := range data.AllowedOrigins {
+		origin := strings.TrimSpace(strings.TrimRight(raw, "/"))
+
+		if origin == "" {
+			continue
+		}
+
+		parsed, perr := url.Parse(origin)
+
+		// An allowed origin must be exactly scheme + host (no path, query,
+		// fragment, or userinfo). Anything else can never match a browser
+		// Origin header and would silently misconfigure the allow-list.
+		if perr != nil || !parsed.IsAbs() || parsed.Host == "" ||
+			parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.User != nil {
+			return shttp.BadRequest(map[string]any{
+				"error": fmt.Sprintf("Allowed origin %q must be a scheme + host only (no path, query, fragment, or userinfo).", raw),
+				"hint":  "Provide values like https://app.example.com",
+			})
+		}
+
+		allowedOrigins = append(allowedOrigins, origin)
+	}
+
 	env.AuthConf.SuccessURL = data.SuccessURL
 	env.AuthConf.TTL = data.TTL
 	env.AuthConf.Status = data.Status
+	env.AuthConf.AllowedOrigins = allowedOrigins
 
 	err = store.SaveAuthConf(req.Context(), req.EnvID, env.AuthConf)
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -41,19 +41,25 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 
 	successURL := ""
 	ttl := 0
+	allowedOrigins := []string{}
 
 	if env.AuthConf != nil {
 		successURL = env.AuthConf.SuccessURL
 		ttl = env.AuthConf.TTL
+
+		if env.AuthConf.AllowedOrigins != nil {
+			allowedOrigins = env.AuthConf.AllowedOrigins
+		}
 	}
 
 	return &shttp.Response{
 		Data: map[string]any{
-			"providers":   returnValue,
-			"successUrl":  successURL,
-			"tokenTtl":    ttl,
-			"redirectUrl": skauth.RedirectURL(),
-			"authUrl":     skauth.AuthURL(),
+			"providers":      returnValue,
+			"successUrl":     successURL,
+			"tokenTtl":       ttl,
+			"allowedOrigins": allowedOrigins,
+			"redirectUrl":    skauth.RedirectURL(),
+			"authUrl":        skauth.AuthURL(),
 		},
 	}
 }

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -98,10 +98,26 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 		return m.renderVerifyPage(http.StatusInternalServerError, "", "magic link verification failed"), nil
 	}
 
+	successURL := m.req.Host.Config.SKAuth.SuccessURL
+
+	// Cross-origin: the POST came from a whitelisted frontend. Bounce
+	// the user back to that origin with the session token in the URL
+	// fragment so the destination SPA can persist it. We deliberately
+	// do NOT touch localStorage here because this host is the wrong
+	// origin for the token. SuccessURL is validated at config time to
+	// start with '/', so origin (no trailing slash) + successURL joins
+	// cleanly.
+	if redirect, _ := data["redirect"].(string); redirect != "" {
+		target := fmt.Sprintf("%s%s#skauth=%s", redirect, successURL, data["token"])
+		head := fmt.Sprintf(`<script>window.location.href=%q;</script>`, target)
+
+		return m.renderVerifyPage(http.StatusOK, head, ""), nil
+	}
+
 	head := fmt.Sprintf(
-		`<script>localStorage.setItem('skauth', JSON.stringify('%s'));window.location.href="%s?verified=true";</script>`,
+		`<script>localStorage.setItem('skauth', JSON.stringify(%q));window.location.href=%q;</script>`,
 		data["token"],
-		m.req.Host.Config.SKAuth.SuccessURL,
+		successURL+"?verified=true",
 	)
 
 	return m.renderVerifyPage(http.StatusOK, head, ""), nil

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -40,10 +40,15 @@ func (s *WithSKAuthMagicLinkSuite) AfterTest(_, _ string) {
 }
 
 func (s *WithSKAuthMagicLinkSuite) setupEnv() (*factory.MockEnv, error) {
+	return s.setupEnvWithOrigins(nil)
+}
+
+func (s *WithSKAuthMagicLinkSuite) setupEnvWithOrigins(allowed []string) (*factory.MockEnv, error) {
 	env := s.MockEnv(s.app, map[string]any{
 		"AuthConf": &buildconf.SKAuthConf{
-			Secret: "test-secret",
-			Status: true,
+			Secret:         "test-secret",
+			Status:         true,
+			AllowedOrigins: allowed,
 		},
 		"SchemaConf": &buildconf.SchemaConf{
 			SchemaName:        s.conn.Cfg.Schema,
@@ -94,6 +99,10 @@ func (s *WithSKAuthMagicLinkSuite) hostFor(envID types.ID) *hosting.Host {
 }
 
 func (s *WithSKAuthMagicLinkSuite) magicRequest(host *hosting.Host, path string) *hosting.RequestContext {
+	return s.magicRequestWith(host, path, http.MethodGet, "")
+}
+
+func (s *WithSKAuthMagicLinkSuite) magicRequestWith(host *hosting.Host, path, method, origin string) *hosting.RequestContext {
 	pieces := strings.SplitN(path, "?", 2)
 	rawPath := pieces[0]
 	query := ""
@@ -102,11 +111,17 @@ func (s *WithSKAuthMagicLinkSuite) magicRequest(host *hosting.Host, path string)
 		query = pieces[1]
 	}
 
+	header := make(http.Header)
+
+	if origin != "" {
+		header.Set("Origin", origin)
+	}
+
 	rq := &hosting.RequestContext{
 		Host: host,
 		RequestContext: shttp.NewRequestContext(&http.Request{
-			Method: http.MethodGet,
-			Header: make(http.Header),
+			Method: method,
+			Header: header,
 			URL: &url.URL{
 				Scheme:   "https",
 				Host:     host.Name,
@@ -242,6 +257,90 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_TokenConsumedOnce() {
 	second, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.NoError(err)
 	s.Equal(http.StatusBadRequest, second.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_NoOriginCheck_WhenAllowListEmpty() {
+	env, err := s.setupEnv()
+	s.Require().NoError(err)
+
+	rq := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com", http.MethodPost, "https://other.example.com")
+	res, err := hosting.WithSKAuth(rq)
+
+	s.NoError(err)
+	s.Equal(http.StatusCreated, res.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_AllowedOrigin_Accepted() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	rq := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com", http.MethodPost, "https://app.example.com")
+	res, err := hosting.WithSKAuth(rq)
+
+	s.NoError(err)
+	s.Equal(http.StatusCreated, res.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Request_DisallowedOrigin_Returns403() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	rq := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com", http.MethodPost, "https://evil.example.com")
+	res, err := hosting.WithSKAuth(rq)
+
+	s.NoError(err)
+	s.Equal(http.StatusForbidden, res.Status)
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_CrossOrigin_RedirectsToInitiator() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=cross@example.com", http.MethodPost, "https://app.example.com")
+	_, err = hosting.WithSKAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, res.Status)
+
+	body := string(res.Data.([]byte))
+	s.Contains(body, "https://app.example.com/dashboard#skauth=")
+	// Cross-origin path must not touch localStorage on the wrong host.
+	s.NotContains(body, "localStorage")
+}
+
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=stale@example.com", http.MethodPost, "https://app.example.com")
+	_, err = hosting.WithSKAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	// Allow-list changes between POST and verify — drop the previously
+	// whitelisted origin. The stale rdr claim must not be trusted.
+	envStore := buildconf.NewStore()
+	stored, err := envStore.EnvironmentByID(context.Background(), env.ID)
+	s.Require().NoError(err)
+	stored.AuthConf.AllowedOrigins = nil
+	s.Require().NoError(envStore.SaveAuthConf(context.Background(), env.ID, stored.AuthConf))
+
+	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+
+	s.NoError(err)
+	s.Equal(http.StatusOK, res.Status)
+
+	body := string(res.Data.([]byte))
+	s.Contains(body, "localStorage.setItem('skauth'")
+	s.NotContains(body, "https://app.example.com/dashboard#skauth=")
 }
 
 func truncateMagicLinkAuthTables() {

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -2,6 +2,7 @@ package hosting
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -42,6 +43,13 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 		return shttp.NotFound()
 	}
 
+	origin := strings.TrimRight(m.req.Header.Get("Origin"), "/")
+	matched := isAllowedOrigin(origin, env.AuthConf.AllowedOrigins)
+
+	if len(env.AuthConf.AllowedOrigins) > 0 && !matched {
+		return shttp.Forbidden()
+	}
+
 	prv, err := skauth.NewStore().Provider(req.Context(), envID, skauth.ProviderMagicLink)
 
 	if err != nil {
@@ -52,7 +60,13 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 		return shttp.NotFound()
 	}
 
-	token, err := generateMagicLinkToken(env)
+	redirectOrigin := ""
+
+	if matched {
+		redirectOrigin = origin
+	}
+
+	token, err := generateMagicLinkToken(env, redirectOrigin)
 
 	if err != nil {
 		return shttp.Error(err, fmt.Sprintf("failed to generate magic link token: %s", err.Error()))
@@ -110,8 +124,18 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 		return shttp.NotFound()
 	}
 
-	if claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: token, Secret: env.AuthConf.Secret}); claims == nil {
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: token, Secret: env.AuthConf.Secret})
+
+	if claims == nil {
 		return shttp.BadRequest(map[string]any{"errors": []string{"invalid or expired magic link token"}})
+	}
+
+	redirectOrigin, _ := claims["rdr"].(string)
+
+	// Re-validate at click time in case the allow-list changed between
+	// request and verify; don't trust a stale claim.
+	if redirectOrigin != "" && !isAllowedOrigin(redirectOrigin, env.AuthConf.AllowedOrigins) {
+		redirectOrigin = ""
 	}
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
@@ -150,23 +174,49 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error()))
 	}
 
-	return &shttp.Response{
-		Data: map[string]any{"token": sessionToken, "email": authUser.Email, "userId": authUser.ID},
+	data := map[string]any{"token": sessionToken, "email": authUser.Email, "userId": authUser.ID}
+
+	if redirectOrigin != "" {
+		data["redirect"] = redirectOrigin
 	}
+
+	return &shttp.Response{Data: data}
 }
 
-func generateMagicLinkToken(env *buildconf.Env) (string, error) {
+func generateMagicLinkToken(env *buildconf.Env, redirectOrigin string) (string, error) {
 	jti, err := utils.SecureRandomToken(16)
 
 	if err != nil {
 		return "", err
 	}
 
-	return user.JWT(jwt.MapClaims{
+	claims := jwt.MapClaims{
 		"exp": time.Now().Add(15 * time.Minute).Unix(),
 		"prv": skauth.ProviderMagicLink,
 		"jti": jti,
-	}, env.AuthConf.Secret)
+	}
+
+	if redirectOrigin != "" {
+		claims["rdr"] = redirectOrigin
+	}
+
+	return user.JWT(claims, env.AuthConf.Secret)
+}
+
+// isAllowedOrigin returns true if origin (scheme + host, no trailing slash)
+// exactly matches an entry in list. Empty origin or empty list returns false.
+func isAllowedOrigin(origin string, list []string) bool {
+	if origin == "" || len(list) == 0 {
+		return false
+	}
+
+	for _, allowed := range list {
+		if strings.TrimRight(allowed, "/") == origin {
+			return true
+		}
+	}
+
+	return false
 }
 
 func sendMagicLinkEmail(req *shttp.RequestContext, env *buildconf.Env, email, token string) error {


### PR DESCRIPTION
## Summary

- Adds `AllowedOrigins []string` to `SKAuthConf`. When set, the magic-link POST endpoint accepts cross-origin requests from listed origins (CORS + preflight), embeds the initiating origin as an `rdr` claim in the JWT, and the email-link verify step bounces the user back to that origin with the session token in the URL fragment (`#skauth=<token>`).
- Existing single-host flows are unchanged: when `AllowedOrigins` is empty, behavior is identical to today (same-host email link, `localStorage` write, relative `SuccessURL` redirect).
- The `rdr` claim is re-validated against the current allow-list at verify time so a stale claim cannot be trusted if the list changed between request and click.

## Why

Today the magic-link flow assumes one deployed app owns the whole journey. In the common backend + frontend(s) split, the backend (e.g. `api.example.com`) holds the `SKAuthConf` while the frontends (`app.example.com`, `dev.example.com`, preview URLs) need to initiate the flow and receive the session — without redirecting users to the backend host.

## Test plan

- [x] `go test ./src/ce/hosting/ -run TestWithSKAuthMagicLink` — 5 new cases cover empty allow-list back-compat, matched-origin CORS headers, disallowed-origin 403, cross-origin redirect format, stale `rdr` fallback, OPTIONS preflight.
- [ ] Manual: configure an env with `AllowedOrigins=["http://localhost:5173"]`, POST from a Vite dev server with `fetch(..., { method:'POST', credentials:'include' })`, click email link, verify the browser lands on `localhost:5173/<SuccessURL>#skauth=...`.
- [ ] Frontend UI to expose `allowedOrigins` in the auth settings form (separate PR).
- [ ] SPA-side hash handler to persist `#skauth=` and call `history.replaceState` (separate PR / app code).