### PR TITLE
feat: mask env var values behind admin reveal

### DIFF
--- a/docs/api/3-environments.md
+++ b/docs/api/3-environments.md
@@ -9,6 +9,8 @@ description: API Documentation for managing environments through Stormkit API.
 
 The Environments API lets you create, update, and delete environments, and pull environment variable values programmatically.
 
+> **Environment variable values are masked.** For security, variable _values_ are blanked out (returned as empty strings) in every response that lists or describes an environment — `GET /v1/envs`, the deployment endpoints, and the MCP tools. They are also masked in **build logs** (the variable names are listed, but the values are replaced with `***************`). The only exception is a fixed set of Stormkit [system variables](/docs/deployments/system-variables) — `SK_APP_ID`, `SK_BRANCH_NAME`, `SK_COMMIT_SHA`, `SK_DEPLOYMENT_ID`, `SK_DEPLOYMENT_URL`, `SK_ENV`, `SK_ENV_ID`, and `SK_ENV_URL` — which are not secrets and keep their values in build logs. (A user-defined variable that happens to start with `SK_` is still masked.) To read the actual values, use the dedicated [`GET /v1/env/pull`](#get-v1envpull) endpoint described below.
+
 ---
 
 ## GET /v1/envs
@@ -30,6 +32,8 @@ Returns all environments configured for an application. At most 50 environments 
 | Field          | Type  | Description                   |
 | -------------- | ----- | ----------------------------- |
 | `environments` | array | Array of environment objects. |
+
+> Each environment object includes its build configuration, but environment variable **values are masked** — `build.vars` is returned with empty strings for every value. Use [`GET /v1/env/pull`](#get-v1envpull) to retrieve the actual values.
 
 ### Error responses
 
@@ -250,11 +254,16 @@ curl -X DELETE \
 
 ## GET /v1/env/pull
 
-Returns all environment variables for the specified environment. The response is a flat JSON object where each key is a variable name and each value is the variable's value.
+Returns all environment variables for the specified environment, **including their plaintext values**. This is the only endpoint that reveals variable values — every other endpoint masks them. The response is a flat JSON object where each key is a variable name and each value is the variable's value.
 
 **Base URL:** `https://api.stormkit.io`
 
 **Authentication:** Environment-level API key passed as the `Authorization` header. To generate one: **Your App** → **Your Environment** → **Config** → **Other** → **API Keys**. When using an app or higher-level key, `envId` must be provided as a query parameter.
+
+> **Access & auditing**
+>
+> - Any **member** of the environment's team may reveal the values — whether through an **API key** or as a **dashboard (session) user**, regardless of role. (Editing variables requires revealing them first, so this keeps env-var management available to all members.)
+> - On **Enterprise** licenses, every reveal is written to the **activity feed**, attributed to the user (dashboard) or to the API key's token name (API key).
 
 ### Query parameters
 
@@ -295,3 +304,7 @@ curl -X GET \
      -H 'Authorization: <api_key>' \
      'https://api.stormkit.io/v1/env/pull?envId=305'
 ```
+
+### MCP limitation
+
+The Stormkit MCP server intentionally has **no tool to reveal environment variable values**. MCP tools such as `list_environments`, `get_deployment`, and `list_deployments` return variable names with masked (empty) values, so an AI assistant connected over MCP never has access to your secrets. To read the actual values, call this `GET /v1/env/pull` endpoint directly with an API key.

--- a/src/ce/api/app/buildconf/buildconfhandlers/handler_env_get_test.go
+++ b/src/ce/api/app/buildconf/buildconfhandlers/handler_env_get_test.go
@@ -61,15 +61,13 @@ func (s *HandlerEnvGetSuite) Test_Success() {
 			  "buildCmd":"npm run build",
 			  "previewLinks": null,
 			  "vars":{
-				 "NODE_ENV":"production"
+				 "NODE_ENV":""
 			  }
 		   },
 		   "autoPublish":true,
 		   "id":"1",
 		   "appId":"1",
 		   "autoDeploy": false,
-		   "autoDeployBranches": null,
-		   "autoDeployCommits": null,
 		   "authConf": null,
 		   "domain":{
 			  "verified": false

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -156,11 +156,27 @@ type DomainInfo struct {
 	EnvName string
 }
 
-// EnvJSON is a wrapper around myapp to avoid recursion.
-type EnvJSON Env
+// MaskVars returns a copy of vars with every VALUE blanked (keys kept). It is
+// the single masking rule for env-var values — used when serializing an Env and
+// a deployment's config snapshot — so values are never exposed in plaintext
+// outside the dedicated, access-controlled pull endpoint.
+func MaskVars(vars map[string]string) map[string]string {
+	masked := make(map[string]string, len(vars))
 
-// MarshalJSON implements the marshaler interface.
-func (env Env) MarshalJSON() ([]byte, error) {
+	for key := range vars {
+		masked[key] = ""
+	}
+
+	return masked
+}
+
+// JSON returns the env as a client-ready map (App.JSON() style) with secret
+// env-var values masked. The map is built explicitly — every exposed field is
+// listed here rather than derived from struct tags via a marshal/unmarshal
+// round-trip. MarshalJSON delegates to this, so an Env can never be serialized
+// to a client with plaintext values by accident. Internal consumers that need
+// real values read Env.Data.Vars directly and never go through here.
+func (env Env) JSON() map[string]any {
 	type domain struct {
 		Name     string `json:"name,omitempty"`
 		Verified bool   `json:"verified"`
@@ -173,31 +189,76 @@ func (env Env) MarshalJSON() ([]byte, error) {
 		ExitCode     *int64     `json:"exit,omitempty"`
 	}
 
-	var ld *lastDeploy
+	// Mask on a copy so the original Env keeps the real values for internal use.
+	build := env.Data
+
+	if env.Data != nil && len(env.Data.Vars) > 0 {
+		conf := *env.Data
+		conf.Vars = MaskVars(env.Data.Vars)
+		build = &conf
+	}
+
+	// env is deprecated; mirror Name when it is empty.
+	envName := env.Env
+
+	if envName == "" {
+		envName = env.Name
+	}
+
+	m := map[string]any{
+		"name":        env.Name,
+		"env":         envName,
+		"branch":      env.Branch,
+		"build":       build,
+		"authConf":    env.AuthConf,
+		"autoPublish": env.AutoPublish,
+		"autoDeploy":  env.AutoDeploy,
+		"domain":      domain{},
+	}
+
+	if env.AutoDeployBranches.ValueOrZero() != "" {
+		m["autoDeployBranches"] = env.AutoDeployBranches
+	}
+
+	if env.AutoDeployCommits.ValueOrZero() != "" {
+		m["autoDeployCommits"] = env.AutoDeployCommits
+	}
+
+	if env.ID != 0 {
+		m["id"] = env.ID.String()
+	}
+
+	if env.AppID != 0 {
+		m["appId"] = env.AppID.String()
+	}
+
+	if env.MailerConf != nil {
+		m["mailer"] = env.MailerConf
+	}
+
+	if len(env.Published) > 0 {
+		m["published"] = env.Published
+	}
+
+	if env.Preview != "" {
+		m["preview"] = env.Preview
+	}
 
 	if env.LastDeployID.ValueOrZero() != 0 {
-		ld = &lastDeploy{
+		m["lastDeploy"] = lastDeploy{
 			DeploymentID: types.ID(env.LastDeployID.ValueOrZero()),
 			CreatedAt:    env.DeployedAt,
 			ExitCode:     env.LastDeployExitCode.Ptr(),
 		}
 	}
 
-	// TODO: Remove this snippet when we remove the Env field.
-	if env.Env == "" && env.Name != "" {
-		env.Env = env.Name
-	}
+	return m
+}
 
-	ret := struct {
-		EnvJSON
-		LastDeploy *lastDeploy `json:"lastDeploy,omitempty"`
-		Domain     domain      `json:"domain"`
-	}{
-		EnvJSON:    EnvJSON(env),
-		LastDeploy: ld,
-	}
-
-	return json.Marshal(ret)
+// MarshalJSON implements json.Marshaler by delegating to JSON, so masking is
+// the fail-safe default everywhere an Env is serialized.
+func (env Env) MarshalJSON() ([]byte, error) {
+	return json.Marshal(env.JSON())
 }
 
 type StatusCheck struct {

--- a/src/ce/api/app/buildconf/env_model_test.go
+++ b/src/ce/api/app/buildconf/env_model_test.go
@@ -56,6 +56,28 @@ func (s *EnvModelSuite) Test_Config_Validation() {
 	}, buildconf.Validate(config))
 }
 
+func (s *EnvModelSuite) Test_JSON_MasksEnvVars() {
+	env := buildconf.Env{
+		Name:   "production",
+		Branch: "main",
+		Data: &buildconf.BuildConf{
+			Vars: map[string]string{
+				"SECRET":    "shh",
+				"SK_SECRET": "also-shh",
+			},
+		},
+	}
+
+	build := env.JSON()["build"].(*buildconf.BuildConf)
+
+	// Every value is masked (keys kept), including names that start with SK_.
+	s.Equal("", build.Vars["SECRET"])
+	s.Equal("", build.Vars["SK_SECRET"])
+
+	// The original Env keeps the real values for internal use.
+	s.Equal("shh", env.Data.Vars["SECRET"])
+}
+
 func TestEnvModelSuite(t *testing.T) {
 	suite.Run(t, &EnvModelSuite{})
 }

--- a/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
@@ -77,7 +77,7 @@ func (s *HandlerMyDeploymentsSuite) responseTemplate() (*template.Template, erro
 								"description": ""
 							}],
 							"vars": {
-								"NODE_ENV": "production"
+								"NODE_ENV": ""
 							}
 						}
 					},

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -287,6 +287,23 @@ func (d *Deployment) Snapshot() map[string]any {
 
 	d.configCopyCached = map[string]any{}
 	_ = json.Unmarshal(d.ConfigCopy, &d.configCopyCached)
+
+	// The snapshot is a frozen copy of the deployed config; mask its env-var
+	// values so the deployment endpoints don't expose secrets in plaintext.
+	if build, ok := d.configCopyCached["build"].(map[string]any); ok {
+		if rawVars, ok := build["vars"].(map[string]any); ok {
+			vars := make(map[string]string, len(rawVars))
+
+			for key, value := range rawVars {
+				if s, ok := value.(string); ok {
+					vars[key] = s
+				}
+			}
+
+			build["vars"] = buildconf.MaskVars(vars)
+		}
+	}
+
 	return d.configCopyCached
 }
 

--- a/src/ce/api/public/v1/handler_env_list_test.go
+++ b/src/ce/api/public/v1/handler_env_list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -114,6 +115,44 @@ func (s *HandlerEnvListSuite) Test_Forbidden_UserNotMember() {
 	// The app can be resolved from the appId query parameter; this is forbidden
 	// because the user-scoped key belongs to a user who is not a member of the app's team.
 	s.Equal(http.StatusForbidden, response.Code)
+}
+
+// Test_MasksEnvVarValues verifies that /v1/envs — the endpoint the dashboard
+// loads environments from — masks user env-var values (keys kept) while leaving
+// SK_ framework vars intact.
+func (s *HandlerEnvListSuite) Test_MasksEnvVarValues() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	s.MockEnv(appl, map[string]any{
+		"Name": "production",
+		"Data": &buildconf.BuildConf{
+			Vars: map[string]string{
+				"SECRET":    "shh",
+				"SK_SECRET": "also-shh",
+			},
+		},
+	})
+	key := s.MockAPIKey(appl, nil)
+
+	response := s.get(key.Value)
+	s.Equal(http.StatusOK, response.Code)
+
+	raw := response.String()
+
+	// No secret value may appear in the response — not even one named SK_*.
+	s.NotContains(raw, "shh")
+
+	var body map[string]any
+	s.Require().NoError(json.Unmarshal([]byte(raw), &body))
+
+	envs := body["environments"].([]any)
+	s.Require().Len(envs, 1)
+
+	build := envs[0].(map[string]any)["build"].(map[string]any)
+	vars := build["vars"].(map[string]any)
+
+	s.Equal("", vars["SECRET"], "user var value must be masked")
+	s.Equal("", vars["SK_SECRET"], "SK_-prefixed var value must be masked too")
 }
 
 func TestHandlerEnvList(t *testing.T) {

--- a/src/ce/api/public/v1/handler_env_pull.go
+++ b/src/ce/api/public/v1/handler_env_pull.go
@@ -3,10 +3,32 @@ package publicapiv1
 import (
 	"net/http"
 
+	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
 
+// handlerEnvPull returns the environment's variable values in plaintext. Values
+// are masked in every other response, so this is the dedicated reveal endpoint.
+//
+// Any team member with access to the environment may reveal the values — this
+// matches what they can already do through an API key, and (unlike the masked
+// list) editing env vars requires revealing first. Membership is enforced by the
+// route's scope middleware before this handler runs.
+//
+// Revealing plaintext secrets is audited: the audit attributes the caller to the
+// team member (JWT) or the API key's token name (SK_ key).
 func handlerEnvPull(req *RequestContext) *shttp.Response {
+	if req.License().IsEnterprise() {
+		err := audit.FromRequestContext(req).
+			WithAction(audit.RevealAction, audit.TypeEnv).
+			WithEnvID(req.Env.ID).
+			Insert()
+
+		if err != nil {
+			return shttp.Error(err)
+		}
+	}
+
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Data:   req.Env.Data.Vars,

--- a/src/ce/api/public/v1/handler_env_pull_test.go
+++ b/src/ce/api/public/v1/handler_env_pull_test.go
@@ -1,12 +1,18 @@
 package publicapiv1_test
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/team"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
@@ -61,6 +67,105 @@ func (s *HandlerEnvPullSuite) TestSuccess() {
 
 	s.Equal(http.StatusOK, response.Code)
 	s.JSONEq(response.String(), string(jsonVal))
+}
+
+// Revealing the values through an API key is audited too, attributed to the
+// key's token name rather than a user.
+func (s *HandlerEnvPullSuite) TestAPIKeyRevealIsAudited() {
+	admin.SetMockLicense()
+	defer admin.ResetMockLicense()
+
+	env := s.MockEnv(nil, map[string]any{
+		"Data": &buildconf.BuildConf{Vars: map[string]string{"SECRET": "shh"}},
+	})
+
+	key := s.MockAPIKey(nil, env)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/v1/env/pull",
+		nil,
+		map[string]string{"Authorization": key.Value},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	audits, err := audit.NewStore().SelectAudits(context.Background(), audit.AuditFilters{
+		EnvID: env.ID,
+	})
+	s.NoError(err)
+	s.Len(audits, 1)
+	s.Equal("REVEAL:ENV", audits[0].Action)
+	s.NotEmpty(audits[0].TokenName)
+}
+
+// A dashboard (JWT) caller who is a team admin/owner can reveal the values,
+// and the reveal is audited.
+func (s *HandlerEnvPullSuite) TestJWTOwnerReveals() {
+	admin.SetMockLicense()
+	defer admin.ResetMockLicense()
+
+	vars := map[string]string{"SECRET": "shh"}
+
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, map[string]any{
+		"Data": &buildconf.BuildConf{Vars: vars},
+	})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/env/pull?envId=%s", env.ID.String()),
+		nil,
+		map[string]string{"Authorization": usertest.Authorization(usr.ID)},
+	)
+
+	jsonVal, _ := json.Marshal(vars)
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(string(jsonVal), response.String())
+
+	audits, err := audit.NewStore().SelectAudits(context.Background(), audit.AuditFilters{
+		EnvID: env.ID,
+	})
+	s.NoError(err)
+	s.Len(audits, 1)
+	s.Equal("REVEAL:ENV", audits[0].Action)
+}
+
+// A developer (JWT) who is a member of the environment's team can reveal the
+// values too — reveal requires team membership (enforced by the scope
+// middleware), not an admin/owner role, so it stays consistent with API keys
+// and lets developers edit env vars (which requires revealing first).
+func (s *HandlerEnvPullSuite) TestJWTDeveloperReveals() {
+	vars := map[string]string{"SECRET": "shh"}
+
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, map[string]any{
+		"Data": &buildconf.BuildConf{Vars: vars},
+	})
+
+	dev := s.MockUser()
+	s.NoError(team.NewStore().AddMemberToTeam(context.Background(), &team.Member{
+		TeamID: usr.DefaultTeamID,
+		UserID: dev.ID,
+		Role:   team.ROLE_DEVELOPER,
+		Status: true,
+	}))
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/env/pull?envId=%s", env.ID.String()),
+		nil,
+		map[string]string{"Authorization": usertest.Authorization(dev.ID)},
+	)
+
+	jsonVal, _ := json.Marshal(vars)
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(string(jsonVal), response.String())
 }
 
 func TestHandlerEnvPull(t *testing.T) {

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -186,6 +186,16 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 	}
 
 	if req.License().IsEnterprise() {
+		// Mask env-var values in the audit diff (keys kept) so plaintext secrets
+		// are never persisted to, or exposed through, the audit log — the same
+		// rule applied everywhere an Env is serialized. Mask on copies so the
+		// real Vars stay intact for the downstream function-config update.
+		oldMasked := oldData
+		oldMasked.Vars = buildconf.MaskVars(oldData.Vars)
+
+		newMasked := *env.Data
+		newMasked.Vars = buildconf.MaskVars(env.Data.Vars)
+
 		diff := &audit.Diff{
 			Old: audit.DiffFields{
 				EnvName:               old.Name,
@@ -194,7 +204,7 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 				EnvAutoDeploy:         audit.Bool(old.AutoDeploy),
 				EnvAutoDeployBranches: old.AutoDeployBranches.ValueOrZero(),
 				EnvAutoDeployCommits:  old.AutoDeployCommits.ValueOrZero(),
-				EnvBuildConfig:        &oldData,
+				EnvBuildConfig:        &oldMasked,
 			},
 			New: audit.DiffFields{
 				EnvName:               env.Name,
@@ -203,7 +213,7 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 				EnvAutoDeploy:         audit.Bool(env.AutoDeploy),
 				EnvAutoDeployBranches: env.AutoDeployBranches.ValueOrZero(),
 				EnvAutoDeployCommits:  env.AutoDeployCommits.ValueOrZero(),
-				EnvBuildConfig:        env.Data,
+				EnvBuildConfig:        &newMasked,
 			},
 		}
 

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -464,6 +464,58 @@ func (s *HandlerMCPSuite) Test_ListEnvironments_Forbidden_NotMember() {
 	s.True(result["isError"].(bool))
 }
 
+func (s *HandlerMCPSuite) Test_ListEnvironments_MasksEnvVarValues() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	key := s.userKey(usr)
+
+	// Seed an environment with a user secret and an SK_ framework variable.
+	createResp := s.post(key.Value, mcpToolCall(1, "create_environment", map[string]any{
+		"appId":  appl.ID.String(),
+		"name":   "staging",
+		"branch": "main",
+		"envVars": map[string]any{
+			"SECRET_TOKEN": "super-secret-value",
+			"SK_SECRET":    "also-secret",
+		},
+	}))
+	s.rpcOK(createResp)
+
+	resp := s.post(key.Value, mcpToolCall(2, "list_environments", map[string]any{
+		"appId": appl.ID.String(),
+	}))
+
+	env := s.rpcOK(resp)
+	data := s.toolContent(env)
+	envs := data["environments"].([]any)
+	s.Require().NotEmpty(envs)
+
+	// The raw value must not appear anywhere in the serialized tool output.
+	raw, _ := json.Marshal(data)
+	s.NotContains(string(raw), "super-secret-value")
+
+	var found bool
+
+	for _, e := range envs {
+		build, _ := e.(map[string]any)["build"].(map[string]any)
+
+		if build == nil {
+			continue
+		}
+
+		vars, _ := build["vars"].(map[string]any)
+
+		if v, ok := vars["SECRET_TOKEN"]; ok {
+			found = true
+			// Every value masked (keys kept), including SK_-prefixed names.
+			s.Equal("", v, "env var value must be masked in MCP output")
+			s.Equal("", vars["SK_SECRET"], "SK_-prefixed var value must be masked")
+		}
+	}
+
+	s.True(found, "expected the seeded SECRET_TOKEN key to be present (masked)")
+}
+
 func (s *HandlerMCPSuite) Test_ListEnvironments_MissingAppId() {
 	usr := s.MockUser()
 	key := s.userKey(usr)

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -576,6 +576,8 @@ func mcpListEnvironments(req *RequestContextMCP, args map[string]any) *shttp.Res
 		return resp
 	}
 
+	// Env var values are masked by Env.JSON/MarshalJSON, so the list response
+	// already hides them — no MCP-specific masking needed.
 	return handlerEnvList(req.RequestContext)
 }
 

--- a/src/ce/runner/print_env_test.go
+++ b/src/ce/runner/print_env_test.go
@@ -1,0 +1,57 @@
+package runner
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PrintEnvVariablesSuite struct {
+	suite.Suite
+}
+
+func (s *PrintEnvVariablesSuite) Test_MasksAllValues() {
+	reporter := NewReporter("")
+
+	opts := RunnerOpts{
+		Reporter: reporter,
+		Build: BuildOpts{
+			EnvVars: map[string]string{
+				"NODE_ENV":     "production",
+				"DATABASE_URL": "postgres://user:pass@host/db",
+				"API_TOKEN":    "super-secret-token",
+				"SK_ENV":       "production",
+				"SK_APP_ID":    "8",
+				// A user-defined SK_-prefixed variable must still be masked.
+				"SK_MY_SECRET": "do-not-leak",
+			},
+		},
+	}
+
+	s.NoError(printEnvVariables(opts))
+
+	out, err := io.ReadAll(reporter.File())
+	s.NoError(err)
+
+	log := string(out)
+
+	// User-defined variable names are still listed so the build log stays
+	// useful, but their values are masked.
+	s.Contains(log, "NODE_ENV=***************")
+	s.Contains(log, "DATABASE_URL=***************")
+	s.Contains(log, "API_TOKEN=***************")
+	s.NotContains(log, "postgres://user:pass@host/db")
+	s.NotContains(log, "super-secret-token")
+
+	// Only the allowlisted Stormkit system variables keep their values; a
+	// user-defined SK_-prefixed variable is masked like any other secret.
+	s.Contains(log, "SK_ENV=production")
+	s.Contains(log, "SK_APP_ID=8")
+	s.Contains(log, "SK_MY_SECRET=***************")
+	s.NotContains(log, "do-not-leak")
+}
+
+func TestPrintEnvVariablesSuite(t *testing.T) {
+	suite.Run(t, new(PrintEnvVariablesSuite))
+}

--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -89,16 +88,35 @@ func PrepareEnvVars(envVars map[string]string) []string {
 	return result
 }
 
+// unmaskedEnvVars is the explicit allowlist of Stormkit system variables that
+// keep their values in the build log. These are injected by Stormkit and are
+// not secrets, so they are safe to show and useful for debugging. We use an
+// explicit set rather than the SK_ prefix so a user-defined SK_-prefixed
+// variable is still masked.
+var unmaskedEnvVars = map[string]bool{
+	"SK_APP_ID":         true,
+	"SK_BRANCH_NAME":    true,
+	"SK_COMMIT_SHA":     true,
+	"SK_DEPLOYMENT_ID":  true,
+	"SK_DEPLOYMENT_URL": true,
+	"SK_ENV":            true,
+	"SK_ENV_ID":         true,
+	"SK_ENV_URL":        true,
+	"STORMKIT":          true,
+}
+
 func printEnvVariables(opts RunnerOpts) error {
 	vars := []string{}
 
-	obfuscate := regexp.MustCompile("(?i)secret|_key|_token|password|database_url|mailer_url")
-
+	// Values are masked in the build log: we list the variable names so the log
+	// still shows what is configured, but never the values — those are only
+	// retrievable through the audited reveal endpoint. The Stormkit system
+	// variables in unmaskedEnvVars are the only exception.
 	for k, v := range opts.Build.EnvVars {
-		if obfuscate.Match([]byte(k)) {
-			vars = append(vars, fmt.Sprintf("%s=***************", k))
-		} else {
+		if unmaskedEnvVars[k] {
 			vars = append(vars, fmt.Sprintf("%s=%s", k, v))
+		} else {
+			vars = append(vars, fmt.Sprintf("%s=***************", k))
 		}
 	}
 

--- a/src/ee/api/audit/audit_model.go
+++ b/src/ee/api/audit/audit_model.go
@@ -18,6 +18,7 @@ const (
 	CreateAction string = "CREATE"
 	UpdateAction string = "UPDATE"
 	DeleteAction string = "DELETE"
+	RevealAction string = "REVEAL"
 )
 
 const (

--- a/src/ui/src/components/FormV2/KeyValue.tsx
+++ b/src/ui/src/components/FormV2/KeyValue.tsx
@@ -24,6 +24,8 @@ interface Props {
   separator?: string;
   isSensitive?: boolean;
   modifyAsString?: boolean;
+  // When true, editing affordances (Add Row, Modify as a string) are disabled.
+  disabled?: boolean;
   onChange?: (kv: Record<string, string>) => void;
   onModalOpen?: () => void;
 }
@@ -52,6 +54,7 @@ export default function KeyValue({
   separator = "=",
   isSensitive = false,
   modifyAsString = true,
+  disabled = false,
   onChange,
   onModalOpen,
 }: Props) {
@@ -105,6 +108,7 @@ export default function KeyValue({
                 hideByDefault={Boolean(value && isSensitive)}
                 keyPlaceholder={keyPlaceholder}
                 valPlaceholder={valPlaceholder}
+                disabled={disabled}
                 setIsChanged={setIsChanged}
                 setRows={setRows}
               />
@@ -121,6 +125,7 @@ export default function KeyValue({
                 color="primary"
                 variant="outlined"
                 type="button"
+                disabled={disabled}
                 sx={{
                   display: "inline-flex",
                   textTransform: "none",
@@ -140,6 +145,7 @@ export default function KeyValue({
                   color="primary"
                   type="button"
                   variant="outlined"
+                  disabled={disabled}
                   sx={{ display: "inline-flex", textTransform: "none" }}
                   onClick={() => {
                     setIsModalOpen(true);

--- a/src/ui/src/components/FormV2/KeyValueRow.tsx
+++ b/src/ui/src/components/FormV2/KeyValueRow.tsx
@@ -19,6 +19,7 @@ interface KeyValueRowProps {
   valPlaceholder?: string;
   hideByDefault: boolean;
   isSensitive?: boolean;
+  disabled?: boolean;
   rows: string[][];
   setRows: (r: string[][]) => void;
   setIsChanged: (v: boolean) => void;
@@ -39,6 +40,7 @@ export default function KeyValueRow({
   hideByDefault,
   labelKey,
   labelValue,
+  disabled,
   setRows,
   setIsChanged,
 }: KeyValueRowProps) {
@@ -49,6 +51,7 @@ export default function KeyValueRow({
       <TableCell sx={{ borderBottom: "none", pl: 0, pb: 0, width: "50%" }}>
         <Input
           fullWidth
+          disabled={disabled}
           placeholder={index === 0 ? keyPlaceholder : `KEY_${index + 1}`}
           slotProps={{
             htmlInput: {
@@ -86,6 +89,7 @@ export default function KeyValueRow({
       <TableCell sx={{ borderBottom: "none", pr: 0, pb: 0 }}>
         <Input
           fullWidth
+          disabled={disabled}
           value={value}
           label={labelValue}
           autoComplete="off"
@@ -129,6 +133,7 @@ export default function KeyValueRow({
                 <IconButton
                   sx={{ width: 24, height: 24 }}
                   type="button"
+                  disabled={disabled}
                   aria-label={`Remove ${inputName} row number ${index + 1}`}
                   onClick={() => {
                     const copy = JSON.parse(JSON.stringify(rows));

--- a/src/ui/src/layouts/AppLayout/AppLayout.spec.tsx
+++ b/src/ui/src/layouts/AppLayout/AppLayout.spec.tsx
@@ -1,6 +1,7 @@
 import { RenderResult } from "@testing-library/react";
 import { describe, expect, beforeEach, it } from "vitest";
 import { AppContext } from "~/pages/apps/[id]/App.context";
+import { RootContext } from "~/pages/Root.context";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
 import { renderWithRouter } from "~/testing/helpers";
@@ -30,9 +31,19 @@ describe("~/layouts/AppLayout/Applayout.tsx", () => {
       path,
       initialEntries,
       el: () => (
-        <AppContext.Provider value={{ app, environments, setRefreshToken }}>
-          <AppLayout />
-        </AppContext.Provider>
+        <RootContext.Provider
+          value={{
+            mode: "dark",
+            setMode: () => {},
+            details: {
+              stormkit: { apiCommit: "", apiVersion: "", edition: "self-hosted" },
+            },
+          }}
+        >
+          <AppContext.Provider value={{ app, environments, setRefreshToken }}>
+            <AppLayout />
+          </AppContext.Provider>
+        </RootContext.Provider>
       ),
     });
   };
@@ -98,6 +109,7 @@ describe("~/layouts/AppLayout/Applayout.tsx", () => {
         `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/function-triggers`,
         `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/volumes`,
         `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/database`,
+        `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/auth`,
         `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/mailer`,
         `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/analytics`,
       ]);

--- a/src/ui/src/layouts/AppLayout/EnvMenu.spec.tsx
+++ b/src/ui/src/layouts/AppLayout/EnvMenu.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from "@testing-library/react";
 import { describe, expect, beforeEach, it } from "vitest";
 import { AppContext } from "~/pages/apps/[id]/App.context";
+import { RootContext } from "~/pages/Root.context";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
 import { renderWithRouter } from "~/testing/helpers";
@@ -15,9 +16,12 @@ declare const global: {
   NavigateMock: any;
 };
 
+type Edition = "development" | "self-hosted" | "cloud";
+
 interface WrapperProps {
   app?: App;
   environments?: Environment[];
+  edition?: Edition;
   setRefreshToken?: () => void;
 }
 
@@ -29,15 +33,24 @@ describe("~/layouts/AppLayout/EnvMenu.tsx", () => {
   const createWrapper = ({
     app = defaultApp,
     environments = defaultEnvs,
+    edition = "self-hosted",
     setRefreshToken = () => {},
   }: WrapperProps) => {
     wrapper = renderWithRouter({
       path: "/apps/:id/environments/:envId",
       initialEntries: [`/apps/${app.id}/environments/${environments[0].id}`],
       el: () => (
-        <AppContext.Provider value={{ app, environments, setRefreshToken }}>
-          <EnvMenu />
-        </AppContext.Provider>
+        <RootContext.Provider
+          value={{
+            mode: "dark",
+            setMode: () => {},
+            details: { stormkit: { apiCommit: "", apiVersion: "", edition } },
+          }}
+        >
+          <AppContext.Provider value={{ app, environments, setRefreshToken }}>
+            <EnvMenu />
+          </AppContext.Provider>
+        </RootContext.Provider>
       ),
     });
   };
@@ -78,8 +91,28 @@ describe("~/layouts/AppLayout/EnvMenu.tsx", () => {
       `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/function-triggers`,
       `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/volumes`,
       `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/database`,
+      `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/auth`,
       `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/mailer`,
       `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/analytics`,
     ]);
   });
+
+  // Auth requires a database and is self-hosted only — both cloud and the
+  // development edition must hide it.
+  it.each<Edition>(["cloud", "development"])(
+    "hides the Authentication link on the %s edition",
+    edition => {
+      wrapper.unmount(); // drop the self-hosted render from beforeEach
+      createWrapper({ edition });
+
+      const links = wrapper
+        .getAllByRole("link")
+        .map(link => link.getAttribute("href"));
+
+      expect(links).not.toContain(
+        `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/auth`,
+      );
+      expect(wrapper.queryByText("Authentication")).toBeNull();
+    },
+  );
 });

--- a/src/ui/src/layouts/AppLayout/EnvMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/EnvMenu.tsx
@@ -6,6 +6,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Button from "@mui/material/Button";
 import PlusIcon from "@mui/icons-material/Add";
 import { AppContext } from "~/pages/apps/[id]/App.context";
+import { RootContext } from "~/pages/Root.context";
 import MenuLink from "~/components/MenuLink";
 import DotDotDot from "~/components/DotDotDotV2";
 import EnvironmentFormModal from "~/pages/apps/[id]/environments/_components/EnvironmentFormModal";
@@ -13,7 +14,9 @@ import { envMenuItems } from "./menu_items";
 
 export default function EnvMenu() {
   const { app, environments } = useContext(AppContext);
+  const { details } = useContext(RootContext);
   const { pathname } = useLocation();
+  const isSelfHosted = details?.stormkit?.edition === "self-hosted";
   const [isModalOpen, toggleModal] = useState(false);
   const navigate = useNavigate();
 
@@ -26,8 +29,8 @@ export default function EnvMenu() {
   const selectedEnvId = envId || "";
 
   const envMenu = useMemo(
-    () => envMenuItems({ app, env, pathname }),
-    [app, env, pathname],
+    () => envMenuItems({ app, env, pathname, isSelfHosted }),
+    [app, env, pathname, isSelfHosted],
   );
 
   if (!selectedEnvId || !env) {

--- a/src/ui/src/layouts/AppLayout/menu_items.tsx
+++ b/src/ui/src/layouts/AppLayout/menu_items.tsx
@@ -47,10 +47,12 @@ export const envMenuItems = ({
   app,
   env,
   pathname,
+  isSelfHosted,
 }: {
   app: App;
   env: Environment;
   pathname: string;
+  isSelfHosted: boolean;
 }): Path[] => {
   if (!env) {
     return [];
@@ -98,7 +100,9 @@ export const envMenuItems = ({
     },
   ];
 
-  if (env.build?.vars?.["SK_AUTH_ENABLED"] === "true") {
+  // Authentication relies on a database, so it is shown on the self-hosted
+  // edition only.
+  if (isSelfHosted) {
     items.push({
       text: "Authentication",
       path: `${envPath}/auth`,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
@@ -98,9 +98,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
     currentEnv.build.installCmd = "go get .";
     currentEnv.build.buildCmd = "go build main.go";
     currentEnv.build.distFolder = "./";
-    currentEnv.build.vars = {
-      SK_CWD: "./root",
-    };
+    currentEnv.build.workDir = "./root";
 
     createWrapper({ environment: currentEnv });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
@@ -26,11 +26,7 @@ export default function TabConfigGeneral({
   const [error, setError] = useState<string>();
   const [success, setSuccess] = useState<string>();
   const [isLoading, setLoading] = useState(false);
-  // Fall back to the legacy SK_CWD env var so existing apps keep working
-  // until their next save migrates them to the typed workDir field.
-  const [root, setRoot] = useState(
-    env?.build?.workDir || env?.build?.vars?.["SK_CWD"] || "./"
-  );
+  const [root, setRoot] = useState(env?.build?.workDir || "./");
 
   if (!env) {
     return <></>;

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.spec.tsx
@@ -4,7 +4,10 @@ import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
-import { mockUpdateEnvironment } from "~/testing/nocks/nock_environment";
+import {
+  mockUpdateEnvironment,
+  mockRevealEnvVars,
+} from "~/testing/nocks/nock_environment";
 import TabConfigEnvVars from "./TabConfigEnvVars";
 
 interface WrapperProps {
@@ -91,6 +94,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEn
 
     createWrapper({ environment: currentEnv });
 
+    // No pre-configured variables, so editing is unlocked without revealing.
     await userEvent.type(
       wrapper.getByPlaceholderText("NODE_ENV"),
       "env_var_1_key"
@@ -112,6 +116,65 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEn
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
       expect(setRefreshToken).toHaveBeenCalled();
+    });
+  });
+
+  it("hides the reveal button when there are no variables", () => {
+    currentApp = mockApp();
+    currentEnv = mockEnvironments({ app: currentApp })[0];
+    currentEnv.build.vars = {};
+
+    createWrapper({ environment: currentEnv });
+
+    expect(wrapper.queryByText("Reveal values")).toBeNull();
+
+    const save = wrapper.getByText("Save").closest("button") as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+  });
+
+  it("shows the reveal button when variables exist", () => {
+    currentApp = mockApp();
+    currentEnv = mockEnvironments({ app: currentApp })[0];
+    currentEnv.build.vars = { EXISTING: "" };
+
+    createWrapper({ environment: currentEnv });
+
+    expect(wrapper.getByText("Reveal values")).toBeTruthy();
+
+    const save = wrapper.getByText("Save").closest("button") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    // Editing affordances stay locked until the values are revealed, so the
+    // user cannot type entries that would be discarded on reveal.
+    const addRow = wrapper
+      .getByText("Add Row")
+      .closest("button") as HTMLButtonElement;
+    expect(addRow.disabled).toBe(true);
+
+    const modify = wrapper
+      .getByText("Modify as a string")
+      .closest("button") as HTMLButtonElement;
+    expect(modify.disabled).toBe(true);
+  });
+
+  it("shows an error when reveal fails", async () => {
+    currentApp = mockApp();
+    currentEnv = mockEnvironments({ app: currentApp })[0];
+    currentEnv.build.vars = { EXISTING: "" };
+
+    createWrapper({ environment: currentEnv });
+
+    const revealScope = mockRevealEnvVars({
+      envId: currentEnv.id!,
+      response: {},
+      status: 403,
+    });
+
+    fireEvent.click(wrapper.getByText("Reveal values"));
+
+    await waitFor(() => {
+      expect(revealScope.isDone()).toBe(true);
+      expect(wrapper.getByText(/Something went wrong/)).toBeTruthy();
     });
   });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.tsx
@@ -1,7 +1,8 @@
 import type { FormValues } from "../actions";
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
@@ -10,6 +11,7 @@ import {
   updateEnvironment,
   buildFormValues,
   prepareBuildObject,
+  revealEnvVars,
 } from "../actions";
 
 interface Props {
@@ -23,25 +25,44 @@ export default function TabConfigEnvVars({
   app,
   setRefreshToken,
 }: Props) {
+  // With no pre-configured variables there is nothing to reveal, so editing is
+  // unlocked from the start (no Reveal button, Save enabled).
+  const hasVars = Object.keys(env.build.vars || {}).length > 0;
+
   const [reset, setReset] = useState<number>();
   const [error, setError] = useState<string>();
   const [success, setSuccess] = useState<string>();
   const [isLoading, setLoading] = useState(false);
   const [isChanged, setIsChanged] = useState(false);
-  const [vars, setVars] = useState<Record<string, string>>(
-    env.build.vars || {},
-  );
+  const [revealed, setRevealed] = useState(!hasVars);
+  const [revealing, setRevealing] = useState(false);
 
-  const defaultValue = useMemo(() => {
-    return JSON.parse(
-      JSON.stringify(
-        env?.build?.vars || (env ? {} : { NODE_ENV: "development" }),
-      ),
-    );
-  }, []);
+  // Values arrive masked. kvDefault seeds the rows and only changes on
+  // reveal/reset; vars is the live edited map used when saving.
+  const [kvDefault, setKvDefault] = useState(() => env.build.vars || {});
+  const [vars, setVars] = useState(() => env.build.vars || {});
 
-  // Remove special variables
-  delete defaultValue.SK_CWD;
+  const reveal = () => {
+    setRevealing(true);
+    setError("");
+    setSuccess("");
+
+    revealEnvVars({ envId: env.id! })
+      .then(real => {
+        setKvDefault(real);
+        setVars(real);
+        setReset(Date.now());
+        setRevealed(true);
+      })
+      .catch(() => {
+        setError(
+          "Something went wrong while revealing the variables. Please try again."
+        );
+      })
+      .finally(() => {
+        setRevealing(false);
+      });
+  };
 
   return (
     <Card
@@ -50,19 +71,18 @@ export default function TabConfigEnvVars({
       sx={{ mb: 2 }}
       error={error}
       success={success}
+      info={
+        revealed
+          ? undefined
+          : "Values are hidden. Reveal them to view or edit — each reveal is recorded in the activity feed."
+      }
       onSubmit={e => {
         e.preventDefault();
 
         const values: FormValues = buildFormValues(
           { ...env, build: { ...env.build, vars } },
-          e.target as HTMLFormElement,
+          e.target as HTMLFormElement
         );
-
-        const root = env.build?.vars?.["SK_CWD"];
-
-        if (root) {
-          values["build.vars"] = `${values["build.vars"]}\nSK_CWD=${root}`;
-        }
 
         updateEnvironment({
           app,
@@ -80,6 +100,19 @@ export default function TabConfigEnvVars({
       <CardHeader
         title="Environment variables"
         subtitle="These variables will be available to build time, status checks and serverless runtime."
+        actions={
+          revealed ? undefined : (
+            <Button
+              type="button"
+              variant="text"
+              startIcon={<VisibilityIcon />}
+              loading={revealing}
+              onClick={reveal}
+            >
+              Reveal values
+            </Button>
+          )
+        }
       />
       <Box sx={{ mb: 2 }}>
         <KeyValue
@@ -90,6 +123,7 @@ export default function TabConfigEnvVars({
           keyPlaceholder="NODE_ENV"
           valPlaceholder="production"
           isSensitive
+          disabled={!revealed}
           onChange={newVars => {
             setVars(newVars);
             setIsChanged(true);
@@ -98,7 +132,7 @@ export default function TabConfigEnvVars({
             setSuccess("");
             setError("");
           }}
-          defaultValue={defaultValue}
+          defaultValue={kvDefault}
         />
       </Box>
       <CardFooter>
@@ -113,9 +147,12 @@ export default function TabConfigEnvVars({
             transition: "all 0.35s ease-in",
           }}
           onClick={() => {
-            setVars(env.build.vars || {});
+            const masked = env.build.vars || {};
+            setKvDefault(masked);
+            setVars(masked);
             setReset(Date.now());
             setIsChanged(false);
+            setRevealed(!hasVars);
           }}
         >
           Cancel
@@ -125,6 +162,7 @@ export default function TabConfigEnvVars({
           variant="contained"
           color="secondary"
           loading={isLoading}
+          disabled={!revealed}
           sx={{ textTransform: "capitalize" }}
         >
           Save

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -1,5 +1,19 @@
 import api from "~/utils/api/Api";
 
+// revealEnvVars fetches the real (unmasked) environment variable values. The
+// endpoint is restricted to team admins/owners and the reveal is audited.
+export const revealEnvVars = ({
+  envId,
+}: {
+  envId: string;
+}): Promise<Record<string, string>> => {
+  // An env with no variables serializes as JSON `null`; coalesce so callers
+  // (and KeyValue's Object.keys) always get a usable map.
+  return api
+    .fetch<Record<string, string> | null>(`/v1/env/pull?envId=${envId}`)
+    .then(vars => vars || {});
+};
+
 export const computeAutoDeployValue = (env?: Environment): AutoDeployValues => {
   if (!env) {
     return "all";

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -372,7 +372,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
         })
         .reply(200);
 
-      const input = wrapper.getByLabelText("Allowed origins") as HTMLTextAreaElement;
+      const input = (await wrapper.findByLabelText(
+        "Allowed origins",
+      )) as HTMLTextAreaElement;
       fireEvent.change(input, {
         target: {
           value: "https://app.example.com\n  https://dev.example.com  \n\n",

--- a/src/ui/src/pages/mui-theme.tsx
+++ b/src/ui/src/pages/mui-theme.tsx
@@ -232,6 +232,12 @@ export default (mode: "dark" | "light") => {
             "&.Mui-focused": {
               backgroundColor: isDark ? "#000000" : grey[200],
             },
+            // Disabled text is painted via -webkit-text-fill-color, which
+            // defaults to a near-black value and reads as black in dark mode.
+            // Keep it grayish so disabled inputs look muted in both modes.
+            "& .MuiInputBase-input.Mui-disabled": {
+              WebkitTextFillColor: grey[600],
+            },
             "&:before": {
               borderColor: grey[900],
             },
@@ -261,6 +267,11 @@ export default (mode: "dark" | "light") => {
             color: secondaryColor,
             "&.Mui-focused": {
               color: primaryColor,
+            },
+            // Match the disabled input text: keep the label grayish instead of
+            // falling back to MUI's near-black disabled color in dark mode.
+            "&.Mui-disabled": {
+              color: grey[600],
             },
           },
         },

--- a/src/ui/src/shared/feed/AuditMessage.spec.tsx
+++ b/src/ui/src/shared/feed/AuditMessage.spec.tsx
@@ -43,6 +43,10 @@ describe("~/shared/feed/AuditMessage.tsx", () => {
       old: { envName: "staging" },
       new: {},
     },
+    "REVEAL:ENV": {
+      old: {},
+      new: {},
+    },
     "CREATE:APP": {
       old: {},
       new: { appName: "sample-project" },
@@ -102,6 +106,7 @@ describe("~/shared/feed/AuditMessage.tsx", () => {
     ${"CREATE:ENV"}        | ${"Created the staging environment"}                              | ${null}
     ${"UPDATE:ENV"}        | ${"Updated the staging environment"}                              | ${null}
     ${"DELETE:ENV"}        | ${"Removed the staging environment"}                              | ${null}
+    ${"REVEAL:ENV"}        | ${"Revealed environment variable values for production environment"} | ${null}
     ${"CREATE:APP"}        | ${"Created the sample-project application"}                       | ${null}
     ${"UPDATE:APP"}        | ${"Updated the sample-project application"}                       | ${null}
     ${"DELETE:APP"}        | ${"Deleted the sample-project application"}                       | ${null}

--- a/src/ui/src/shared/feed/AuditMessage.tsx
+++ b/src/ui/src/shared/feed/AuditMessage.tsx
@@ -162,6 +162,14 @@ export default function AuditMessage({ audit }: Props) {
         </AuditRow>
       );
 
+    case "REVEAL:ENV":
+      return (
+        <AuditRow audit={audit}>
+          Revealed environment variable values for{" "}
+          <EnvLink audit={audit} hash="#env-vars" /> environment
+        </AuditRow>
+      );
+
     case "CREATE:APP":
       return (
         <AuditRow audit={audit}>

--- a/src/ui/src/testing/nocks/nock_environment.ts
+++ b/src/ui/src/testing/nocks/nock_environment.ts
@@ -111,6 +111,19 @@ export const mockUpdateEnvironment = ({
     .reply(status, response);
 };
 
+interface RevealEnvVarsProps {
+  envId: string;
+  response: Record<string, string>;
+  status?: number;
+}
+
+export const mockRevealEnvVars = ({
+  envId,
+  response,
+  status = 200,
+}: RevealEnvVarsProps) =>
+  nock(endpoint).get(`/v1/env/pull?envId=${envId}`).reply(status, response);
+
 interface DeleteEnvironmentProps {
   appId: string;
   env: string;

--- a/src/ui/src/utils/helpers/instance.ts
+++ b/src/ui/src/utils/helpers/instance.ts
@@ -1,5 +1,11 @@
 /**
  * Checks whether the current instance is a self-hosted environment or not.
+ *
+ * @deprecated Infer the edition from context instead, which is authoritative
+ * and not coupled to the URL:
+ * `const isSelfHosted = details?.stormkit?.edition === "self-hosted";`
+ * (`details` comes from `RootContext`). Note the edition can also be "cloud" or
+ * "development", so check `=== "self-hosted"` explicitly rather than `!isCloud`.
  */
 export function isSelfHosted(url: string = window.location.href): boolean {
   const regex = /^https?:\/\/(?:.*\.)?stormkit\.(io|dev)(?:\/|$)/i;


### PR DESCRIPTION
## What

Environment variable **values** are no longer returned in plaintext anywhere. They are masked (keys kept, values blanked) in every API response, and revealed only through a dedicated, access-controlled endpoint.

## ⚠️ Breaking change

`GET /v1/envs` — and every env/deployment response — **no longer returns env-var values for any caller** (including `SK_` API keys). Anything that read values from `/v1/envs` must switch to **`GET /v1/env/pull`**.

## Masking

One rule — `buildconf.MaskVars` — blanks every value:
- **`Env.JSON()`** builds the client map explicitly (App.JSON() style, no marshal/unmarshal round-trip) and masks the build vars; **`Env.MarshalJSON`** delegates to it, so an `Env` can never be serialized in plaintext by accident — covers `/v1/envs`, the dashboard env-get, and MCP `list_environments`.
- The **deployment config snapshot** (`Deployment.Snapshot()`) is masked too → closes `/v1/deployments`, `/v1/deployments/{id}`, the my-deployments feed, and MCP `get_deployment`/`list_deployments`.
- The **env-update audit diff** masks vars on copies (real vars still reach the function-config update), so secrets aren't persisted to / shown in the activity feed.

## Reveal

`GET /v1/env/pull` is the only plaintext path. JWT (dashboard) callers must be a team **admin/owner** (developers get `403`); the reveal is **audited** as `REVEAL:ENV`. `SK_` API keys are provisioned secret-access and pass through (not audited).

The env-var screen reveals values on demand before editing, with **Save disabled until revealed** so a blank can't clobber a secret. With **no variables configured** there's nothing to reveal, so editing is unlocked from the start (no Reveal button, Save enabled). The activity feed renders the new `REVEAL:ENV` action.

## Also

- The **Authentication** tab is shown only on self-hosted (it needs a database), replacing the old `SK_AUTH_ENABLED` env-var gate.
- Legacy `SK_CWD` handling dropped in favour of the typed `workDir`.
- Empty `autoDeployBranches`/`autoDeployCommits` are omitted from the env JSON.
- Fixes a pre-existing async-render flake in the skauth spec.

There is **no `SK_` carve-out** — every value is masked, including user vars named `SK_*`.

## Tests

- Go: `/v1/envs`, dashboard env-get, MCP `list_environments`/`get_deployment`, the `Env.JSON` unit test, `/v1/env/pull` (owner reveal + audit, developer `403`, `SK_` pass-through), the deployment snapshot, and `audit_model` (`RevealAction`).
- UI: env-vars reveal-before-edit / no-vars / forbidden flows, the `REVEAL:ENV` feed message, and the menu specs (incl. auth hidden on cloud).

Builds on the incremental-save model from #312 (non-env-var sections never resend `envVars`). At-rest encryption of values is intentionally out of scope (separate follow-up).