### PR TITLE
fix: inject skauth token on cross-origin oauth login

### DIFF
--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -1,9 +1,12 @@
 package hosting
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
@@ -102,47 +105,108 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	}
 
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
+	token, _ := data["token"].(string)
 
-	// Cross-origin: the POST came from a whitelisted frontend. Bounce
-	// the user back to that origin with the session token in the URL
-	// fragment so the destination SPA can persist it. We deliberately
-	// do NOT touch localStorage here because this host is the wrong
-	// origin for the token. SuccessURL is validated at config time to
-	// start with '/', so origin (no trailing slash) + successURL joins
-	// cleanly.
+	// Cross-origin: the POST came from a whitelisted frontend. Stash the token
+	// under a one-time code and bounce the user back to that origin's landing
+	// page, which injects it into localStorage there (codeLanding). We do NOT
+	// touch localStorage here because this host is the wrong origin for the
+	// token. SuccessURL is validated at config time to start with '/', so origin
+	// (no trailing slash) + successURL joins cleanly.
 	if redirect, _ := data["redirect"].(string); redirect != "" {
-		target := fmt.Sprintf("%s%s#skauth=%s", redirect, successURL, data["token"])
-		head := fmt.Sprintf(`<script>window.location.href=%q;</script>`, target)
+		landing, err := stashSessionToken(m.req.Context(), redirect, successURL, token)
+
+		if err != nil {
+			return m.renderVerifyPage(http.StatusInternalServerError, "", "magic link verification failed"), nil
+		}
+
+		head := fmt.Sprintf(`<script>window.location.href=%q;</script>`, landing)
 
 		return m.renderVerifyPage(http.StatusOK, head, ""), nil
 	}
 
 	head := fmt.Sprintf(
 		`<script>localStorage.setItem('skauth', JSON.stringify(%q));window.location.href=%q;</script>`,
-		data["token"],
+		token,
 		successURL+"?verified=true",
 	)
 
 	return m.renderVerifyPage(http.StatusOK, head, ""), nil
 }
 
-func (m *skAuthMiddleware) handleCallback() (*shttp.Response, error) {
-	var head, content string
+// sessionCode is the payload stored in Redis under the one-time login code. The
+// auth host mints the session token and computes the post-login redirect, then
+// stashes both so the landing page can inject the token and redirect — without
+// the landing host needing its own auth config.
+type sessionCode struct {
+	Token    string `json:"token"`
+	Redirect string `json:"redirect"`
+}
 
+// stashSessionToken stores the session token and its post-login redirect under a
+// fresh one-time code and returns the landing URL on the destination origin. The
+// browser is sent there; codeLanding reads the payload back and injects the token
+// into localStorage on that origin. origin is scheme+host (no trailing slash);
+// successURL is validated at config time to start with '/'.
+func stashSessionToken(ctx context.Context, origin, successURL, token string) (string, error) {
+	payload, err := json.Marshal(sessionCode{Token: token, Redirect: origin + successURL})
+
+	if err != nil {
+		return "", err
+	}
+
+	code := utils.RandomToken(64)
+
+	if err := rediscache.Client().Set(ctx, code, payload, time.Minute*2).Err(); err != nil {
+		return "", err
+	}
+
+	return origin + "/_stormkit/auth?code=" + code, nil
+}
+
+// codeLanding serves the one-time-code login landing. It is host-config
+// independent: the token and redirect were stashed in Redis by the auth host, so
+// it works even on a frontend deployment that has no auth config of its own.
+// Returns nil when the code is absent or unknown, so the request falls through to
+// normal serving (the SPA) instead of rendering an error.
+func (m *skAuthMiddleware) codeLanding() *shttp.Response {
 	code := m.req.Query().Get("code")
-	status := http.StatusOK
 
 	if code == "" {
+		return nil
+	}
+
+	raw, err := rediscache.Client().GetDel(m.req.Context(), code).Result()
+
+	if err != nil || raw == "" {
+		return nil
+	}
+
+	var sc sessionCode
+
+	if err := json.Unmarshal([]byte(raw), &sc); err != nil {
+		return nil
+	}
+
+	head := fmt.Sprintf(
+		`<script>localStorage.setItem('skauth', JSON.stringify('%s'));window.location.href=%q;</script>`,
+		sc.Token,
+		sc.Redirect,
+	)
+
+	return m.renderVerifyPage(http.StatusOK, head, "")
+}
+
+// handleCallback renders the terminal states of the one-time-code landing on an
+// auth-enabled host. The success path (a valid code) is handled earlier by
+// codeLanding, so by the time we get here the code is missing or unknown.
+func (m *skAuthMiddleware) handleCallback() (*shttp.Response, error) {
+	status := http.StatusOK
+	content := "invalid session"
+
+	if m.req.Query().Get("code") == "" {
 		status = http.StatusBadRequest
 		content = "code is missing"
-	} else if sessionToken := rediscache.Client().Get(m.req.Context(), code).Val(); sessionToken != "" {
-		head = fmt.Sprintf(
-			`<script>localStorage.setItem('skauth', JSON.stringify('%s'));window.location.href="%s";</script>`,
-			sessionToken,
-			m.req.Host.Config.SKAuth.SuccessURL,
-		)
-	} else {
-		content = "invalid session"
 	}
 
 	return &shttp.Response{
@@ -153,7 +217,6 @@ func (m *skAuthMiddleware) handleCallback() (*shttp.Response, error) {
 		Data: html.MustRender(html.RenderArgs{
 			PageTitle:   "Stormkit - Auth",
 			PageContent: content,
-			PageHead:    head,
 		}),
 	}, nil
 }
@@ -175,6 +238,23 @@ func (m *skAuthMiddleware) renderVerifyPage(status int, head, content string) *s
 }
 
 func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
+	path := req.URL().Path
+
+	// The one-time-code login landing works on any Stormkit host: the token and
+	// its redirect live in Redis (stashed by the auth host), so the destination
+	// frontend doesn't need its own auth config. This must run before the
+	// SKAuth-nil gate below. The exact-match compare keeps normal traffic free —
+	// the query is parsed only on /_stormkit/auth, and Redis is touched only when
+	// a code is actually present. codeLanding returns nil for an absent/unknown
+	// code so we fall through to normal serving (the SPA). Skip OPTIONS so a CORS
+	// preflight can't consume the one-time code (real landings are GET
+	// navigations and are never preflighted).
+	if path == "/_stormkit/auth" && req.Method != http.MethodOptions && req.Query().Get("code") != "" {
+		if resp := (&skAuthMiddleware{req: req}).codeLanding(); resp != nil {
+			return resp, nil
+		}
+	}
+
 	if req.Host.Config.SKAuth == nil {
 		return nil, nil
 	}
@@ -204,8 +284,6 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 			}
 		}
 	}
-
-	path := req.URL().Path
 
 	if !strings.HasPrefix(path, "/_stormkit/auth") {
 		return nil, nil

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -355,8 +355,11 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_CrossOrigin_RedirectsToInitiator(
 	s.Equal(http.StatusOK, res.Status)
 
 	body := string(res.Data.([]byte))
-	s.Contains(body, "https://app.example.com/dashboard#skauth=")
-	// Cross-origin path must not touch localStorage on the wrong host.
+	// Cross-origin path bounces to the initiator's one-time-code landing, which
+	// injects the token into localStorage there — no fragment, and this response
+	// must not touch localStorage on the wrong host.
+	s.Contains(body, "https://app.example.com/_stormkit/auth?code=")
+	s.NotContains(body, "#skauth=")
 	s.NotContains(body, "localStorage")
 }
 

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -168,14 +168,15 @@ func (s *WithSKAuthSuite) Test_InvalidCode() {
 }
 
 // Test_ValidCode checks that the middleware returns 200 and injects a script that
-// stores the session token in localStorage when a valid code is presented.
+// stores the session token in localStorage and redirects to the stashed target
+// when a valid code is presented.
 func (s *WithSKAuthSuite) Test_ValidCode() {
 	ctx := context.Background()
 	code := "test-valid-code-123"
 	sessionToken := "test.session.jwt"
 
 	rds := rediscache.Client()
-	rds.Set(ctx, code, sessionToken, time.Minute*2)
+	rds.Set(ctx, code, `{"token":"`+sessionToken+`","redirect":"https://app.example.com/dashboard"}`, time.Minute*2)
 	defer rds.Del(ctx, code)
 
 	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth?code="+code)
@@ -189,6 +190,44 @@ func (s *WithSKAuthSuite) Test_ValidCode() {
 	body := string(res.Data.([]byte))
 	s.Contains(body, `localStorage.setItem('skauth'`)
 	s.Contains(body, sessionToken)
+	s.Contains(body, "https://app.example.com/dashboard")
+}
+
+// Test_CodeLanding_FrontendWithoutSKAuth verifies the one-time-code landing works
+// on a Stormkit host with NO auth config of its own — the cross-origin case where
+// the frontend is a separate deployment. The token + redirect were stashed in
+// Redis by the auth host, so injection must still happen here, and the code is
+// consumed one-time.
+func (s *WithSKAuthSuite) Test_CodeLanding_FrontendWithoutSKAuth() {
+	ctx := context.Background()
+	code := "frontend-code-456"
+	sessionToken := "front.session.jwt"
+
+	rds := rediscache.Client()
+	rds.Set(ctx, code, `{"token":"`+sessionToken+`","redirect":"https://www.triplan.to/"}`, time.Minute*2)
+	defer rds.Del(ctx, code)
+
+	host := &hosting.Host{
+		Name:   "www.triplan.to",
+		Config: &appconf.Config{}, // no SKAuth configured on the frontend host
+	}
+
+	res, err := hosting.WithSKAuth(s.newRequest(host, "/_stormkit/auth?code="+code))
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+
+	body := string(res.Data.([]byte))
+	s.Contains(body, `localStorage.setItem('skauth'`)
+	s.Contains(body, sessionToken)
+	s.Contains(body, "https://www.triplan.to/")
+
+	// One-time use: the code is consumed, so a replay falls through to normal
+	// serving (nil response).
+	res2, err := hosting.WithSKAuth(s.newRequest(host, "/_stormkit/auth?code="+code))
+	s.NoError(err)
+	s.Nil(res2)
 }
 
 // Test_RegisterPath_SKAuthDisabled checks that /_stormkit/auth/register is a no-op when SKAuth is not configured.

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -5,13 +5,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
-	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
@@ -187,7 +185,8 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	}
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
-		"uid": usr.ID,
+		"uid": usr.UUID,
+		"eml": utils.EncryptToString(usr.Email, emlKey(env.AuthConf.Secret)),
 		"eid": fmt.Sprintf("%d", env.ID),
 		"prv": provider,
 	}, env.AuthConf.Secret)
@@ -196,22 +195,23 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error())), nil
 	}
 
-	code := utils.RandomToken(64)
-
-	if err := rediscache.Client().Set(req.Context(), code, sessionToken, time.Minute*2).Err(); err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed saving session code: %s", err.Error())), nil
-	}
-
 	parsed, err := url.ParseRequestURI(refer)
 
 	if err != nil {
 		return shttp.BadRequest(map[string]any{"errors": []string{"referrer URL is not a valid format"}}), nil
 	}
 
-	target := fmt.Sprintf("%s://%s/_stormkit/auth?code=%s",
-		utils.GetString(parsed.Scheme, "https"),
-		parsed.Host,
-		code)
+	referOrigin := utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
+
+	// Stash the token under a one-time code and send the browser to the landing
+	// page on the initiating origin, which injects it into localStorage there
+	// (codeLanding). This works whether or not that origin runs its own auth
+	// config, and keeps the token out of the URL.
+	target, err := stashSessionToken(req.Context(), referOrigin, m.req.Host.Config.SKAuth.SuccessURL, sessionToken)
+
+	if err != nil {
+		return shttp.Error(err, fmt.Sprintf("failed saving session code: %s", err.Error())), nil
+	}
 
 	return &shttp.Response{
 		Status:   http.StatusFound,

--- a/src/ui/src/components/CopyBox/CopyBox.tsx
+++ b/src/ui/src/components/CopyBox/CopyBox.tsx
@@ -8,6 +8,31 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 let id = 0;
 
+// copyToClipboard prefers the async Clipboard API, which is the reliable path on
+// modern browsers and secure contexts. It falls back to selecting the input and
+// the legacy execCommand for older browsers or non-secure (http) contexts where
+// navigator.clipboard is unavailable.
+function copyToClipboard(value: string, inputId: string) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(value).catch(() => selectAndExec(inputId));
+    return;
+  }
+
+  selectAndExec(inputId);
+}
+
+function selectAndExec(inputId: string) {
+  const input = document.querySelector<HTMLInputElement>(`#${inputId}`);
+
+  if (!input) {
+    return;
+  }
+
+  input.focus();
+  input.select();
+  document.execCommand("copy");
+}
+
 export default function CopyBox({
   value,
   slotProps,
@@ -43,13 +68,7 @@ export default function CopyBox({
                 type="button"
                 aria-label="Copy to clipboard"
                 onClick={() => {
-                  (
-                    document.querySelector(`#${inputId}`) as HTMLInputElement
-                  ).focus();
-                  (
-                    document.querySelector(`#${inputId}`) as HTMLInputElement
-                  ).select();
-                  document.execCommand("copy");
+                  copyToClipboard(String(value ?? ""), inputId);
                   setClicked(true);
                   setTimeout(() => {
                     setClicked(false);

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
@@ -76,6 +76,10 @@ export default function ProviderSettings({
     return Array.from(new Set(origins));
   }, [environment.preview, domains]);
 
+  // The preview origin is always the first candidate; flag it so it can be
+  // labelled in the dropdown and told apart from verified custom domains.
+  const previewOrigin = callbackOrigins[0];
+
   // Default the dropdown to the first known domain, keeping the current choice
   // if it survives a domains refresh.
   useEffect(() => {
@@ -187,12 +191,13 @@ export default function ProviderSettings({
                 variant="filled"
                 value={selectedOrigin}
                 onChange={e => setSelectedOrigin(e.target.value)}
-                helperText="Your app is served from multiple domains. Pick one to get its callback URL, and register the callback URL for each domain you use."
+                helperText="Select one of these domains as the callback URL. To support multiple domains, create a separate app for each one."
                 sx={{ mb: 2 }}
               >
                 {callbackOrigins.map(origin => (
                   <MenuItem key={origin} value={origin}>
                     {origin}
+                    {origin === previewOrigin ? " (preview)" : ""}
                   </MenuItem>
                 ))}
               </TextField>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -302,7 +302,7 @@ export default function SkAuth() {
             defaultValue={(config?.allowedOrigins || []).join("\n")}
             variant="filled"
             autoComplete="off"
-            helperText="Optional. One origin per line (scheme + host, no path). Applies to every provider: cross-origin sign-in (magic link and OAuth) is only allowed to redirect back to an origin on this list, and the user is returned to the origin that initiated the flow (session token in the URL fragment as #skauth=…). Leave empty to keep the single-host behaviour."
+            helperText="Optional. One origin per line (scheme + host, no path). Applies to every provider: cross-origin sign-in (magic link and OAuth) is only allowed to redirect back to an origin on this list, and the user is returned to the origin that initiated the flow with the session token written to localStorage there. Leave empty to keep the single-host behaviour."
             slotProps={{
               inputLabel: {
                 shrink: true,


### PR DESCRIPTION
## Problem

After OAuth sign-in, the callback redirects the session token to
`<frontendOrigin>/_stormkit/auth?code=...` and expects that origin to inject it into
`localStorage`. When the frontend is a **separate Stormkit deployment without its own
SKAuth config**, `WithSKAuth` early-returns (`SKAuth == nil`) and the SPA is served
instead of the injection page — so the token is silently lost and the user never gets
authenticated.

A second latent bug: the OAuth session JWT used `"uid": usr.ID` (a numeric `types.ID`),
but `WithSKAuth` reads `claims["uid"].(string)`, so `X-User-Id` was never set for OAuth
users (magic-link/email correctly use the string `UUID` + encrypted `eml`).

## Fix

- **Host-config-independent code landing.** Stash the token *and* its post-login redirect
  in Redis under the one-time code, and dispatch the landing **before** the `SKAuth == nil`
  gate so any Stormkit host can inject it. The gate is a cheap exact-match path compare;
  Redis is touched only when a `code` is actually present, and the code is read once with
  `GETDEL` (one-time use). OPTIONS is skipped so a preflight can't consume the code.
- **No more URL fragments.** Both OAuth and magic-link cross-origin flows now use this
  injection landing instead of the `#skauth=` fragment hand-off. `#skauth=` is gone from
  the codebase; the `SkAuth.tsx` help text is updated to match.
- **Correct OAuth claims:** `uid` = string `UUID`, plus an encrypted `eml` claim, so
  `X-User-Id` / `X-User-Email` are populated for OAuth sessions.
- **UI:** `CopyBox` copies via `navigator.clipboard.writeText` (with the legacy
  `execCommand` as a fallback); the OAuth domain selector labels the preview origin and
  reworded its helper text.

## Tests

- `Test_ValidCode` updated for the new `{token, redirect}` Redis payload.
- Added `Test_CodeLanding_FrontendWithoutSKAuth` — proves injection works on a host with
  no SKAuth config and that the code is consumed one-time.
- `Test_Verify_CrossOrigin_RedirectsToInitiator` updated to assert the `?code=` landing
  (no fragment).
- Full `./src/ce/hosting/...` suite passes (`go test -p 1`).