### PR TITLE
fix: remove entire deployment root dir after run

### DIFF
--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -283,16 +283,8 @@ func Start(payload, rootDir string) error {
 	}
 
 	defer func(opts RunnerOpts) {
-		if opts.Repo.Dir != "" {
-			if err := os.RemoveAll(opts.Repo.Dir); err != nil {
-				slog.Errorf("could not remove repo dir: %v", err)
-			}
-		}
-
-		if opts.KeysDir != "" {
-			if err := os.RemoveAll(opts.KeysDir); err != nil {
-				slog.Errorf("could not remove keys dir: %v", err)
-			}
+		if err := opts.RemoveAll(); err != nil {
+			slog.Errorf("could not remove root dir: %v", err)
 		}
 	}(opts)
 


### PR DESCRIPTION
## Summary
- The runner's deferred cleanup in `Start` only removed `<RootDir>/repo` and `<RootDir>/keys`, leaving `<RootDir>` itself plus `<RootDir>/dist/*.zip` behind in `os.TempDir()` after every deploy.
- On long-running self-hosted workers this accumulates and eventually fills the disk.
- Once `Upload` completes, the artifacts have already been extracted to `Deployer.StorageDir` (`/shared/deployments/deployment-<id>/...` on the shared docker volume), so nothing downstream needs the tmp folder.
- Switch the deferred cleanup to `opts.RemoveAll()`, which removes the whole `<RootDir>` and subsumes the previous repo/keys removal.

## Test plan
- [ ] Run a local deploy on self-hosted and confirm `/tmp/deployment-<id>` is gone after the deploy completes (both success and failure paths).
- [ ] Confirm the deployment still serves correctly from `/shared/deployments/deployment-<id>/`.