### PR TITLE
fix: dismissible origins hint and select z-index

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
@@ -191,8 +191,14 @@ export default function ProviderSettings({
                 variant="filled"
                 value={selectedOrigin}
                 onChange={e => setSelectedOrigin(e.target.value)}
-                helperText="Select one of these domains as the callback URL. To support multiple domains, create a separate app for each one."
+                helperText="Pick a domain to get its callback URL. Register the callback URL with your provider for every domain you use."
                 sx={{ mb: 2 }}
+                slotProps={{
+                  // The Drawer is raised to zIndex 1600; without this the Select
+                  // menu renders behind it (default modal zIndex 1300) and
+                  // clicking appears to do nothing.
+                  select: { MenuProps: { sx: { zIndex: 1700 } } },
+                }}
               >
                 {callbackOrigins.map(origin => (
                   <MenuItem key={origin} value={origin}>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -270,6 +270,60 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
     });
   });
 
+  describe("allowed origins hint", () => {
+    const enabledProviders = { google: { status: true } };
+    const hintText = /A provider is enabled but no allowed origins are set/;
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it("warns when a provider is enabled but no origins are set", async () => {
+      await createWrapper({ hasSchema: true, providers: enabledProviders });
+
+      await waitFor(() => {
+        expect(wrapper.getByText(hintText)).toBeTruthy();
+      });
+    });
+
+    it("dismisses the hint and remembers it in localStorage", async () => {
+      await createWrapper({ hasSchema: true, providers: enabledProviders });
+
+      await waitFor(() => {
+        expect(wrapper.getByText(hintText)).toBeTruthy();
+      });
+
+      fireEvent.click(wrapper.getByLabelText("Close"));
+
+      await waitFor(() => {
+        expect(wrapper.queryByText(hintText)).toBeNull();
+      });
+
+      expect(
+        localStorage.getItem(`skauth_origins_hint_dismissed_${currentEnv.id}`),
+      ).toBe("1");
+    });
+
+    it("stays hidden when it was dismissed previously", async () => {
+      localStorage.setItem(
+        `skauth_origins_hint_dismissed_${mockEnv({ app: mockApp() }).id}`,
+        "1",
+      );
+
+      await createWrapper({ hasSchema: true, providers: enabledProviders });
+
+      await waitFor(() => {
+        expect(wrapper.getByText("Allowed origins")).toBeTruthy();
+      });
+
+      expect(wrapper.queryByText(hintText)).toBeNull();
+    });
+  });
+
   describe("auth config form", () => {
     beforeEach(async () => {
       await createWrapper({ hasSchema: true });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -164,6 +164,15 @@ export default function SkAuth() {
   const [success, setSuccess] = useState<string>();
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string>();
+  const originsHintKey = `skauth_origins_hint_dismissed_${env.id}`;
+  const [originsHintDismissed, setOriginsHintDismissed] = useState(
+    () => localStorage.getItem(originsHintKey) === "1",
+  );
+
+  const dismissOriginsHint = () => {
+    localStorage.setItem(originsHintKey, "1");
+    setOriginsHintDismissed(true);
+  };
   const { providers, loading, error, config } = useFetchProviders({
     envId: env.id!,
     refreshToken,
@@ -176,6 +185,7 @@ export default function SkAuth() {
   // Guide decoupled (separate frontend domain / native) setups: an enabled
   // provider with no allow-list silently returns users to this environment.
   const showOriginsHint =
+    !originsHintDismissed &&
     providers.some(p => p.enabled) &&
     (config?.allowedOrigins || []).length === 0;
 
@@ -302,7 +312,7 @@ export default function SkAuth() {
             defaultValue={(config?.allowedOrigins || []).join("\n")}
             variant="filled"
             autoComplete="off"
-            helperText="Optional. One origin per line (scheme + host, no path). Applies to every provider: cross-origin sign-in (magic link and OAuth) is only allowed to redirect back to an origin on this list, and the user is returned to the origin that initiated the flow with the session token written to localStorage there. Leave empty to keep the single-host behaviour."
+            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. Leave empty for single-host setups."
             slotProps={{
               inputLabel: {
                 shrink: true,
@@ -310,12 +320,10 @@ export default function SkAuth() {
             }}
           />
           {showOriginsHint && (
-            <Alert severity="warning" sx={{ mt: 1 }}>
-              A provider is enabled but no allowed origins are set. Leave this
-              empty only if your frontend is served from this same environment.
-              If your frontend runs on a separate domain (or a native app), add
-              its origin here — otherwise sign-in will return users to this
-              environment instead of your app.
+            <Alert severity="warning" sx={{ mt: 2 }} onClose={dismissOriginsHint}>
+              A provider is enabled but no allowed origins are set. If your
+              frontend runs on a separate domain (or a native app), add its
+              origin — otherwise sign-in returns users here instead of your app.
             </Alert>
           )}
         </Box>


### PR DESCRIPTION
## Changes

### Dismissible "allowed origins" warning
The warning shown when a provider is enabled but no allowed origins are set is now dismissible via the `Alert`'s close button. The dismissal is persisted **per-environment** in `localStorage` (`skauth_origins_hint_dismissed_<envId>`), so it stays hidden across reloads.

### Domain picker not opening / text not selectable in the provider drawer
The provider settings `Drawer` is raised to `zIndex: 1600`, but MUI's `Select` menu renders in a portal at the default modal z-index `1300` — so it opened **behind** the drawer and clicking appeared to do nothing. While that invisible menu stayed open, MUI's modal manager also marked the drawer content `inert`, which is why **text wasn't selectable** in the modal either. Raising the menu above the drawer (`MenuProps` z-index) fixes both symptoms.

For the record: there is **no `user-select: none`** anywhere in the codebase, theme, or global CSS — the non-selectable text was a side effect of the stuck hidden menu, not a CSS rule.

## Tests
- Added 3 specs for the hint: shows when applicable, dismiss hides + persists to `localStorage`, and stays hidden when previously dismissed.
- Full skauth UI suite passes (`SkAuth` 17, `ProviderSettings` 11).