### PR TITLE
feat: skauth refresh endpoint and 7d default TTL

### DIFF
--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
@@ -45,7 +45,7 @@ func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 	// Let's create an auth conf on the fly, with default settings
 	if env.AuthConf == nil {
 		env.AuthConf = &buildconf.SKAuthConf{
-			TTL:        10,
+			TTL:        7 * 24 * 60,
 			SuccessURL: "/",
 			Secret:     utils.RandomToken(128),
 			Status:     true,

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
@@ -93,7 +93,7 @@ func (s *HandlerAuthUpsertSuite) Test_Success() {
 	s.NotNil(env)
 	s.NotNil(env.AuthConf)
 	s.Equal("/", env.AuthConf.SuccessURL)
-	s.Equal(10, env.AuthConf.TTL)
+	s.Equal(7*24*60, env.AuthConf.TTL)
 	s.Len(env.AuthConf.Secret, 128)
 	s.True(env.AuthConf.Status)
 }

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
@@ -226,5 +227,68 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 		return m.handleMagicLinkRequest()
 	}
 
+	if path == "/_stormkit/auth/refresh" {
+		return m.handleRefresh()
+	}
+
 	return m.handleCallback()
+}
+
+// handleRefresh trades a currently-valid skauth bearer for a freshly signed
+// one carrying the same uid claim. Expired bearers are rejected — the user
+// must re-run the magic-link flow. Clients call this proactively (e.g. on
+// app open and on a periodic timer) so the token never reaches its TTL while
+// the user is active.
+func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
+	if m.req.Method != http.MethodPost {
+		return &shttp.Response{
+			Status: http.StatusMethodNotAllowed,
+			Data:   map[string]any{"errors": []string{"method not allowed"}},
+		}, nil
+	}
+
+	bearer := user.ParseBearer(m.req.Header.Get("Authorization"))
+
+	if bearer == "" {
+		return &shttp.Response{
+			Status: http.StatusUnauthorized,
+			Data:   map[string]any{"errors": []string{"missing bearer token"}},
+		}, nil
+	}
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer:  bearer,
+		Secret:  m.req.Host.Config.SKAuth.Secret,
+		MaxMins: m.req.Host.Config.SKAuth.TTL,
+	})
+
+	if claims == nil {
+		return &shttp.Response{
+			Status: http.StatusUnauthorized,
+			Data:   map[string]any{"errors": []string{"invalid or expired token"}},
+		}, nil
+	}
+
+	uid, _ := claims["uid"].(string)
+
+	if uid == "" {
+		return &shttp.Response{
+			Status: http.StatusUnauthorized,
+			Data:   map[string]any{"errors": []string{"invalid token claims"}},
+		}, nil
+	}
+
+	token, err := user.JWT(jwt.MapClaims{"uid": uid}, m.req.Host.Config.SKAuth.Secret)
+
+	if err != nil {
+		return &shttp.Response{
+			Status: http.StatusInternalServerError,
+			Data:   map[string]any{"errors": []string{"failed to sign token"}},
+		}, nil
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   map[string]any{"token": token},
+	}, nil
 }

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -411,6 +411,88 @@ func (s *WithSKAuthSuite) Test_UserIDNotInjectedWhenNoAuthHeader() {
 	s.Empty(req.Header.Get("X-User-Id"))
 }
 
+// generateBearerIssuedAt signs a JWT with a forged "issued" claim so tests
+// can exercise expiry behavior without sleeping.
+func (s *WithSKAuthSuite) generateBearerIssuedAt(userID types.ID, secret string, issuedAt time.Time) string {
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"uid":    userID,
+		"issued": issuedAt.Unix(),
+	})
+
+	signed, err := tok.SignedString([]byte(secret))
+	s.Require().NoError(err)
+	return fmt.Sprintf("Bearer %s", signed)
+}
+
+// Test_Refresh_ValidToken checks that POSTing a still-valid bearer to
+// /_stormkit/auth/refresh returns a new JWT carrying the same uid.
+func (s *WithSKAuthSuite) Test_Refresh_ValidToken() {
+	host := s.hostWithSKAuth() // TTL = 10 min
+	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
+	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+
+	data, ok := res.Data.(map[string]any)
+	s.Require().True(ok)
+
+	newToken, ok := data["token"].(string)
+	s.Require().True(ok)
+	s.NotEmpty(newToken)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer:  newToken,
+		Secret:  "test-secret",
+		MaxMins: 10,
+	})
+	s.Require().NotNil(claims)
+	s.Equal("42", claims["uid"])
+}
+
+// Test_Refresh_ExpiredToken checks that an expired bearer is rejected with
+// 401 — expired means expired, no grace window.
+func (s *WithSKAuthSuite) Test_Refresh_ExpiredToken() {
+	host := s.hostWithSKAuth() // TTL = 10 min
+	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
+	req.Header.Set("Authorization", s.generateBearerIssuedAt(types.ID(7), "test-secret", time.Now().Add(-30*time.Minute)))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusUnauthorized, res.Status)
+}
+
+// Test_Refresh_MissingBearer checks that calls without an Authorization
+// header are rejected with 401.
+func (s *WithSKAuthSuite) Test_Refresh_MissingBearer() {
+	host := s.hostWithSKAuth()
+	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusUnauthorized, res.Status)
+}
+
+// Test_Refresh_WrongMethod checks that non-POST verbs on /refresh return 405.
+func (s *WithSKAuthSuite) Test_Refresh_WrongMethod() {
+	host := s.hostWithSKAuth()
+	req := s.newGetRequest(host, "/_stormkit/auth/refresh")
+	req.Header.Set("Authorization", s.generateBearer(types.ID(1), "test-secret"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusMethodNotAllowed, res.Status)
+}
+
 func TestWithSKAuth(t *testing.T) {
 	suite.Run(t, new(WithSKAuthSuite))
 }

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -16,7 +16,13 @@ import CardFooter from "~/components/CardFooter";
 import { RootContext } from "~/pages/Root.context";
 import Drawer from "./ProviderSettings";
 import { useFetchSchema } from "../database/actions";
-import { AuthProvider, saveConfig, useFetchProviders } from "./actions";
+import {
+  AuthProvider,
+  formatDuration,
+  parseDuration,
+  saveConfig,
+  useFetchProviders,
+} from "./actions";
 
 interface EmptyViewProps {
   isCloud?: boolean;
@@ -203,10 +209,21 @@ export default function SkAuth() {
             .map(line => line.trim())
             .filter(Boolean);
 
+          const ttlInput = ((data.get("tokenTtl") as string) || "").trim();
+          const tokenTtl = ttlInput ? parseDuration(ttlInput) : 0;
+
+          if (ttlInput && tokenTtl === null) {
+            setSaveError(
+              "Session TTL must be a duration like 7d, 12h, 30min, or 1w.",
+            );
+            setSaving(false);
+            return;
+          }
+
           saveConfig({
             envId: env.id!,
             successUrl: (data.get("successUrl") as string) || "",
-            tokenTtl: Number(data.get("tokenTtl") || 0),
+            tokenTtl: tokenTtl || 0,
             status: true,
             allowedOrigins,
           })
@@ -245,13 +262,14 @@ export default function SkAuth() {
           <TextField
             label="Session TTL"
             name="tokenTtl"
-            type="number"
-            placeholder="10"
+            placeholder="7d"
             fullWidth
-            defaultValue={config?.sessionTtl || ""}
+            defaultValue={
+              config?.sessionTtl ? formatDuration(config.sessionTtl) : ""
+            }
             variant="filled"
             autoComplete="off"
-            helperText="Token lifetime in minutes"
+            helperText="Token lifetime. Accepts e.g. 30min, 12h, 7d, 1w, 1mo."
             slotProps={{
               inputLabel: {
                 shrink: true,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -6,6 +6,53 @@ import LinkIcon from "@mui/icons-material/Link";
 import MuiLink from "@mui/material/Link";
 import api from "~/utils/api/Api";
 
+// Duration unit table for the Session TTL field. Order matters for
+// formatDuration: largest unit that divides cleanly wins.
+const DURATION_UNITS: { suffix: string; minutes: number }[] = [
+  { suffix: "y", minutes: 365 * 24 * 60 },
+  { suffix: "mo", minutes: 30 * 24 * 60 },
+  { suffix: "w", minutes: 7 * 24 * 60 },
+  { suffix: "d", minutes: 24 * 60 },
+  { suffix: "h", minutes: 60 },
+  { suffix: "min", minutes: 1 },
+];
+
+// parseDuration turns "7d", "12h", "30min", "1w", "1mo", "1y" (case-
+// insensitive, optional whitespace) into minutes. Returns null on garbage so
+// the caller can surface a validation error.
+export const parseDuration = (input: string): number | null => {
+  const match = input.trim().toLowerCase().match(/^(\d+)\s*(min|mo|h|d|w|y)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  const value = Number(match[1]);
+  const unit = DURATION_UNITS.find(u => u.suffix === match[2]);
+
+  if (!unit || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return value * unit.minutes;
+};
+
+// formatDuration renders minutes as the largest unit that divides evenly,
+// falling back to plain minutes. 10080 → "1w", 360 → "6h", 1500 → "1500min".
+export const formatDuration = (minutes: number): string => {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return "";
+  }
+
+  for (const unit of DURATION_UNITS) {
+    if (minutes % unit.minutes === 0) {
+      return `${minutes / unit.minutes}${unit.suffix}`;
+    }
+  }
+
+  return `${minutes}min`;
+};
+
 export interface Field {
   name: string;
   label: string;


### PR DESCRIPTION
## Summary
- New endpoint `POST /_stormkit/auth/refresh` — accepts a currently-valid bearer in the `Authorization` header, returns `{ "token": "<new bearer>" }` carrying the same `uid` claim and a fresh `issued` timestamp.
- Default TTL for freshly created auth configs bumped from 10 minutes to **7 days**. Existing configs are untouched.
- Dashboard **Session TTL** input now accepts human-readable durations (`30min`, `12h`, `7d`, `1w`, `1mo`, `1y`) and translates to minutes behind the scenes.

## Why this shape (vs sliding renewal in the middleware)
Initial pass implemented sliding renewal via an `X-Stormkit-Token` response header. Switched to an explicit refresh endpoint because:
- it matches the standard web-app pattern (Auth0 documents this exact approach) — easier for customers' frontend devs to reason about;
- the client controls *when* to refresh (e.g. on app open + every hour), so we don't tag every asset response with a per-request token that browsers can't read anyway;
- normal responses stay cacheable;
- it's a cleaner foundation for a future "revoke session" feature.

No separate refresh token: the JWT itself acts as the refresh credential within its expiry window, which is what Auth0 recommends for web apps.

## Expiry semantics
Expired means expired — there is no grace window. A client that lets the bearer expire must re-run the magic-link flow. The 7-day default TTL gives plenty of headroom for proactive refresh.

## Client contract
On app open and on a periodic timer (e.g. once an hour):

```
POST /_stormkit/auth/refresh
Authorization: Bearer <current token>

→ 200 { "token": "<new token>" }
→ 401 if missing / invalid / expired → redirect to magic-link flow
```

## Test plan
- [ ] Mint a bearer, POST to `/_stormkit/auth/refresh` → 200 with a new token carrying the same `uid`.
- [ ] Forge a bearer issued > TTL ago, POST to `/refresh` → 401.
- [ ] POST without Authorization header → 401.
- [ ] GET on `/refresh` → 405.
- [ ] Create a brand-new skauth config via the dashboard → TTL defaults to 10080 (7 days).
- [ ] In the dashboard Session TTL field, enter `7d`, `12h`, `30min`, `1w`, `1mo` → saves correctly and renders back in the same units.
- [ ] Enter garbage like `forever` → inline error, no save.