### PR TITLE
feat: add STORMKIT_DISABLE_ARI to disable ARI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ STORMKIT_RUNNER_SECRET_KEY=''
 STORMKIT_RUNNER_CONCURRENCY=4
 STORMKIT_DEPLOYER_SERVICE=local
 STORMKIT_ACME_EMAIL=''
+# Set to 'true' to disable ACME Renewal Information (ARI). Use this if the ACME
+# account changed and existing certificates fail to renew with an HTTP 403 on
+# the 'replaces' field; re-enable once all certificates have been reissued.
+STORMKIT_DISABLE_ARI=''
 
 VITE_PORT=8080
 VITE_API_DOMAIN=/api

--- a/src/ce/hosting/certmagic_server.go
+++ b/src/ce/hosting/certmagic_server.go
@@ -72,6 +72,19 @@ func Magic(opts MagicOpts) {
 		DisableStapling: true,
 	}
 
+	// ARI (ACME Renewal Information) lets the CA suggest renewal timing and adds
+	// a "replaces" field to renewal orders pointing at the previous certificate.
+	// Let's Encrypt requires the renewing account to be the same one that issued
+	// the certificate being replaced; if the ACME account changes (e.g. the email
+	// is changed), every existing certificate fails to renew with an HTTP 403.
+	// Disabling ARI makes renewals ordinary new orders so they succeed until all
+	// certificates have been reissued under the current account. Set this on the
+	// Default template before NewDefault() so it propagates to every issuer.
+	if os.Getenv("STORMKIT_DISABLE_ARI") == "true" {
+		certmagic.Default.DisableARI = true
+		slog.Infof("ARI disabled via STORMKIT_DISABLE_ARI; renewal orders will omit the replaces field")
+	}
+
 	server := certmagic.NewDefault()
 	server.Logger = logger
 


### PR DESCRIPTION
## What

Adds a `STORMKIT_DISABLE_ARI` environment variable. When set to `true`, certmagic's ACME Renewal Information (ARI) is disabled by setting `certmagic.Default.DisableARI` on the template before the `NewDefault()` calls, so it propagates to every issuer (cloud DNS issuer, the non-cloud on-demand serving config, and the lazy `CertMagic()` config).

## Why

ARI adds a `replaces` field to renewal orders pointing at the previous certificate. Let's Encrypt requires the renewing ACME account to be the **same** account that issued the certificate being replaced. If the ACME account changes — e.g. `STORMKIT_ACME_EMAIL` is changed, which makes certmagic register a brand-new account — every existing certificate fails to renew with:

```
HTTP 403 urn:ietf:params:acme:error:unauthorized -
Could not validate ARI 'replaces' field ::
requester account did not request the certificate being replaced by this order
```

This was observed on a self-hosted instance whose ACME email was introduced during a migration: all pre-existing certificates silently stopped renewing and began expiring. ARI is purely an optimization (CA-suggested renewal timing + relaxed renewal rate limits), so disabling it makes renewals ordinary new orders that succeed.

## Usage

Set `STORMKIT_DISABLE_ARI=true` to unblock renewals after an ACME account change. It can be re-enabled once all certificates have been reissued under the current account (each renewal with ARI disabled is a plain new order, so the resulting cert is owned by the current account and future ARI renewals pass the ownership check).

## Changes

- `src/ce/hosting/certmagic_server.go` — read the env var in `Magic()` and set `certmagic.Default.DisableARI`.
- `.env.example` — document the new variable.