### PR TITLE
fix: respond 204 to CORS preflight on skauth endpoints

### DIFF
--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -199,6 +199,15 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 		return nil, nil
 	}
 
+	// CORS preflight — respond 204 so the browser proceeds with the actual
+	// request. Per-path custom headers (e.g. Access-Control-Allow-Origin)
+	// are layered on by finalize() afterwards. Without this short-circuit
+	// the request would fall through to handlers that expect a JSON body
+	// and reject OPTIONS with 400, breaking the preflight.
+	if req.Method == http.MethodOptions {
+		return &shttp.Response{Status: http.StatusNoContent}, nil
+	}
+
 	m := &skAuthMiddleware{req: req}
 
 	if path == "/_stormkit/auth/register" || path == "/_stormkit/auth/login" {

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -113,6 +113,20 @@ func (s *WithSKAuthSuite) Test_SKAuthDisabled() {
 	s.Nil(res)
 }
 
+// Test_CORSPreflight checks that OPTIONS requests to /_stormkit/auth/* return
+// 204 so the browser preflight succeeds. The custom CORS headers are layered
+// on later by finalize() in HandlerForward.
+func (s *WithSKAuthSuite) Test_CORSPreflight() {
+	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic")
+	req.RequestContext.Method = http.MethodOptions
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal(http.StatusNoContent, res.Status)
+}
+
 // Test_NonAuthPath checks that the middleware is a no-op for paths that don't
 // start with /_stormkit/auth.
 func (s *WithSKAuthSuite) Test_NonAuthPath() {


### PR DESCRIPTION
## Summary
Reported in conversation: configuring CORS headers for `/_stormkit/auth/magic` correctly attaches them to the response (visible since #271), but cross-origin POSTs still fail because the browser's `OPTIONS` preflight hits `magicLinkRequest()` which expects a JSON body and returns 400. Browsers reject any non-2xx preflight regardless of CORS headers.

Short-circuit `OPTIONS` at the skauth middleware entry with a 204. Affects every `/_stormkit/auth/*` endpoint, not just `/magic`. Configured custom headers are still applied by `finalize()` so the preflight response carries `Access-Control-*` as expected.

## Test plan
- [x] `go test ./src/ce/hosting/...` — added `Test_CORSPreflight`
- [ ] Verify in production: `curl -X OPTIONS https://triplan-be.corgy.ai/_stormkit/auth/magic -H 'Origin: https://triplan-fe.corgy.ai' -H 'Access-Control-Request-Method: POST'` returns 204 with the configured CORS headers