### PR TITLE
fix: apply custom headers to middleware-returned responses

### DIFF
--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -31,13 +31,19 @@ const SESSION_COOKIE_NAME = "stormkit_session"
 
 var stormkitServerHeaderOff = os.Getenv("STORMKIT_SERVER_HEADER") == "off"
 
-// HandlerForward forwards all requests
-func HandlerForward(req *RequestContext) *shttp.Response {
+// HandlerForward forwards all requests. The return value is named so that the
+// deferred finalize() can post-process every exit path (middleware
+// short-circuit, NotFound, error, or the main Handle() flow).
+func HandlerForward(req *RequestContext) (res *shttp.Response) {
 	rs := NewRequestServer(req)
 
-	// Send artifacts such as analytics record, logs, etc to redis queue
 	defer func() {
-		go rs.artifacts()
+		// Finalize the response (custom headers, snippets, analytics) so the
+		// same transforms apply uniformly regardless of which path produced it.
+		res = rs.finalize(res)
+
+		// Send artifacts to redis queue with the finalized response visible.
+		go rs.artifacts(res)
 	}()
 
 	slog.Debug(slog.LogOpts{
@@ -57,20 +63,20 @@ func HandlerForward(req *RequestContext) *shttp.Response {
 	}
 
 	for _, md := range middlewares {
-		res, err := md(req)
+		mres, err := md(req)
 
 		if err != nil {
 			return rs.Error(err)
 		}
 
-		if res != nil {
+		if mres != nil {
 			// We still want to be able to serve custom 404 pages
 			// when the proxy request returns 404.
-			if res.Status == http.StatusNotFound {
+			if mres.Status == http.StatusNotFound {
 				return rs.NotFound()
 			}
 
-			return res
+			return mres
 		}
 	}
 
@@ -81,6 +87,27 @@ func HandlerForward(req *RequestContext) *shttp.Response {
 	})
 
 	return rs.Handle()
+}
+
+// finalize applies post-handler transforms — custom headers, snippet
+// injection, analytics — uniformly to every response path.
+func (r *RequestServer) finalize(res *shttp.Response) *shttp.Response {
+	if res == nil || r.req.Host == nil || r.req.Host.Config == nil {
+		return res
+	}
+
+	res = injectHeaders(r.req, res)
+	res = injectSnippets(r.req, res)
+
+	if r.req.Host.Config.IsEnterprise {
+		contentType := strings.ToLower(res.Headers.Get("Content-Type"))
+
+		if strings.HasPrefix(contentType, "text/html") {
+			r.record = analyticsRecord(r.req, res)
+		}
+	}
+
+	return res
 }
 
 type FileMeta struct {
@@ -110,15 +137,15 @@ func NewRequestServer(req *RequestContext) *RequestServer {
 	return r
 }
 
-func (r *RequestServer) artifacts() {
+func (r *RequestServer) artifacts(res *shttp.Response) {
 	var data []byte
 
-	if r.res == nil || r.req == nil || r.req.Host == nil || r.req.Host.Config == nil {
+	if res == nil || r.req == nil || r.req.Host == nil || r.req.Host.Config == nil {
 		return
 	}
 
-	if r.res.Data != nil {
-		data, _ = r.res.Data.([]byte)
+	if res.Data != nil {
+		data, _ = res.Data.([]byte)
 	}
 
 	Queue(&jobs.HostingRecord{
@@ -130,7 +157,7 @@ func (r *RequestServer) artifacts() {
 		FunctionInvoked: r.fnInvoked,
 		Logs:            r.logs,
 		Analytics:       r.record,
-		TotalBandwidth:  int64(len(data)) + headersSize(r.res.Headers),
+		TotalBandwidth:  int64(len(data)) + headersSize(res.Headers),
 	})
 }
 
@@ -160,25 +187,11 @@ func (r *RequestServer) FileMeta() *FileMeta {
 }
 
 func (r *RequestServer) Handle() *shttp.Response {
-	defer func() {
-		r.res = injectHeaders(r.req, r.res)
-		r.res = injectSnippets(r.req, r.res)
-
-		if r.req.Host.Config.IsEnterprise {
-			contentType := strings.ToLower(r.res.Headers.Get("Content-Type"))
-
-			if strings.HasPrefix(contentType, "text/html") {
-				r.record = analyticsRecord(r.req, r.res)
-			}
-		}
-	}()
-
 	if r.fileMeta = r.FileMeta(); r.fileMeta != nil {
 		return r.Static()
 	}
 
 	return r.Dynamic()
-
 }
 
 func (r *RequestServer) Static() *shttp.Response {

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -410,6 +410,34 @@ func (s *HandlerForwardSuite) Test_CustomHeaders_EmptyValueDeletes() {
 	s.False(present, "X-Powered-By should be removed, not emitted with empty value")
 }
 
+func (s *HandlerForwardSuite) Test_CustomHeaders_AppliedToMiddlewareResponse() {
+	// Verifies headers apply to responses returned by middlewares
+	// (e.g. WithRedirect) that short-circuit before Handle() runs.
+	customHeaders, err := deploy.ParseHeaders("/old\nX-Custom: yes")
+	s.NoError(err)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Request: &shttp.RequestContext{
+			Request: &http.Request{},
+		},
+		Config: &appconf.Config{
+			DeploymentID: types.ID(1),
+			EnvID:        types.ID(1),
+			Redirects: []redirects.Redirect{
+				{From: "/old", To: "/new", Status: 301},
+			},
+			CustomHeaders: customHeaders,
+		},
+	}
+
+	req := s.newRequest(host, "/old")
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusMovedPermanently, res.Status)
+	s.Equal("yes", res.Headers.Get("X-Custom"))
+}
+
 func (s *HandlerForwardSuite) Test_CustomHeaders_LocationDoesNotMatch() {
 	customHeaders, err := deploy.ParseHeaders("/api/*\nX-Custom: yes")
 	s.NoError(err)
@@ -1077,7 +1105,6 @@ func (s *HandlerForwardSuite) Test_AuthWall_LoginSuccess() {
 
 	s.Empty(res.Data)
 	s.Equal(http.StatusFound, res.Status)
-	s.Equal("", res.Headers.Get("Content-Type"))
 	s.Equal("http://www.stormkit.io/my-page?a=b", *res.Redirect)
 	s.Equal(http.Cookie{
 		Name:     hosting.SESSION_COOKIE_NAME,


### PR DESCRIPTION
## Summary
Follow-up to #269. Custom headers still didn't apply to responses produced by middlewares — `WithSKAuth`, `WithAuthWall`, `WithRedirect` — because those short-circuit before `rs.Handle()`, where the deferred `injectHeaders` lived. Endpoints like `/_stormkit/auth/magic` therefore never picked up the user-configured headers (real-world CORS hit reported by a user).

Moved the post-handler transforms (custom headers, snippet injection, analytics) into a `finalize()` method on `RequestServer` and call it from a single defer in `HandlerForward` using a **named return value** so it runs on every exit path — middleware short-circuit, `NotFound`, `Error`, and the main `Handle()` flow.

Behavior changes worth flagging:
- Middleware-short-circuit responses (redirects, auth wall logins, skauth endpoints) now also get the `x-sk-version`, `Server`, default `Content-Type` injections that `Handle()`-produced responses already had. Previously they were skipped.
- One existing test (`Test_AuthWall_LoginSuccess`) asserted `Content-Type: \"\"` on a 302 redirect; now the default `text/html; charset=utf-8` is set. Updated the test to drop that assertion — the header is irrelevant for a body-less 302.

## Test plan
- [x] `go test ./src/ce/hosting/...` — added `Test_CustomHeaders_AppliedToMiddlewareResponse` covering the redirect path
- [ ] Manually verify against the reported failing curl: configure custom headers for `/_stormkit/auth/magic`, hit the endpoint, confirm `Access-Control-Allow-Origin` appears in the response