### PR TITLE
feat: From address for magic-link emails

### DIFF
--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -52,6 +52,7 @@ type ProviderData struct {
 	ClientSecret string   `json:"clientSecret"`
 	RedirectURL  string   `json:"redirectURL"`
 	Scopes       []string `json:"scopes"`
+	FromAddress  string   `json:"fromAddress,omitempty"`
 }
 
 type Provider struct {

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
@@ -16,6 +16,7 @@ type AuthUpsertRequest struct {
 	ProviderName string `json:"providerName"`
 	ClientID     string `json:"clientId"`
 	ClientSecret string `json:"clientSecret"`
+	FromAddress  string `json:"fromAddress"`
 	Status       bool   `json:"status"`
 }
 
@@ -109,7 +110,17 @@ func handleOAuthProvider(req *app.RequestContext, data *AuthUpsertRequest, env *
 // handleEmailProvider saves the email/password provider configuration.
 // Email providers do not require OAuth credentials.
 func handleEmailProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env) *shttp.Response {
-	return saveProvider(req, data, env, skauth.ProviderData{})
+	fromAddress := strings.TrimSpace(data.FromAddress)
+
+	if data.ProviderName == skauth.ProviderMagicLink && fromAddress == "" {
+		return shttp.BadRequest(map[string]any{
+			"error": "From address is required",
+		})
+	}
+
+	return saveProvider(req, data, env, skauth.ProviderData{
+		FromAddress: fromAddress,
+	})
 }
 
 // saveProvider creates the auth table (idempotent) and upserts the provider record.

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
@@ -283,6 +283,7 @@ func (s *HandlerAuthUpsertSuite) Test_Success_MagicLinkProvider() {
 		map[string]any{
 			"envId":        s.env.ID,
 			"providerName": skauth.ProviderMagicLink,
+			"fromAddress":  "Acme <noreply@acme.com>",
 			"status":       true,
 		},
 		map[string]string{
@@ -296,7 +297,25 @@ func (s *HandlerAuthUpsertSuite) Test_Success_MagicLinkProvider() {
 	s.NoError(err)
 	s.NotNil(provider, "Magic link provider should be saved")
 	s.True(provider.Status)
-	s.Equal(skauth.ProviderData{}, provider.Data, "Magic link provider should have no OAuth credentials")
+	s.Equal(skauth.ProviderData{FromAddress: "Acme <noreply@acme.com>"}, provider.Data)
+}
+
+func (s *HandlerAuthUpsertSuite) Test_MagicLinkProvider_RequiresFromAddress() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth",
+		map[string]any{
+			"envId":        s.env.ID,
+			"providerName": skauth.ProviderMagicLink,
+			"status":       true,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
 }
 
 func TestHandlerUpsertSuite(t *testing.T) {

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -37,6 +37,10 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 		if p.Data.ClientSecret != "" {
 			returnValue[p.Name]["clientSecret"] = ClientSecretPlaceholder
 		}
+
+		if p.Data.FromAddress != "" {
+			returnValue[p.Name]["fromAddress"] = p.Data.FromAddress
+		}
 	}
 
 	successURL := ""

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -82,7 +82,7 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 		return shttp.Error(err, fmt.Sprintf("failed to upsert magic link user: %s", err.Error()))
 	}
 
-	if err := sendMagicLinkEmail(req, env, email, token); err != nil {
+	if err := sendMagicLinkEmail(req, env, prv, email, token); err != nil {
 		return shttp.Error(err, fmt.Sprintf("failed to send magic link email: %s", err.Error()))
 	}
 
@@ -219,12 +219,13 @@ func isAllowedOrigin(origin string, list []string) bool {
 	return false
 }
 
-func sendMagicLinkEmail(req *shttp.RequestContext, env *buildconf.Env, email, token string) error {
+func sendMagicLinkEmail(req *shttp.RequestContext, env *buildconf.Env, prv *skauth.Provider, email, token string) error {
 	u := req.URL()
 	link := fmt.Sprintf("%s://%s/_stormkit/auth/magic?token=%s", u.Scheme, u.Host, token)
 
 	params := buildconf.SendEmailParams{
 		To:      email,
+		From:    prv.Data.FromAddress,
 		Subject: "Your magic link",
 		Body:    fmt.Sprintf(`<p>Click the link below to sign in. The link expires in 15 minutes.</p><p><a href="%s">%s</a></p>`, link, link),
 	}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
@@ -61,6 +61,7 @@ export default function ProviderSettings({
             providerName: provider?.id,
             clientId: data.clientId,
             clientSecret: data.clientSecret,
+            fromAddress: data.fromAddress,
             status: isEnabled,
           })
             .then(() => {
@@ -97,6 +98,7 @@ export default function ProviderSettings({
               label={field.label}
               defaultValue={field.value}
               helperText={field.helperText}
+              required={field.required}
               fullWidth
               sx={{ mb: 2 }}
             />

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -254,6 +254,12 @@ export default function SkAuth() {
               inputLabel: {
                 shrink: true,
               },
+              htmlInput: {
+                "data-lpignore": "true",
+                "data-1p-ignore": "true",
+                "data-bwignore": "true",
+                "data-form-type": "other",
+              },
             }}
           />
         </Box>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -57,6 +57,7 @@ export interface Field {
   name: string;
   label: string;
   value: string;
+  required?: boolean;
   helperText?: string;
 }
 
@@ -111,6 +112,16 @@ const allProviders: AuthProvider[] = [
     name: "Magic Link",
     drawerTitle: "Magic Link Settings",
     drawerDesc: "Allow passwordless sign-in via a one-time link sent by email.",
+    fields: [
+      {
+        name: "fromAddress",
+        label: "From address",
+        value: "",
+        required: true,
+        helperText:
+          "Address used as the From header for magic-link emails (e.g. \"Acme <noreply@acme.com>\").",
+      },
+    ],
     steps: [
       "Enable this provider to allow users to sign in with a magic link sent to their email address.",
       <>


### PR DESCRIPTION
## Summary
- Add a required **From address** field to the Magic Link provider settings, stored on the provider's `ProviderData` and used as the SMTP `From` header when sending magic-link emails.
- Disable LastPass / 1Password / Bitwarden autofill on the SkAuth "Success callback URL" input (plain `autoComplete="off"` is ignored by these extensions).

## Test plan
- [ ] In the SkAuth settings page, confirm LastPass/1Password no longer offer to fill the Success callback URL field.
- [ ] Open the Magic Link provider drawer, try to save without a From address — request is rejected (`From address is required`).
- [ ] Save with a valid value (e.g. `Acme <noreply@acme.com>`); reopen the drawer to verify it round-trips.
- [ ] Trigger a magic-link sign-in; inspect the resulting email's `From` header matches the configured value.