### PR TITLE
feat: allowed origins field on auth config UI

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -285,10 +285,42 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           successUrl: "",
           tokenTtl: 0,
           status: true,
+          allowedOrigins: [],
         })
         .reply(200);
 
       fireEvent.submit(wrapper.getByRole("button", { name: "Save" }).closest("form")!);
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
+        expect(wrapper.getByText("Settings saved successfully")).toBeTruthy();
+      });
+    });
+
+    it("should submit allowed origins as a trimmed list", async () => {
+      const scope = nock(apiDomain)
+        .post("/skauth/config", {
+          envId: currentEnv.id,
+          successUrl: "",
+          tokenTtl: 0,
+          status: true,
+          allowedOrigins: [
+            "https://app.example.com",
+            "https://dev.example.com",
+          ],
+        })
+        .reply(200);
+
+      const input = wrapper.getByLabelText("Allowed origins") as HTMLTextAreaElement;
+      fireEvent.change(input, {
+        target: {
+          value: "https://app.example.com\n  https://dev.example.com  \n\n",
+        },
+      });
+
+      fireEvent.submit(
+        wrapper.getByRole("button", { name: "Save" }).closest("form")!,
+      );
 
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -198,11 +198,17 @@ export default function SkAuth() {
           setSaving(true);
           setSaveError(undefined);
 
+          const allowedOrigins = ((data.get("allowedOrigins") as string) || "")
+            .split("\n")
+            .map(line => line.trim())
+            .filter(Boolean);
+
           saveConfig({
             envId: env.id!,
             successUrl: (data.get("successUrl") as string) || "",
             tokenTtl: Number(data.get("tokenTtl") || 0),
             status: true,
+            allowedOrigins,
           })
             .then(() => {
               setSuccess("Settings saved successfully");
@@ -246,6 +252,26 @@ export default function SkAuth() {
             variant="filled"
             autoComplete="off"
             helperText="Token lifetime in minutes"
+            slotProps={{
+              inputLabel: {
+                shrink: true,
+              },
+            }}
+          />
+        </Box>
+
+        <Box sx={{ mb: 4 }}>
+          <TextField
+            label="Allowed origins"
+            name="allowedOrigins"
+            placeholder={"https://app.example.com\nhttps://dev.example.com"}
+            fullWidth
+            multiline
+            minRows={3}
+            defaultValue={(config?.allowedOrigins || []).join("\n")}
+            variant="filled"
+            autoComplete="off"
+            helperText="Optional. One origin per line (scheme + host, no path). When set, the magic-link POST endpoint only accepts requests from these origins, and the email link redirects the user back to the origin that initiated the flow (with the session token in the URL fragment as #skauth=…). Leave empty to keep the single-host behaviour."
             slotProps={{
               inputLabel: {
                 shrink: true,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -161,6 +161,7 @@ interface ProviderData {
 interface FetchProvidersResult {
   successUrl?: string;
   tokenTtl?: number;
+  allowedOrigins?: string[];
   redirectUrl: string;
   authUrl: string;
   providers: {
@@ -171,6 +172,7 @@ interface FetchProvidersResult {
 interface AuthConfig {
   sessionTtl?: number; // in minutes
   successUrl?: string;
+  allowedOrigins?: string[];
 }
 
 interface SaveConfigParams {
@@ -178,6 +180,7 @@ interface SaveConfigParams {
   successUrl: string;
   tokenTtl: number;
   status: boolean;
+  allowedOrigins: string[];
 }
 
 export const saveConfig = ({
@@ -185,8 +188,15 @@ export const saveConfig = ({
   successUrl,
   tokenTtl,
   status,
+  allowedOrigins,
 }: SaveConfigParams): Promise<void> =>
-  api.post("/skauth/config", { envId, successUrl, tokenTtl, status });
+  api.post("/skauth/config", {
+    envId,
+    successUrl,
+    tokenTtl,
+    status,
+    allowedOrigins,
+  });
 
 export const useFetchProviders = ({
   envId,
@@ -210,6 +220,7 @@ export const useFetchProviders = ({
           authUrl,
           successUrl,
           tokenTtl: sessionTtl,
+          allowedOrigins,
         }) => {
           const result: AuthProvider[] = [];
 
@@ -234,7 +245,7 @@ export const useFetchProviders = ({
             });
 
           setProviders(result);
-          setConfig({ successUrl, sessionTtl });
+          setConfig({ successUrl, sessionTtl, allowedOrigins });
         },
       )
       .catch(() => {


### PR DESCRIPTION
## Summary

Adds an "Allowed origins" textarea to the SkAuth config form (one origin per line, scheme + host). Submit handler trims, filters empty lines, and forwards the list to `/skauth/config` as `allowedOrigins`.

## Why

Companion UI for #265, which adds opt-in cross-origin support to the magic-link flow: when `AllowedOrigins` is set, a whitelisted frontend can POST to the backend's `/_stormkit/auth/magic` and the email link bounces the user back to that frontend with the session token in the URL fragment.

## Depends on

- #265 (backend) — the new `allowedOrigins` field doesn't exist on `main` yet. Do not merge this PR until #265 is merged.

## Test plan

- [x] `npx vitest run src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx` — 14 tests pass, including a new case asserting the trim/filter behaviour.
- [ ] Manual: configure an env, paste two origins on separate lines, save, reload, confirm both come back populated.