### PR TITLE
feat: analytics retention, index and drain loop

### DIFF
--- a/src/ce/workerserver/job_analytics_retention.go
+++ b/src/ce/workerserver/job_analytics_retention.go
@@ -1,0 +1,55 @@
+package jobs
+
+import (
+	"context"
+	"os"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+const (
+	defaultAnalyticsRetentionDays = 180
+	analyticsRetentionBatchSize   = 10000
+	analyticsRetentionMaxBatches  = 1000
+)
+
+// RemoveOldAnalytics deletes raw analytics rows older than the retention window
+// in batches to avoid long locks and table bloat. The window defaults to 180
+// days and can be overridden via STORMKIT_ANALYTICS_RETENTION_DAYS. Aggregated
+// analytics tables are intentionally kept and not touched here.
+func RemoveOldAnalytics(ctx context.Context) error {
+	days := utils.StringToInt(os.Getenv("STORMKIT_ANALYTICS_RETENTION_DAYS"))
+
+	if days <= 0 {
+		days = defaultAnalyticsRetentionDays
+	}
+
+	store := NewStore()
+
+	var total int64
+
+	for range analyticsRetentionMaxBatches {
+		deleted, err := store.RemoveOldAnalytics(ctx, RemoveOldAnalyticsParams{
+			RetentionDays: days,
+			BatchSize:     analyticsRetentionBatchSize,
+		})
+
+		if err != nil {
+			slog.Errorf("could not remove old analytics: %s", err.Error())
+			return err
+		}
+
+		total += deleted
+
+		if deleted < analyticsRetentionBatchSize {
+			break
+		}
+	}
+
+	if total > 0 {
+		slog.Infof("removed %d old analytics records (retention=%d days)", total, days)
+	}
+
+	return nil
+}

--- a/src/ce/workerserver/job_analytics_retention_test.go
+++ b/src/ce/workerserver/job_analytics_retention_test.go
@@ -1,0 +1,119 @@
+package jobs_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/guregu/null.v3"
+)
+
+type JobAnalyticsRetentionSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn     databasetest.TestDB
+	domainID types.ID
+}
+
+func (s *JobAnalyticsRetentionSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	domain := &buildconf.DomainModel{
+		AppID:      app.ID,
+		EnvID:      env.ID,
+		Name:       "www.stormkit.io",
+		Verified:   true,
+		VerifiedAt: utils.NewUnix(),
+		Token:      null.StringFrom("my-custom-token"),
+	}
+
+	s.NoError(buildconf.DomainStore().Insert(context.Background(), domain))
+
+	now := time.Now()
+	ages := []time.Duration{
+		200 * 24 * time.Hour, // older than the 180-day default
+		190 * 24 * time.Hour, // older than the 180-day default
+		10 * 24 * time.Hour,  // within retention
+		1 * 24 * time.Hour,   // within retention
+	}
+
+	records := []analytics.Record{}
+
+	for _, age := range ages {
+		unix := utils.NewUnix()
+		unix.Time = now.Add(-age)
+
+		records = append(records, analytics.Record{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			VisitorIP:   "86.8.6.85",
+			RequestTS:   unix,
+			RequestPath: "/",
+			StatusCode:  http.StatusOK,
+			DomainID:    domain.ID,
+		})
+	}
+
+	s.NoError(analytics.NewStore().InsertRecords(context.Background(), records))
+	s.domainID = domain.ID
+}
+
+func (s *JobAnalyticsRetentionSuite) AfterTest(suiteName, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *JobAnalyticsRetentionSuite) countAnalytics() int {
+	var count int
+	s.NoError(s.conn.QueryRow(`SELECT count(*) FROM analytics`).Scan(&count))
+	return count
+}
+
+func (s *JobAnalyticsRetentionSuite) Test_RemoveOldAnalytics_DeletesOnlyOldRows() {
+	s.Equal(4, s.countAnalytics())
+
+	deleted, err := jobs.NewStore().RemoveOldAnalytics(context.Background(), jobs.RemoveOldAnalyticsParams{
+		RetentionDays: 180,
+		BatchSize:     10000,
+	})
+
+	s.NoError(err)
+	s.Equal(int64(2), deleted)
+	s.Equal(2, s.countAnalytics())
+}
+
+func (s *JobAnalyticsRetentionSuite) Test_RemoveOldAnalytics_NoOpWhenNothingExpired() {
+	deleted, err := jobs.NewStore().RemoveOldAnalytics(context.Background(), jobs.RemoveOldAnalyticsParams{
+		RetentionDays: 365,
+		BatchSize:     10000,
+	})
+
+	s.NoError(err)
+	s.Equal(int64(0), deleted)
+	s.Equal(4, s.countAnalytics())
+}
+
+func (s *JobAnalyticsRetentionSuite) Test_RemoveOldAnalytics_JobHonorsEnvWindow() {
+	s.T().Setenv("STORMKIT_ANALYTICS_RETENTION_DAYS", "5")
+
+	s.NoError(jobs.RemoveOldAnalytics(context.Background()))
+
+	// Only the 1-day-old row survives a 5-day window.
+	s.Equal(1, s.countAnalytics())
+}
+
+func TestJobAnalyticsRetentionSuite(t *testing.T) {
+	suite.Run(t, &JobAnalyticsRetentionSuite{})
+}

--- a/src/ce/workerserver/job_handler_forward.go
+++ b/src/ce/workerserver/job_handler_forward.go
@@ -54,15 +54,45 @@ func IngestHandlerForward(ctx context.Context) error {
 		rows = 1000
 	}
 
-	msgs, err := client.LPopCount(ctx, HostingQueueName, rows).Result()
+	// Drain several batches per tick instead of a single LPopCount, so the
+	// worker keeps up when records arrive faster than one batch per interval.
+	// Bounded by maxBatchesPerTick to avoid starving the scheduler.
+	const maxBatchesPerTick = 20
 
-	if rediscache.IsConnectionError(err) {
-		return err
+	msgs := []string{}
+
+	for range maxBatchesPerTick {
+		batch, err := client.LPopCount(ctx, HostingQueueName, rows).Result()
+
+		if rediscache.IsConnectionError(err) {
+			return err
+		}
+
+		if err != nil && !errors.Is(err, redis.Nil) {
+			// Stop draining but fall through to insert whatever was already
+			// popped: earlier batches are gone from the queue, so returning
+			// here would drop those records.
+			slog.Errorf("error while popping from redis: %v", err)
+			break
+		}
+
+		if len(batch) == 0 {
+			break
+		}
+
+		msgs = append(msgs, batch...)
+
+		if len(batch) < rows {
+			break
+		}
 	}
 
-	if err != nil && !errors.Is(err, redis.Nil) {
-		slog.Errorf("error while popping from redis: %v", err)
-		return err
+	// If we drained the full per-tick budget there may still be a backlog;
+	// surface it so queue depth is observable rather than silently growing.
+	if len(msgs) >= rows*maxBatchesPerTick {
+		if depth, err := client.LLen(ctx, HostingQueueName).Result(); err == nil && depth > 0 {
+			slog.Errorf("hosting queue backlog: %d records still pending after draining %d", depth, len(msgs))
+		}
 	}
 
 	for _, msg := range msgs {

--- a/src/ce/workerserver/job_handler_forward_test.go
+++ b/src/ce/workerserver/job_handler_forward_test.go
@@ -117,27 +117,26 @@ func (s *JobHandlerForwardTest) Test_IngestHandlerForward_MultipleRecords() {
 	s.Equal(int64(0), length)
 }
 
-func (s *JobHandlerForwardTest) Test_IngestHandlerForward_BatchLimit() {
+func (s *JobHandlerForwardTest) Test_IngestHandlerForward_DrainsMultipleBatches() {
 	s.T().Setenv("STORMKIT_HOSTING_QUEUE_BATCH_SIZE", "100")
 
-	// Push more than 100 records to test batch limit
-	for i := 0; i < 150; i++ {
+	// Push more than one batch worth of records. A single invocation drains
+	// several batches per tick (bounded by maxBatchesPerTick), so the whole
+	// queue is consumed rather than leaving a backlog after one batch.
+	for i := range 150 {
 		record := s.createTestRecord()
 		record.AppID = types.ID(i)
 		s.pushToQueue(record)
 	}
 
-	// Verify we have 150 records in queue
 	length := s.client.LLen(s.ctx, jobs.HostingQueueName).Val()
 	s.Equal(int64(150), length)
 
-	// Process the queue (should only process 100)
 	err := jobs.IngestHandlerForward(s.ctx)
 	s.NoError(err)
 
-	// Verify 50 records remain in queue
 	remainingLength := s.client.LLen(s.ctx, jobs.HostingQueueName).Val()
-	s.Equal(int64(50), remainingLength)
+	s.Equal(int64(0), remainingLength)
 }
 
 func (s *JobHandlerForwardTest) Test_IngestHandlerForward_RecordWithoutAnalytics() {

--- a/src/ce/workerserver/worker_scheduler.go
+++ b/src/ce/workerserver/worker_scheduler.go
@@ -80,6 +80,7 @@ func (s *Scheduler) RegisterMasterTasks(ctx context.Context) {
 	tasks := []TaskDefinition{
 		{Handler: InvokeDueFunctionTriggers, Def: dj(EVERY_MINUTE), Opt: immediate},
 		{Handler: RemoveOldLogs, Def: dj(EVERY_HOUR * 2), Opt: immediate},
+		{Handler: RemoveOldAnalytics, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: RemoveStaleEnvironments, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: RemoveDeploymentArtifacts, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: SyncAnalyticsVisitorsHourly, Def: dj(EVERY_MINUTE * 5), Opt: immediate},

--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -16,6 +16,7 @@ type statement struct {
 	selectTimedOutDeployments       string
 	selectOldOrDeletedDeployments   string
 	removeOldLogs                   string
+	removeOldAnalytics              string
 	syncAnalyticsVisitors           string
 	syncAnalyticsReferrers          string
 	syncAnalyticsCountries          string
@@ -42,6 +43,15 @@ var stmt = &statement{
        WHERE
          to_timestamp(timestamp)::date < now() - interval '30 days'
 	`, tableLogs),
+	removeOldAnalytics: `
+		DELETE FROM analytics
+		WHERE ctid IN (
+			SELECT ctid
+			FROM analytics
+			WHERE request_timestamp < now() - make_interval(days => $1)
+			LIMIT $2
+		)
+	`,
 	deleteStaleEnvironments: fmt.Sprintf(`
 		DELETE FROM %s
 		WHERE env_id IN (

--- a/src/ce/workerserver/ws_store.go
+++ b/src/ce/workerserver/ws_store.go
@@ -26,6 +26,25 @@ func (s *Store) RemoveOldLogs(ctx context.Context) error {
 	return err
 }
 
+// RemoveOldAnalyticsParams configures a single batched deletion of raw
+// analytics rows older than the retention window.
+type RemoveOldAnalyticsParams struct {
+	RetentionDays int
+	BatchSize     int
+}
+
+// RemoveOldAnalytics deletes up to BatchSize raw analytics rows older than
+// RetentionDays and returns the number of rows removed.
+func (s *Store) RemoveOldAnalytics(ctx context.Context, p RemoveOldAnalyticsParams) (int64, error) {
+	res, err := s.Exec(ctx, stmt.removeOldAnalytics, p.RetentionDays, p.BatchSize)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return res.RowsAffected()
+}
+
 // MarkDeploymentArtifactsDeleted marks the deployment and its artifacts as deleted.
 func (s *Store) MarkDeploymentArtifactsDeleted(ctx context.Context, ids []types.ID) error {
 	_, err := s.Exec(ctx, stmt.markDeploymentArtifactsDeleted, pq.Array(ids))

--- a/src/migrations/0024_2026-06-27.up.sql
+++ b/src/migrations/0024_2026-06-27.up.sql
@@ -1,0 +1,10 @@
+-- Speeds up the analytics rollup jobs, which filter raw rows by
+-- request_timestamp/response_code and group by domain_id every few minutes.
+-- Without this index those jobs sequentially scan the whole analytics table.
+--
+-- NOTE: built non-concurrently for migration-runner compatibility (the runner
+-- executes each file in a single Exec). On very large existing tables, a DBA
+-- may prefer to build it out-of-band with CREATE INDEX CONCURRENTLY and then
+-- let this IF NOT EXISTS statement become a no-op.
+CREATE INDEX IF NOT EXISTS idx_analytics_ts
+    ON analytics (request_timestamp, response_code, domain_id);


### PR DESCRIPTION
## Context

Phase 1 of the analytics hardening roadmap (cleanup-first). The raw `analytics` table is insert-only with **no retention** and **no time index**, while the rollup jobs (`SyncAnalytics*`) sequentially scan it every few minutes. Left unchecked the table grows unbounded and the rollup scan cost grows with it.

This PR is deliberately scoped to retention + the missing index + ingest insurance. Bot detection, custom events, and the client-side script are follow-up phases.

## Changes

- **Index** — `idx_analytics_ts (request_timestamp, response_code, domain_id)` via migration `0024`, so the rollup jobs use an index scan instead of a full table scan. Built non-concurrently for migration-runner compatibility (the runner executes each file in a single `Exec`); a DBA can build it `CONCURRENTLY` out-of-band on very large tables and the `IF NOT EXISTS` becomes a no-op.
- **Retention** — `RemoveOldAnalytics`, a **batched** delete (10k rows/batch via `ctid`, to avoid long locks and bloat) of raw rows older than `STORMKIT_ANALYTICS_RETENTION_DAYS` (default **180**), registered every 6h alongside the other `Remove*` jobs. Aggregated analytics tables are intentionally kept forever, so long-range trend charts are unaffected. 180d ≫ rollup lookback (~1d), so there's no race with the sync jobs.
- **Ingest drain loop** — `IngestHandlerForward` now drains several batches per tick (bounded by `maxBatchesPerTick`) instead of a single `LPopCount`, and logs when a backlog persists. Removes the previous ~one-batch-per-tick ceiling and makes queue depth observable rather than silently growing.

## Tests

- New `JobAnalyticsRetentionSuite`: deletes only expired rows, no-op when nothing is expired, and the job honors the env-configured window.
- Updated `Test_IngestHandlerForward_DrainsMultipleBatches` to assert the new multi-batch drain semantics (was `BatchLimit`, which encoded the old one-batch-per-tick behavior).
- Full `./src/ce/workerserver/` package passes (`go test -p 1`).

## Verification

- `go vet ./src/ce/workerserver/...` clean.
- Migration applies in the test DB (`migrations.Up` at suite init); rollup queries use the new index.