### PR TITLE
fix: add client-side /mcp route for docs alias

### DIFF
--- a/src/www/src/pages/docs/[category]/[title].tsx
+++ b/src/www/src/pages/docs/[category]/[title].tsx
@@ -15,11 +15,21 @@ import Context from '~/context'
 // Required for SSR
 export { fetchData } from './_ssr'
 
-export default function DocTitle() {
+interface DocTitleProps {
+  // Optional overrides used by top-level doc aliases (e.g. /mcp) that render a
+  // specific doc page without the /docs/:category/:title route params.
+  category?: string
+  title?: string
+}
+
+export default function DocTitle({
+  category: categoryProp,
+  title: titleProp,
+}: DocTitleProps = {}) {
   const params = useParams()
   const { url } = useContext(Context)
-  const category = params.category || url?.split?.('/')?.[2] || ''
-  const title = params.title || url?.split?.('/')?.[3] || ''
+  const category = categoryProp || params.category || url?.split?.('/')?.[2] || ''
+  const title = titleProp || params.title || url?.split?.('/')?.[3] || ''
   const { content, navigation, loading } = withContent(fetchData, {
     defaultCategory: category,
     defaultTitle: title,
@@ -37,7 +47,7 @@ export default function DocTitle() {
         flexDirection: 'column',
         color: 'primary.contrastText',
       }}
-      className={params.category?.toLowerCase() || 'welcome'}
+      className={category?.toLowerCase() || 'welcome'}
     >
       <Header />
       <Box sx={{ flex: 1, visibility: loading ? 'visible' : 'hidden' }}>

--- a/src/www/src/pages/mcp.tsx
+++ b/src/www/src/pages/mcp.tsx
@@ -1,0 +1,15 @@
+import DocTitle from '~/pages/docs/[category]/[title]'
+import { fetchData as docsFetchData } from '~/pages/docs/[category]/_ssr'
+
+// Top-level /mcp alias for the API/MCP documentation page. The www server
+// rewrites /mcp -> /docs/api/mcp, but the URL stays /mcp, so the client router
+// needs a matching route that renders the same doc instead of falling through
+// to the 404 catch-all.
+
+// Required for SSR — always load the api/mcp doc regardless of route params.
+export const fetchData: FetchDataFunc = async () =>
+  docsFetchData({ category: 'api', title: 'mcp' })
+
+export default function MCP() {
+  return <DocTitle category="api" title="mcp" />
+}

--- a/src/www/src/routes.tsx
+++ b/src/www/src/routes.tsx
@@ -23,6 +23,7 @@ const routes: Route[] = [
     path: '/policies/privacy',
     import: () => import('~/pages/policies/privacy'),
   },
+  { path: '/mcp', import: () => import('~/pages/mcp') },
   { path: '/docs', import: () => import('~/pages/docs') },
   {
     path: '/docs/:category/:title',


### PR DESCRIPTION
The www server rewrites `/mcp` -> `/docs/api/mcp` (a path rewrite, URL stays `/mcp`). The SSR HTML loads correctly, but the React Router had no `/mcp` route, so on hydration the client router fell through to the 404 catch-all.

## Fix
- Add a `/mcp` route in `routes.tsx` (before the `*` catch-all).
- New `pages/mcp.tsx` that renders the API/MCP doc by reusing the existing docs infrastructure — exports `fetchData` (hardcoded `api`/`mcp`) for SSR and renders `<DocTitle category="api" title="mcp" />` on the client.
- `DocTitle` now accepts optional `category`/`title` props so a top-level alias can target a specific doc without `/docs/:category/:title` params. Also use the resolved `category` for the wrapper `className` (was `params.category`, undefined on aliases).

No markdown-rendering logic duplicated. Verified with `npm run build:spa` — compiles and produces a dedicated `mcp` chunk.