### PR TITLE
fix: parse header values with colons; clear redirects via MCP

### DIFF
--- a/src/ce/api/app/deploy/custom_headers.go
+++ b/src/ce/api/app/deploy/custom_headers.go
@@ -79,7 +79,7 @@ func ParseHeaders(customHeaders string) ([]CustomHeader, error) {
 			continue
 		}
 
-		pieces := strings.Split(line, ":")
+		pieces := strings.SplitN(line, ":", 2)
 
 		if len(pieces) == 2 {
 			headers = append(headers, CustomHeader{

--- a/src/ce/api/app/deploy/custom_headers_test.go
+++ b/src/ce/api/app/deploy/custom_headers_test.go
@@ -63,6 +63,15 @@ func (s *CustomHeadersSuite) Test_ParseCustomHeaders_Success() {
 	s.Equal("/*", headers[0].Location)
 }
 
+func (s *CustomHeadersSuite) Test_ParseCustomHeaders_ValueWithColon() {
+	headers, err := deploy.ParseHeaders("/*\nAccess-Control-Allow-Origin: https://example.com")
+	s.NoError(err)
+	s.Len(headers, 1)
+	s.Equal("Access-Control-Allow-Origin", headers[0].Key)
+	s.Equal("https://example.com", headers[0].Value)
+	s.Equal("/*", headers[0].Location)
+}
+
 func (s *CustomHeadersSuite) Test_ParseCustomHeaders_Error() {
 	headers, err := deploy.ParseHeaders("/*\nX-Message Hello World!")
 	s.Error(err)

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -31,7 +31,7 @@ type EnvUpdateRequest struct {
 	HeadersFile        *string                 `json:"headersFile,omitempty"`
 	InstallCmd         *string                 `json:"installCmd,omitempty"`
 	PreviewLinks       *bool                   `json:"previewLinks,omitempty"`
-	Redirects          []redirects.Redirect    `json:"redirects,omitempty"`
+	Redirects          *[]redirects.Redirect   `json:"redirects,omitempty"`
 	RedirectsFile      *string                 `json:"redirectsFile,omitempty"`
 	ServerCmd          *string                 `json:"serverCmd,omitempty"`
 	ServerFolder       *string                 `json:"serverFolder,omitempty"`
@@ -139,7 +139,7 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 	}
 
 	if data.Redirects != nil {
-		env.Data.Redirects = data.Redirects
+		env.Data.Redirects = *data.Redirects
 
 		if errs := redirects.Validate(env.Data.Redirects); len(errs) > 0 {
 			return shttp.BadRequest(map[string]any{"errors": errs})

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -720,7 +720,10 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 		update.EnvVars = m
 	}
 
-	update.Redirects = parseRedirectsArg(args)
+	if r := parseRedirectsArg(args); r != nil {
+		update.Redirects = &r
+	}
+
 	update.StatusChecks = parseStatusChecksArg(args)
 
 	resp := req.setBody(id, update)


### PR DESCRIPTION
## Summary
- **Custom headers parser**: `ParseHeaders` used `strings.Split(line, \":\")` so values containing a colon (e.g. `Access-Control-Allow-Origin: https://triplan-fe.corgy.ai`) were rejected with `invalid syntax (missing colon)`. Switched to `SplitN(line, \":\", 2)` and added a regression test.
- **MCP `update_environment` couldn't clear redirects**: `EnvUpdateRequest.Redirects` was `[]redirects.Redirect` with `omitempty`. The MCP layer marshals the request struct to JSON before re-parsing it in `handlerEnvUpdate`, and `json.Marshal` drops an empty slice — the downstream handler then saw `nil` and skipped the clear. Made the field a pointer so an explicit empty slice survives the round trip.

## Test plan
- [x] `go test ./src/ce/api/app/deploy/...` (custom headers suite)
- [x] `go test ./src/ce/api/public/v1/...` (env update + MCP suites)
- [ ] Manually verify via MCP: `update_environment(redirects: [])` clears existing redirects
- [ ] Manually verify via UI: saving `Access-Control-Allow-Origin: https://example.com` in the headers editor succeeds