### PR TITLE
feat: redirect auth failures with login_error

### DIFF
--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -89,10 +90,28 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	if resp.Status != 0 && resp.Status != http.StatusOK {
 		errMsg := "magic link verification failed"
 
+		// Redirect base: the validated origin carried in the token when we have
+		// it (cross-origin), otherwise this host's own origin — which, for magic
+		// links, is the domain the email link was issued from. The underlying
+		// cause was already logged when magicLinkVerify built the error response.
+		origin := "https://" + m.req.Host.Name
+
 		if d, ok := resp.Data.(map[string]any); ok {
 			if errs, ok := d["errors"].([]string); ok && len(errs) > 0 {
 				errMsg = errs[0]
 			}
+
+			if r, ok := d["redirect"].(string); ok && r != "" {
+				origin = r
+			}
+		}
+
+		// Token-level failures (missing/invalid/expired/consumed token) bounce the
+		// user back to the app with a friendly login_error. Config (404) and
+		// internal (5xx) responses keep their original page — they mean the host
+		// isn't set up for auth or hit a fault, not a user sign-in failure.
+		if resp.Status == http.StatusBadRequest {
+			return m.loginErrorRedirect(origin, errMsg), nil
 		}
 
 		return m.renderVerifyPage(resp.Status, "", errMsg), nil
@@ -162,6 +181,23 @@ func stashSessionToken(ctx context.Context, origin, successURL, token string) (s
 	}
 
 	return origin + "/_stormkit/auth?code=" + code, nil
+}
+
+// loginErrorRedirect bounces a failed sign-in back to the app's redirect page
+// (origin + SuccessURL) with a user-friendly message in the login_error query
+// param, instead of rendering a Stormkit error page. The underlying cause should
+// be logged by the caller. Used by both the OAuth and magic-link flows.
+func (m *skAuthMiddleware) loginErrorRedirect(origin, message string) *shttp.Response {
+	target := fmt.Sprintf("%s%s?login_error=%s",
+		origin,
+		m.req.Host.Config.SKAuth.SuccessURL,
+		url.QueryEscape(message),
+	)
+
+	return &shttp.Response{
+		Status:   http.StatusFound,
+		Redirect: &target,
+	}
 }
 
 // codeLanding serves the one-time-code login landing. It is host-config

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -213,6 +213,9 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_CreatesNewUser() {
 	s.Equal("newuser@example.com", authUser.Email)
 }
 
+// Test_Verify_InvalidToken checks that an unparseable token bounces the user back
+// to the app's redirect page with a login_error message. The origin is unknown
+// (the token can't be parsed), so we fall back to this host's own origin.
 func (s *WithSKAuthMagicLinkSuite) Test_Verify_InvalidToken() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
@@ -220,7 +223,10 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_InvalidToken() {
 	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?token=bad-token"))
 
 	s.NoError(err)
-	s.Equal(http.StatusBadRequest, res.Status)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Contains(*res.Redirect, "https://my.example.com/dashboard?login_error=")
 }
 
 func (s *WithSKAuthMagicLinkSuite) Test_Verify_Success() {
@@ -300,9 +306,41 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_TokenConsumedOnce() {
 	s.NoError(err)
 	s.Equal(http.StatusOK, first.Status)
 
+	// Reusing a consumed token bounces back to the app with a login_error.
 	second, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.NoError(err)
-	s.Equal(http.StatusBadRequest, second.Status)
+	s.Equal(http.StatusFound, second.Status)
+	s.Require().NotNil(second.Redirect)
+	s.Contains(*second.Redirect, "/dashboard?login_error=")
+}
+
+// Test_Verify_Error_CrossOrigin_RedirectsToInitiator checks that a failed verify
+// for a cross-origin flow lands the login_error on the initiating origin (carried
+// in the token) rather than this host.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_Error_CrossOrigin_RedirectsToInitiator() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=err@example.com", http.MethodPost, "https://app.example.com")
+	_, err = hosting.WithSKAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	path := fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)
+
+	first, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, first.Status)
+
+	// Replaying the consumed token: the error redirect must target the initiating
+	// origin, not the verify host.
+	second, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	s.NoError(err)
+	s.Equal(http.StatusFound, second.Status)
+	s.Require().NotNil(second.Redirect)
+	s.Contains(*second.Redirect, "https://app.example.com/dashboard?login_error=")
 }
 
 func (s *WithSKAuthMagicLinkSuite) Test_Request_NoOriginCheck_WhenAllowListEmpty() {

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -173,7 +173,10 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_InvalidState() {
 	s.Equal(http.StatusBadRequest, res.Status)
 }
 
-func (s *WithSKAuthOAuthSuite) Test_Callback_ProviderDisabled_NotFound() {
+// Test_Callback_ProviderDisabled_RedirectsWithError checks that a disabled
+// provider bounces the user back to the initiating origin with a friendly
+// login_error message instead of rendering a Stormkit error page.
+func (s *WithSKAuthOAuthSuite) Test_Callback_ProviderDisabled_RedirectsWithError() {
 	host := s.setupCallbackEnv(false)
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
@@ -185,5 +188,55 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ProviderDisabled_NotFound() {
 	))
 
 	s.Require().NoError(err)
-	s.Equal(http.StatusNotFound, res.Status)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Contains(*res.Redirect, "https://app.example.com/dashboard?login_error=")
+	s.Contains(*res.Redirect, "not+available")
+}
+
+// Test_Callback_ProviderDenied_RedirectsWithError checks that when the provider
+// round-trips an error param (e.g. the user denied consent), we bounce back with
+// a friendly message and never attempt the token exchange.
+func (s *WithSKAuthOAuthSuite) Test_Callback_ProviderDenied_RedirectsWithError() {
+	host := s.setupCallbackEnv(true)
+
+	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
+
+	res, err := hosting.WithSKAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&error=access_denied", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Contains(*res.Redirect, "https://app.example.com/dashboard?login_error=")
+	s.Contains(*res.Redirect, "cancelled")
+}
+
+// Test_Callback_ExchangeFails_RedirectsWithError checks that a failed token
+// exchange redirects the user back with a friendly message rather than a 500.
+func (s *WithSKAuthOAuthSuite) Test_Callback_ExchangeFails_RedirectsWithError() {
+	host := s.setupCallbackEnv(true)
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).
+		Return((*oauth2.Token)(nil), fmt.Errorf("invalid_grant")).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
+
+	res, err := hosting.WithSKAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=bad-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Contains(*res.Redirect, "https://app.example.com/dashboard?login_error=")
+	s.Contains(*res.Redirect, "complete+sign-in")
 }

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -160,7 +160,12 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 	}
 
 	if userID == 0 {
-		return shttp.BadRequest(map[string]any{"errors": []string{"invalid or expired magic link token"}})
+		// We parsed the token, so we know the initiating origin — pass it through
+		// so the error redirect lands on the right app rather than this host.
+		return shttp.BadRequest(map[string]any{
+			"errors":   []string{"invalid or expired magic link token"},
+			"redirect": redirectOrigin,
+		})
 	}
 
 	authUser, err := store.AuthUser(req.Context(), userID)

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -130,7 +130,7 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	// instead of an authorization code. Bounce back without attempting an
 	// exchange that would fail anyway.
 	if req.FormValue("error") != "" {
-		return m.oauthError(referOrigin, "Sign-in was cancelled."), nil
+		return m.loginErrorRedirect(referOrigin, "Sign-in was cancelled."), nil
 	}
 
 	envID := m.req.Host.Config.EnvID
@@ -139,53 +139,53 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to get environment %d: %s", envID, err.Error())
-		return m.oauthError(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
 	if env == nil || env.SchemaConf == nil || env.AuthConf == nil || !env.AuthConf.Status {
-		return m.oauthError(referOrigin, "Sign-in is not available right now."), nil
+		return m.loginErrorRedirect(referOrigin, "Sign-in is not available right now."), nil
 	}
 
 	prv, err := skauth.NewStore().Provider(req.Context(), env.ID, provider)
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to get provider %s for env %d: %s", provider, env.ID, err.Error())
-		return m.oauthError(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
 	if prv == nil || !prv.Status {
-		return m.oauthError(referOrigin, "This sign-in method is not available."), nil
+		return m.loginErrorRedirect(referOrigin, "This sign-in method is not available."), nil
 	}
 
 	client := prv.Client(m.callbackURL())
 
 	if client == nil {
-		return m.oauthError(referOrigin, "This sign-in method is not available."), nil
+		return m.loginErrorRedirect(referOrigin, "This sign-in method is not available."), nil
 	}
 
 	token, err := client.Exchange(req.Context(), req)
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to exchange authorization code: %s", err.Error())
-		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to get schema store: %s", err.Error())
-		return m.oauthError(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
 	info, err := client.UserInfo(req.Context(), token)
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to get user info: %s", err.Error())
-		return m.oauthError(referOrigin, "We couldn't read your account details. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "We couldn't read your account details. Please try again."), nil
 	}
 
 	if info == nil {
-		return m.oauthError(referOrigin, "We couldn't read your account details. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "We couldn't read your account details. Please try again."), nil
 	}
 
 	oauth := skauth.OAuth{
@@ -206,7 +206,7 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	if err := store.UpsertAuthUser(req.Context(), &oauth, &usr); err != nil {
 		slog.Errorf("oauth callback: failed to upsert auth user: %s", err.Error())
-		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
@@ -218,7 +218,7 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to generate session token: %s", err.Error())
-		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	// Stash the token under a one-time code and send the browser to the landing
@@ -229,29 +229,13 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to save session code: %s", err.Error())
-		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
+		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	return &shttp.Response{
 		Status:   http.StatusFound,
 		Redirect: &target,
 	}, nil
-}
-
-// oauthError sends the user back to the initiating origin's redirect page with a
-// user-friendly message in the login_error query param, instead of rendering a
-// Stormkit error page. Pair it with a slog.Error log for the underlying cause.
-func (m *skAuthMiddleware) oauthError(referOrigin, message string) *shttp.Response {
-	target := fmt.Sprintf("%s%s?login_error=%s",
-		referOrigin,
-		m.req.Host.Config.SKAuth.SuccessURL,
-		url.QueryEscape(message),
-	)
-
-	return &shttp.Response{
-		Status:   http.StatusFound,
-		Redirect: &target,
-	}
 }
 
 // resolveRedirect determines and validates the post-login redirect origin.

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
@@ -114,54 +115,77 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return shttp.BadRequest(map[string]any{"errors": []string{"invalid state parameter"}}), nil
 	}
 
+	// Resolve the initiating origin up-front so any failure below can bounce the
+	// user back to the app with a friendly message instead of rendering a
+	// Stormkit error page.
+	parsed, err := url.ParseRequestURI(refer)
+
+	if err != nil {
+		return shttp.BadRequest(map[string]any{"errors": []string{"referrer URL is not a valid format"}}), nil
+	}
+
+	referOrigin := utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
+
+	// The provider round-trips an `error` param (e.g. the user denied access)
+	// instead of an authorization code. Bounce back without attempting an
+	// exchange that would fail anyway.
+	if req.FormValue("error") != "" {
+		return m.oauthError(referOrigin, "Sign-in was cancelled."), nil
+	}
+
 	envID := m.req.Host.Config.EnvID
 
 	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), envID)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to get environment by ID %d", envID)), nil
+		slog.Errorf("oauth callback: failed to get environment %d: %s", envID, err.Error())
+		return m.oauthError(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
 	if env == nil || env.SchemaConf == nil || env.AuthConf == nil || !env.AuthConf.Status {
-		return shttp.NotFound(), nil
+		return m.oauthError(referOrigin, "Sign-in is not available right now."), nil
 	}
 
 	prv, err := skauth.NewStore().Provider(req.Context(), env.ID, provider)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to get provider %s for env %d", provider, env.ID)), nil
+		slog.Errorf("oauth callback: failed to get provider %s for env %d: %s", provider, env.ID, err.Error())
+		return m.oauthError(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
 	if prv == nil || !prv.Status {
-		return shttp.NotFound(), nil
+		return m.oauthError(referOrigin, "This sign-in method is not available."), nil
 	}
 
 	client := prv.Client(m.callbackURL())
 
 	if client == nil {
-		return shttp.BadRequest(map[string]any{"errors": []string{"provider is not an OAuth2 provider"}}), nil
+		return m.oauthError(referOrigin, "This sign-in method is not available."), nil
 	}
 
 	token, err := client.Exchange(req.Context(), req)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to exchange authorization code: %s", err.Error())), nil
+		slog.Errorf("oauth callback: failed to exchange authorization code: %s", err.Error())
+		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to get schema store: %s", err.Error())), nil
+		slog.Errorf("oauth callback: failed to get schema store: %s", err.Error())
+		return m.oauthError(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
 	info, err := client.UserInfo(req.Context(), token)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to get user info: %s", err.Error())), nil
+		slog.Errorf("oauth callback: failed to get user info: %s", err.Error())
+		return m.oauthError(referOrigin, "We couldn't read your account details. Please try again."), nil
 	}
 
 	if info == nil {
-		return shttp.NotFound(), nil
+		return m.oauthError(referOrigin, "We couldn't read your account details. Please try again."), nil
 	}
 
 	oauth := skauth.OAuth{
@@ -181,7 +205,8 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	}
 
 	if err := store.UpsertAuthUser(req.Context(), &oauth, &usr); err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to upsert auth user: %s", err.Error())), nil
+		slog.Errorf("oauth callback: failed to upsert auth user: %s", err.Error())
+		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	sessionToken, err := user.JWT(jwt.MapClaims{
@@ -192,16 +217,9 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	}, env.AuthConf.Secret)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error())), nil
+		slog.Errorf("oauth callback: failed to generate session token: %s", err.Error())
+		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
-
-	parsed, err := url.ParseRequestURI(refer)
-
-	if err != nil {
-		return shttp.BadRequest(map[string]any{"errors": []string{"referrer URL is not a valid format"}}), nil
-	}
-
-	referOrigin := utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
 
 	// Stash the token under a one-time code and send the browser to the landing
 	// page on the initiating origin, which injects it into localStorage there
@@ -210,13 +228,30 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	target, err := stashSessionToken(req.Context(), referOrigin, m.req.Host.Config.SKAuth.SuccessURL, sessionToken)
 
 	if err != nil {
-		return shttp.Error(err, fmt.Sprintf("failed saving session code: %s", err.Error())), nil
+		slog.Errorf("oauth callback: failed to save session code: %s", err.Error())
+		return m.oauthError(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
 	return &shttp.Response{
 		Status:   http.StatusFound,
 		Redirect: &target,
 	}, nil
+}
+
+// oauthError sends the user back to the initiating origin's redirect page with a
+// user-friendly message in the login_error query param, instead of rendering a
+// Stormkit error page. Pair it with a slog.Error log for the underlying cause.
+func (m *skAuthMiddleware) oauthError(referOrigin, message string) *shttp.Response {
+	target := fmt.Sprintf("%s%s?login_error=%s",
+		referOrigin,
+		m.req.Host.Config.SKAuth.SuccessURL,
+		url.QueryEscape(message),
+	)
+
+	return &shttp.Response{
+		Status:   http.StatusFound,
+		Redirect: &target,
+	}
 }
 
 // resolveRedirect determines and validates the post-login redirect origin.


### PR DESCRIPTION
## Problem

When sign-in failed, the OAuth callback rendered a Stormkit error page (the "blue page") and magic-link verification rendered a Stormkit verify page — both jarring for end users who started from a customer app.

## Fix

On a user-facing failure, bounce the user back to the app's redirect page (`<origin> + SuccessURL`) with a friendly message in a `login_error` query param, so the app can surface it. Same landing page as success, so the page reads either the `skauth` token (success) or `login_error` (failure).

```
https://app.example.com/dashboard?login_error=We%20couldn%27t%20complete%20sign-in.%20Please%20try%20again.
```

**OAuth** (`handleOAuthCallback`): resolve the initiating origin up-front; every failure after that redirects with `login_error`. Also handles the provider round-tripping an `error` param (user denied consent) without a doomed token exchange → "Sign-in was cancelled."

**Magic link** (`handleMagicLinkVerify`): token-level failures (missing / invalid / expired / consumed) redirect with `login_error`. The redirect origin is the validated origin carried in the token when available (cross-origin), otherwise this host's own origin — which for magic links is the domain the email link was issued from, so there's no need to recover the origin from an expired token. Config (404) / internal (5xx) responses keep their page.

Both paths share a `loginErrorRedirect` helper. The underlying cause is still logged server-side (OAuth via `slog.Errorf`; magic link via the existing `shttp.Error` at construction). Failures before the origin is known (invalid OAuth state, unparseable referrer) still return a normal error response — nowhere safe to redirect.

## Tests
- OAuth: provider-disabled, provider-denied (`error` param), and exchange-failure all assert the `login_error` redirect.
- Magic link: invalid-token, consumed-token, and a cross-origin error redirect (lands on the initiating origin).
- Full `./src/ce/hosting/...` suite passes (`go test -p 1`).