### PR TITLE
fix: schema delete permission check uses user_id

### DIFF
--- a/src/ce/api/public/v1/handler_schema_delete.go
+++ b/src/ce/api/public/v1/handler_schema_delete.go
@@ -28,13 +28,13 @@ func handlerSchemaDelete(req *app.RequestContext) *shttp.Response {
 		}
 	}
 
-	member, err := team.NewStore().TeamMember(req.Context(), req.App.TeamID, req.User.ID)
+	myTeam, err := team.NewStore().Team(req.Context(), req.App.TeamID, req.User.ID)
 
 	if err != nil {
 		return shttp.Error(err)
 	}
 
-	if member == nil || !team.HasWriteAccess(member.Role) {
+	if myTeam == nil || !team.HasWriteAccess(myTeam.CurrentUserRole) {
 		return shttp.Forbidden()
 	}
 

--- a/src/ee/api/team/team_store.go
+++ b/src/ee/api/team/team_store.go
@@ -296,26 +296,6 @@ type TeamMemberFilters struct {
 	Role     string
 }
 
-// TeamMember returns the member with the given id in the given team.
-func (s *Store) TeamMember(ctx context.Context, teamID, memberID types.ID) (*Member, error) {
-	filters := TeamMemberFilters{
-		TeamID:   teamID,
-		MemberID: memberID,
-	}
-
-	members, err := s.TeamMembers(ctx, filters)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(members) == 0 {
-		return nil, nil
-	}
-
-	return &members[0], nil
-}
-
 // TeamMembers returns members for the given team.
 func (s *Store) TeamMembers(ctx context.Context, filters TeamMemberFilters) ([]Member, error) {
 	members := []Member{}


### PR DESCRIPTION
## Summary
- `handlerSchemaDelete` called `team.Store.TeamMember(ctx, teamID, req.User.ID)`, but `TeamMember`/`TeamMembers` filters by `tm.member_id` (the team_members row PK), not `tm.user_id`. The lookup almost always returned nil, so even team owners got a 403 and the UI surfaced *"You don't have permission to delete this database schema. Contact team admin."*
- Switched to `store.Team(ctx, teamID, userID)`, which already filters by `user_id` and returns `CurrentUserRole` — the same pattern used by `handlerTeamMemberRemove`.

## Test plan
- [x] `go test ./src/ce/api/public/v1/ -run TestSchemaDeleteHandler` passes (Success, Success_AuditLogs, Forbidden_NoWriteAccess)
- [ ] Manually verify a team owner can now delete a database schema from the UI