### PR TITLE
fix: reset hosting cache on skauth config update

### DIFF
--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -96,6 +97,15 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 
 	if err != nil {
 		return shttp.Error(err, fmt.Sprintf("error while saving auth conf for env: %s, err=%s", req.EnvID.String(), err.Error()))
+	}
+
+	// Invalidate the hosting cache so the SKAuth middleware picks up the
+	// new TTL/SuccessURL/AllowedOrigins on the next request. Without this
+	// the cached appconf keeps serving the previous values until the cache
+	// expires on its own, which manifests as users getting kicked out
+	// before the new TTL has elapsed.
+	if err := appcache.Service().Reset(req.EnvID); err != nil {
+		return shttp.Error(err)
 	}
 
 	return shttp.OK()

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
@@ -12,17 +13,20 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
 	"github.com/stretchr/testify/suite"
 )
 
 type HandlerAuthConfigUpdateSuite struct {
 	suite.Suite
 	*factory.Factory
-	conn databasetest.TestDB
-	usr  *factory.MockUser
-	app  *factory.MockApp
-	env  *factory.MockEnv
+	conn             databasetest.TestDB
+	usr              *factory.MockUser
+	app              *factory.MockApp
+	env              *factory.MockEnv
+	mockCacheService *mocks.CacheInterface
 }
 
 func (s *HandlerAuthConfigUpdateSuite) BeforeTest(suiteName, _ string) {
@@ -33,13 +37,19 @@ func (s *HandlerAuthConfigUpdateSuite) BeforeTest(suiteName, _ string) {
 	s.usr = s.MockUser(nil)
 	s.app = s.MockApp(s.usr, nil)
 	s.env = s.MockEnv(s.app)
+
+	s.mockCacheService = &mocks.CacheInterface{}
+	appcache.DefaultCacheService = s.mockCacheService
 }
 
 func (s *HandlerAuthConfigUpdateSuite) AfterTest(_, _ string) {
 	s.conn.CloseTx()
+	appcache.DefaultCacheService = nil
 }
 
 func (s *HandlerAuthConfigUpdateSuite) Test_Update() {
+	s.mockCacheService.On("Reset", types.ID(s.env.ID)).Return(nil).Once()
+
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
 		shttp.MethodPost,
@@ -74,6 +84,8 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_Existing() {
 	}
 
 	s.NoError(buildconf.NewStore().SaveAuthConf(context.Background(), s.env.ID, authConf))
+
+	s.mockCacheService.On("Reset", types.ID(s.env.ID)).Return(nil).Once()
 
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),


### PR DESCRIPTION
## Summary
- The skauth config update handler (`POST /skauth/config`) writes TTL / SuccessURL / AllowedOrigins to the DB but never invalidates the hosting appconf cache.
- The `WithSKAuth` middleware reads `SKAuth.TTL` from the cached config, so a freshly saved TTL (e.g. 1d) does not take effect on the live host — the stale value (often the old 10-minute default) keeps rejecting tokens, manifesting as users being kicked out well before the new TTL elapses.
- Calls `appcache.Service().Reset(req.EnvID)` after `SaveAuthConf`, matching the pattern in `handler_auth_upsert.go` and `authwall/handler_auth_config_set.go`.

## Test plan
- [x] `go test ./src/ce/api/app/skauth/skauthhandlers/ -run TestHandlerAuthConfigUpdate`
- [ ] Update TTL in dashboard → confirm new value enforced without restart