### PR TITLE
feat: trigger function triggers on demand

### DIFF
--- a/src/ce/api/app/functiontrigger/function_trigger_run.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_run.go
@@ -1,0 +1,50 @@
+package functiontrigger
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+type RunParams struct {
+	TriggerID types.ID
+	Method    string
+	URL       string
+	Headers   shttp.Headers
+	Payload   []byte
+}
+
+// Run executes the trigger's HTTP request and returns a log describing the
+// request and its response. It does not persist anything.
+func Run(p RunParams) (TriggerLog, error) {
+	res, err := shttp.NewRequestV2(utils.GetString(p.Method, shttp.MethodGet), p.URL).
+		Headers(p.Headers.Make()).
+		Payload(p.Payload).
+		Do()
+
+	request := map[string]any{
+		"url":     p.URL,
+		"method":  p.Method,
+		"headers": p.Headers,
+		"payload": string(p.Payload),
+	}
+
+	var response map[string]any
+
+	if res != nil {
+		response = map[string]any{
+			"code": res.StatusCode,
+			"body": res.String(),
+		}
+	} else if err != nil {
+		response = map[string]any{
+			"error": err.Error(),
+		}
+	}
+
+	return TriggerLog{
+		TriggerID: p.TriggerID,
+		Request:   request,
+		Response:  response,
+	}, err
+}

--- a/src/ce/api/app/functiontrigger/functiontriggerhandlers/handler_function_trigger_invoke.go
+++ b/src/ce/api/app/functiontrigger/functiontriggerhandlers/handler_function_trigger_invoke.go
@@ -1,0 +1,55 @@
+package functiontriggerhandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+func handlerFunctionTriggerInvoke(req *app.RequestContext) *shttp.Response {
+	body := struct {
+		ID types.ID `json:"id,string"`
+	}{}
+
+	if err := req.Post(&body); err != nil {
+		return shttp.Error(err)
+	}
+
+	if body.ID == 0 {
+		return shttp.NotFound()
+	}
+
+	store := functiontrigger.NewStore()
+
+	trigger, err := store.ByID(req.Context(), body.ID)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	if trigger == nil || trigger.EnvID != req.EnvID {
+		return shttp.NotFound()
+	}
+
+	log, _ := functiontrigger.Run(functiontrigger.RunParams{
+		TriggerID: trigger.ID,
+		Method:    trigger.Options.Method,
+		URL:       trigger.Options.URL,
+		Headers:   trigger.Options.Headers,
+		Payload:   trigger.Options.Payload,
+	})
+
+	if err := store.InsertLogs(req.Context(), []functiontrigger.TriggerLog{log}); err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"log": log,
+		},
+	}
+}

--- a/src/ce/api/app/functiontrigger/functiontriggerhandlers/handler_function_trigger_invoke_test.go
+++ b/src/ce/api/app/functiontrigger/functiontriggerhandlers/handler_function_trigger_invoke_test.go
@@ -1,0 +1,119 @@
+package functiontriggerhandlers_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger/functiontriggerhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerFunctionTriggerInvokeSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn        databasetest.TestDB
+	mockRequest *mocks.RequestInterface
+}
+
+func (s *HandlerFunctionTriggerInvokeSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+	s.mockRequest = &mocks.RequestInterface{}
+	shttp.DefaultRequest = s.mockRequest
+	admin.SetMockLicense()
+}
+
+func (s *HandlerFunctionTriggerInvokeSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+	shttp.DefaultRequest = nil
+	admin.ResetMockLicense()
+}
+
+func (s *HandlerFunctionTriggerInvokeSuite) Test_Invoke() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+	tf := s.MockTriggerFunction(env, map[string]any{
+		"Options": functiontrigger.Options{URL: "https://example.org"},
+	})
+
+	s.mockRequest.On("URL", "https://example.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.Headers(nil).Make()).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("pong")),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(functiontriggerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/apps/trigger/invoke",
+		map[string]any{
+			"id":    tf.ID.String(),
+			"envId": env.ID.String(),
+			"appId": app.ID.String(),
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	logs, err := functiontrigger.NewStore().Logs(context.Background(), tf.ID)
+
+	s.NoError(err)
+	s.Len(logs, 1)
+}
+
+func (s *HandlerFunctionTriggerInvokeSuite) Test_Permission() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	app2 := s.MockApp(usr)
+	env2 := s.MockEnv(app2)
+	tf2 := s.MockTriggerFunction(env2)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(functiontriggerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/apps/trigger/invoke",
+		map[string]any{
+			"id":    tf2.ID.String(),
+			"envId": env.ID.String(),
+			"appId": app.ID.String(),
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusNotFound, response.Code)
+
+	logs, err := functiontrigger.NewStore().Logs(context.Background(), tf2.ID)
+
+	s.NoError(err)
+	s.Len(logs, 0)
+}
+
+func TestHandlerInvokeTrigger(t *testing.T) {
+	suite.Run(t, &HandlerFunctionTriggerInvokeSuite{})
+}

--- a/src/ce/api/app/functiontrigger/functiontriggerhandlers/services.go
+++ b/src/ce/api/app/functiontrigger/functiontriggerhandlers/services.go
@@ -13,6 +13,7 @@ func Services(r *shttp.Router) *shttp.Service {
 		Handler(shttp.MethodDelete, "/trigger", app.WithApp(handlerFunctionTriggerDelete)).
 		Handler(shttp.MethodPatch, "/trigger", app.WithApp(handlerFunctionTriggerUpdate)).
 		Handler(shttp.MethodPost, "/trigger", app.WithApp(handlerFunctionTriggerCreate)).
+		Handler(shttp.MethodPost, "/trigger/invoke", app.WithApp(handlerFunctionTriggerInvoke)).
 		Handler(shttp.MethodGet, "/triggers", app.WithApp(handlerFunctionTriggersGet)).
 		Handler(shttp.MethodGet, "/trigger/logs", app.WithApp(handleTriggerLogsGet))
 

--- a/src/ce/api/app/functiontrigger/functiontriggerhandlers/services_test.go
+++ b/src/ce/api/app/functiontrigger/functiontriggerhandlers/services_test.go
@@ -22,6 +22,7 @@ func (s *ServicesSuite) Test_Services() {
 		"GET:/apps/triggers",
 		"PATCH:/apps/trigger",
 		"POST:/apps/trigger",
+		"POST:/apps/trigger/invoke",
 	}
 
 	s.Equal(handlers, services.HandlerKeys())

--- a/src/ce/workerserver/job_trigger_functions.go
+++ b/src/ce/workerserver/job_trigger_functions.go
@@ -3,8 +3,6 @@ package jobs
 import (
 	"context"
 	"encoding/json"
-	"io"
-	"net/http"
 	"time"
 
 	"github.com/adhocore/gronx"
@@ -80,36 +78,15 @@ func HandleFunctionTrigger(ctx context.Context, t *asynq.Task) error {
 	updates := map[types.ID]utils.Unix{}
 
 	for _, tf := range tfs {
-		res, err := shttp.NewRequestV2(utils.GetString(tf.Method, shttp.MethodGet), tf.URL).
-			Headers(tf.Headers.Make()).
-			Payload(tf.Payload).
-			Do()
-
-		request := map[string]any{
-			"url":     tf.URL,
-			"method":  tf.Method,
-			"headers": tf.Headers,
-			"payload": string(tf.Payload),
-		}
-
-		var response map[string]any
-
-		if res != nil {
-			response = map[string]any{
-				"code": res.StatusCode,
-				"body": readBody(res.Response),
-			}
-		} else if err != nil {
-			response = map[string]any{
-				"error": err.Error(),
-			}
-		}
-
-		logs = append(logs, functiontrigger.TriggerLog{
+		log, err := functiontrigger.Run(functiontrigger.RunParams{
 			TriggerID: tf.ID,
-			Request:   request,
-			Response:  response,
+			Method:    tf.Method,
+			URL:       tf.URL,
+			Headers:   tf.Headers,
+			Payload:   tf.Payload,
 		})
+
+		logs = append(logs, log)
 
 		if err != nil {
 			slog.Errorf("trigger function request failed %v", err)
@@ -130,16 +107,4 @@ func HandleFunctionTrigger(ctx context.Context, t *asynq.Task) error {
 	}
 
 	return nil
-}
-
-func readBody(res *http.Response) string {
-	body, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return ""
-	}
-
-	defer res.Body.Close()
-
-	return string(body)
 }

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.spec.tsx
@@ -15,7 +15,11 @@ import mockEnvironment from "~/testing//data/mock_environment";
 import * as mockActions from "~/testing/nocks/nock_function_triggers";
 import FunctionTriggers from "./FunctionTriggers";
 
-const { mockFetchFunctionTriggers, mockDeleteFunctionTrigger } = mockActions;
+const {
+  mockFetchFunctionTriggers,
+  mockDeleteFunctionTrigger,
+  mockInvokeFunctionTrigger,
+} = mockActions;
 
 interface Props {
   app?: App;
@@ -118,6 +122,38 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.t
     await waitFor(() => {
       expect(deleteScope.isDone()).toBe(true);
       expect(refetchScope.isDone()).toBe(true);
+    });
+  });
+
+  it("should handle running a trigger immediately", async () => {
+    createWrapper();
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(
+        wrapper.getByText("https://app.stormkit.io/api/test")
+      ).toBeTruthy();
+    });
+
+    const invokeScope = mockInvokeFunctionTrigger({
+      appId: currentApp.id,
+      envId: currentEnv.id!,
+      tfid: currentTriggers[0].id!,
+    });
+
+    fireEvent.click(wrapper.getAllByLabelText("expand").at(0)!);
+
+    await waitFor(() => {
+      expect(wrapper.getByText("Trigger now")).toBeTruthy();
+    });
+
+    fireEvent.click(wrapper.getByText("Trigger now"));
+
+    await waitFor(() => {
+      expect(invokeScope.isDone()).toBe(true);
+      expect(
+        wrapper.getByText(/Open 'Past triggers' to see the output/)
+      ).toBeTruthy();
     });
   });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState } from "react";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/ModeEdit";
+import PlayIcon from "@mui/icons-material/PlayArrow";
 import TimeIcon from "@mui/icons-material/AccessTime";
 import CircleIcon from "@mui/icons-material/Circle";
 import Button from "@mui/material/Button";
@@ -19,7 +20,8 @@ import Span from "~/components/Span";
 import FunctionTriggerModal from "./FunctionTriggerModal";
 import * as actions from "./actions";
 
-const { useFetchFunctionTriggers, deleteFunctionTrigger } = actions;
+const { useFetchFunctionTriggers, deleteFunctionTrigger, invokeFunctionTrigger } =
+  actions;
 
 const colors: Record<
   FunctionTriggerMethod,
@@ -48,6 +50,9 @@ export default function FunctionTriggers() {
   const [toBeModified, setToBeModified] = useState<FunctionTrigger>();
   const [toBeDeleted, setToBeDeleted] = useState<FunctionTrigger>();
   const [isFunctionTriggerModalOpen, setFunctionTriggerModal] = useState(false);
+  const [actionError, setActionError] = useState<string>();
+  const [actionSuccess, setActionSuccess] = useState<string>();
+  const [invoking, setInvoking] = useState<string>();
   const [refreshToken, setRefreshToken] = useState(0);
   const { error, loading, functionTriggers, paymentRequired } =
     useFetchFunctionTriggers({
@@ -86,6 +91,33 @@ export default function FunctionTriggers() {
       });
   };
 
+  const handleInvoke = (f: FunctionTrigger) => {
+    setActionError(undefined);
+    setActionSuccess(undefined);
+    setInvoking(f.id);
+
+    invokeFunctionTrigger({
+      tfid: f.id!,
+      appId: app.id,
+      envId: environment.id!,
+    })
+      .then(() => {
+        setActionSuccess(
+          "Trigger executed. Open 'Past triggers' to see the output."
+        );
+      })
+      .catch(res => {
+        setActionError(
+          typeof res === "string"
+            ? res
+            : "Something went wrong while running the trigger."
+        );
+      })
+      .finally(() => {
+        setInvoking(undefined);
+      });
+  };
+
   if (paymentRequired) {
     return (
       <Card
@@ -107,7 +139,8 @@ export default function FunctionTriggers() {
     <Card
       sx={{ width: "100%" }}
       loading={loading}
-      error={error}
+      error={error || actionError}
+      success={actionSuccess}
       contentPadding={false}
     >
       <CardHeader
@@ -117,8 +150,13 @@ export default function FunctionTriggers() {
       {functionTriggers?.map((f, i) => (
         <CardRow
           key={f.id}
-          sx={{ display: "flex", alignItems: "center" }}
           menuItems={[
+            {
+              icon: <PlayIcon />,
+              text: invoking === f.id ? "Running…" : "Trigger now",
+              disabled: invoking === f.id,
+              onClick: () => handleInvoke(f),
+            },
             {
               icon: <TimeIcon />,
               text: "Past triggers",
@@ -142,7 +180,9 @@ export default function FunctionTriggers() {
             },
           ]}
         >
-          <Typography sx={{ display: "flex" }}>
+          <Typography
+            sx={{ display: "flex", alignItems: "center", width: "100%" }}
+          >
             <Chip
               size="small"
               component="span"
@@ -153,11 +193,12 @@ export default function FunctionTriggers() {
             <Typography
               component="span"
               color="text.secondary"
+              noWrap
               sx={{ mr: 2, flex: 1 }}
             >
               {f.options.url}
             </Typography>
-            <Span>
+            <Span sx={{ display: "inline-flex", alignItems: "center" }}>
               <Tooltip
                 title={
                   f.status &&
@@ -168,13 +209,13 @@ export default function FunctionTriggers() {
                   )
                 }
               >
-                <span>
+                <span style={{ display: "inline-flex", alignItems: "center" }}>
                   <TimeIcon sx={{ mr: 1, fontSize: 16 }} />
                   {f.cron}
                 </span>
               </Tooltip>
             </Span>
-            <Span>
+            <Span sx={{ display: "inline-flex", alignItems: "center" }}>
               <CircleIcon
                 color={f.status ? "success" : "error"}
                 sx={{ fontSize: 10, mr: 1 }}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/[trigger-id]/TriggerLogs.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/[trigger-id]/TriggerLogs.spec.tsx
@@ -1,7 +1,7 @@
 import type { RenderResult } from "@testing-library/react";
 import type { Scope } from "nock";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter } from "react-router";
 import { AppContext } from "~/pages/apps/[id]/App.context";
 import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
@@ -126,6 +126,34 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/[trigger-id]/Trigg
     await waitFor(() => {
       fireEvent.click(wrapper.getByTestId("refresh-logs"));
       expect(newScope.isDone()).toBe(true);
+    });
+  });
+
+  it("should render failed logs that have no response code", async () => {
+    cleanup();
+    createWrapper({
+      logs: [
+        {
+          createdAt: 1734602569,
+          request: { url: "https://api.example.com/trigger-fail" },
+          response: { error: "dial tcp: connection refused" },
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByText("https://api.example.com/trigger-fail")
+      ).toBeTruthy();
+      expect(wrapper.getByText("ERR")).toBeTruthy();
+    });
+
+    fireEvent.click(wrapper.getAllByTestId("trigger-log").at(0)!);
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByText("dial tcp: connection refused")
+      ).toBeTruthy();
     });
   });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/[trigger-id]/TriggerLogs.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/[trigger-id]/TriggerLogs.tsx
@@ -70,15 +70,21 @@ export default function TriggerLogs() {
           <Typography sx={{ display: "flex", alignItems: "center" }}>
             <Span
               color={
-                log.response?.code.toString()?.[0] === "2"
+                log.response?.code?.toString()?.[0] === "2"
                   ? "success"
-                  : "default"
+                  : log.response?.code
+                    ? "default"
+                    : "failure"
               }
             >
-              {log.response?.code}
+              {log.response?.code || "ERR"}
             </Span>
             <Span>{log.request?.url}</Span>
-            <Typography component="span" sx={{ flex: 1 }}>
+            <Typography
+              component="span"
+              color="text.secondary"
+              sx={{ flex: 1, textAlign: "right" }}
+            >
               {formatDate(log.createdAt * 1000)}
             </Typography>
           </Typography>
@@ -128,12 +134,12 @@ export default function TriggerLogs() {
                     sx={{ mr: 0 }}
                     size="small"
                     color={
-                      drawerContent.response.code?.toString()?.[0] === "2"
+                      drawerContent.response?.code?.toString()?.[0] === "2"
                         ? "success"
                         : undefined
                     }
                   >
-                    {drawerContent.response.code}
+                    {drawerContent.response?.code || "ERR"}
                   </Span>
                 </Typography>
                 <Box
@@ -145,7 +151,9 @@ export default function TriggerLogs() {
                     overflow: "auto",
                   }}
                 >
-                  {drawerContent?.response?.body}
+                  {drawerContent?.response?.body ||
+                  drawerContent?.response?.error ||
+                  "No response body"}
                 </Box>
               </Box>
             </Box>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/actions.ts
@@ -62,6 +62,24 @@ export function deleteFunctionTrigger({
   );
 }
 
+interface InvokeFunctionTriggerProps {
+  tfid: string;
+  appId: string;
+  envId: string;
+}
+
+export function invokeFunctionTrigger({
+  tfid,
+  appId,
+  envId,
+}: InvokeFunctionTriggerProps): Promise<void> {
+  return api.post(`/apps/trigger/invoke`, {
+    id: tfid,
+    appId,
+    envId,
+  });
+}
+
 interface CreateFunctionTriggerProps extends Omit<FunctionTrigger, "options"> {
   appId: string;
   envId: string;

--- a/src/ui/src/testing/nocks/nock_function_triggers.ts
+++ b/src/ui/src/testing/nocks/nock_function_triggers.ts
@@ -36,6 +36,28 @@ export const mockDeleteFunctionTrigger = ({
     .reply(200, { ok: true });
 };
 
+interface MockInvokeFunctionTriggerProps {
+  appId: string;
+  envId: string;
+  tfid: string;
+  status?: number;
+}
+
+export const mockInvokeFunctionTrigger = ({
+  appId,
+  envId,
+  tfid,
+  status = 200,
+}: MockInvokeFunctionTriggerProps) => {
+  return nock(endpoint)
+    .post(`/apps/trigger/invoke`, {
+      id: tfid,
+      appId,
+      envId,
+    })
+    .reply(status, { ok: true });
+};
+
 interface MockUpdateFunctionTriggerProps {
   tfid: string;
   appId: string;

--- a/src/ui/src/types/function-triggers.d.ts
+++ b/src/ui/src/types/function-triggers.d.ts
@@ -29,7 +29,8 @@ declare interface TriggerLog {
   };
   response: {
     body?: string;
-    code: number;
+    code?: number;
+    error?: string;
   };
   createdAt: number;
 }


### PR DESCRIPTION
## What

Adds a **Trigger now** action to each row on the Periodic Triggers page that executes a function trigger immediately, on demand, regardless of its schedule or enabled/disabled state. The execution is stored as a normal log (viewable under **Past triggers**) and does not disturb the trigger's `next_run_at`.

## Why

There was no way to run a trigger ad-hoc — you had to wait for the cron schedule to fire to verify an endpoint. This makes it possible to test a trigger and inspect its request/response right away.

## How

### Backend
- Extract the per-trigger HTTP execution (request → request/response log) into a reusable `functiontrigger.Run`, so the scheduler and the new on-demand path share the same logic (no duplication).
- New synchronous handler `POST /apps/trigger/invoke` — validates ownership, runs the trigger, and inserts a single log. It runs inline (not via the async worker queue).

### Frontend
- `invokeFunctionTrigger` action + "Trigger now" menu item with a running/disabled state and success/error feedback.
- Aligned the trigger list rows.

### Logs view hardening
- A failed run stores a response with an `error` but no status `code`. The logs page read `response.code.toString()` without guarding, crashing the whole page to a blank screen. Guarded the optional chain, render **ERR** for codeless logs, and surface the error text in the drawer.
- Right-aligned the date in log rows.

## Tests
- Go: new handler test (success inserts a log; cross-env returns 404 and writes nothing); existing worker/handler suites still pass.
- UI: "run a trigger immediately" spec + a regression test for failed (codeless) logs rendering. FunctionTriggers and TriggerLogs suites pass.