### PR TITLE
feat: forward x-user-email header for skauth

### DIFF
--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 type skAuthMiddleware struct {
@@ -177,19 +178,28 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 		return nil, nil
 	}
 
-	// Strip the header to prevent clients from spoofing it.
+	// Strip the headers to prevent clients from spoofing them.
 	req.Header.Del("X-User-Id")
+	req.Header.Del("X-User-Email")
 
 	if bearer := user.ParseBearer(req.Header.Get("Authorization")); bearer != "" {
+		secret := req.Host.Config.SKAuth.Secret
+
 		claims := user.ParseJWT(&user.ParseJWTArgs{
 			Bearer:  bearer,
-			Secret:  req.Host.Config.SKAuth.Secret,
+			Secret:  secret,
 			MaxMins: req.Host.Config.SKAuth.TTL,
 		})
 
 		if claims != nil {
 			if userID, ok := claims["uid"].(string); ok && userID != "" {
 				req.Header.Set("X-User-Id", userID)
+			}
+
+			if encEmail, ok := claims["eml"].(string); ok && encEmail != "" {
+				if email := utils.DecryptToString(encEmail, []byte(secret)); email != "" {
+					req.Header.Set("X-User-Email", email)
+				}
 			}
 		}
 	}
@@ -278,7 +288,13 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 		}, nil
 	}
 
-	token, err := user.JWT(jwt.MapClaims{"uid": uid}, m.req.Host.Config.SKAuth.Secret)
+	newClaims := jwt.MapClaims{"uid": uid}
+
+	if eml, ok := claims["eml"].(string); ok && eml != "" {
+		newClaims["eml"] = eml
+	}
+
+	token, err := user.JWT(newClaims, m.req.Host.Config.SKAuth.Secret)
 
 	if err != nil {
 		return &shttp.Response{

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -48,7 +48,7 @@ func (s *WithSKAuthMagicLinkSuite) setupEnv() (*factory.MockEnv, error) {
 func (s *WithSKAuthMagicLinkSuite) setupEnvWithOrigins(allowed []string) (*factory.MockEnv, error) {
 	env := s.MockEnv(s.app, map[string]any{
 		"AuthConf": &buildconf.SKAuthConf{
-			Secret:         "test-secret",
+			Secret:         "test-secret-padded-to-32-chars!!",
 			Status:         true,
 			AllowedOrigins: allowed,
 		},
@@ -93,7 +93,7 @@ func (s *WithSKAuthMagicLinkSuite) hostFor(envID types.ID) *hosting.Host {
 		Config: &appconf.Config{
 			EnvID: envID,
 			SKAuth: &buildconf.SKAuthConf{
-				Secret:     "test-secret",
+				Secret:     "test-secret-padded-to-32-chars!!",
 				SuccessURL: "/dashboard",
 			},
 		},

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -59,7 +60,7 @@ func (s *WithSKAuthSuite) hostWithSKAuth() *hosting.Host {
 		Name: "www.stormkit.io",
 		Config: &appconf.Config{
 			SKAuth: &buildconf.SKAuthConf{
-				Secret:     "test-secret",
+				Secret:     "test-secret-padded-to-32-chars!!",
 				SuccessURL: "/",
 				TTL:        10,
 			},
@@ -366,7 +367,7 @@ func (s *WithSKAuthSuite) Test_UserIDNotStrippedWhenSKAuthDisabled() {
 func (s *WithSKAuthSuite) Test_UserIDInjected() {
 	userID := types.ID(42)
 	req := s.newRequest(s.hostWithSKAuth(), "/api/data")
-	req.Header.Set("Authorization", s.generateBearer(userID, "test-secret"))
+	req.Header.Set("Authorization", s.generateBearer(userID, "test-secret-padded-to-32-chars!!"))
 
 	res, err := hosting.WithSKAuth(req)
 
@@ -390,7 +391,7 @@ func (s *WithSKAuthSuite) Test_UserIDNotInjectedOnInvalidToken() {
 // Test_UserIDNotInjectedOnWrongSecret checks that a token signed with a different secret is rejected.
 func (s *WithSKAuthSuite) Test_UserIDNotInjectedOnWrongSecret() {
 	req := s.newRequest(s.hostWithSKAuth(), "/api/data")
-	req.Header.Set("Authorization", s.generateBearer(types.ID(1), "wrong-secret"))
+	req.Header.Set("Authorization", s.generateBearer(types.ID(1), "wrong-secret-padded-to-32-chars!"))
 
 	res, err := hosting.WithSKAuth(req)
 
@@ -411,6 +412,57 @@ func (s *WithSKAuthSuite) Test_UserIDNotInjectedWhenNoAuthHeader() {
 	s.Empty(req.Header.Get("X-User-Id"))
 }
 
+// generateBearerWithEmail signs a JWT carrying both uid and an encrypted eml
+// claim — mirrors what the login/register/verify/magic-link handlers issue.
+func (s *WithSKAuthSuite) generateBearerWithEmail(userID types.ID, email, secret string) string {
+	token, err := user.JWT(jwt.MapClaims{
+		"uid": userID,
+		"eml": utils.EncryptToString(email, []byte(secret)),
+	}, secret)
+	s.Require().NoError(err)
+	return fmt.Sprintf("Bearer %s", token)
+}
+
+// Test_UserEmailStripped checks that X-User-Email is removed when SKAuth is
+// configured to prevent clients from spoofing it.
+func (s *WithSKAuthSuite) Test_UserEmailStripped() {
+	req := s.newRequest(s.hostWithSKAuth(), "/some/path")
+	req.Header.Set("X-User-Email", "spoofed@example.com")
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res)
+	s.Empty(req.Header.Get("X-User-Email"))
+}
+
+// Test_UserEmailInjected checks that a valid bearer with an encrypted eml
+// claim results in X-User-Email being decrypted and set on the request.
+func (s *WithSKAuthSuite) Test_UserEmailInjected() {
+	secret := "test-secret-padded-to-32-chars!!"
+	req := s.newRequest(s.hostWithSKAuth(), "/api/data")
+	req.Header.Set("Authorization", s.generateBearerWithEmail(types.ID(42), "user@example.com", secret))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res)
+	s.Equal("user@example.com", req.Header.Get("X-User-Email"))
+}
+
+// Test_UserEmailNotInjectedWhenClaimMissing checks that a bearer without an
+// eml claim leaves X-User-Email unset.
+func (s *WithSKAuthSuite) Test_UserEmailNotInjectedWhenClaimMissing() {
+	req := s.newRequest(s.hostWithSKAuth(), "/api/data")
+	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res)
+	s.Empty(req.Header.Get("X-User-Email"))
+}
+
 // generateBearerIssuedAt signs a JWT with a forged "issued" claim so tests
 // can exercise expiry behavior without sleeping.
 func (s *WithSKAuthSuite) generateBearerIssuedAt(userID types.ID, secret string, issuedAt time.Time) string {
@@ -429,7 +481,7 @@ func (s *WithSKAuthSuite) generateBearerIssuedAt(userID types.ID, secret string,
 func (s *WithSKAuthSuite) Test_Refresh_ValidToken() {
 	host := s.hostWithSKAuth() // TTL = 10 min
 	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
-	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret"))
+	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
 
 	res, err := hosting.WithSKAuth(req)
 
@@ -446,11 +498,40 @@ func (s *WithSKAuthSuite) Test_Refresh_ValidToken() {
 
 	claims := user.ParseJWT(&user.ParseJWTArgs{
 		Bearer:  newToken,
-		Secret:  "test-secret",
+		Secret:  "test-secret-padded-to-32-chars!!",
 		MaxMins: 10,
 	})
 	s.Require().NotNil(claims)
 	s.Equal("42", claims["uid"])
+}
+
+// Test_Refresh_PreservesEmail checks that the eml claim survives a refresh —
+// the new token carries the same encrypted email as the old one.
+func (s *WithSKAuthSuite) Test_Refresh_PreservesEmail() {
+	secret := "test-secret-padded-to-32-chars!!"
+	host := s.hostWithSKAuth()
+	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
+	req.Header.Set("Authorization", s.generateBearerWithEmail(types.ID(42), "user@example.com", secret))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+
+	data := res.Data.(map[string]any)
+	newToken := data["token"].(string)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer:  newToken,
+		Secret:  secret,
+		MaxMins: 10,
+	})
+	s.Require().NotNil(claims)
+
+	encEmail, ok := claims["eml"].(string)
+	s.Require().True(ok)
+	s.Equal("user@example.com", utils.DecryptToString(encEmail, []byte(secret)))
 }
 
 // Test_Refresh_ExpiredToken checks that an expired bearer is rejected with
@@ -458,7 +539,7 @@ func (s *WithSKAuthSuite) Test_Refresh_ValidToken() {
 func (s *WithSKAuthSuite) Test_Refresh_ExpiredToken() {
 	host := s.hostWithSKAuth() // TTL = 10 min
 	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
-	req.Header.Set("Authorization", s.generateBearerIssuedAt(types.ID(7), "test-secret", time.Now().Add(-30*time.Minute)))
+	req.Header.Set("Authorization", s.generateBearerIssuedAt(types.ID(7), "test-secret-padded-to-32-chars!!", time.Now().Add(-30*time.Minute)))
 
 	res, err := hosting.WithSKAuth(req)
 
@@ -484,7 +565,7 @@ func (s *WithSKAuthSuite) Test_Refresh_MissingBearer() {
 func (s *WithSKAuthSuite) Test_Refresh_WrongMethod() {
 	host := s.hostWithSKAuth()
 	req := s.newGetRequest(host, "/_stormkit/auth/refresh")
-	req.Header.Set("Authorization", s.generateBearer(types.ID(1), "test-secret"))
+	req.Header.Set("Authorization", s.generateBearer(types.ID(1), "test-secret-padded-to-32-chars!!"))
 
 	res, err := hosting.WithSKAuth(req)
 

--- a/src/ce/hosting/skauth_email.go
+++ b/src/ce/hosting/skauth_email.go
@@ -115,6 +115,7 @@ func (m *skAuthMiddleware) login() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": authUser.UUID,
+		"eml": utils.EncryptToString(ctx.email, []byte(ctx.env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", ctx.envID),
 		"prv": skauth.ProviderEmail,
 	}, ctx.env.AuthConf.Secret)
@@ -192,6 +193,7 @@ func (m *skAuthMiddleware) register() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": usr.UUID,
+		"eml": utils.EncryptToString(ctx.email, []byte(ctx.env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", ctx.envID),
 		"prv": skauth.ProviderEmail,
 	}, ctx.env.AuthConf.Secret)
@@ -273,6 +275,7 @@ func (m *skAuthMiddleware) verifyEmail() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": authUser.UUID,
+		"eml": utils.EncryptToString(authUser.Email, []byte(env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", envID),
 		"prv": skauth.ProviderEmail,
 	}, env.AuthConf.Secret)

--- a/src/ce/hosting/skauth_email_test.go
+++ b/src/ce/hosting/skauth_email_test.go
@@ -51,7 +51,7 @@ func (s *WithSKAuthEmailSuite) hostFor(envID types.ID) *hosting.Host {
 		Config: &appconf.Config{
 			EnvID: envID,
 			SKAuth: &buildconf.SKAuthConf{
-				Secret:     "test-secret",
+				Secret:     "test-secret-padded-to-32-chars!!",
 				SuccessURL: "/dashboard",
 			},
 		},
@@ -126,7 +126,7 @@ func (s *WithSKAuthEmailSuite) getRequest(host *hosting.Host, path string) *host
 func (s *WithSKAuthEmailSuite) setupEnv(withMailer bool) (*factory.MockEnv, error) {
 	fields := map[string]any{
 		"AuthConf": &buildconf.SKAuthConf{
-			Secret:     "test-secret",
+			Secret:     "test-secret-padded-to-32-chars!!",
 			Status:     true,
 			SuccessURL: "/dashboard",
 		},
@@ -287,7 +287,7 @@ func (s *WithSKAuthEmailSuite) Test_Register_AuthNotEnabled() {
 func (s *WithSKAuthEmailSuite) Test_Register_EmailProviderNotEnabled() {
 	env := s.MockEnv(s.app, map[string]any{
 		"AuthConf": &buildconf.SKAuthConf{
-			Secret: "test-secret",
+			Secret: "test-secret-padded-to-32-chars!!",
 			Status: true,
 		},
 		"SchemaConf": &buildconf.SchemaConf{
@@ -398,7 +398,7 @@ func (s *WithSKAuthEmailSuite) Test_Login_AuthNotEnabled() {
 func (s *WithSKAuthEmailSuite) Test_Login_EmailProviderNotEnabled() {
 	env := s.MockEnv(s.app, map[string]any{
 		"AuthConf": &buildconf.SKAuthConf{
-			Secret: "test-secret",
+			Secret: "test-secret-padded-to-32-chars!!",
 			Status: true,
 		},
 		"SchemaConf": &buildconf.SchemaConf{

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -166,6 +166,7 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": authUser.UUID,
+		"eml": utils.EncryptToString(authUser.Email, []byte(env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", envID),
 		"prv": skauth.ProviderMagicLink,
 	}, env.AuthConf.Secret)


### PR DESCRIPTION
## Summary
- Embed an AES-GCM-encrypted `eml` claim in every skauth session JWT (login, register, email verify, magic-link verify).
- Middleware decrypts `eml` and forwards it as `X-User-Email` alongside `X-User-Id`. Inbound `X-User-Email` is stripped to block client spoofing.
- Refresh handler preserves the encrypted claim verbatim, so the email survives token rotation without server-side decryption on the refresh path.

## Test plan
- [x] `go test -p 1 ./src/ce/hosting/...` passes
- [ ] Manual: sign in via magic link against a configured host and confirm the upstream app sees `X-User-Email`
- [ ] Manual: send a request with a spoofed `X-User-Email` header and confirm it is stripped before reaching the upstream