### PR TITLE
fix: use bare address as smtp envelope sender

### DIFF
--- a/src/ce/api/app/buildconf/mailer_model.go
+++ b/src/ce/api/app/buildconf/mailer_model.go
@@ -3,6 +3,7 @@ package buildconf
 import (
 	"encoding/json"
 	"fmt"
+	"net/mail"
 	"net/smtp"
 	"net/url"
 	"strings"
@@ -85,7 +86,10 @@ func SanitizeHeader(v string) string {
 }
 
 // Send delivers an HTML email using the environment's SMTP configuration.
-// The SMTP envelope sender is always mc.Username; p.From controls the display From header only.
+// p.From sets the From: header (may include a display name); the SMTP
+// envelope MAIL FROM is the bare address parsed from it — display-name
+// forms like `Acme <foo@bar.com>` are rejected by many SMTP servers with
+// a 501.
 func (mc *MailerConf) Send(p SendEmailParams) error {
 	fromHeader := SanitizeHeader(utils.GetString(p.From, mc.Username))
 	port := utils.GetString(mc.Port, "587")
@@ -105,7 +109,13 @@ func (mc *MailerConf) Send(p SendEmailParams) error {
 		to[i] = strings.TrimSpace(to[i])
 	}
 
-	return SendMailFunc(mc.Host+":"+port, auth, mc.Username, to, msg)
+	envelope := fromHeader
+
+	if addr, err := mail.ParseAddress(fromHeader); err == nil {
+		envelope = addr.Address
+	}
+
+	return SendMailFunc(mc.Host+":"+port, auth, envelope, to, msg)
 }
 
 type Email struct {

--- a/src/ce/api/app/buildconf/mailer_model_test.go
+++ b/src/ce/api/app/buildconf/mailer_model_test.go
@@ -1,6 +1,7 @@
 package buildconf_test
 
 import (
+	"net/smtp"
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -9,6 +10,10 @@ import (
 
 type MailerModelSuite struct {
 	suite.Suite
+}
+
+func (s *MailerModelSuite) AfterTest(_, _ string) {
+	buildconf.SendMailFunc = smtp.SendMail
 }
 
 func (s *MailerModelSuite) Test_String_DefaultPort() {
@@ -32,6 +37,56 @@ func (s *MailerModelSuite) Test_String_SpecialCharsInCredentials() {
 
 	expected := "smtp://user%40example.com:p%40ss%3Aword%2F123@smtp.example.com:465"
 	s.Equal(expected, mailer.String())
+}
+
+func (s *MailerModelSuite) Test_Send_EnvelopeExtractsBareAddress() {
+	mailer := &buildconf.MailerConf{
+		Host:     "smtp.example.com",
+		Username: "Triplan <mailer@triplan.to>",
+		Password: "secret",
+	}
+
+	var capturedFrom string
+	var capturedMsg []byte
+
+	buildconf.SendMailFunc = func(_ string, _ smtp.Auth, from string, _ []string, msg []byte) error {
+		capturedFrom = from
+		capturedMsg = msg
+		return nil
+	}
+
+	s.NoError(mailer.Send(buildconf.SendEmailParams{
+		To:      "user@example.com",
+		Subject: "Hello",
+		Body:    "Body",
+	}))
+
+	s.Equal("mailer@triplan.to", capturedFrom, "envelope must be the bare address")
+	s.Contains(string(capturedMsg), "From: Triplan <mailer@triplan.to>", "From header keeps display name")
+}
+
+func (s *MailerModelSuite) Test_Send_EnvelopeUsesParamsFromAddress() {
+	mailer := &buildconf.MailerConf{
+		Host:     "smtp.example.com",
+		Username: "smtp-user@example.com",
+		Password: "secret",
+	}
+
+	var capturedFrom string
+
+	buildconf.SendMailFunc = func(_ string, _ smtp.Auth, from string, _ []string, _ []byte) error {
+		capturedFrom = from
+		return nil
+	}
+
+	s.NoError(mailer.Send(buildconf.SendEmailParams{
+		To:      "user@example.com",
+		From:    "Acme <noreply@acme.com>",
+		Subject: "Hello",
+		Body:    "Body",
+	}))
+
+	s.Equal("noreply@acme.com", capturedFrom)
 }
 
 func TestMailerModel(t *testing.T) {

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail_test.go
@@ -48,7 +48,7 @@ func (s *MailerSuite) Test_Success() {
 	buildconf.SendMailFunc = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
 		mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 		s.Equal("smtp.gmail.com:587", addr)
-		s.Equal("test", from)
+		s.Equal("hello@stormkit.io", from)
 		s.Equal([]string{"joe@stormkit.io", "jane@stormkit.io"}, to)
 		s.Equal([]byte(
 			""+


### PR DESCRIPTION
## Summary
- `MailerConf.Send` was passing the raw From value (e.g. `Triplan <mailer@triplan.to>`) as the SMTP envelope `MAIL FROM`, which servers reject with `501 Invalid MAIL FROM address provided`.
- Parse the From header with `net/mail.ParseAddress` and use the bare address (`mailer@triplan.to`) for the envelope. The visible `From:` header keeps the display-name form.
- Aligns the envelope (and therefore the bounce path) with the actual sender, instead of always using the SMTP username.

## Test plan
- [x] `go test -p 1 ./src/ce/api/app/buildconf/...` — new unit tests cover the display-name and bare-address cases; existing handler test updated.
- [ ] Reproduce the original failure with a real SMTP relay (e.g. configure Mailer with `Triplan <mailer@triplan.to>` and trigger a magic-link sign-in) and confirm the email is accepted.