### PR TITLE
feat: apply custom headers to all responses

### DIFF
--- a/content/blog/whats-new.md
+++ b/content/blog/whats-new.md
@@ -5,6 +5,10 @@ description: Discover the latest changes and improvements to Stormkit. Stay up-t
 
 Follow the latest developments on Stormkit.
 
+## May 25th, 2026
+
+Custom headers now apply to **all** responses — not just static files. Rules defined in your `_headers` file or the Environment Config headers editor are matched against the request URL path and applied to static files, SSR, serverless functions, and proxied responses alike. User-configured headers take precedence over Stormkit's defaults. [Learn more](/docs/features/custom-headers).
+
 ## May 16th, 2026
 
 Introducing **Priority Deployments**: move any queued deployment to the front of the build queue with a single click — without cancelling other waiting builds. You can also configure a commit message pattern per environment so that matching auto-deploys are automatically routed to the priority queue (e.g. `hotfix|urgent|critical`). Prioritized deployments are marked with a **priority** label in the deployment list. [Learn more](/docs/deployments/priority-deployments).

--- a/docs/features/9-custom-headers.md
+++ b/docs/features/9-custom-headers.md
@@ -15,7 +15,7 @@ To enable custom headers for your served files:
 
 Check out our [YouTube](https://www.youtube.com/watch?v=0-JE_MoXP68) video to see it in action.
 
-**Note: Custom headers are not applied to responses from serverless functions.**
+Rules are matched against the request URL path and apply to **all** responses — static files, SSR, serverless functions, and proxied responses. User-configured headers take precedence over Stormkit's defaults (e.g. `Cache-Control`, `Content-Type`).
 
 Header rules are structured in multi-line blocks. Each block begins with a URL or URL pattern that specifies where the rule's headers should take effect. Following this, header names and their corresponding values are listed on indented lines.
 

--- a/src/ce/api/app/appconf/appconf_model.go
+++ b/src/ce/api/app/appconf/appconf_model.go
@@ -2,6 +2,7 @@ package appconf
 
 import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/redirects"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -35,6 +36,7 @@ type Config struct {
 	CertValue        string                `json:"certValue,omitempty"`
 	DomainID         types.ID              `json:"domainId,omitempty"`
 	StaticFiles      StaticFileConfig      `json:"staticFiles,omitempty"`
+	CustomHeaders    []deploy.CustomHeader `json:"-"` // Parsed user-configured header rules; matched against request path at response time.
 	SKAuth           *buildconf.SKAuthConf `json:"-"`
 	AuthWall         string                `json:"authWall,omitempty"`     // Whether to display an auth wall or not. Possible values: dev | all
 	IsEnterprise     bool                  `json:"isEnterprise,omitempty"` // Whether the app is running in enterprise mode

--- a/src/ce/api/app/appconf/appconf_store.go
+++ b/src/ce/api/app/appconf/appconf_store.go
@@ -361,6 +361,7 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 				}
 			}
 
+			cnf.CustomHeaders = customHeaders
 			cnf.Redirects = data.Redirects
 			cnf.ServerCmd = data.ServerCmd
 			cnf.ErrorFile = data.ErrorFile
@@ -387,14 +388,14 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 			// Backwards compatibility
 			for _, v := range buildManifest.CDNFiles {
 				staticFiles["/"+strings.TrimPrefix(strings.ToLower(v.Name), "/")] = &StaticFile{
-					Headers:  deploy.ApplyHeaders(v.Name, NormalizeHeaders(v.Name, v.Headers), customHeaders),
+					Headers:  NormalizeHeaders(v.Name, v.Headers),
 					FileName: v.Name,
 				}
 			}
 
 			for k, v := range buildManifest.StaticFiles {
 				staticFiles[strings.ToLower(k)] = &StaticFile{
-					Headers:  deploy.ApplyHeaders(k, v, customHeaders),
+					Headers:  v,
 					FileName: k,
 				}
 			}

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -643,6 +644,23 @@ func injectHeaders(req *RequestContext, res *shttp.Response) *shttp.Response {
 	// If we're here, it probably means that the dynamic request returned no content.
 	if res.Headers.Get("content-type") == "" {
 		res.Headers.Set("content-type", "text/html; charset=utf-8")
+	}
+
+	// Apply user-configured custom headers last so they take precedence over
+	// any defaults set above. Matches against the request URL path so the
+	// same rules cover static, dynamic, SSR and proxied responses. An empty
+	// value (e.g. the `!Header-Name` negate syntax in _headers) removes the
+	// header rather than emitting it with an empty value.
+	if len(req.Host.Config.CustomHeaders) > 0 {
+		overrides := deploy.ApplyHeaders(strings.ToLower(req.URL().Path), nil, req.Host.Config.CustomHeaders)
+
+		for k, v := range overrides {
+			if v == "" {
+				res.Headers.Del(k)
+			} else {
+				res.Headers.Set(k, v)
+			}
+		}
 	}
 
 	return res

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -296,6 +296,153 @@ func (s *HandlerForwardSuite) Test_ServeDynamic_ServerCmd() {
 	s.Equal("1", res.Headers.Get("x-sk-version"))
 }
 
+func (s *HandlerForwardSuite) Test_CustomHeaders_AppliedToDynamic() {
+	customHeaders, err := deploy.ParseHeaders("/api/*\nAccess-Control-Allow-Origin: *\nX-Custom: yes")
+	s.NoError(err)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Request: &shttp.RequestContext{
+			Request: &http.Request{},
+		},
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			EnvID:            types.ID(1),
+			AppID:            types.ID(2),
+			FunctionLocation: "local:my-function/10",
+			ServerCmd:        "node index.js",
+			CustomHeaders:    customHeaders,
+		},
+	}
+
+	req := s.newRequest(host, "/api/users")
+
+	s.mockClient.On("Invoke", mock.Anything).Return(&integrations.InvokeResult{
+		Headers:    http.Header{"Content-Type": []string{"application/json"}},
+		StatusCode: http.StatusOK,
+		Body:       []byte(`{}`),
+	}, nil)
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("*", res.Headers.Get("Access-Control-Allow-Origin"))
+	s.Equal("yes", res.Headers.Get("X-Custom"))
+	s.Equal("application/json", res.Headers.Get("Content-Type"))
+}
+
+func (s *HandlerForwardSuite) Test_CustomHeaders_AppliedToStatic() {
+	customHeaders, err := deploy.ParseHeaders("/*\nX-Frame-Options: DENY")
+	s.NoError(err)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Request: &shttp.RequestContext{
+			Request: &http.Request{},
+		},
+		Config: &appconf.Config{
+			DeploymentID:    types.ID(1),
+			EnvID:           types.ID(1),
+			StorageLocation: "local:/deployments/deployment-1",
+			StaticFiles: appconf.StaticFileConfig{
+				"/blog/index.html": &appconf.StaticFile{
+					FileName: "/blog/index.html",
+					Headers: map[string]string{
+						"content-type": "text/html; charset=utf-8",
+					},
+				},
+			},
+			CustomHeaders: customHeaders,
+		},
+	}
+
+	req := s.newRequest(host, "/blog")
+
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "local:/deployments/deployment-1",
+		FileName:     "/blog/index.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("Hello world"),
+	}, nil)
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("DENY", res.Headers.Get("X-Frame-Options"))
+}
+
+func (s *HandlerForwardSuite) Test_CustomHeaders_EmptyValueDeletes() {
+	customHeaders, err := deploy.ParseHeaders("/*\n!X-Powered-By")
+	s.NoError(err)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Request: &shttp.RequestContext{
+			Request: &http.Request{},
+		},
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			EnvID:            types.ID(1),
+			AppID:            types.ID(2),
+			FunctionLocation: "local:my-function/10",
+			ServerCmd:        "node index.js",
+			CustomHeaders:    customHeaders,
+		},
+	}
+
+	req := s.newRequest(host, "/")
+
+	returnHeaders := make(http.Header)
+	returnHeaders.Set("Content-Type", "text/html")
+	returnHeaders.Set("X-Powered-By", "Express")
+
+	s.mockClient.On("Invoke", mock.Anything).Return(&integrations.InvokeResult{
+		Headers:    returnHeaders,
+		StatusCode: http.StatusOK,
+		Body:       []byte(``),
+	}, nil)
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusOK, res.Status)
+	_, present := res.Headers["X-Powered-By"]
+	s.False(present, "X-Powered-By should be removed, not emitted with empty value")
+}
+
+func (s *HandlerForwardSuite) Test_CustomHeaders_LocationDoesNotMatch() {
+	customHeaders, err := deploy.ParseHeaders("/api/*\nX-Custom: yes")
+	s.NoError(err)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Request: &shttp.RequestContext{
+			Request: &http.Request{},
+		},
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			EnvID:            types.ID(1),
+			AppID:            types.ID(2),
+			FunctionLocation: "local:my-function/10",
+			ServerCmd:        "node index.js",
+			CustomHeaders:    customHeaders,
+		},
+	}
+
+	req := s.newRequest(host, "/not-api/users")
+
+	s.mockClient.On("Invoke", mock.Anything).Return(&integrations.InvokeResult{
+		Headers:    http.Header{"Content-Type": []string{"application/json"}},
+		StatusCode: http.StatusOK,
+		Body:       []byte(`{}`),
+	}, nil)
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("", res.Headers.Get("X-Custom"))
+}
+
 func (s *HandlerForwardSuite) Test_Redirects_Rewrite() {
 	s.mockClient.On("GetFile", integrations.GetFileArgs{
 		Location: "aws:my-bucket/my-key-prefix",

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.spec.tsx
@@ -39,7 +39,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHe
     expect(wrapper.getByText("Headers")).toBeTruthy();
     expect(
       wrapper.getByText(
-        "Configure your application's headers for static files."
+        "Configure response headers. Rules match against the request path and apply to static, SSR and proxied responses."
       )
     ).toBeTruthy();
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.tsx
@@ -51,7 +51,7 @@ export default function TabConfigGeneral({
     >
       <CardHeader
         title="Headers"
-        subtitle="Configure your application's headers for static files."
+        subtitle="Configure response headers. Rules match against the request path and apply to static, SSR and proxied responses."
       />
       <Box sx={{ mb: 4 }}>
         <TextField


### PR DESCRIPTION
## Summary
Custom header rules (from the `_headers` file or the Environment Config headers editor) used to apply only to static files. They were baked into `StaticFiles[*].Headers` at appconf load time, and the dynamic/SSR/proxy paths bypassed `Static()` and never saw them — breaking the common case of CORS, CSP, and security headers needing to cover API + SSR routes alongside bundled assets.

This PR stores the parsed `CustomHeader` rules on `appconf.Config` and overlays them in `injectHeaders`, matching against the lowercased request URL path. Behavior:

- Applies to **static, dynamic, SSR, and proxied** responses uniformly.
- User-configured headers take **precedence** over Stormkit's defaults (e.g. `Cache-Control`, `Content-Type`, `x-robots-tag`).
- No re-deploy required — the env-level headers editor already triggers an appcache reset, and the next request sees the new rules. The `_headers` file in the repo still requires a deploy (build-time input).
- The existing per-static-file bake in `appconf_store.go` is left untouched; it's idempotent with the request-time overlay.

Pairs with #268 (colon-parse fix) — without that, values like `Access-Control-Allow-Origin: https://example.com` still get rejected at parse time. This PR doesn't depend on it for build/test, but the user-visible CORS use case needs both.

## Test plan
- [x] `go test ./src/ce/hosting/...` — three new tests cover dynamic match, static match, and location-doesn't-match
- [ ] Manually verify in the UI: configure `X-Frame-Options: DENY` for `/*`, hit an SSR/serverless route, confirm the header appears in the response