### PR TITLE
feat: add claude code plugin and marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "stormkit",
+  "description": "Official Stormkit plugins for Claude Code.",
+  "owner": { "name": "Stormkit", "email": "hello@stormkit.io" },
+  "plugins": [
+    {
+      "name": "stormkit",
+      "source": "./plugins/stormkit",
+      "description": "Deploy and manage Stormkit apps, environments, domains and deployments from Claude Code. Works with Stormkit Cloud and self-hosted instances.",
+      "category": "deployment",
+      "tags": ["deployment", "hosting", "stormkit", "mcp"]
+    }
+  ]
+}

--- a/plugins/stormkit/.claude-plugin/plugin.json
+++ b/plugins/stormkit/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "stormkit",
+  "description": "Deploy and manage Stormkit apps, environments, domains and deployments from Claude Code.",
+  "version": "1.0.0",
+  "author": { "name": "Stormkit", "email": "hello@stormkit.io" },
+  "homepage": "https://www.stormkit.io",
+  "repository": "https://github.com/stormkit-io/stormkit-io",
+  "license": "MIT"
+}

--- a/plugins/stormkit/.mcp.json
+++ b/plugins/stormkit/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "stormkit": {
+      "type": "http",
+      "url": "${STORMKIT_HOST:-https://api.stormkit.io}/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${STORMKIT_API_KEY:-}"
+      }
+    }
+  }
+}

--- a/plugins/stormkit/README.md
+++ b/plugins/stormkit/README.md
@@ -1,0 +1,32 @@
+# Stormkit plugin for Claude Code
+
+Deploy and manage Stormkit apps, environments, domains and deployments from
+Claude Code. Talks to Stormkit's hosted MCP server (`/v1/mcp`).
+
+## Install
+
+```
+/plugin marketplace add stormkit-io/stormkit-io
+/plugin install stormkit@stormkit
+```
+
+## Configure
+
+The connection is driven by two environment variables:
+
+| Variable            | Required           | Default                     | Notes                                            |
+| ------------------- | ------------------ | --------------------------- | ------------------------------------------------ |
+| `STORMKIT_API_KEY`  | yes                | —                           | Stormkit API key (`SK_...`), from User Settings. |
+| `STORMKIT_HOST`     | self-hosted only   | `https://api.stormkit.io`   | Base URL only; `/v1/mcp` is appended for you.    |
+
+```bash
+# Stormkit Cloud
+export STORMKIT_API_KEY="SK_xxxxxxxx"
+
+# Self-hosted
+export STORMKIT_HOST="https://stormkit.mycompany.com"
+export STORMKIT_API_KEY="SK_xxxxxxxx"
+```
+
+Restart Claude Code, then run `/mcp` to confirm the `stormkit` server is
+connected. Run `/stormkit:setup` for a guided walkthrough.

--- a/plugins/stormkit/skills/setup/SKILL.md
+++ b/plugins/stormkit/skills/setup/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: setup
+description: Configure the Stormkit MCP connection. Use when the user wants to connect Claude Code to Stormkit, set their Stormkit host or API key, or is getting 401/connection errors from Stormkit tools.
+---
+
+# Stormkit setup
+
+Help the user connect Claude Code to their Stormkit instance. The Stormkit MCP
+server is configured in this plugin's `.mcp.json` via two environment variables:
+
+- `STORMKIT_HOST` — base URL of the instance. Defaults to `https://api.stormkit.io`
+  (Stormkit Cloud). Self-hosted users must set this to their own host, e.g.
+  `https://stormkit.mycompany.com`. Do **not** include a trailing `/v1/mcp` — the
+  plugin appends `/v1/mcp` automatically.
+- `STORMKIT_API_KEY` — a Stormkit API key (starts with `SK_`). Created from the
+  Stormkit UI under **User Settings → API Keys**.
+
+## Steps
+
+1. Ask the user whether they're on **Stormkit Cloud** or **self-hosted**.
+   - Cloud → leave `STORMKIT_HOST` unset (the default is used).
+   - Self-hosted → ask for their host URL and validate it looks like
+     `https://<host>` with no path.
+
+2. Ask for their API key (`SK_...`). Never echo the full key back; confirm only
+   the last 4 characters.
+
+3. Tell the user to export the variables in their shell profile so Claude Code
+   picks them up on the next launch, for example:
+
+   ```bash
+   # Self-hosted
+   export STORMKIT_HOST="https://stormkit.mycompany.com"
+   export STORMKIT_API_KEY="SK_xxxxxxxx"
+
+   # Cloud — only the key is needed
+   export STORMKIT_API_KEY="SK_xxxxxxxx"
+   ```
+
+4. Have them restart Claude Code (or reload the shell) so the env vars are read,
+   then run `/mcp` to confirm the `stormkit` server shows as connected.
+
+## Troubleshooting
+
+- **401 / unauthorized** → the API key is missing, malformed (must start with
+  `SK_`), or revoked. Re-issue a key from the Stormkit UI.
+- **Connection refused / DNS errors** → `STORMKIT_HOST` is wrong or the instance
+  isn't reachable from the user's machine. Confirm the base URL and that the
+  Stormkit API is up.
+- **Config didn't take effect** → env vars are read at startup. The user must
+  fully restart Claude Code after exporting them.


### PR DESCRIPTION
Adds a Claude Code plugin for Stormkit, distributed via this repo acting as a plugin marketplace.

## What's included
- `.claude-plugin/marketplace.json` — registers this repo as a marketplace so users can `/plugin marketplace add stormkit-io/stormkit-io`.
- `plugins/stormkit/` — the plugin itself:
  - `.claude-plugin/plugin.json` — manifest.
  - `.mcp.json` — points Claude at the hosted MCP server (`/v1/mcp`).
  - `skills/setup/SKILL.md` — `/stormkit:setup` guided connect flow.
  - `README.md` — install + config docs.

## Cloud and self-hosted
The MCP URL is driven by env vars so one plugin serves both audiences:

```json
"url": "${STORMKIT_HOST:-https://api.stormkit.io}/v1/mcp",
"headers": { "Authorization": "Bearer ${STORMKIT_API_KEY:-}" }
```

- Cloud users set only `STORMKIT_API_KEY`.
- Self-hosted users also set `STORMKIT_HOST` to their instance base URL.

## Usage
```
/plugin marketplace add stormkit-io/stormkit-io
/plugin install stormkit@stormkit
```

Both manifests pass `claude plugin validate`. To appear in the `/plugin` Discover tab, submit the repo at platform.claude.com/plugins/submit.