### PR TITLE
feat: incremental env config saves

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
@@ -73,16 +73,11 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
       await userEvent.type(wrapper.getByLabelText("Output folder"), "dist");
 
       const scope = mockUpdateEnvironment({
-        environment: {
-          ...currentEnv,
-          build: {
-            ...currentEnv.build,
-            installCmd: "go get .",
-            buildCmd: "go build .",
-            distFolder: "./dist",
-            workDir: "./",
-            vars: {},
-          },
+        payload: {
+          installCmd: "go get .",
+          buildCmd: "go build .",
+          distFolder: "./dist",
+          workDir: "./",
         },
         status: 200,
         response: { ok: true },

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
@@ -6,7 +6,11 @@ import Button from "@mui/material/Button";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
-import { updateEnvironment, buildFormValues } from "../actions";
+import {
+  updateEnvironment,
+  buildFormValues,
+  prepareBuildObject,
+} from "../actions";
 
 interface Props {
   app: App;
@@ -42,22 +46,24 @@ export default function TabConfigGeneral({
       onSubmit={e => {
         e.preventDefault();
 
-        env.build.workDir = root;
-
-        // Drop the legacy var once we save — workDir is the source of truth.
-        if (env.build.vars?.["SK_CWD"]) {
-          delete env.build.vars["SK_CWD"];
-        }
-
+        // workDir is a controlled input (no form name), so feed it in directly.
         const values: FormValues = buildFormValues(
           env,
-          e.target as HTMLFormElement
+          e.target as HTMLFormElement,
+          { "build.workDir": root }
         );
+
+        const build = prepareBuildObject(values);
 
         updateEnvironment({
           app,
           envId: env.id!,
-          values,
+          payload: {
+            installCmd: build.installCmd,
+            buildCmd: build.buildCmd,
+            distFolder: build.distFolder,
+            workDir: build.workDir,
+          },
           setError,
           setLoading,
           setSuccess,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.spec.tsx
@@ -102,13 +102,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEn
     );
 
     const scope = mockUpdateEnvironment({
-      environment: {
-        ...currentEnv,
-        build: {
-          ...currentEnv.build,
-          vars: { env_var_1_key: "env_var_1_val" },
-        },
-      },
+      payload: { envVars: { env_var_1_key: "env_var_1_val" } },
       status: 200,
       response: { ok: true },
     });
@@ -139,13 +133,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEn
     );
 
     const scope = mockUpdateEnvironment({
-      environment: {
-        ...currentEnv,
-        build: {
-          ...currentEnv.build,
-          vars: { env_var_1_key: "env_var_1_val" },
-        },
-      },
+      payload: { envVars: { env_var_1_key: "env_var_1_val" } },
       status: 200,
       response: { ok: true },
     });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigEnvVars.tsx
@@ -6,7 +6,11 @@ import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
 import KeyValue from "~/components/FormV2/KeyValue";
-import { updateEnvironment, buildFormValues } from "../actions";
+import {
+  updateEnvironment,
+  buildFormValues,
+  prepareBuildObject,
+} from "../actions";
 
 interface Props {
   app: App;
@@ -63,7 +67,7 @@ export default function TabConfigEnvVars({
         updateEnvironment({
           app,
           envId: env.id!,
-          values,
+          payload: { envVars: prepareBuildObject(values).vars },
           setError,
           setLoading,
           setSuccess,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigGeneral.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigGeneral.spec.tsx
@@ -5,15 +5,14 @@ import userEvent from "@testing-library/user-event";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
 import { mockUpdateEnvironment } from "~/testing/nocks/nock_environment";
-import TabConfigServer from "./TabConfigServer";
+import TabConfigGeneral from "./TabConfigGeneral";
 
 interface WrapperProps {
   app?: App;
   environment?: Environment;
-  setRefreshToken?: () => void;
 }
 
-describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServer.tsx", () => {
+describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigGeneral.tsx", () => {
   let wrapper: RenderResult;
   let currentApp: App;
   let currentEnv: Environment;
@@ -25,7 +24,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigSe
     currentEnv = environment || mockEnvironments({ app: currentApp })[0];
 
     wrapper = render(
-      <TabConfigServer
+      <TabConfigGeneral
         app={currentApp}
         environment={currentEnv}
         setRefreshToken={setRefreshToken}
@@ -36,38 +35,40 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigSe
   it("should have a form", () => {
     createWrapper({});
 
-    expect(wrapper.getByText("Server settings")).toBeTruthy();
-    expect(
-      wrapper.getByText("Configure your long-running processes.")
-    ).toBeTruthy();
-
-    const startCmdInput = wrapper.getByLabelText(
-      "Start command"
-    ) as HTMLInputElement;
-
-    expect(startCmdInput.value).toBe("");
+    expect(wrapper.getByText("General settings")).toBeTruthy();
+    expect(wrapper.getByLabelText("Environment name")).toBeTruthy();
   });
 
-  it("should submit the form", async () => {
+  // Saving the general section must send only the general fields — never the
+  // build config or environment variables of other sections.
+  it("should submit only the general fields", async () => {
     createWrapper({});
 
     await userEvent.type(
-      wrapper.getByLabelText("Start command"),
-      "npm run start"
+      wrapper.getByLabelText("Priority deployment pattern"),
+      "hotfix"
     );
 
     const scope = mockUpdateEnvironment({
-      payload: { serverCmd: "npm run start" },
-      status: 200,
-      response: {
-        ok: true,
+      payload: {
+        name: "production",
+        branch: "master",
+        autoPublish: true,
+        autoDeploy: false,
+        autoDeployBranches: "",
+        autoDeployCommits: "",
+        previewLinks: true,
+        priorityPattern: "hotfix",
       },
+      status: 200,
+      response: { ok: true },
     });
 
     fireEvent.click(wrapper.getByText("Save"));
 
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
+      expect(setRefreshToken).toHaveBeenCalled();
     });
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigGeneral.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigGeneral.tsx
@@ -16,7 +16,8 @@ import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
 import ConfirmModal from "~/components/ConfirmModal";
 import {
-  useSubmitHandler,
+  updateEnvironment,
+  buildFormValues,
   deleteEnvironment,
   computeAutoDeployValue,
 } from "../actions";
@@ -40,15 +41,9 @@ export default function TabConfigGeneral({
     computeAutoDeployValue(env),
   );
 
-  const { submitHandler, error, isLoading, success } = useSubmitHandler({
-    app,
-    env,
-    setRefreshToken,
-    controlled: {
-      autoPublish: autoPublish ? "on" : "off",
-      "build.previewLinks": previewLinks ? "on" : "off",
-    },
-  });
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+  const [isLoading, setLoading] = useState(false);
 
   useEffect(() => {
     setAutoDeploy(computeAutoDeployValue(env));
@@ -67,7 +62,33 @@ export default function TabConfigGeneral({
       error={error}
       success={success}
       sx={{ mb: 2 }}
-      onSubmit={submitHandler}
+      onSubmit={e => {
+        e.preventDefault();
+
+        const values = buildFormValues(env, e.target as HTMLFormElement, {
+          autoPublish: autoPublish ? "on" : "off",
+          "build.previewLinks": previewLinks ? "on" : "off",
+        });
+
+        updateEnvironment({
+          app,
+          envId: env.id!,
+          payload: {
+            name: values.name,
+            branch: values.branch,
+            autoPublish: values.autoPublish === "on",
+            autoDeploy: values.autoDeploy !== "disabled",
+            autoDeployBranches: values.autoDeployBranches,
+            autoDeployCommits: values.autoDeployCommits,
+            previewLinks: values["build.previewLinks"] === "on",
+            priorityPattern: values["build.priorityPattern"]?.trim() || "",
+          },
+          setError,
+          setLoading,
+          setSuccess,
+          setRefreshToken,
+        });
+      }}
     >
       <CardHeader
         title="General settings"

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.spec.tsx
@@ -68,13 +68,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHe
     );
 
     const scope = mockUpdateEnvironment({
-      environment: {
-        ...currentEnv,
-        build: {
-          ...currentEnv.build,
-          headersFile: "/headers.json",
-        },
-      },
+      payload: { headers: "", headersFile: "/headers.json" },
       status: 200,
       response: {
         ok: true,
@@ -97,14 +91,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHe
     );
 
     const scope = mockUpdateEnvironment({
-      environment: {
-        ...currentEnv,
-        build: {
-          ...currentEnv.build,
-          headers: "",
-          headersFile: "/headers.json",
-        },
-      },
+      payload: { headers: "", headersFile: "/headers.json" },
       status: 200,
       response: {
         ok: true,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigHeaders.tsx
@@ -11,7 +11,11 @@ import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
 import HeadersEditor from "./Editor";
-import { useSubmitHandler } from "../actions";
+import {
+  updateEnvironment,
+  buildFormValues,
+  prepareBuildObject,
+} from "../actions";
 
 interface Props {
   app: App;
@@ -27,14 +31,9 @@ export default function TabConfigGeneral({
   const [headers, setHeaders] = useState(env.build.headers);
   const [showHeaders, setShowHeaders] = useState(Boolean(env.build.headers));
 
-  const { submitHandler, error, success, isLoading } = useSubmitHandler({
-    app,
-    env,
-    setRefreshToken,
-    controlled: {
-      "build.headers": showHeaders ? headers : undefined,
-    },
-  });
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+  const [isLoading, setLoading] = useState(false);
 
   if (!env) {
     return <></>;
@@ -47,7 +46,25 @@ export default function TabConfigGeneral({
       sx={{ mb: 2 }}
       error={error}
       success={success}
-      onSubmit={submitHandler}
+      onSubmit={e => {
+        e.preventDefault();
+
+        const build = prepareBuildObject(
+          buildFormValues(env, e.target as HTMLFormElement, {
+            "build.headers": showHeaders ? headers : undefined,
+          })
+        );
+
+        updateEnvironment({
+          app,
+          envId: env.id!,
+          payload: { headers: build.headers, headersFile: build.headersFile },
+          setError,
+          setLoading,
+          setSuccess,
+          setRefreshToken,
+        });
+      }}
     >
       <CardHeader
         title="Headers"

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.spec.tsx
@@ -78,15 +78,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRe
     );
 
     const scope = mockUpdateEnvironment({
-      environment: {
-        ...currentEnv,
-        build: {
-          ...currentEnv.build,
-          previewLinks: true,
-          errorFile: "/index.html",
-          redirectsFile: "/redirects.json",
-        },
-      },
+      payload: { redirectsFile: "/redirects.json", errorFile: "/index.html" },
       status: 200,
       response: {
         ok: true,
@@ -114,15 +106,10 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRe
     );
 
     const scope = mockUpdateEnvironment({
-      environment: {
-        ...currentEnv,
-        build: {
-          ...currentEnv.build,
-          previewLinks: true,
-          redirects: [],
-          redirectsFile: "/redirects.json",
-          errorFile: "/index.html",
-        },
+      payload: {
+        redirects: [],
+        redirectsFile: "/redirects.json",
+        errorFile: "/index.html",
       },
       status: 200,
       response: {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.tsx
@@ -9,7 +9,12 @@ import { grey } from "@mui/material/colors";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
-import { useSubmitHandler } from "../actions";
+import {
+  updateEnvironment,
+  buildFormValues,
+  prepareBuildObject,
+  validateRedirects,
+} from "../actions";
 import RedirectsPlaygroundModal from "./RedirectsPlaygroundModal";
 import RedirectsEditor from "./Editor";
 
@@ -36,14 +41,9 @@ export default function TabConfigRedirects({
   const [showRedirects, setShowRedirects] = useState(hasRedirects);
   const [redirects, setRedirects] = useState(initialRedirects);
 
-  const { submitHandler, error, success, isLoading } = useSubmitHandler({
-    app,
-    env,
-    setRefreshToken,
-    controlled: {
-      "build.redirects": showRedirects ? redirects : undefined,
-    },
-  });
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+  const [isLoading, setLoading] = useState(false);
 
   if (!env) {
     return <></>;
@@ -56,7 +56,34 @@ export default function TabConfigRedirects({
       sx={{ mb: 2 }}
       error={error}
       success={success}
-      onSubmit={submitHandler}
+      onSubmit={e => {
+        e.preventDefault();
+
+        const values = buildFormValues(env, e.target as HTMLFormElement, {
+          "build.redirects": showRedirects ? redirects : undefined,
+        });
+
+        if (!validateRedirects(values["build.redirects"] || "", setError)) {
+          setError("Invalid redirects format.");
+          return;
+        }
+
+        const build = prepareBuildObject(values);
+
+        updateEnvironment({
+          app,
+          envId: env.id!,
+          payload: {
+            redirects: build.redirects,
+            redirectsFile: build.redirectsFile,
+            errorFile: build.errorFile,
+          },
+          setError,
+          setLoading,
+          setSuccess,
+          setRefreshToken,
+        });
+      }}
     >
       <CardHeader
         title="Redirects"

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServer.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServer.tsx
@@ -1,10 +1,15 @@
+import { useState } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
-import { useSubmitHandler } from "../actions";
+import {
+  updateEnvironment,
+  buildFormValues,
+  prepareBuildObject,
+} from "../actions";
 
 interface Props {
   app: App;
@@ -17,11 +22,9 @@ export default function TabConfigServer({
   app,
   setRefreshToken,
 }: Props) {
-  const { error, success, isLoading, submitHandler } = useSubmitHandler({
-    env,
-    app,
-    setRefreshToken,
-  });
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+  const [isLoading, setLoading] = useState(false);
 
   if (!env) {
     return <></>;
@@ -34,7 +37,21 @@ export default function TabConfigServer({
       sx={{ mb: 2 }}
       error={error}
       success={success}
-      onSubmit={submitHandler}
+      onSubmit={e => {
+        e.preventDefault();
+
+        const values = buildFormValues(env, e.target as HTMLFormElement);
+
+        updateEnvironment({
+          app,
+          envId: env.id!,
+          payload: { serverCmd: prepareBuildObject(values).serverCmd },
+          setError,
+          setLoading,
+          setSuccess,
+          setRefreshToken,
+        });
+      }}
     >
       <CardHeader
         title="Server settings"

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServerless.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServerless.spec.tsx
@@ -1,19 +1,17 @@
 import { RenderResult, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, type Mock } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
 import { mockUpdateEnvironment } from "~/testing/nocks/nock_environment";
-import TabConfigServer from "./TabConfigServer";
+import TabConfigServerless from "./TabConfigServerless";
 
 interface WrapperProps {
   app?: App;
   environment?: Environment;
-  setRefreshToken?: () => void;
 }
 
-describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServer.tsx", () => {
+describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServerless.tsx", () => {
   let wrapper: RenderResult;
   let currentApp: App;
   let currentEnv: Environment;
@@ -22,10 +20,19 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigSe
   const createWrapper = ({ app, environment }: WrapperProps) => {
     setRefreshToken = vi.fn();
     currentApp = app || mockApp();
-    currentEnv = environment || mockEnvironments({ app: currentApp })[0];
+    currentEnv =
+      environment ||
+      ({
+        ...mockEnvironments({ app: currentApp })[0],
+        build: {
+          ...mockEnvironments({ app: currentApp })[0].build,
+          apiFolder: "/functions",
+          apiPathPrefix: "/fn",
+        },
+      } as Environment);
 
     wrapper = render(
-      <TabConfigServer
+      <TabConfigServerless
         app={currentApp}
         environment={currentEnv}
         setRefreshToken={setRefreshToken}
@@ -36,38 +43,25 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigSe
   it("should have a form", () => {
     createWrapper({});
 
-    expect(wrapper.getByText("Server settings")).toBeTruthy();
-    expect(
-      wrapper.getByText("Configure your long-running processes.")
-    ).toBeTruthy();
-
-    const startCmdInput = wrapper.getByLabelText(
-      "Start command"
-    ) as HTMLInputElement;
-
-    expect(startCmdInput.value).toBe("");
+    expect(wrapper.getByText("Serverless functions")).toBeTruthy();
+    expect(wrapper.getByLabelText("API folder")).toBeTruthy();
   });
 
-  it("should submit the form", async () => {
+  // Saving serverless settings must send only the serverless fields.
+  it("should submit only the serverless fields", async () => {
     createWrapper({});
 
-    await userEvent.type(
-      wrapper.getByLabelText("Start command"),
-      "npm run start"
-    );
-
     const scope = mockUpdateEnvironment({
-      payload: { serverCmd: "npm run start" },
+      payload: { apiFolder: "/functions", apiPathPrefix: "/fn" },
       status: 200,
-      response: {
-        ok: true,
-      },
+      response: { ok: true },
     });
 
     fireEvent.click(wrapper.getByText("Save"));
 
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
+      expect(setRefreshToken).toHaveBeenCalled();
     });
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServerless.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigServerless.tsx
@@ -1,10 +1,15 @@
+import { useState } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
-import { useSubmitHandler } from "../actions";
+import {
+  updateEnvironment,
+  buildFormValues,
+  prepareBuildObject,
+} from "../actions";
 
 interface Props {
   app: App;
@@ -17,11 +22,9 @@ export default function TabConfigGeneral({
   app,
   setRefreshToken,
 }: Props) {
-  const { error, success, isLoading, submitHandler } = useSubmitHandler({
-    env,
-    app,
-    setRefreshToken,
-  });
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+  const [isLoading, setLoading] = useState(false);
 
   if (!env) {
     return <></>;
@@ -34,7 +37,26 @@ export default function TabConfigGeneral({
       sx={{ mb: 2 }}
       error={error}
       success={success}
-      onSubmit={submitHandler}
+      onSubmit={e => {
+        e.preventDefault();
+
+        const build = prepareBuildObject(
+          buildFormValues(env, e.target as HTMLFormElement)
+        );
+
+        updateEnvironment({
+          app,
+          envId: env.id!,
+          payload: {
+            apiFolder: build.apiFolder,
+            apiPathPrefix: build.apiPathPrefix,
+          },
+          setError,
+          setLoading,
+          setSuccess,
+          setRefreshToken,
+        });
+      }}
     >
       <CardHeader
         title="Serverless functions"

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/StatusCheckModal.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/StatusCheckModal.spec.tsx
@@ -63,18 +63,10 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusCh
       await userEvent.type(wrapper.getByLabelText("Description"), "desc");
 
       const scope = mockUpdateEnvironment({
-        environment: {
-          ...currentEnv,
-          build: {
-            ...currentEnv.build,
-            statusChecks: [
-              {
-                cmd: "npm run test",
-                name: "Run e2e tests",
-                description: "desc",
-              },
-            ],
-          },
+        payload: {
+          statusChecks: [
+            { cmd: "npm run test", name: "Run e2e tests", description: "desc" },
+          ],
         },
         status: 200,
         response: {
@@ -127,19 +119,15 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusCh
       await userEvent.type(wrapper.getByLabelText("Description"), " - 2");
 
       const scope = mockUpdateEnvironment({
-        environment: {
-          ...currentEnv,
-          build: {
-            ...currentEnv.build,
-            statusChecks: [
-              checks[0],
-              {
-                cmd: "npm run test:random:2",
-                name: "Run random tests - 2",
-                description: "My other description - 2",
-              },
-            ],
-          },
+        payload: {
+          statusChecks: [
+            checks[0],
+            {
+              cmd: "npm run test:random:2",
+              name: "Run random tests - 2",
+              description: "My other description - 2",
+            },
+          ],
         },
         status: 200,
         response: {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/StatusCheckModal.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/StatusCheckModal.tsx
@@ -1,4 +1,3 @@
-import type { FormValues } from "../../actions";
 import { useState } from "react";
 import Button from "@mui/material/Button";
 import TextInput from "@mui/material/TextField";
@@ -7,7 +6,7 @@ import Modal from "~/components/Modal";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
-import { updateEnvironment, buildFormValues } from "../../actions";
+import { updateEnvironment } from "../../actions";
 import { buildStatusChecks } from "./helpers";
 
 interface Props {
@@ -62,18 +61,10 @@ export default function StatusChecksModal({
             );
           }
 
-          const values: FormValues = buildFormValues(
-            env,
-            document.createElement("form"),
-            {
-              "build.statusChecks": JSON.stringify(checks),
-            }
-          );
-
           updateEnvironment({
             app,
             envId: env.id!,
-            values,
+            payload: { statusChecks: checks },
             setError,
             setLoading,
             setSuccess,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/TabStatusChecks.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/TabStatusChecks.spec.tsx
@@ -102,13 +102,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusCh
       ).toBeTruthy();
 
       const scope = mockUpdateEnvironment({
-        environment: {
-          ...currentEnv,
-          build: {
-            ...currentEnv.build,
-            statusChecks: [checks[1]],
-          },
-        },
+        payload: { statusChecks: [checks[1]] },
         status: 200,
         response: {
           ok: true,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/TabStatusChecks.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabStatusChecks/TabStatusChecks.tsx
@@ -1,4 +1,3 @@
-import type { FormValues } from "../../actions";
 import { useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -9,7 +8,7 @@ import CardRow from "~/components/CardRow";
 import CardFooter from "~/components/CardFooter";
 import ConfirmModal from "~/components/ConfirmModal";
 import StatusChecksModal from "./StatusCheckModal";
-import { updateEnvironment, buildFormValues } from "../../actions";
+import { updateEnvironment } from "../../actions";
 import { buildStatusChecks } from "./helpers";
 
 interface Props {
@@ -112,24 +111,16 @@ export default function TabConfigGeneral({
             setLoading(true);
             setError(null);
 
-            const values: FormValues = buildFormValues(
-              env,
-              document.createElement("form"),
-              {
-                "build.statusChecks": JSON.stringify(
-                  buildStatusChecks(
-                    env.build.statusChecks || [],
-                    undefined,
-                    deleted
-                  )
-                ),
-              }
-            );
-
             updateEnvironment({
               app,
               envId: env.id!,
-              values,
+              payload: {
+                statusChecks: buildStatusChecks(
+                  env.build.statusChecks || [],
+                  undefined,
+                  deleted
+                ),
+              },
               setError,
               setLoading,
               setSuccess: () => {},

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -1,4 +1,3 @@
-import { FormEventHandler, useState } from "react";
 import api from "~/utils/api/Api";
 
 export const computeAutoDeployValue = (env?: Environment): AutoDeployValues => {
@@ -141,6 +140,36 @@ interface ControlledFormValues {
   "build.redirects"?: string;
   "build.headers"?: string;
   "build.statusChecks"?: string;
+  "build.workDir"?: string;
+}
+
+// EnvUpdatePayload is a partial environment update: each config section sends
+// only the keys it owns, and the API leaves any omitted field untouched. This
+// keeps a section's save from overwriting fields it does not control — most
+// importantly `envVars`, which only the environment-variables section sends.
+export interface EnvUpdatePayload {
+  name?: string;
+  branch?: string;
+  autoPublish?: boolean;
+  autoDeploy?: boolean;
+  autoDeployBranches?: string;
+  autoDeployCommits?: string;
+  previewLinks?: boolean;
+  priorityPattern?: string;
+  buildCmd?: string;
+  serverCmd?: string;
+  installCmd?: string;
+  distFolder?: string;
+  workDir?: string;
+  headers?: string;
+  headersFile?: string;
+  redirectsFile?: string;
+  errorFile?: string;
+  apiFolder?: string;
+  apiPathPrefix?: string;
+  statusChecks?: StatusCheck[];
+  redirects?: Redirect[];
+  envVars?: Record<string, string>;
 }
 
 export interface FormValues {
@@ -173,7 +202,8 @@ export interface FormValues {
 interface UpdateEnvironmentProps {
   app: App;
   envId: string;
-  values: FormValues;
+  // payload holds only the keys to update; omitted fields are left unchanged.
+  payload: EnvUpdatePayload;
   successMsg?: string;
   setLoading: (b: boolean) => void;
   setError: (s: string) => void;
@@ -182,18 +212,15 @@ interface UpdateEnvironmentProps {
 }
 
 export const updateEnvironment = ({
-  app,
   envId,
-  values,
+  payload,
   setError,
   setLoading,
   setSuccess,
   setRefreshToken,
   successMsg = "The environment has been successfully updated.",
 }: UpdateEnvironmentProps): Promise<void> => {
-  const build = prepareBuildObject(values);
-
-  if (!values.name || !values.branch) {
+  if (("name" in payload && !payload.name) || ("branch" in payload && !payload.branch)) {
     setError("Environment and branch names are required.");
     return Promise.resolve();
   }
@@ -202,32 +229,18 @@ export const updateEnvironment = ({
   setError("");
   setSuccess("");
 
+  // Send envId plus only the provided keys; drop undefined so a section can
+  // include a field conditionally without clearing it server-side.
+  const body: Record<string, unknown> = { envId };
+
+  (Object.keys(payload) as (keyof EnvUpdatePayload)[]).forEach(key => {
+    if (payload[key] !== undefined) {
+      body[key] = payload[key];
+    }
+  });
+
   return api
-    .put<{ status: boolean }>(`/v1/env`, {
-      envId,
-      name: values.name,
-      branch: values.branch,
-      autoPublish: values.autoPublish === "on",
-      autoDeploy: values.autoDeploy !== "disabled",
-      autoDeployBranches: values.autoDeployBranches,
-      autoDeployCommits: values.autoDeployCommits,
-      buildCmd: build.buildCmd,
-      serverCmd: build.serverCmd,
-      installCmd: build.installCmd,
-      distFolder: build.distFolder,
-      workDir: build.workDir,
-      headers: build.headers,
-      headersFile: build.headersFile,
-      redirectsFile: build.redirectsFile,
-      errorFile: build.errorFile,
-      apiFolder: build.apiFolder,
-      apiPathPrefix: build.apiPathPrefix,
-      previewLinks: build.previewLinks,
-      priorityPattern: build.priorityPattern,
-      statusChecks: build.statusChecks,
-      redirects: build.redirects,
-      envVars: build.vars,
-    })
+    .put<{ status: boolean }>(`/v1/env`, body)
     .then(() => {
       setSuccess(successMsg);
       setRefreshToken(Date.now());
@@ -381,47 +394,3 @@ export const validateRedirects = (
   return true;
 };
 
-interface SubmitHandlerProps {
-  app: App;
-  env: Environment;
-  setRefreshToken: (v: number) => void;
-  controlled?: ControlledFormValues;
-}
-
-export const useSubmitHandler = ({
-  env,
-  app,
-  setRefreshToken,
-  controlled,
-}: SubmitHandlerProps) => {
-  const [error, setError] = useState<string>();
-  const [success, setSuccess] = useState<string>();
-  const [isLoading, setLoading] = useState(false);
-
-  const handler: FormEventHandler = e => {
-    e.preventDefault();
-
-    const values: FormValues = buildFormValues(
-      env,
-      e.target as HTMLFormElement,
-      controlled,
-    );
-
-    if (!validateRedirects(values["build.redirects"] || "", setError)) {
-      setError("Invalid redirects format.");
-      return Promise.resolve();
-    }
-
-    return updateEnvironment({
-      app,
-      envId: env.id!,
-      values,
-      setError,
-      setLoading,
-      setSuccess,
-      setRefreshToken,
-    });
-  };
-
-  return { submitHandler: handler, error, isLoading, success };
-};

--- a/src/ui/src/testing/nocks/nock_environment.ts
+++ b/src/ui/src/testing/nocks/nock_environment.ts
@@ -35,41 +35,6 @@ const toRequestObject = (environment: Environment) => {
   );
 };
 
-// Used for PUT /v1/env (update) — flat body, no nesting.
-const toUpdateRequestObject = (environment: Environment) => {
-  return JSON.parse(
-    JSON.stringify({
-      envId: environment.id,
-      name: environment.name || environment.env,
-      branch: environment.branch,
-      autoPublish: !!environment.autoPublish,
-      autoDeploy: !!environment.autoDeploy,
-      autoDeployBranches: environment.autoDeployBranches || undefined,
-      autoDeployCommits: environment.autoDeployCommits || undefined,
-      buildCmd: environment.build.buildCmd?.trim() || "",
-      serverCmd: environment.build.serverCmd?.trim() || "",
-      installCmd: environment.build.installCmd?.trim() || "",
-      distFolder: (
-        environment.build.distFolder ||
-        environment.build.serverFolder ||
-        ""
-      ).trim(),
-      workDir: environment.build.workDir?.trim() || "",
-      headers: environment.build.headers?.trim() || "",
-      headersFile: environment.build.headersFile,
-      redirectsFile: environment.build.redirectsFile,
-      errorFile: environment.build.errorFile,
-      apiFolder: environment.build.apiFolder,
-      apiPathPrefix: environment.build.apiPathPrefix,
-      previewLinks: environment.build.previewLinks !== false,
-      priorityPattern: environment.build.priorityPattern || "",
-      statusChecks: environment.build.statusChecks,
-      redirects: environment.build.redirects,
-      envVars: environment.build.vars,
-    }),
-  );
-};
-
 interface FetchStatusProps {
   url: string;
   appId: string;
@@ -121,19 +86,26 @@ export const mockInsertEnvironment = ({
 };
 
 interface UpdateEnvironmentProps {
-  environment: Environment;
+  // payload is the exact partial body the section is expected to send. Saves
+  // are incremental, so the request must contain envId plus precisely these
+  // keys — nothing else (in particular, no other section's fields).
+  payload: Record<string, unknown>;
   status?: number;
   response?: { ok: true };
 }
 
 export const mockUpdateEnvironment = ({
-  environment,
+  payload,
   status = 200,
   response = { ok: true },
 }: UpdateEnvironmentProps) => {
   return nock(endpoint)
     .put(`/v1/env`, (body: any) => {
-      expect(body).toEqual(toUpdateRequestObject(environment));
+      const { envId, ...rest } = body;
+
+      expect(envId).toBeTruthy();
+      expect(rest).toEqual(payload);
+
       return true;
     })
     .reply(status, response);


### PR DESCRIPTION
## What

Each environment **config** section (general, build, server, serverless, headers, redirects, env vars, status checks) is its own `<form>` with its own Save button — but every save rebuilt and submitted the **entire** env object via `updateEnvironment`, including `envVars`. So saving the build command (or any other section) resubmitted the whole variables map.

This switches saves to **incremental updates**: each section declares the fields it owns, and `updateEnvironment` sends only those (plus `envId`). The API already treats omitted fields as "leave unchanged" (`handlerEnvUpdate` uses optional pointer fields).

## Why

Frontend-only prep for the env-var masking work. Once list/get responses mask variable **values**, a whole-object save would overwrite real secrets with masked/blank values. Making `envVars` something that **only the env-vars section ever sends** removes that clobber risk structurally — no diffing or guesswork.

## How

- `updateEnvironment` / `useSubmitHandler` gain a `fields: EnvUpdateField[]` whitelist; the built payload is filtered to those keys before the `PUT /v1/env`.
- Each section passes its own `fields` (e.g. build → `installCmd/buildCmd/distFolder/workDir`; env vars → `envVars`).
- `TabConfigBuild` no longer mutates the `env` prop (workDir is fed in as a controlled value), so it no longer touches the variables map at all.
- Test nock `mockUpdateEnvironment` now asserts the exact per-section payload (it takes the same `fields`), so each section's contract — including *not* sending `envVars` — is enforced.

## Tests

`209 passed` across the environments tree (`npx vitest run "src/pages/apps/[id]/environments"`), including every config section spec updated to its new payload.

## Scope

Frontend only. No backend or API change (the API already supports partial updates). Backend value-masking + an admin/owner reveal flow are separate, later changes.