### PR TITLE
fix: authorize domainId in analytics handlers

### DIFF
--- a/src/ee/api/analytics/analytics_store.go
+++ b/src/ee/api/analytics/analytics_store.go
@@ -126,6 +126,7 @@ var stmt = struct {
 				event_name = $2 AND
 				event_ts >= now() - make_interval(days => $3) AND
 				metadata IS NOT NULL
+			ORDER BY event_ts DESC
 			LIMIT 1000
 		) sampled,
 		LATERAL jsonb_object_keys(sampled.metadata) AS key

--- a/src/ee/api/analytics/analyticshandlers/guard.go
+++ b/src/ee/api/analytics/analyticshandlers/guard.go
@@ -1,0 +1,34 @@
+package analyticshandlers
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// authorizedDomainID resolves the `domainId` query param and verifies it belongs
+// to the request's authorized environment. The analytics queries filter on
+// domain_id alone, so without this check any env member could read another
+// tenant's analytics (including raw event metadata) by passing an arbitrary,
+// enumerable domainId. On failure it returns a response the handler must return.
+func authorizedDomainID(req *app.RequestContext) (types.ID, *shttp.Response) {
+	domainID := utils.StringToID(req.Query().Get("domainId"))
+
+	if domainID == 0 {
+		return 0, shttp.BadRequest()
+	}
+
+	domain, err := buildconf.DomainStore().DomainByID(req.Context(), domainID)
+
+	if err != nil {
+		return 0, shttp.Error(err)
+	}
+
+	if domain == nil || domain.EnvID != req.EnvID {
+		return 0, shttp.Forbidden()
+	}
+
+	return domainID, nil
+}

--- a/src/ee/api/analytics/analyticshandlers/handler_countries.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_countries.go
@@ -7,12 +7,17 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 func handlerCountries(req *app.RequestContext) *shttp.Response {
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	countries, err := analytics.NewStore().ByCountries(req.Context(), analytics.ByCountriesArgs{
-		DomainID: utils.StringToID(req.Query().Get("domainId")),
+		DomainID: domainID,
 	})
 
 	if err != nil {

--- a/src/ee/api/analytics/analyticshandlers/handler_countries_test.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_countries_test.go
@@ -117,6 +117,33 @@ func (s *HandlerCountriesSuite) Test_Success() {
 	s.JSONEq(expected, response.String())
 }
 
+func (s *HandlerCountriesSuite) Test_Forbidden_DomainFromAnotherEnv() {
+	otherUser := s.MockUser()
+	otherApp := s.MockApp(otherUser)
+	otherEnv := s.MockEnv(otherApp)
+	otherDomain := &buildconf.DomainModel{
+		AppID:      otherApp.ID,
+		EnvID:      otherEnv.ID,
+		Name:       "tenant-b.example.org",
+		Verified:   true,
+		VerifiedAt: utils.NewUnix(),
+	}
+
+	s.NoError(buildconf.DomainStore().Insert(context.Background(), otherDomain))
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(analyticshandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/analytics/countries?envId=%s&domainId=%d", s.env.ID.String(), otherDomain.ID),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(s.user.ID),
+		},
+	)
+
+	s.Equal(http.StatusForbidden, response.Code)
+}
+
 func TestHandlerCountries(t *testing.T) {
 	suite.Run(t, &HandlerCountriesSuite{})
 }

--- a/src/ee/api/analytics/analyticshandlers/handler_events.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_events.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 func handlerEvents(req *app.RequestContext) *shttp.Response {
@@ -16,9 +15,15 @@ func handlerEvents(req *app.RequestContext) *shttp.Response {
 		span = analytics.SPAN_30D
 	}
 
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	events, err := analytics.NewStore().Events(req.Context(), analytics.EventsArgs{
 		Span:     span,
-		DomainID: utils.StringToID(req.Query().Get("domainId")),
+		DomainID: domainID,
 	})
 
 	if err != nil {
@@ -38,8 +43,14 @@ func handlerEventProperties(req *app.RequestContext) *shttp.Response {
 		span = analytics.SPAN_30D
 	}
 
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	keys, err := analytics.NewStore().EventPropertyKeys(req.Context(), analytics.EventBreakdownArgs{
-		DomainID:  utils.StringToID(req.Query().Get("domainId")),
+		DomainID:  domainID,
 		EventName: req.Query().Get("event"),
 		Span:      span,
 	})
@@ -61,8 +72,14 @@ func handlerEventBreakdown(req *app.RequestContext) *shttp.Response {
 		span = analytics.SPAN_30D
 	}
 
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	breakdown, err := analytics.NewStore().EventBreakdown(req.Context(), analytics.EventBreakdownArgs{
-		DomainID:  utils.StringToID(req.Query().Get("domainId")),
+		DomainID:  domainID,
 		EventName: req.Query().Get("event"),
 		Property:  req.Query().Get("property"),
 		Span:      span,

--- a/src/ee/api/analytics/analyticshandlers/handler_top_paths.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_top_paths.go
@@ -6,13 +6,18 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 func handlerTopPaths(req *app.RequestContext) *shttp.Response {
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	visitors, err := analytics.NewStore().TopPaths(req.Context(), analytics.TopPathsArgs{
 		EnvID:    req.EnvID,
-		DomainID: utils.StringToID(req.Query().Get("domainId")),
+		DomainID: domainID,
 	})
 
 	if err != nil {

--- a/src/ee/api/analytics/analyticshandlers/handler_top_referrers.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_top_referrers.go
@@ -7,16 +7,21 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 func handlerTopReferrers(req *app.RequestContext) *shttp.Response {
 	query := req.Query()
 
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	visitors, err := analytics.NewStore().TopReferrers(req.Context(), analytics.TopReferrersArgs{
 		EnvID:       req.EnvID,
 		RequestPath: strings.ToLower(strings.TrimSpace(query.Get("requestPath"))),
-		DomainID:    utils.StringToID(req.Query().Get("domainId")),
+		DomainID:    domainID,
 	})
 
 	if err != nil {

--- a/src/ee/api/analytics/analyticshandlers/handler_visitors.go
+++ b/src/ee/api/analytics/analyticshandlers/handler_visitors.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 func handlerVisitors(req *app.RequestContext) *shttp.Response {
@@ -16,10 +15,16 @@ func handlerVisitors(req *app.RequestContext) *shttp.Response {
 		span = analytics.SPAN_24h
 	}
 
+	domainID, errResp := authorizedDomainID(req)
+
+	if errResp != nil {
+		return errResp
+	}
+
 	visitors, err := analytics.NewStore().Visitors(req.Context(), analytics.VisitorsArgs{
 		Span:       span,
 		EnvID:      req.EnvID,
-		DomainID:   utils.StringToID(req.Query().Get("domainId")),
+		DomainID:   domainID,
 		StatusCode: http.StatusOK,
 	})
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventBreakdown.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/EventBreakdown.tsx
@@ -66,10 +66,7 @@ export default function EventBreakdown({
       </CardRow>
 
       {!hasProperties ? (
-        <Alert
-          color="info"
-          sx={{ m: 2, bgcolor: "rgba(255,255,255,0.025)" }}
-        >
+        <Alert color="info" sx={{ m: 2 }}>
           This event has no properties to group by yet. Attach a property with
           the second argument of track(), e.g. {`{ ref: "mobile" }`}.
         </Alert>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
@@ -255,7 +255,7 @@ export const useFetchEventProperties = ({
 }: FetchEventPropertiesProps) => {
   const [properties, setProperties] = useState<string[]>([]);
   const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (skip || !domainId || !event) {


### PR DESCRIPTION
## Context

Follow-up to #325 — these changes were meant to land with it but missed the merge. The main item is a **cross-tenant authorization fix**.

## The vulnerability

The analytics read handlers filter queries by `domain_id` alone and never verify the domain belongs to the caller's environment. Since `domainId` is an enumerable integer passed as a query param, **any environment member could read another tenant's analytics** — visitors, referrers, paths, countries, and (most sensitively) **custom-event data including raw metadata** — by passing an arbitrary `domainId`. Classic IDOR.

## The fix

- New `authorizedDomainID(req)` (`guard.go`): resolves `domainId`, looks the domain up via `DomainByID`, and returns `403` unless `domain.EnvID == req.EnvID` (`400` if missing). Returns an error response the handler short-circuits on.
- Applied across **all** analytics handlers: visitors, countries, paths, referrers, events, properties, breakdown.
- `handler_countries_test.go` covers the authorized/forbidden paths.

## Also included
- Property-key discovery now samples the **most recent** 1000 rows (`ORDER BY event_ts DESC`) rather than an arbitrary 1000.
- Minor events UI polish: the breakdown empty-state alert drops a redundant bgcolor (uses the theme info color), and `useFetchEventProperties` starts in `loading` to avoid a flash.

## Tests
- Go analytics handler suite passes (incl. new authz test); build + gofmt clean.
- 17 UI analytics specs pass.