### PR TITLE
fix: derive aes key for eml claim from skauth secret

### DIFF
--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -197,7 +197,7 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 			}
 
 			if encEmail, ok := claims["eml"].(string); ok && encEmail != "" {
-				if email := utils.DecryptToString(encEmail, []byte(secret)); email != "" {
+				if email := utils.DecryptToString(encEmail, emlKey(secret)); email != "" {
 					req.Header.Set("X-User-Email", email)
 				}
 			}
@@ -288,11 +288,7 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 		}, nil
 	}
 
-	newClaims := jwt.MapClaims{"uid": uid}
-
-	if eml, ok := claims["eml"].(string); ok && eml != "" {
-		newClaims["eml"] = eml
-	}
+	newClaims := jwt.MapClaims{"uid": uid, "eml": claims["eml"]}
 
 	token, err := user.JWT(newClaims, m.req.Host.Config.SKAuth.Secret)
 

--- a/src/ce/hosting/skauth_email.go
+++ b/src/ce/hosting/skauth_email.go
@@ -7,6 +7,7 @@ import (
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
@@ -15,6 +16,17 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// emlKey derives a 32-byte AES key for encrypting the `eml` JWT claim.
+// SKAuth secrets are normally 128-char ASCII tokens; if a shorter secret
+// is encountered (which AES rejects), fall back to the app secret.
+func emlKey(secret string) []byte {
+	if len(secret) >= 32 {
+		return []byte(secret)[:32]
+	}
+
+	return []byte(config.AppSecret())
+}
 
 type emailAuthCtx struct {
 	env      *buildconf.Env
@@ -115,7 +127,7 @@ func (m *skAuthMiddleware) login() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": authUser.UUID,
-		"eml": utils.EncryptToString(ctx.email, []byte(ctx.env.AuthConf.Secret)),
+		"eml": utils.EncryptToString(ctx.email, emlKey(ctx.env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", ctx.envID),
 		"prv": skauth.ProviderEmail,
 	}, ctx.env.AuthConf.Secret)
@@ -193,7 +205,7 @@ func (m *skAuthMiddleware) register() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": usr.UUID,
-		"eml": utils.EncryptToString(ctx.email, []byte(ctx.env.AuthConf.Secret)),
+		"eml": utils.EncryptToString(ctx.email, emlKey(ctx.env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", ctx.envID),
 		"prv": skauth.ProviderEmail,
 	}, ctx.env.AuthConf.Secret)
@@ -275,7 +287,7 @@ func (m *skAuthMiddleware) verifyEmail() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": authUser.UUID,
-		"eml": utils.EncryptToString(authUser.Email, []byte(env.AuthConf.Secret)),
+		"eml": utils.EncryptToString(authUser.Email, emlKey(env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", envID),
 		"prv": skauth.ProviderEmail,
 	}, env.AuthConf.Secret)

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -166,7 +166,7 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
 		"uid": authUser.UUID,
-		"eml": utils.EncryptToString(authUser.Email, []byte(env.AuthConf.Secret)),
+		"eml": utils.EncryptToString(authUser.Email, emlKey(env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", envID),
 		"prv": skauth.ProviderMagicLink,
 	}, env.AuthConf.Secret)


### PR DESCRIPTION
## Summary
- The previous commit added an encrypted `eml` claim to the SKAuth session JWT so the middleware could forward `X-User-Email`, but the consumer app never received the header.
- Root cause: `SKAuthConf.Secret` is `utils.RandomToken(128)` — 128 bytes — while AES requires a 16/24/32-byte key. `aes.NewCipher` errored, `EncryptToString` silently returned `""`, and the middleware's empty-string guard skipped header injection. Existing tests didn't catch it because all fixtures used a 32-char secret.
- Fix: added an `emlKey` helper that slices the first 32 bytes of the secret (or falls back to `config.AppSecret()` when shorter), and routed all 4 encrypt sites and the 1 decrypt site through it.

## Test plan
- [x] `go test -p 1 -run "SKAuth|Skauth|skauth" ./src/ce/hosting` passes
- [ ] Verify in a real environment that `X-User-Email` is forwarded to the upstream app after a magic-link / email login