### PR TITLE
fix: link auth providers by email to avoid duplicates

### DIFF
--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -18,16 +18,17 @@ import (
 )
 
 var schemaStmt = struct {
-	selectSchema           string
-	selectTables           string
-	createAuthTable        string
-	createMigrationsTable  string
-	selectMigrations       string
-	insertOAuth            string
-	insertAuthUser         string
-	verifyEmailUser        string
-	updateMagicLinkToken   string
-	consumeMagicLinkToken  string
+	selectSchema          string
+	selectTables          string
+	createAuthTable       string
+	createMigrationsTable string
+	selectMigrations      string
+	insertOAuth           string
+	upsertProvider        string
+	insertAuthUser        string
+	selectUserIDByEmail   string
+	verifyEmailUser       string
+	consumeMagicLinkToken string
 }{
 	createAuthTable: `
 		CREATE TABLE IF NOT EXISTS stormkit_auth_users (
@@ -107,6 +108,29 @@ var schemaStmt = struct {
 		);
 	`,
 
+	// upsertProvider attaches a provider to an existing user, or refreshes the
+	// record (tokens / verification token) when the user already has it. The
+	// (user_id, provider_name) conflict target matches the table's unique
+	// constraint, so re-logins and account linking are both idempotent.
+	upsertProvider: `
+		INSERT INTO stormkit_auth_providers (
+			user_id, account_id, access_token, refresh_token, token_type, provider_name, expiry, verification_token
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, NULLIF($8, '')
+		)
+		ON CONFLICT (user_id, provider_name) DO UPDATE SET
+			account_id = EXCLUDED.account_id,
+			access_token = EXCLUDED.access_token,
+			refresh_token = EXCLUDED.refresh_token,
+			token_type = EXCLUDED.token_type,
+			expiry = EXCLUDED.expiry,
+			verification_token = EXCLUDED.verification_token;
+	`,
+
+	selectUserIDByEmail: `
+		SELECT user_id, uuid FROM stormkit_auth_users WHERE email = $1;
+	`,
+
 	insertAuthUser: `
 		INSERT INTO stormkit_auth_users (
 			email, first_name, last_name, avatar
@@ -121,12 +145,6 @@ var schemaStmt = struct {
 		SET verified_at = NOW(), verification_token = NULL
 		WHERE verification_token = $1 AND provider_name = 'email'
 		RETURNING user_id;
-	`,
-
-	updateMagicLinkToken: `
-		UPDATE stormkit_auth_providers
-		SET verification_token = $1
-		WHERE user_id = $2 AND provider_name = 'magiclink';
 	`,
 
 	consumeMagicLinkToken: `
@@ -657,6 +675,42 @@ func (s *schemaStore) InsertAuthUser(ctx context.Context, oauth *skauth.OAuth, u
 	return tx.Commit()
 }
 
+// UpsertAuthUser links a provider login to a user identified by email (account
+// linking). It looks the user up by email — independently of which provider
+// originally created them — and attaches or refreshes the given provider record.
+// When no user with the email exists, a new user is inserted together with the
+// provider. This prevents the duplicate-email failure that occurs when the same
+// person signs in through a second provider (e.g. magic link first, then OAuth).
+// On success user.ID and user.UUID are populated.
+func (s *schemaStore) UpsertAuthUser(ctx context.Context, oauth *skauth.OAuth, user *skauth.User) error {
+	if s.conf == nil {
+		return fmt.Errorf("schema configuration is required to upsert auth user")
+	}
+
+	err := s.Conn.QueryRowContext(ctx, schemaStmt.selectUserIDByEmail, user.Email).Scan(&user.ID, &user.UUID)
+
+	if err == sql.ErrNoRows {
+		return s.InsertAuthUser(ctx, oauth, user)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	_, err = s.Exec(ctx, schemaStmt.upsertProvider,
+		user.ID,
+		oauth.AccountID,
+		null.NewString(utils.EncryptToString(oauth.AccessToken), oauth.AccessToken != ""),
+		null.NewString(utils.EncryptToString(oauth.RefreshToken), oauth.RefreshToken != ""),
+		oauth.TokenType,
+		oauth.ProviderName,
+		oauth.Expiry,
+		oauth.VerificationToken,
+	)
+
+	return err
+}
+
 // AuthUser retrieves the authentication user by its ID.
 func (s *schemaStore) AuthUser(ctx context.Context, authID types.ID) (*skauth.User, error) {
 	if s.conf == nil {
@@ -834,30 +888,14 @@ func (s *schemaStore) VerifyEmailUser(ctx context.Context, token string) (types.
 	return userID, err
 }
 
-// UpsertMagicLinkUser finds or creates a user by email and sets a new magic link token
-// on their magiclink provider record. Returns the user ID.
+// UpsertMagicLinkUser finds or creates a user by email and sets a new magic link
+// token on their magiclink provider record. The lookup is by email regardless of
+// provider, so a user who first signed in through OAuth (or email/password) is
+// reused and a magiclink provider record is attached to them. Returns the user ID.
 func (s *schemaStore) UpsertMagicLinkUser(ctx context.Context, email, token string) (types.ID, error) {
-	if s.conf == nil {
-		return 0, fmt.Errorf("schema configuration is required to upsert magic link user")
-	}
-
-	existing, err := s.AuthUserByEmail(ctx, AuthUserByEmailParams{
-		Email:    email,
-		Provider: skauth.ProviderMagicLink,
-	})
-
-	if err != nil {
-		return 0, err
-	}
-
-	if existing != nil {
-		_, err = s.Exec(ctx, schemaStmt.updateMagicLinkToken, token, existing.ID)
-		return existing.ID, err
-	}
-
 	user := &skauth.User{Email: email}
 
-	err = s.InsertAuthUser(ctx, &skauth.OAuth{
+	err := s.UpsertAuthUser(ctx, &skauth.OAuth{
 		AccountID:         email,
 		ProviderName:      skauth.ProviderMagicLink,
 		TokenType:         skauth.ProviderMagicLink,

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -98,6 +98,68 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
 	s.Contains(*res.Redirect, "https://app.example.com/_stormkit/auth?code=")
 }
 
+// Test_Callback_LinksToExistingMagicLinkUser guards against the duplicate-account
+// failure that occurred when a user who first signed up through magic link later
+// logged in through OAuth with the same email: the callback must link the OAuth
+// provider to the existing user, not insert a second user (which violated the
+// unique email constraint).
+func (s *WithSKAuthOAuthSuite) Test_Callback_LinksToExistingMagicLinkUser() {
+	host := s.setupCallbackEnv(true)
+
+	conf := &buildconf.SchemaConf{
+		SchemaName:        s.conn.Cfg.Schema,
+		DBName:            s.conn.Cfg.DBName,
+		Port:              s.conn.Cfg.Port,
+		Host:              s.conn.Cfg.Host,
+		MigrationUserName: s.conn.Cfg.User,
+		MigrationPassword: s.conn.Cfg.Password,
+		AppUserName:       s.conn.Cfg.User,
+		AppPassword:       s.conn.Cfg.Password,
+	}
+
+	store, err := conf.Store(buildconf.SchemaAccessTypeAppUser)
+	s.Require().NoError(err)
+
+	// The user first registers through magic link with this email.
+	_, err = store.UpsertMagicLinkUser(context.Background(), "jane@stormkit.io", "magic-token")
+	s.Require().NoError(err)
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID: "google-account-id",
+		Email:     "jane@stormkit.io",
+		FirstName: "Jane",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
+
+	res, err := hosting.WithSKAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+
+	// The OAuth login linked to the existing user — no duplicate was created.
+	users, err := store.ListAuthUsers(context.Background(), 0, 100)
+	s.Require().NoError(err)
+
+	matched := 0
+
+	for _, u := range users {
+		if u.Email == "jane@stormkit.io" {
+			matched++
+		}
+	}
+
+	s.Equal(1, matched)
+}
+
 func (s *WithSKAuthOAuthSuite) Test_Callback_InvalidState() {
 	host := s.setupCallbackEnv(true)
 

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -182,8 +182,8 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		LastName:  info.LastName,
 	}
 
-	if err := store.InsertAuthUser(req.Context(), &oauth, &usr); err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to insert auth user: %s", err.Error())), nil
+	if err := store.UpsertAuthUser(req.Context(), &oauth, &usr); err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed to upsert auth user: %s", err.Error())), nil
 	}
 
 	sessionToken, err := user.JWT(jwt.MapClaims{


### PR DESCRIPTION
## Problem

When a user first registered through **magic link** and later logged in through **OAuth** with the same email, account creation failed with a duplicate-account error.

The data model already supports account linking — `stormkit_auth_users` is one row per email (`email UNIQUE`) and `stormkit_auth_providers` allows many providers per user via `UNIQUE (user_id, provider_name)`. But the OAuth callback called `InsertAuthUser`, which *always* inserts a new user row, so an existing email hit the unique constraint.

The symmetric case (OAuth first, then magic link) was broken the same way: `UpsertMagicLinkUser` looked the user up via an inner join on the provider, so it could never find a user created by a *different* provider.

## Fix

- Add `selectUserIDByEmail` (provider-independent email lookup) and `upsertProvider` (`ON CONFLICT (user_id, provider_name) DO UPDATE`, making re-logins and linking idempotent).
- Add `UpsertAuthUser`: find the user by email; attach/refresh the provider record if found, otherwise insert a new user + provider.
- Route both the OAuth callback and `UpsertMagicLinkUser` through it, fixing both directions.
- Remove the now-dead `updateMagicLinkToken` statement.

`InsertAuthUser` is retained as the low-level primitive — email/password `register()` still uses its strict insert for duplicate detection.

## Tests

- Added `Test_Callback_LinksToExistingMagicLinkUser` regression test.
- Full skauth hosting suite passes.