### PR TITLE
feat: custom events dashboard with property grouping

### DIFF
--- a/src/ce/workerserver/job_analytics_events_test.go
+++ b/src/ce/workerserver/job_analytics_events_test.go
@@ -60,11 +60,18 @@ func (s *JobAnalyticsEventsSuite) BeforeTest(suiteName, _ string) {
 	insertion.RequestID = null.StringFrom("11111111-1111-1111-1111-111111111111")
 	insertion.Metadata = null.StringFrom(`{"price": 42}`)
 
+	// trip_creation events carry a `ref` property for breakdown tests.
+	withRef := func(name, visitor string, ref string) analytics.Event {
+		e := event(name, visitor, domain.ID)
+		e.Metadata = null.StringFrom(`{"ref": "` + ref + `"}`)
+		return e
+	}
+
 	events := []analytics.Event{
-		event("trip_creation", "v1", domain.ID),
-		event("trip_creation", "v2", domain.ID),
-		event("trip_creation", "v1", domain.ID), // repeat visitor
-		event("trip_creation", "", domain.ID),   // server-side, no identity
+		withRef("trip_creation", "v1", "mobile"),
+		withRef("trip_creation", "v2", "web"),
+		withRef("trip_creation", "v1", "mobile"), // repeat visitor
+		withRef("trip_creation", "", "web"),      // server-side, no identity
 		insertion,
 		event("trip_creation", "v3", 0), // other domain -> excluded from this domain's read
 	}
@@ -125,6 +132,41 @@ func (s *JobAnalyticsEventsSuite) Test_SyncAnalyticsEvents() {
 
 	// The event without a domain is not aggregated.
 	s.Len(events, 2)
+}
+
+func (s *JobAnalyticsEventsSuite) Test_EventBreakdown_GroupsByProperty() {
+	breakdown, err := analytics.NewStore().EventBreakdown(context.Background(), analytics.EventBreakdownArgs{
+		DomainID:  s.domainID,
+		EventName: "trip_creation",
+		Property:  "ref",
+		Span:      analytics.SPAN_30D,
+	})
+
+	s.NoError(err)
+
+	counts := map[string]analytics.EventCount{}
+
+	for _, b := range breakdown {
+		counts[b.Name] = b
+	}
+
+	// mobile: v1 twice (total 2, unique 1); web: v2 + null visitor (total 2, unique 1).
+	s.Equal(2, counts["mobile"].TotalCount)
+	s.Equal(1, counts["mobile"].UniqueActors)
+	s.Equal(2, counts["web"].TotalCount)
+	s.Equal(1, counts["web"].UniqueActors)
+	s.Len(breakdown, 2)
+}
+
+func (s *JobAnalyticsEventsSuite) Test_EventPropertyKeys_ReturnsDistinctKeys() {
+	keys, err := analytics.NewStore().EventPropertyKeys(context.Background(), analytics.EventBreakdownArgs{
+		DomainID:  s.domainID,
+		EventName: "trip_creation",
+		Span:      analytics.SPAN_30D,
+	})
+
+	s.NoError(err)
+	s.Equal([]string{"ref"}, keys)
 }
 
 func TestJobAnalyticsEventsSuite(t *testing.T) {

--- a/src/ee/api/analytics/analytics_events_store.go
+++ b/src/ee/api/analytics/analytics_events_store.go
@@ -64,19 +64,24 @@ type EventCount struct {
 	UniqueActors int    `json:"unique"`
 }
 
-// Events returns custom event counts for a domain over the requested span.
-func (s *Store) Events(ctx context.Context, args EventsArgs) ([]EventCount, error) {
+// spanDays maps an analytics span to a number of days, defaulting to 30.
+func spanDays(span string) int {
 	days := map[string]int{
 		SPAN_24h: 1,
 		SPAN_7D:  7,
 		SPAN_30D: 30,
-	}[args.Span]
+	}[span]
 
 	if days == 0 {
 		days = 30
 	}
 
-	rows, err := s.Query(ctx, stmt.selectEvents, args.DomainID, days)
+	return days
+}
+
+// Events returns custom event counts for a domain over the requested span.
+func (s *Store) Events(ctx context.Context, args EventsArgs) ([]EventCount, error) {
+	rows, err := s.Query(ctx, stmt.selectEvents, args.DomainID, spanDays(args.Span))
 
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
@@ -102,4 +107,82 @@ func (s *Store) Events(ctx context.Context, args EventsArgs) ([]EventCount, erro
 	}
 
 	return events, nil
+}
+
+type EventBreakdownArgs struct {
+	DomainID  types.ID
+	EventName string
+	Property  string
+	Span      string
+}
+
+// EventBreakdown groups a single event by one metadata property over the span,
+// returning the count and unique actors per property value. Reuses EventCount
+// where Name holds the property value.
+func (s *Store) EventBreakdown(ctx context.Context, args EventBreakdownArgs) ([]EventCount, error) {
+	if args.EventName == "" || args.Property == "" {
+		return []EventCount{}, nil
+	}
+
+	rows, err := s.Query(ctx, stmt.breakdownEvents, args.DomainID, args.EventName, args.Property, spanDays(args.Span))
+
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+
+	if rows == nil {
+		return nil, nil
+	}
+
+	defer rows.Close()
+
+	breakdown := []EventCount{}
+
+	for rows.Next() {
+		var value EventCount
+
+		if err := rows.Scan(&value.Name, &value.TotalCount, &value.UniqueActors); err != nil {
+			slog.Errorf("[analytics.EventBreakdown]: error while scanning %s", err.Error())
+			return nil, err
+		}
+
+		breakdown = append(breakdown, value)
+	}
+
+	return breakdown, nil
+}
+
+// EventPropertyKeys returns the distinct metadata property keys seen for an
+// event over the span, sampled to keep discovery cheap.
+func (s *Store) EventPropertyKeys(ctx context.Context, args EventBreakdownArgs) ([]string, error) {
+	if args.EventName == "" {
+		return []string{}, nil
+	}
+
+	rows, err := s.Query(ctx, stmt.eventPropertyKeys, args.DomainID, args.EventName, spanDays(args.Span))
+
+	if err != nil && err != sql.ErrNoRows {
+		return nil, err
+	}
+
+	if rows == nil {
+		return nil, nil
+	}
+
+	defer rows.Close()
+
+	keys := []string{}
+
+	for rows.Next() {
+		var key string
+
+		if err := rows.Scan(&key); err != nil {
+			slog.Errorf("[analytics.EventPropertyKeys]: error while scanning %s", err.Error())
+			return nil, err
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, nil
 }

--- a/src/ee/api/analytics/analytics_store.go
+++ b/src/ee/api/analytics/analytics_store.go
@@ -24,6 +24,8 @@ var stmt = struct {
 	insertRecord                string
 	insertEvents                string
 	selectEvents                string
+	breakdownEvents             string
+	eventPropertyKeys           string
 	visitors                    string
 	topReferrers                string
 	topPaths                    string
@@ -91,6 +93,44 @@ var stmt = struct {
 		GROUP BY event_name
 		ORDER BY total DESC
 		LIMIT 100;
+	`,
+
+	// breakdownEvents groups a single event by one metadata property, computed
+	// from the raw events (within the retention window). The (domain_id,
+	// event_name, event_ts) index bounds the scan to that event's rows. The
+	// property key ($3) is a bind parameter, so it is not SQL-interpolated.
+	breakdownEvents: `
+		SELECT
+			COALESCE(metadata->>$3, '(not set)') AS property_value,
+			COUNT(*) AS total,
+			COUNT(DISTINCT visitor_id) AS unique_actors
+		FROM analytics_events
+		WHERE
+			domain_id = $1 AND
+			event_name = $2 AND
+			event_ts >= now() - make_interval(days => $4)
+		GROUP BY 1
+		ORDER BY total DESC
+		LIMIT 100;
+	`,
+
+	// eventPropertyKeys returns the distinct metadata keys seen for an event,
+	// sampled from up to 1000 recent rows to keep discovery cheap.
+	eventPropertyKeys: `
+		SELECT DISTINCT key
+		FROM (
+			SELECT metadata
+			FROM analytics_events
+			WHERE
+				domain_id = $1 AND
+				event_name = $2 AND
+				event_ts >= now() - make_interval(days => $3) AND
+				metadata IS NOT NULL
+			LIMIT 1000
+		) sampled,
+		LATERAL jsonb_object_keys(sampled.metadata) AS key
+		ORDER BY key
+		LIMIT 50;
 	`,
 
 	visitors: `

--- a/src/ee/api/analytics/analyticshandlers/handler_events.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_events.go
@@ -30,3 +30,50 @@ func handlerEvents(req *app.RequestContext) *shttp.Response {
 		Data:   events,
 	}
 }
+
+func handlerEventProperties(req *app.RequestContext) *shttp.Response {
+	span := req.Query().Get("ts")
+
+	if span == "" {
+		span = analytics.SPAN_30D
+	}
+
+	keys, err := analytics.NewStore().EventPropertyKeys(req.Context(), analytics.EventBreakdownArgs{
+		DomainID:  utils.StringToID(req.Query().Get("domainId")),
+		EventName: req.Query().Get("event"),
+		Span:      span,
+	})
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   keys,
+	}
+}
+
+func handlerEventBreakdown(req *app.RequestContext) *shttp.Response {
+	span := req.Query().Get("ts")
+
+	if span == "" {
+		span = analytics.SPAN_30D
+	}
+
+	breakdown, err := analytics.NewStore().EventBreakdown(req.Context(), analytics.EventBreakdownArgs{
+		DomainID:  utils.StringToID(req.Query().Get("domainId")),
+		EventName: req.Query().Get("event"),
+		Property:  req.Query().Get("property"),
+		Span:      span,
+	})
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   breakdown,
+	}
+}

--- a/src/ee/api/analytics/analyticshandlers/services.go
+++ b/src/ee/api/analytics/analyticshandlers/services.go
@@ -20,7 +20,9 @@ func Services(r *shttp.Router) *shttp.Service {
 		Handler(shttp.MethodGet, "/referrers", app.WithApp(handlerTopReferrers, opts)).
 		Handler(shttp.MethodGet, "/paths", app.WithApp(handlerTopPaths, opts)).
 		Handler(shttp.MethodGet, "/countries", app.WithApp(handlerCountries, opts)).
-		Handler(shttp.MethodGet, "/events", app.WithApp(handlerEvents, opts))
+		Handler(shttp.MethodGet, "/events", app.WithApp(handlerEvents, opts)).
+		Handler(shttp.MethodGet, "/events/properties", app.WithApp(handlerEventProperties, opts)).
+		Handler(shttp.MethodGet, "/events/breakdown", app.WithApp(handlerEventBreakdown, opts))
 
 	return s
 }

--- a/src/ee/api/analytics/analyticshandlers/services_test.go
+++ b/src/ee/api/analytics/analyticshandlers/services_test.go
@@ -20,6 +20,8 @@ func (s *ServicesSuite) Test_Handlers() {
 	s.Equal([]string{
 		"GET:/analytics/countries",
 		"GET:/analytics/events",
+		"GET:/analytics/events/breakdown",
+		"GET:/analytics/events/properties",
 		"GET:/analytics/paths",
 		"GET:/analytics/referrers",
 		"GET:/analytics/visitors",

--- a/src/migrations/0024_2026-06-27.up.sql
+++ b/src/migrations/0024_2026-06-27.up.sql
@@ -40,6 +40,12 @@ CREATE INDEX IF NOT EXISTS idx_analytics_events_ts
 CREATE INDEX IF NOT EXISTS idx_analytics_events_request_id
     ON analytics_events (request_id);
 
+-- Supports per-event property breakdown queries, which filter by domain+event
+-- (equality) and range on time. Distinct from idx_analytics_events_ts, which
+-- leads with event_ts for the rollup's "recent across everything" scan.
+CREATE INDEX IF NOT EXISTS idx_analytics_events_breakdown
+    ON analytics_events (domain_id, event_name, event_ts);
+
 CREATE TABLE IF NOT EXISTS analytics_events_agg (
     aggregate_date date   NOT NULL,
     domain_id      bigint NOT NULL,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Analytics.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Analytics.tsx
@@ -10,6 +10,7 @@ import EmptyPage from "~/components/EmptyPage";
 import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
 import DomainSelector from "~/shared/domains/DomainSelector";
 import Visitors from "./Visitors";
+import Events from "./Events";
 import TopReferrers from "./TopReferrers";
 import TopPaths from "./TopPaths";
 import ByCountries from "./Countries";
@@ -91,6 +92,7 @@ export default function Analytics() {
         ts={timeSpan}
         onTimeSpanChange={setTimeSpan}
       />
+      <Events domain={domain!} environment={environment} ts={timeSpan} />
       <Box
         sx={{
           mt: 2,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventBreakdown.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventBreakdown.tsx
@@ -1,0 +1,122 @@
+import type { TimeSpan } from "./index.d";
+import { useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Alert from "@mui/material/Alert";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import LinearProgress from "@mui/material/LinearProgress";
+import ArrowBack from "@mui/icons-material/ArrowBackIos";
+import CardRow from "~/components/CardRow";
+import { useFetchEventBreakdown, useFetchEventProperties } from "./actions";
+import { truncate } from "./helpers";
+
+interface Props {
+  envId: string;
+  domainId?: string;
+  event: string;
+  ts: TimeSpan;
+  onBack: () => void;
+}
+
+export default function EventBreakdown({
+  envId,
+  domainId,
+  event,
+  ts,
+  onBack,
+}: Props) {
+  const [property, setProperty] = useState("");
+
+  const { properties, loading: propsLoading } = useFetchEventProperties({
+    envId,
+    domainId,
+    event,
+    ts,
+  });
+
+  const { breakdown, loading } = useFetchEventBreakdown({
+    envId,
+    domainId,
+    event,
+    property,
+    ts,
+    skip: property === "",
+  });
+
+  useEffect(() => {
+    if (!property && properties.length) {
+      setProperty(properties[0]);
+    }
+  }, [properties, property]);
+
+  const hasProperties = propsLoading || properties.length > 0;
+
+  return (
+    <Box>
+      <CardRow
+        actions={
+          <IconButton size="small" aria-label="Back to events" onClick={onBack}>
+            <ArrowBack sx={{ fontSize: 14 }} />
+          </IconButton>
+        }
+      >
+        <Typography component="span">{truncate(event)}</Typography>
+      </CardRow>
+
+      {!hasProperties ? (
+        <Alert
+          color="info"
+          sx={{ m: 2, bgcolor: "rgba(255,255,255,0.025)" }}
+        >
+          This event has no properties to group by yet. Attach a property with
+          the second argument of track(), e.g. {`{ ref: "mobile" }`}.
+        </Alert>
+      ) : (
+        <>
+          <Box
+            sx={{ px: 2, py: 1, display: "flex", alignItems: "center", gap: 1 }}
+          >
+            <Typography sx={{ fontSize: 14, opacity: 0.6 }}>Group by</Typography>
+            <Select
+              size="small"
+              value={property}
+              onChange={e => setProperty(e.target.value)}
+              aria-label="Property"
+            >
+              {properties.map(p => (
+                <MenuItem key={p} value={p}>
+                  {p}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+
+          {loading && <LinearProgress color="secondary" />}
+
+          <Box sx={{ maxHeight: "260px", overflow: "auto" }}>
+            {breakdown.map(row => (
+              <CardRow
+                key={row.name}
+                chipLabel={
+                  <Typography component="span">
+                    {row.total.toLocaleString()}
+                  </Typography>
+                }
+              >
+                <Typography component="span">{truncate(row.name)}</Typography>
+                <Typography
+                  component="span"
+                  sx={{ ml: 1, opacity: 0.6, fontSize: 12 }}
+                >
+                  · {row.unique.toLocaleString()} unique
+                </Typography>
+              </CardRow>
+            ))}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
@@ -6,7 +6,11 @@ import { describe, expect, it } from "vitest";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
 import mockDomain from "~/testing/data/mock_domain";
-import { mockFetchEvents } from "~/testing/nocks/nock_analytics";
+import {
+  mockFetchEvents,
+  mockFetchEventProperties,
+  mockFetchEventBreakdown,
+} from "~/testing/nocks/nock_analytics";
 import Events from "./Events";
 
 interface WrapperProps {
@@ -18,20 +22,21 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx", () => {
   let wrapper: RenderResult;
   let scope: Scope;
   let currentEnv: Environment;
+  let currentDomain: Domain;
 
   const createWrapper = ({ ts = "30d", response }: WrapperProps) => {
-    const domain = mockDomain();
+    currentDomain = mockDomain();
     currentEnv = mockEnvironments({ app: mockApp() })[0];
 
     scope = mockFetchEvents({
       ts,
       envId: currentEnv.id,
-      domainId: domain.id,
+      domainId: currentDomain.id,
       response,
     });
 
     wrapper = render(
-      <Events environment={currentEnv} domain={domain} ts={ts} />,
+      <Events environment={currentEnv} domain={currentDomain} ts={ts} />,
     );
   };
 
@@ -78,5 +83,45 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx", () => {
     expect(screen.getByText("Track events")).toBeTruthy();
     expect(screen.getByDisplayValue(/window.stormkit.track/)).toBeTruthy();
     expect(screen.getByDisplayValue(/_stormkit\/collect/)).toBeTruthy();
+  });
+
+  it("drills into an event and groups by a property", async () => {
+    createWrapper({
+      response: [{ name: "trip_creation", total: 4, unique: 2 }],
+    });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    const propsScope = mockFetchEventProperties({
+      ts: "30d",
+      envId: currentEnv.id,
+      domainId: currentDomain.id,
+      event: "trip_creation",
+      response: ["ref"],
+    });
+
+    const breakdownScope = mockFetchEventBreakdown({
+      ts: "30d",
+      envId: currentEnv.id,
+      domainId: currentDomain.id,
+      event: "trip_creation",
+      property: "ref",
+      response: [
+        { name: "mobile", total: 2, unique: 1 },
+        { name: "web", total: 2, unique: 1 },
+      ],
+    });
+
+    fireEvent.click(wrapper.getByLabelText("Group trip_creation"));
+
+    await waitFor(() => {
+      expect(propsScope.isDone()).toBe(true);
+      expect(breakdownScope.isDone()).toBe(true);
+      expect(wrapper.getByText("Group by")).toBeTruthy();
+      expect(wrapper.getByText("mobile")).toBeTruthy();
+      expect(wrapper.getByText("web")).toBeTruthy();
+    });
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
@@ -1,7 +1,7 @@
 import type { TimeSpan } from "./index.d";
 import type { RenderResult } from "@testing-library/react";
 import type { Scope } from "nock";
-import { waitFor, render } from "@testing-library/react";
+import { waitFor, render, fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
@@ -53,13 +53,30 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx", () => {
     });
   });
 
-  it("shows an empty state with an integration hint when there are no events", async () => {
+  it("shows an empty state with a link to the help drawer", async () => {
     createWrapper({ response: [] });
 
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
       expect(wrapper.getByText(/No events yet/)).toBeTruthy();
-      expect(wrapper.getByText(/window.stormkit.track/)).toBeTruthy();
+      expect(wrapper.getByText("Learn how to send events")).toBeTruthy();
     });
+  });
+
+  it("opens the help drawer with client and server examples", async () => {
+    createWrapper({
+      response: [{ name: "trip_creation", total: 1, unique: 1 }],
+    });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    fireEvent.click(wrapper.getByText("How to track"));
+
+    // The drawer renders in a portal, so query the whole document.
+    expect(screen.getByText("Track events")).toBeTruthy();
+    expect(screen.getByDisplayValue(/window.stormkit.track/)).toBeTruthy();
+    expect(screen.getByDisplayValue(/_stormkit\/collect/)).toBeTruthy();
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
@@ -1,0 +1,65 @@
+import type { TimeSpan } from "./index.d";
+import type { RenderResult } from "@testing-library/react";
+import type { Scope } from "nock";
+import { waitFor, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import mockApp from "~/testing/data/mock_app";
+import mockEnvironments from "~/testing/data/mock_environments";
+import mockDomain from "~/testing/data/mock_domain";
+import { mockFetchEvents } from "~/testing/nocks/nock_analytics";
+import Events from "./Events";
+
+interface WrapperProps {
+  ts?: TimeSpan;
+  response?: { name: string; total: number; unique: number }[];
+}
+
+describe("~/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx", () => {
+  let wrapper: RenderResult;
+  let scope: Scope;
+  let currentEnv: Environment;
+
+  const createWrapper = ({ ts = "30d", response }: WrapperProps) => {
+    const domain = mockDomain();
+    currentEnv = mockEnvironments({ app: mockApp() })[0];
+
+    scope = mockFetchEvents({
+      ts,
+      envId: currentEnv.id,
+      domainId: domain.id,
+      response,
+    });
+
+    wrapper = render(
+      <Events environment={currentEnv} domain={domain} ts={ts} />,
+    );
+  };
+
+  it("renders event counts from the api", async () => {
+    createWrapper({
+      response: [
+        { name: "trip_creation", total: 1234, unique: 987 },
+        { name: "product_insertion", total: 456, unique: 321 },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByText("Events")).toBeTruthy();
+      expect(wrapper.getByText("trip_creation")).toBeTruthy();
+      expect(wrapper.getByText("1,234")).toBeTruthy();
+      expect(wrapper.getByText(/987 unique/)).toBeTruthy();
+      expect(wrapper.getByText("product_insertion")).toBeTruthy();
+    });
+  });
+
+  it("shows an empty state with an integration hint when there are no events", async () => {
+    createWrapper({ response: [] });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByText(/No events yet/)).toBeTruthy();
+      expect(wrapper.getByText(/window.stormkit.track/)).toBeTruthy();
+    });
+  });
+});

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
@@ -1,6 +1,5 @@
 import type { TimeSpan } from "./index.d";
 import Box from "@mui/material/Box";
-import Alert from "@mui/material/Alert";
 import Typography from "@mui/material/Typography";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
@@ -21,43 +20,47 @@ export default function Events({ environment, domain, ts }: Props) {
     ts,
   });
 
+  const isEmpty = !loading && !error && events.length === 0;
+
   return (
-    <Card sx={{ mt: 2 }} error={error} loading={loading}>
+    <Card
+      sx={{ mt: 2 }}
+      error={error}
+      loading={loading}
+      info={
+        isEmpty ? (
+          <>
+            No events yet. Track events from the browser with{" "}
+            <Box component="code">window.stormkit.track("event_name")</Box> or
+            by posting to <Box component="code">/_stormkit/collect</Box>.
+          </>
+        ) : undefined
+      }
+    >
       <CardHeader
         title="Events"
         subtitle="Custom events tracked for this domain."
       />
-      {!loading && events.length === 0 ? (
-        <Alert
-          color="info"
-          sx={{ mb: 4, mx: 4, bgcolor: "rgba(255,255,255,0.025)" }}
-        >
-          No events yet. Track events from the browser with{" "}
-          <Box component="code">window.stormkit.track("event_name")</Box> or by
-          posting to <Box component="code">/_stormkit/collect</Box>.
-        </Alert>
-      ) : (
-        <Box sx={{ maxHeight: "300px", overflow: "auto" }}>
-          {events.map(event => (
-            <CardRow
-              key={event.name}
-              chipLabel={
-                <Typography component="span">
-                  {event.total.toLocaleString()}
-                </Typography>
-              }
-            >
-              <Typography component="span">{truncate(event.name)}</Typography>
-              <Typography
-                component="span"
-                sx={{ ml: 1, opacity: 0.6, fontSize: 12 }}
-              >
-                · {event.unique.toLocaleString()} unique
+      <Box sx={{ maxHeight: "300px", overflow: "auto" }}>
+        {events.map(event => (
+          <CardRow
+            key={event.name}
+            chipLabel={
+              <Typography component="span">
+                {event.total.toLocaleString()}
               </Typography>
-            </CardRow>
-          ))}
-        </Box>
-      )}
+            }
+          >
+            <Typography component="span">{truncate(event.name)}</Typography>
+            <Typography
+              component="span"
+              sx={{ ml: 1, opacity: 0.6, fontSize: 12 }}
+            >
+              · {event.unique.toLocaleString()} unique
+            </Typography>
+          </CardRow>
+        ))}
+      </Box>
     </Card>
   );
 }

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
@@ -1,6 +1,9 @@
 import type { TimeSpan } from "./index.d";
+import { useState } from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import ArrowForward from "@mui/icons-material/ArrowForwardIos";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardRow from "~/components/CardRow";
@@ -8,6 +11,7 @@ import Help from "~/components/Help";
 import { useFetchEvents } from "./actions";
 import { truncate } from "./helpers";
 import EventsHelpContent from "./EventsHelpContent";
+import EventBreakdown from "./EventBreakdown";
 
 interface Props {
   environment: Environment;
@@ -19,6 +23,7 @@ const helpTitle = "Track events";
 const helpSubtitle = "Send custom events from the browser or from your backend.";
 
 export default function Events({ environment, domain, ts }: Props) {
+  const [selected, setSelected] = useState("");
   const { events, error, loading } = useFetchEvents({
     envId: environment.id!,
     domainId: domain?.id,
@@ -62,26 +67,46 @@ export default function Events({ environment, domain, ts }: Props) {
           </Help>
         }
       />
-      <Box sx={{ maxHeight: "300px", overflow: "auto" }}>
-        {events.map(event => (
-          <CardRow
-            key={event.name}
-            chipLabel={
-              <Typography component="span">
-                {event.total.toLocaleString()}
-              </Typography>
-            }
-          >
-            <Typography component="span">{truncate(event.name)}</Typography>
-            <Typography
-              component="span"
-              sx={{ ml: 1, opacity: 0.6, fontSize: 12 }}
+      {selected ? (
+        <EventBreakdown
+          envId={environment.id!}
+          domainId={domain?.id}
+          event={selected}
+          ts={ts}
+          onBack={() => setSelected("")}
+        />
+      ) : (
+        <Box sx={{ maxHeight: "300px", overflow: "auto" }}>
+          {events.map(event => (
+            <CardRow
+              key={event.name}
+              chipLabel={
+                <Typography component="span">
+                  {event.total.toLocaleString()}
+                </Typography>
+              }
+              actions={
+                <IconButton
+                  size="small"
+                  sx={{ ml: 2 }}
+                  aria-label={`Group ${event.name}`}
+                  onClick={() => setSelected(event.name)}
+                >
+                  <ArrowForward sx={{ fontSize: 12 }} />
+                </IconButton>
+              }
             >
-              · {event.unique.toLocaleString()} unique
-            </Typography>
-          </CardRow>
-        ))}
-      </Box>
+              <Typography component="span">{truncate(event.name)}</Typography>
+              <Typography
+                component="span"
+                sx={{ ml: 1, opacity: 0.6, fontSize: 12 }}
+              >
+                · {event.unique.toLocaleString()} unique
+              </Typography>
+            </CardRow>
+          ))}
+        </Box>
+      )}
     </Card>
   );
 }

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
@@ -4,14 +4,19 @@ import Typography from "@mui/material/Typography";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardRow from "~/components/CardRow";
+import Help from "~/components/Help";
 import { useFetchEvents } from "./actions";
 import { truncate } from "./helpers";
+import EventsHelpContent from "./EventsHelpContent";
 
 interface Props {
   environment: Environment;
   domain: Domain;
   ts: TimeSpan;
 }
+
+const helpTitle = "Track events";
+const helpSubtitle = "Send custom events from the browser or from your backend.";
 
 export default function Events({ environment, domain, ts }: Props) {
   const { events, error, loading } = useFetchEvents({
@@ -30,9 +35,15 @@ export default function Events({ environment, domain, ts }: Props) {
       info={
         isEmpty ? (
           <>
-            No events yet. Track events from the browser with{" "}
-            <Box component="code">window.stormkit.track("event_name")</Box> or
-            by posting to <Box component="code">/_stormkit/collect</Box>.
+            No events yet.{" "}
+            <Help
+              title={helpTitle}
+              subtitle={helpSubtitle}
+              buttonText="Learn how to send events"
+              buttonVariant="link"
+            >
+              <EventsHelpContent domain={domain} />
+            </Help>
           </>
         ) : undefined
       }
@@ -40,6 +51,16 @@ export default function Events({ environment, domain, ts }: Props) {
       <CardHeader
         title="Events"
         subtitle="Custom events tracked for this domain."
+        actions={
+          <Help
+            title={helpTitle}
+            subtitle={helpSubtitle}
+            buttonText="How to track"
+            buttonVariant="text"
+          >
+            <EventsHelpContent domain={domain} />
+          </Help>
+        }
       />
       <Box sx={{ maxHeight: "300px", overflow: "auto" }}>
         {events.map(event => (

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
@@ -1,0 +1,63 @@
+import type { TimeSpan } from "./index.d";
+import Box from "@mui/material/Box";
+import Alert from "@mui/material/Alert";
+import Typography from "@mui/material/Typography";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardRow from "~/components/CardRow";
+import { useFetchEvents } from "./actions";
+import { truncate } from "./helpers";
+
+interface Props {
+  environment: Environment;
+  domain: Domain;
+  ts: TimeSpan;
+}
+
+export default function Events({ environment, domain, ts }: Props) {
+  const { events, error, loading } = useFetchEvents({
+    envId: environment.id!,
+    domainId: domain?.id,
+    ts,
+  });
+
+  return (
+    <Card sx={{ mt: 2 }} error={error} loading={loading}>
+      <CardHeader
+        title="Events"
+        subtitle="Custom events tracked for this domain."
+      />
+      {!loading && events.length === 0 ? (
+        <Alert
+          color="info"
+          sx={{ mb: 4, mx: 4, bgcolor: "rgba(255,255,255,0.025)" }}
+        >
+          No events yet. Track events from the browser with{" "}
+          <Box component="code">window.stormkit.track("event_name")</Box> or by
+          posting to <Box component="code">/_stormkit/collect</Box>.
+        </Alert>
+      ) : (
+        <Box sx={{ maxHeight: "300px", overflow: "auto" }}>
+          {events.map(event => (
+            <CardRow
+              key={event.name}
+              chipLabel={
+                <Typography component="span">
+                  {event.total.toLocaleString()}
+                </Typography>
+              }
+            >
+              <Typography component="span">{truncate(event.name)}</Typography>
+              <Typography
+                component="span"
+                sx={{ ml: 1, opacity: 0.6, fontSize: 12 }}
+              >
+                · {event.unique.toLocaleString()} unique
+              </Typography>
+            </CardRow>
+          ))}
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventsHelpContent.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventsHelpContent.tsx
@@ -1,0 +1,47 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import CopyBox from "~/components/CopyBox";
+
+interface Props {
+  domain?: Domain;
+}
+
+const clientExample = `window.stormkit.track("new_trip_creation", { ref: "mobile" });`;
+
+function serverExample(host: string) {
+  return [
+    `curl -X POST https://${host}/_stormkit/collect \\`,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -d '{"events":[{"name":"new_trip_creation","metadata":{"ref":"mobile"}}]}'`,
+  ].join("\n");
+}
+
+export default function EventsHelpContent({ domain }: Props) {
+  const host = domain?.domainName || "<your-domain>";
+
+  return (
+    <Box sx={{ px: 4, pb: 4 }}>
+      <Typography sx={{ mb: 1, fontWeight: 500 }}>From the browser</Typography>
+      <Typography sx={{ mb: 2, opacity: 0.6, fontSize: 14 }}>
+        Requires the Stormkit analytics script to be enabled for this
+        environment.
+      </Typography>
+      <CopyBox value={clientExample} multiline />
+
+      <Typography sx={{ mt: 4, mb: 1, fontWeight: 500 }}>
+        From your server
+      </Typography>
+      <Typography sx={{ mb: 2, opacity: 0.6, fontSize: 14 }}>
+        Post directly to the collect endpoint — useful for backend events that
+        never reach the browser.
+      </Typography>
+      <CopyBox value={serverExample(host)} multiline minRows={3} />
+
+      <Typography sx={{ mt: 4, opacity: 0.6, fontSize: 14 }}>
+        Properties (the second argument, stored as <code>metadata</code>) are
+        kept with each event, so an event such as <code>new_trip_creation</code>{" "}
+        can be broken down by a property like <code>ref</code>.
+      </Typography>
+    </Box>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventsHelpContent.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventsHelpContent.tsx
@@ -38,9 +38,11 @@ export default function EventsHelpContent({ domain }: Props) {
       <CopyBox value={serverExample(host)} multiline minRows={3} />
 
       <Typography sx={{ mt: 4, opacity: 0.6, fontSize: 14 }}>
-        Properties (the second argument, stored as <code>metadata</code>) are
-        kept with each event, so an event such as <code>new_trip_creation</code>{" "}
-        can be broken down by a property like <code>ref</code>.
+        The second argument is an arbitrary key-value object, stored as{" "}
+        <code>metadata</code> with each event. Every property can be queried by
+        its name — group an event by any property, e.g. break{" "}
+        <code>new_trip_creation</code> down by <code>ref</code> or{" "}
+        <code>platform</code>.
       </Typography>
     </Box>
   );

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
@@ -238,6 +238,102 @@ export const useFetchEvents = ({
   return { events, loading, error };
 };
 
+interface FetchEventPropertiesProps {
+  envId: string;
+  domainId?: string;
+  event: string;
+  ts?: "24h" | "7d" | "30d";
+  skip?: boolean;
+}
+
+export const useFetchEventProperties = ({
+  envId,
+  domainId,
+  event,
+  ts = "30d",
+  skip,
+}: FetchEventPropertiesProps) => {
+  const [properties, setProperties] = useState<string[]>([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (skip || !domainId || !event) {
+      return;
+    }
+
+    setError("");
+    setLoading(true);
+
+    api
+      .fetch<string[]>(
+        `/analytics/events/properties?envId=${envId}&domainId=${domainId}&event=${encodeURIComponent(
+          event
+        )}&ts=${ts}`
+      )
+      .then(data => {
+        setProperties(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        setError("Something went wrong while fetching event properties.");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [envId, domainId, event, ts, skip]);
+
+  return { properties, loading, error };
+};
+
+interface FetchEventBreakdownProps {
+  envId: string;
+  domainId?: string;
+  event: string;
+  property: string;
+  ts?: "24h" | "7d" | "30d";
+  skip?: boolean;
+}
+
+export const useFetchEventBreakdown = ({
+  envId,
+  domainId,
+  event,
+  property,
+  ts = "30d",
+  skip,
+}: FetchEventBreakdownProps) => {
+  const [breakdown, setBreakdown] = useState<AnalyticsEvent[]>([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (skip || !domainId || !event || !property) {
+      return;
+    }
+
+    setError("");
+    setLoading(true);
+
+    api
+      .fetch<AnalyticsEvent[]>(
+        `/analytics/events/breakdown?envId=${envId}&domainId=${domainId}&event=${encodeURIComponent(
+          event
+        )}&property=${encodeURIComponent(property)}&ts=${ts}`
+      )
+      .then(data => {
+        setBreakdown(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        setError("Something went wrong while fetching the event breakdown.");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [envId, domainId, event, property, ts, skip]);
+
+  return { breakdown, loading, error };
+};
+
 interface FetchCountriesProps {
   envId: string;
   domainId?: string;

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
@@ -191,6 +191,53 @@ export const useFetchTopPaths = ({ envId, domainId }: FetchTopPathsProps) => {
   return { paths, loading, error };
 };
 
+interface FetchEventsProps {
+  envId: string;
+  domainId?: string;
+  ts?: "24h" | "7d" | "30d";
+}
+
+interface AnalyticsEvent {
+  name: string;
+  total: number;
+  unique: number;
+}
+
+export const useFetchEvents = ({
+  envId,
+  domainId,
+  ts = "30d",
+}: FetchEventsProps) => {
+  const [events, setEvents] = useState<AnalyticsEvent[]>([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!domainId) {
+      return;
+    }
+
+    setError("");
+    setLoading(true);
+
+    api
+      .fetch<AnalyticsEvent[]>(
+        `/analytics/events?envId=${envId}&domainId=${domainId}&ts=${ts}`
+      )
+      .then(data => {
+        setEvents(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        setError("Something went wrong while fetching events.");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [envId, domainId, ts]);
+
+  return { events, loading, error };
+};
+
 interface FetchCountriesProps {
   envId: string;
   domainId?: string;

--- a/src/ui/src/pages/mui-theme.tsx
+++ b/src/ui/src/pages/mui-theme.tsx
@@ -158,7 +158,7 @@ export default (mode: "dark" | "light") => {
             flex: 1,
           },
           standardInfo: {
-            backgroundColor: isDark ? "#0f4c64" : blue[200],
+            backgroundColor: isDark ? "#140e24" : blue[200],
             border: isDark ? "" : "1px solid #0f4c64",
             color: isDark ? "#ffffff" : "#0f4c64",
           },

--- a/src/ui/src/testing/nocks/nock_analytics.ts
+++ b/src/ui/src/testing/nocks/nock_analytics.ts
@@ -25,3 +25,23 @@ export const mockFetchVisitors = ({
     )
     .reply(status, response);
 };
+
+interface MockFetchEventsProps {
+  ts?: "24h" | "7d" | "30d";
+  envId?: string;
+  domainId: string;
+  status?: number;
+  response?: { name: string; total: number; unique: number }[];
+}
+
+export const mockFetchEvents = ({
+  ts,
+  envId,
+  status = 200,
+  domainId,
+  response,
+}: MockFetchEventsProps) => {
+  return nock(endpoint)
+    .get(`/analytics/events?envId=${envId}&domainId=${domainId}&ts=${ts}`)
+    .reply(status, response);
+};

--- a/src/ui/src/testing/nocks/nock_analytics.ts
+++ b/src/ui/src/testing/nocks/nock_analytics.ts
@@ -45,3 +45,53 @@ export const mockFetchEvents = ({
     .get(`/analytics/events?envId=${envId}&domainId=${domainId}&ts=${ts}`)
     .reply(status, response);
 };
+
+interface MockFetchEventPropertiesProps {
+  ts?: "24h" | "7d" | "30d";
+  envId?: string;
+  domainId: string;
+  event: string;
+  status?: number;
+  response?: string[];
+}
+
+export const mockFetchEventProperties = ({
+  ts,
+  envId,
+  status = 200,
+  domainId,
+  event,
+  response,
+}: MockFetchEventPropertiesProps) => {
+  return nock(endpoint)
+    .get(
+      `/analytics/events/properties?envId=${envId}&domainId=${domainId}&event=${event}&ts=${ts}`
+    )
+    .reply(status, response);
+};
+
+interface MockFetchEventBreakdownProps {
+  ts?: "24h" | "7d" | "30d";
+  envId?: string;
+  domainId: string;
+  event: string;
+  property: string;
+  status?: number;
+  response?: { name: string; total: number; unique: number }[];
+}
+
+export const mockFetchEventBreakdown = ({
+  ts,
+  envId,
+  status = 200,
+  domainId,
+  event,
+  property,
+  response,
+}: MockFetchEventBreakdownProps) => {
+  return nock(endpoint)
+    .get(
+      `/analytics/events/breakdown?envId=${envId}&domainId=${domainId}&event=${event}&property=${property}&ts=${ts}`
+    )
+    .reply(status, response);
+};


### PR DESCRIPTION
## Context

Surfaces the Phase 3 custom-event data in the dashboard, and adds **grouping by property** so an event can be broken down by a metadata key (e.g. `new_trip_creation` by `ref`). Frontend + a small backend addition; the index goes on the not-yet-released migration `0024`.

## Events display
- `useFetchEvents` → `GET /analytics/events`; `Events` card (full width after Visitors) ranked by total with unique-actor counts.
- Empty state via `Card.info` doubling as onboarding.
- Dark-mode `standardInfo` alert background fixed to `#140e24` (theme-wide).

## Help drawer
- Reuses the shared `Help` component (header + empty-state link) documenting `track(name, props)` and a server-side `curl` to `/_stormkit/collect`, including the properties argument.

## Property grouping (backend)
- `GET /analytics/events/breakdown?event=&property=&ts=` — groups one event by a metadata property, computed on demand from **raw events** within retention. Property key is a bind param.
- `GET /analytics/events/properties?event=&ts=` — sampled distinct metadata keys for the property selector.
- New index `idx_analytics_events_breakdown (domain_id, event_name, event_ts)` on migration `0024` — bounds the breakdown scan to one event's rows (distinct from the rollup's `event_ts`-leading index). Verified at 50M-scale reasoning: bounded breakdowns stay in Postgres; GIN on metadata deliberately avoided (doesn't accelerate `->>`).
- Store methods + tests (grouping by `ref`, key discovery).

## Property grouping (UI)
- Click an event → `EventBreakdown` drill-down: property selector (discovered keys) + per-value totals/unique, back action. `useFetchEventProperties` / `useFetchEventBreakdown` hooks + nocks + spec.

## Tests
- Go: events suite (rollup, request_id/metadata, visitor-id, breakdown, property keys), services handler-list, full build + vet.
- UI: 17 analytics specs (render, empty/help drawer, drill-down grouping).

## Notes
- `unique_actors` over multi-day windows is actor-days, not unique-over-window.
- Couldn't run `tsc` (TypeScript absent from this checkout's node_modules); validated via vitest.
- Migration `0024` is reused since unreleased; an env that already applied it won't pick up the appended index.