### PR TITLE
fix: preserve env headers on build save

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -114,6 +114,7 @@ export const buildFormValues = (
     "build.statusChecks": JSON.stringify(env.build.statusChecks),
     "build.previewLinks": env.build.previewLinks ? "on" : "off",
     "build.priorityPattern": env.build.priorityPattern || "",
+    "build.headers": env.build.headers || "",
     "build.headersFile": env.build.headersFile,
     "build.redirectsFile": env.build.redirectsFile,
     "build.apiFolder": env.build.apiFolder,


### PR DESCRIPTION
## Summary
- Saving build-settings in the dashboard was clearing the environment's `headers` field.
- Root cause is frontend-only: `buildFormValues` populates defaults from `env.*` for every `build.*` field that `prepareBuildObject` coerces to `""` — except `build.headers`. When a tab without a `build.headers` input (e.g. TabConfigBuild) submits, the value arrives as `undefined`, is coerced to `""`, and the API call sends `headers: ""`. The backend's pointer-check correctly applies it, overwriting the stored headers.
- Other coerced-to-`""` fields (`buildCmd`, `serverCmd`, `installCmd`, `distFolder`, `workDir`, `priorityPattern`) already have defaults, so they survive — `headers` was the only gap.

Fix: add `build.headers` to the defaults block so the existing value round-trips when the form doesn't render that input.

A more thorough fix (omit untouched fields from the PUT body entirely, so the backend's `nil`-check handles it for every field) is left as a follow-up — it would also harden against the same class of bug in any future tab.

## Test plan
- [ ] Set headers via MCP `update_environment` or directly on env.
- [ ] Open dashboard → Build tab → change `installCmd` and save.
- [ ] Verify the env's `headers` field is still set (previously it would be cleared).