### PR TITLE
fix: use x.com for x oauth authorize url

### DIFF
--- a/src/ce/api/app/skauth/client_x.go
+++ b/src/ce/api/app/skauth/client_x.go
@@ -12,7 +12,7 @@ import (
 )
 
 var TwitterAPIBase = "https://api.twitter.com/2"
-var TwitterAuthBase = "https://twitter.com/i/oauth2/authorize"
+var TwitterAuthBase = "https://x.com/i/oauth2/authorize"
 
 // Step 1: https://developer.x.com/en/portal/dashboard
 // Step 2: Create a new project and app with Elevated access (required for email)

--- a/src/ce/api/app/skauth/client_x_test.go
+++ b/src/ce/api/app/skauth/client_x_test.go
@@ -119,7 +119,7 @@ func (s *ClientXSuite) Test_AuthCodeURL() {
 
 	s.NoError(err)
 	s.NotEmpty(url)
-	s.Contains(url, "twitter.com/i/oauth2/authorize")
+	s.Contains(url, "x.com/i/oauth2/authorize")
 	s.Contains(url, "client_id=test-client-id")
 	s.Contains(url, "state=")
 	s.Contains(url, "code_challenge_method=S256")


### PR DESCRIPTION
## Summary

The X (Twitter) OAuth authorization endpoint was pointed at `https://twitter.com/i/oauth2/authorize`, which no longer works. Redirect users to `https://x.com/i/oauth2/authorize` instead.

Only the user-facing authorization URL is changed; the API base (`api.twitter.com/2`, used for the token exchange and user lookup) is left as-is.

## Testing

- `go test -p 1 ./src/ce/api/app/skauth/ -run TestClientXSuite` (updated the `AuthCodeURL` assertion to expect `x.com`).