### PR TITLE
feat: partitioned raw access logs + admin viewer

### DIFF
--- a/src/ce/api/accesslog/accesslog_model.go
+++ b/src/ce/api/accesslog/accesslog_model.go
@@ -1,0 +1,51 @@
+package accesslog
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"gopkg.in/guregu/null.v3"
+)
+
+// AccessLog is a single raw request-level access log entry. Unlike
+// analytics.Record it keeps the unmasked client IP, the full user-agent and
+// path, and a bot flag rather than dropping bot traffic — it is an operational
+// access log, not visitor analytics.
+type AccessLog struct {
+	ID           types.ID    `json:"id"`
+	AppID        types.ID    `json:"appId"`
+	EnvID        types.ID    `json:"envId"`
+	DeploymentID types.ID    `json:"deploymentId"`
+	DomainID     types.ID    `json:"domainId"`
+	HostName     string      `json:"hostName"`
+	RequestTS    utils.Unix  `json:"requestTimestamp"`
+	Method       string      `json:"method"`
+	RequestPath  string      `json:"path"`
+	StatusCode   int         `json:"statusCode"`
+	ClientIP     string      `json:"clientIp"`
+	UserAgent    string      `json:"userAgent"`
+	Referrer     string      `json:"referrer"`
+	IsBot        bool        `json:"isBot"`
+	BytesSent    int64       `json:"bytesSent"`
+	RequestID    null.String `json:"requestId"`
+}
+
+func (l AccessLog) ToMap() map[string]any {
+	return map[string]any{
+		"id":               l.ID.String(),
+		"appId":            l.AppID.String(),
+		"envId":            l.EnvID.String(),
+		"deploymentId":     l.DeploymentID.String(),
+		"domainId":         l.DomainID.String(),
+		"hostName":         l.HostName,
+		"requestTimestamp": l.RequestTS.UnixStr(),
+		"method":           l.Method,
+		"path":             l.RequestPath,
+		"statusCode":       l.StatusCode,
+		"clientIp":         l.ClientIP,
+		"userAgent":        l.UserAgent,
+		"referrer":         l.Referrer,
+		"isBot":            l.IsBot,
+		"bytesSent":        l.BytesSent,
+		"requestId":        l.RequestID.ValueOrZero(),
+	}
+}

--- a/src/ce/api/accesslog/accesslog_store.go
+++ b/src/ce/api/accesslog/accesslog_store.go
@@ -1,0 +1,231 @@
+package accesslog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/database"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"gopkg.in/guregu/null.v3"
+)
+
+// accessLogInsertFields is the number of columns written per row (log_id is
+// generated and excluded).
+const accessLogInsertFields = 15
+
+// DefaultLimit caps a single page of access-log results.
+const DefaultLimit = 100
+
+var stmt = struct {
+	insertLogs string
+	selectLogs string
+}{
+	insertLogs: `
+		INSERT INTO request_logs (
+			app_id, env_id, deployment_id, domain_id, host_name,
+			request_timestamp, method, request_path, response_code,
+			client_ip, user_agent, referrer, is_bot, bytes_sent, request_id
+		)
+		VALUES {{ generateValues 15 (len .) }};
+	`,
+
+	selectLogs: `
+		SELECT
+			log_id, app_id, env_id, deployment_id, domain_id, host_name,
+			request_timestamp, method, request_path, response_code,
+			client_ip, user_agent, referrer, is_bot, bytes_sent, request_id
+		FROM request_logs
+		WHERE {{ .where }}
+		ORDER BY request_timestamp DESC, log_id DESC
+		LIMIT {{ .limit }};
+	`,
+}
+
+// Store handles raw access-log persistence and retrieval.
+type Store struct {
+	*database.Store
+}
+
+// NewStore returns a store instance.
+func NewStore() *Store {
+	return &Store{database.NewStore()}
+}
+
+// stripNull removes NUL bytes, which Postgres rejects in text/jsonb and which
+// would otherwise abort an entire multi-row batch insert because of one row.
+func stripNull(s string) string {
+	if !strings.ContainsRune(s, '\x00') {
+		return s
+	}
+
+	return strings.ReplaceAll(s, "\x00", "")
+}
+
+// InsertLogs writes a batch of access logs in a single multi-row INSERT.
+func (s *Store) InsertLogs(ctx context.Context, logs []AccessLog) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	params := make([]any, 0, len(logs)*accessLogInsertFields)
+
+	for _, l := range logs {
+		params = append(params,
+			l.AppID, l.EnvID, l.DeploymentID, l.DomainID, stripNull(l.HostName),
+			l.RequestTS.UTC(), stripNull(l.Method), stripNull(l.RequestPath), l.StatusCode,
+			stripNull(l.ClientIP), stripNull(l.UserAgent), stripNull(l.Referrer),
+			l.IsBot, l.BytesSent, l.RequestID,
+		)
+	}
+
+	var wr bytes.Buffer
+
+	query := template.Must(template.New("insertLogs").
+		Funcs(template.FuncMap{"generateValues": utils.GenerateValues}).
+		Parse(stmt.insertLogs))
+
+	if err := query.Execute(&wr, logs); err != nil {
+		return fmt.Errorf("error while compiling insertLogs template: %v", err)
+	}
+
+	_, err := s.Exec(ctx, wr.String(), params...)
+
+	return err
+}
+
+// SelectLogsParams filters a page of access logs. From/To bound
+// request_timestamp and should always be set so the query prunes partitions
+// instead of scanning the full retention window.
+type SelectLogsParams struct {
+	AppID    types.ID
+	DomainID types.ID
+	HostName string
+	ClientIP string
+	Method   string
+	Path     string
+	Status   int
+	IsBot    *bool
+	From     utils.Unix
+	To       utils.Unix
+	BeforeID types.ID
+	Limit    int
+}
+
+// SelectLogs returns access logs matching the filters, newest first, with one
+// extra row beyond Limit so the caller can detect a next page.
+func (s *Store) SelectLogs(ctx context.Context, p SelectLogsParams) ([]AccessLog, error) {
+	where := []string{}
+	params := []any{}
+
+	add := func(clause string, value any) {
+		params = append(params, value)
+		where = append(where, fmt.Sprintf(clause, len(params)))
+	}
+
+	if p.From.Valid {
+		add("request_timestamp >= $%d", p.From.UTC())
+	}
+
+	if p.To.Valid {
+		add("request_timestamp <= $%d", p.To.UTC())
+	}
+
+	if p.AppID > 0 {
+		add("app_id = $%d", p.AppID)
+	}
+
+	if p.DomainID > 0 {
+		add("domain_id = $%d", p.DomainID)
+	}
+
+	if p.HostName != "" {
+		add("host_name = $%d", p.HostName)
+	}
+
+	if p.ClientIP != "" {
+		add("client_ip = $%d", p.ClientIP)
+	}
+
+	if p.Method != "" {
+		add("method = $%d", p.Method)
+	}
+
+	if p.Path != "" {
+		add("request_path LIKE $%d", p.Path+"%")
+	}
+
+	if p.Status > 0 {
+		add("response_code = $%d", p.Status)
+	}
+
+	if p.IsBot != nil {
+		add("is_bot = $%d", *p.IsBot)
+	}
+
+	if p.BeforeID > 0 {
+		add("log_id < $%d", p.BeforeID)
+	}
+
+	if len(where) == 0 {
+		where = append(where, "TRUE")
+	}
+
+	if p.Limit <= 0 {
+		p.Limit = DefaultLimit
+	}
+
+	var wr bytes.Buffer
+
+	tmpl := template.Must(template.New("selectLogs").Parse(stmt.selectLogs))
+
+	if err := tmpl.Execute(&wr, map[string]any{
+		"where": strings.Join(where, " AND "),
+		"limit": p.Limit + 1,
+	}); err != nil {
+		return nil, err
+	}
+
+	rows, err := s.Query(ctx, wr.String(), params...)
+
+	if err != nil || rows == nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	logs := []AccessLog{}
+
+	for rows.Next() {
+		l := AccessLog{}
+
+		var deploymentID, domainID, bytesSent, status null.Int
+		var hostName, method, path, clientIP, userAgent, referrer null.String
+
+		if err := rows.Scan(
+			&l.ID, &l.AppID, &l.EnvID, &deploymentID, &domainID, &hostName,
+			&l.RequestTS, &method, &path, &status,
+			&clientIP, &userAgent, &referrer, &l.IsBot, &bytesSent, &l.RequestID,
+		); err != nil {
+			return nil, err
+		}
+
+		l.DeploymentID = types.ID(deploymentID.ValueOrZero())
+		l.DomainID = types.ID(domainID.ValueOrZero())
+		l.BytesSent = bytesSent.ValueOrZero()
+		l.StatusCode = int(status.ValueOrZero())
+		l.HostName = hostName.ValueOrZero()
+		l.Method = method.ValueOrZero()
+		l.RequestPath = path.ValueOrZero()
+		l.ClientIP = clientIP.ValueOrZero()
+		l.UserAgent = userAgent.ValueOrZero()
+		l.Referrer = referrer.ValueOrZero()
+
+		logs = append(logs, l)
+	}
+
+	return logs, nil
+}

--- a/src/ce/api/accesslog/accesslog_store_test.go
+++ b/src/ce/api/accesslog/accesslog_store_test.go
@@ -1,0 +1,120 @@
+package accesslog_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/accesslog"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/guregu/null.v3"
+)
+
+type StoreSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *StoreSuite) SetupSuite() {
+	s.conn = databasetest.InitTx("accesslog_store_suite")
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *StoreSuite) TearDownSuite() {
+	s.conn.CloseTx()
+}
+
+func (s *StoreSuite) Test_InsertAndSelect() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	ctx := context.Background()
+
+	logs := []accesslog.AccessLog{
+		{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			DomainID:    42,
+			HostName:    "example.com",
+			RequestTS:   utils.NewUnix(),
+			Method:      http.MethodGet,
+			RequestPath: "/",
+			StatusCode:  http.StatusOK,
+			ClientIP:    "203.0.113.7",
+			UserAgent:   "Mozilla/5.0 (Macintosh)",
+			Referrer:    "https://www.google.com",
+			IsBot:       false,
+			BytesSent:   1234,
+			RequestID:   null.StringFrom("11111111-1111-1111-1111-111111111111"),
+		},
+		{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			DomainID:    42,
+			HostName:    "example.com",
+			RequestTS:   utils.NewUnix(),
+			Method:      http.MethodGet,
+			RequestPath: "/robots.txt",
+			StatusCode:  http.StatusOK,
+			ClientIP:    "198.51.100.9",
+			UserAgent:   "Googlebot/2.1 (+http://www.google.com/bot.html)",
+			IsBot:       true,
+			BytesSent:   42,
+		},
+	}
+
+	s.NoError(accesslog.NewStore().InsertLogs(ctx, logs))
+
+	window := accesslog.SelectLogsParams{
+		AppID: app.ID,
+		From:  utils.UnixFrom(time.Now().Add(-time.Hour)),
+		To:    utils.UnixFrom(time.Now().Add(time.Hour)),
+	}
+
+	all, err := accesslog.NewStore().SelectLogs(ctx, window)
+	s.NoError(err)
+	s.Len(all, 2)
+
+	// The raw client IP and full user-agent are persisted unmasked — the inverse
+	// of the analytics table, which stores a salted IP hash.
+	byPath := map[string]accesslog.AccessLog{}
+	for _, l := range all {
+		byPath[l.RequestPath] = l
+	}
+
+	s.Equal("203.0.113.7", byPath["/"].ClientIP)
+	s.Equal("Mozilla/5.0 (Macintosh)", byPath["/"].UserAgent)
+	s.Equal("https://www.google.com", byPath["/"].Referrer)
+	s.Equal(int64(1234), byPath["/"].BytesSent)
+	s.False(byPath["/"].IsBot)
+	s.True(byPath["/robots.txt"].IsBot)
+	s.Equal("198.51.100.9", byPath["/robots.txt"].ClientIP)
+
+	// is_bot filter narrows to bot traffic only.
+	onlyBots := window
+	isBot := true
+	onlyBots.IsBot = &isBot
+
+	bots, err := accesslog.NewStore().SelectLogs(ctx, onlyBots)
+	s.NoError(err)
+	s.Len(bots, 1)
+	s.Equal("/robots.txt", bots[0].RequestPath)
+
+	// path prefix filter.
+	prefix := window
+	prefix.Path = "/robots"
+
+	robots, err := accesslog.NewStore().SelectLogs(ctx, prefix)
+	s.NoError(err)
+	s.Len(robots, 1)
+	s.Equal("/robots.txt", robots[0].RequestPath)
+}
+
+func TestStore(t *testing.T) {
+	suite.Run(t, &StoreSuite{})
+}

--- a/src/ce/api/admin/adminhandlers/handler_access_logs.go
+++ b/src/ce/api/admin/adminhandlers/handler_access_logs.go
@@ -1,0 +1,94 @@
+package adminhandlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/accesslog"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// accessLogWindow bounds queries that omit from/to, so a request always prunes
+// to a small number of day-partitions instead of scanning the whole retention
+// window.
+const accessLogWindow = 24 * time.Hour
+
+func handlerAccessLogs(req *user.RequestContext) *shttp.Response {
+	query := req.Query()
+
+	from := accessLogUnix(query.Get("from"))
+	to := accessLogUnix(query.Get("to"))
+
+	if !from.Valid {
+		from = utils.UnixFrom(time.Now().Add(-accessLogWindow))
+	}
+
+	params := accesslog.SelectLogsParams{
+		AppID:    utils.StringToID(query.Get("appId")),
+		DomainID: utils.StringToID(query.Get("domainId")),
+		HostName: query.Get("hostName"),
+		ClientIP: query.Get("clientIp"),
+		Method:   query.Get("method"),
+		Path:     query.Get("path"),
+		Status:   utils.StringToInt(query.Get("status")),
+		IsBot:    accessLogBool(query.Get("isBot")),
+		From:     from,
+		To:       to,
+		BeforeID: utils.StringToID(query.Get("beforeId")),
+		Limit:    accesslog.DefaultLimit,
+	}
+
+	logs, err := accesslog.NewStore().SelectLogs(req.Context(), params)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	pagination := map[string]any{"hasNextPage": false}
+	logsLen := len(logs)
+
+	if logsLen > accesslog.DefaultLimit {
+		pagination["hasNextPage"] = true
+		pagination["beforeId"] = logs[logsLen-2].ID.String()
+		logs = logs[:logsLen-1]
+	}
+
+	items := make([]map[string]any, 0, len(logs))
+
+	for _, l := range logs {
+		items = append(items, l.ToMap())
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"accessLogs": items,
+			"pagination": pagination,
+		},
+	}
+}
+
+// accessLogUnix parses a query value as unix seconds, returning an invalid Unix
+// when absent or unparseable.
+func accessLogUnix(v string) utils.Unix {
+	secs := utils.StringToInt64(v)
+
+	if secs <= 0 {
+		return utils.Unix{}
+	}
+
+	return utils.UnixFrom(time.Unix(secs, 0))
+}
+
+func accessLogBool(v string) *bool {
+	switch v {
+	case "true":
+		return utils.Ptr(true)
+	case "false":
+		return utils.Ptr(false)
+	default:
+		return nil
+	}
+}

--- a/src/ce/api/admin/adminhandlers/handler_access_logs_test.go
+++ b/src/ce/api/admin/adminhandlers/handler_access_logs_test.go
@@ -1,0 +1,116 @@
+package adminhandlers_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/accesslog"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin/adminhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerAccessLogsSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *HandlerAccessLogsSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *HandlerAccessLogsSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *HandlerAccessLogsSuite) seed() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+
+	logs := []accesslog.AccessLog{
+		{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			HostName:    "example.com",
+			RequestTS:   utils.NewUnix(),
+			Method:      http.MethodGet,
+			RequestPath: "/humans.txt",
+			StatusCode:  http.StatusOK,
+			ClientIP:    "203.0.113.7",
+			UserAgent:   "Mozilla/5.0",
+			IsBot:       false,
+		},
+		{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			HostName:    "example.com",
+			RequestTS:   utils.NewUnix(),
+			Method:      http.MethodGet,
+			RequestPath: "/robots.txt",
+			StatusCode:  http.StatusOK,
+			ClientIP:    "198.51.100.9",
+			UserAgent:   "Googlebot/2.1",
+			IsBot:       true,
+		},
+	}
+
+	s.NoError(accesslog.NewStore().InsertLogs(context.Background(), logs))
+}
+
+func (s *HandlerAccessLogsSuite) request(token, query string) shttptest.Response {
+	return shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/admin/access-logs"+query,
+		nil,
+		map[string]string{"Authorization": token},
+	)
+}
+
+func (s *HandlerAccessLogsSuite) Test_Admin_ReturnsLogs() {
+	admin := s.MockUser(map[string]any{"IsAdmin": true})
+	s.seed()
+
+	res := s.request(usertest.Authorization(admin.ID), "")
+	body := res.String()
+
+	s.Equal(http.StatusOK, res.Code)
+	s.Contains(body, "/humans.txt")
+	s.Contains(body, "/robots.txt")
+	// Raw client IP and user-agent are surfaced to the admin.
+	s.Contains(body, "203.0.113.7")
+	s.Contains(body, "Googlebot/2.1")
+}
+
+func (s *HandlerAccessLogsSuite) Test_Admin_FiltersBots() {
+	admin := s.MockUser(map[string]any{"IsAdmin": true})
+	s.seed()
+
+	res := s.request(usertest.Authorization(admin.ID), "?isBot=false")
+	body := res.String()
+
+	s.Equal(http.StatusOK, res.Code)
+	s.Contains(body, "/humans.txt")
+	s.NotContains(body, "/robots.txt")
+}
+
+func (s *HandlerAccessLogsSuite) Test_NonAdmin_Rejected() {
+	usr := s.MockUser(map[string]any{"IsAdmin": false})
+	s.seed()
+
+	res := s.request(usertest.Authorization(usr.ID), "")
+
+	s.Equal(http.StatusUnauthorized, res.Code)
+}
+
+func TestHandlerAccessLogs(t *testing.T) {
+	suite.Run(t, &HandlerAccessLogsSuite{})
+}

--- a/src/ce/api/admin/adminhandlers/services.go
+++ b/src/ce/api/admin/adminhandlers/services.go
@@ -27,6 +27,9 @@ func Services(r *shttp.Router) *shttp.Service {
 	s.NewEndpoint("/admin/license").
 		Handler(shttp.MethodPost, "", user.WithAdmin(handlerLicenseSet))
 
+	s.NewEndpoint("/admin/access-logs").
+		Handler(shttp.MethodGet, "", user.WithAdmin(handlerAccessLogs))
+
 	s.NewEndpoint("/admin/git").
 		Handler(shttp.MethodGet, "/details", user.WithAdmin(handlerGitDetails)).
 		Handler(shttp.MethodPost, "/configure", user.WithAdmin(handlerGitConfigure)).

--- a/src/ce/api/admin/adminhandlers/services_test.go
+++ b/src/ce/api/admin/adminhandlers/services_test.go
@@ -20,6 +20,7 @@ func (s *ServicesSuite) Test_Services_SelfHosted() {
 	s.NotNil(services)
 
 	handlers := []string{
+		"GET:/admin/access-logs",
 		"GET:/admin/domains",
 		"GET:/admin/git/details",
 		"GET:/admin/git/github/callback",
@@ -54,6 +55,7 @@ func (s *ServicesSuite) Test_Services_Cloud() {
 
 	handlers := []string{
 		"DELETE:/admin/cloud/app",
+		"GET:/admin/access-logs",
 		"GET:/admin/cloud/app",
 		"GET:/admin/domains",
 		"GET:/admin/git/details",

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/accesslog"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
@@ -157,6 +158,8 @@ func (r *RequestServer) artifacts(res *shttp.Response) {
 		data, _ = res.Data.([]byte)
 	}
 
+	bandwidth := int64(len(data)) + headersSize(res.Headers)
+
 	Queue(&jobs.HostingRecord{
 		AppID:           r.req.Host.Config.AppID,
 		EnvID:           r.req.Host.Config.EnvID,
@@ -166,8 +169,39 @@ func (r *RequestServer) artifacts(res *shttp.Response) {
 		FunctionInvoked: r.fnInvoked,
 		Logs:            r.logs,
 		Analytics:       r.record,
-		TotalBandwidth:  int64(len(data)) + headersSize(res.Headers),
+		AccessLog:       accessLogRecord(r.req, res, bandwidth),
+		TotalBandwidth:  bandwidth,
 	})
+}
+
+// accessLogRecord builds a raw access log for every request — including bots,
+// XHR, static assets and non-HTML responses. Unlike analyticsRecord it applies
+// no filtering and keeps the unmasked client IP and full user-agent; IsBot is
+// recorded as a flag so bot traffic can be included or excluded at query time.
+func accessLogRecord(req *RequestContext, res *shttp.Response, bytesSent int64) *accesslog.AccessLog {
+	if req == nil || req.Host == nil || req.Host.Config == nil {
+		return nil
+	}
+
+	userAgent := req.UserAgent()
+
+	return &accesslog.AccessLog{
+		AppID:        req.Host.Config.AppID,
+		EnvID:        req.Host.Config.EnvID,
+		DeploymentID: req.Host.Config.DeploymentID,
+		DomainID:     req.Host.Config.DomainID,
+		HostName:     req.Host.Name,
+		RequestTS:    utils.NewUnix(),
+		Method:       req.Method,
+		RequestPath:  req.OriginalPath,
+		StatusCode:   res.Status,
+		ClientIP:     req.RemoteIP(),
+		UserAgent:    userAgent,
+		Referrer:     req.Referer(),
+		IsBot:        analytics.IsBot(userAgent),
+		BytesSent:    bytesSent,
+		RequestID:    null.NewString(req.RequestID, req.RequestID != ""),
+	}
 }
 
 func (r *RequestServer) FileMeta() *FileMeta {

--- a/src/ce/hosting/handler_forward_accesslog_test.go
+++ b/src/ce/hosting/handler_forward_accesslog_test.go
@@ -1,0 +1,140 @@
+package hosting
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
+	"github.com/stormkit-io/stormkit-io/src/lib/pool"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type AccessLogArtifactsSuite struct {
+	suite.Suite
+
+	captured   []*jobs.HostingRecord
+	capturedMu sync.Mutex
+	host       *Host
+}
+
+func (s *AccessLogArtifactsSuite) SetupTest() {
+	s.captured = nil
+
+	mu.Lock()
+	Batcher = pool.New(
+		pool.WithSize(1),
+		pool.WithFlushInterval(5*time.Millisecond),
+		pool.WithFlusher(pool.FlusherFunc(func(items []any) {
+			s.capturedMu.Lock()
+			defer s.capturedMu.Unlock()
+
+			for _, it := range items {
+				if rec, ok := it.(*jobs.HostingRecord); ok {
+					s.captured = append(s.captured, rec)
+				}
+			}
+		})),
+	)
+	mu.Unlock()
+
+	s.host = &Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			AppID:    types.ID(1),
+			EnvID:    types.ID(2),
+			DomainID: types.ID(3),
+		},
+	}
+}
+
+func (s *AccessLogArtifactsSuite) TearDownSuite() {
+	mu.Lock()
+	Batcher = nil
+	mu.Unlock()
+}
+
+func (s *AccessLogArtifactsSuite) waitForRecord() *jobs.HostingRecord {
+	deadline := time.Now().Add(time.Second)
+
+	for time.Now().Before(deadline) {
+		s.capturedMu.Lock()
+		got := len(s.captured)
+		s.capturedMu.Unlock()
+
+		if got >= 1 {
+			break
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	s.capturedMu.Lock()
+	defer s.capturedMu.Unlock()
+
+	s.Require().NotEmpty(s.captured)
+
+	return s.captured[0]
+}
+
+func (s *AccessLogArtifactsSuite) requestServer(ua, path, ip string) *RequestServer {
+	h := make(http.Header)
+	h.Set("User-Agent", ua)
+
+	req := &http.Request{
+		Method:     http.MethodGet,
+		Header:     h,
+		URL:        &url.URL{Path: path},
+		RemoteAddr: ip + ":40000",
+	}
+
+	return &RequestServer{
+		req: &RequestContext{
+			Host:           s.host,
+			OriginalPath:   path,
+			RequestContext: shttp.NewRequestContext(req),
+		},
+	}
+}
+
+// A bot request must still produce an access log (flagged is_bot), proving the
+// raw log keeps bot traffic the analytics path drops.
+func (s *AccessLogArtifactsSuite) Test_BotRequest_QueuesAccessLog() {
+	rs := s.requestServer("Googlebot/2.1 (+http://www.google.com/bot.html)", "/robots.txt", "198.51.100.9")
+
+	rs.artifacts(&shttp.Response{Status: http.StatusOK, Data: []byte("hello")})
+
+	record := s.waitForRecord()
+
+	s.Require().NotNil(record.AccessLog)
+	s.True(record.AccessLog.IsBot)
+	s.Equal("/robots.txt", record.AccessLog.RequestPath)
+	s.Equal("198.51.100.9", record.AccessLog.ClientIP)
+	s.Equal(http.MethodGet, record.AccessLog.Method)
+	s.Equal(http.StatusOK, record.AccessLog.StatusCode)
+	s.Greater(record.AccessLog.BytesSent, int64(0))
+}
+
+func (s *AccessLogArtifactsSuite) Test_HumanRequest_NotFlaggedBot() {
+	const ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+		"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+
+	rs := s.requestServer(ua, "/", "203.0.113.7")
+
+	rs.artifacts(&shttp.Response{Status: http.StatusOK, Data: []byte("ok")})
+
+	record := s.waitForRecord()
+
+	s.Require().NotNil(record.AccessLog)
+	s.False(record.AccessLog.IsBot)
+	s.Equal("203.0.113.7", record.AccessLog.ClientIP)
+}
+
+func TestAccessLogArtifactsSuite(t *testing.T) {
+	suite.Run(t, new(AccessLogArtifactsSuite))
+}

--- a/src/ce/workerserver/job_access_log_retention.go
+++ b/src/ce/workerserver/job_access_log_retention.go
@@ -1,0 +1,79 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+const (
+	defaultAccessLogRetentionDays = 30
+	// accessLogCreateAheadDays keeps a few days of partitions ready ahead of
+	// time so ingestion never lands on a missing partition between job runs.
+	accessLogCreateAheadDays = 3
+)
+
+// MaintainAccessLogPartitions keeps the daily-partitioned request_logs table
+// bounded: it creates the partitions for the next few days and drops the ones
+// older than the retention window. DROP PARTITION is an instant metadata
+// operation, unlike the batched ctid-DELETE used for the analytics table.
+//
+// The window defaults to 30 days and can be overridden via
+// STORMKIT_ACCESS_LOG_RETENTION_DAYS.
+func MaintainAccessLogPartitions(ctx context.Context) error {
+	days := utils.StringToInt(os.Getenv("STORMKIT_ACCESS_LOG_RETENTION_DAYS"))
+
+	if days <= 0 {
+		days = defaultAccessLogRetentionDays
+	}
+
+	store := NewStore()
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+
+	for i := 0; i <= accessLogCreateAheadDays; i++ {
+		if err := store.CreateAccessLogPartition(ctx, today.AddDate(0, 0, i)); err != nil {
+			slog.Errorf("could not create access log partition: %s", err.Error())
+			return err
+		}
+	}
+
+	partitions, err := store.AccessLogPartitions(ctx)
+
+	if err != nil {
+		slog.Errorf("could not list access log partitions: %s", err.Error())
+		return err
+	}
+
+	cutoff := today.AddDate(0, 0, -days)
+	dropped := 0
+
+	for _, name := range partitions {
+		match := accessLogPartitionName.FindStringSubmatch(name)
+
+		if match == nil {
+			continue
+		}
+
+		day, err := time.Parse(accessLogPartitionDateLayout, match[1])
+
+		if err != nil || !day.Before(cutoff) {
+			continue
+		}
+
+		if err := store.DropAccessLogPartition(ctx, name); err != nil {
+			slog.Errorf("could not drop access log partition %s: %s", name, err.Error())
+			return err
+		}
+
+		dropped++
+	}
+
+	if dropped > 0 {
+		slog.Infof("dropped %d access log partitions (retention=%d days)", dropped, days)
+	}
+
+	return nil
+}

--- a/src/ce/workerserver/job_access_log_retention_test.go
+++ b/src/ce/workerserver/job_access_log_retention_test.go
@@ -1,0 +1,91 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stretchr/testify/suite"
+)
+
+type JobAccessLogRetentionSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *JobAccessLogRetentionSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *JobAccessLogRetentionSuite) AfterTest(suiteName, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *JobAccessLogRetentionSuite) partitions() map[string]bool {
+	names, err := jobs.NewStore().AccessLogPartitions(context.Background())
+	s.NoError(err)
+
+	set := map[string]bool{}
+
+	for _, n := range names {
+		set[n] = true
+	}
+
+	return set
+}
+
+func name(day time.Time) string {
+	return "request_logs_" + day.UTC().Format("20060102")
+}
+
+func (s *JobAccessLogRetentionSuite) Test_DropsOldAndKeepsRecentPartitions() {
+	ctx := context.Background()
+	store := jobs.NewStore()
+	today := time.Now().UTC()
+
+	old := today.AddDate(0, 0, -60)
+	recent := today.AddDate(0, 0, -10)
+
+	s.NoError(store.CreateAccessLogPartition(ctx, old))
+	s.NoError(store.CreateAccessLogPartition(ctx, recent))
+
+	before := s.partitions()
+	s.True(before[name(old)], "old partition should exist before maintenance")
+
+	s.NoError(jobs.MaintainAccessLogPartitions(ctx))
+
+	after := s.partitions()
+
+	// Older than the 30-day window is dropped; within-window and the DEFAULT
+	// safety-net partition are kept; create-ahead keeps today available.
+	s.False(after[name(old)], "60-day-old partition should be dropped")
+	s.True(after[name(recent)], "10-day-old partition should be kept")
+	s.True(after[name(today)], "today's partition should exist")
+	s.True(after["request_logs_default"], "default partition must never be dropped")
+}
+
+func (s *JobAccessLogRetentionSuite) Test_HonorsEnvRetentionWindow() {
+	ctx := context.Background()
+	store := jobs.NewStore()
+	today := time.Now().UTC()
+
+	day := today.AddDate(0, 0, -10)
+	s.NoError(store.CreateAccessLogPartition(ctx, day))
+	s.True(s.partitions()[name(day)])
+
+	// A 5-day window makes the 10-day-old partition expire.
+	s.T().Setenv("STORMKIT_ACCESS_LOG_RETENTION_DAYS", "5")
+	s.NoError(jobs.MaintainAccessLogPartitions(ctx))
+
+	s.False(s.partitions()[name(day)], "10-day-old partition should expire under a 5-day window")
+}
+
+func TestJobAccessLogRetentionSuite(t *testing.T) {
+	suite.Run(t, &JobAccessLogRetentionSuite{})
+}

--- a/src/ce/workerserver/job_handler_forward.go
+++ b/src/ce/workerserver/job_handler_forward.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/accesslog"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/applog"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
@@ -22,16 +23,17 @@ var HostingQueueName = "hosting_forward_queue"
 var ingestContext = context.Background()
 
 type HostingRecord struct {
-	AppID           types.ID           `json:"appId"`
-	EnvID           types.ID           `json:"envId"`
-	DeploymentID    types.ID           `json:"deploymentId"`
-	BillingUserID   types.ID           `json:"billingUserId"`
-	HostName        string             `json:"hostName"`
-	Logs            []integrations.Log `json:"logs"`
-	Analytics       *analytics.Record  `json:"analytics"`
-	Events          []analytics.Event  `json:"events"`
-	TotalBandwidth  int64              `json:"totalBandwidth"`
-	FunctionInvoked bool               `json:"functionInvoked"`
+	AppID           types.ID             `json:"appId"`
+	EnvID           types.ID             `json:"envId"`
+	DeploymentID    types.ID             `json:"deploymentId"`
+	BillingUserID   types.ID             `json:"billingUserId"`
+	HostName        string               `json:"hostName"`
+	Logs            []integrations.Log   `json:"logs"`
+	Analytics       *analytics.Record    `json:"analytics"`
+	AccessLog       *accesslog.AccessLog `json:"accessLog"`
+	Events          []analytics.Event    `json:"events"`
+	TotalBandwidth  int64                `json:"totalBandwidth"`
+	FunctionInvoked bool                 `json:"functionInvoked"`
 }
 
 // IngestHandlerForward reads rows from redis and inserts them into the database.
@@ -47,6 +49,7 @@ type HostingRecord struct {
 func IngestHandlerForward(ctx context.Context) error {
 	client := rediscache.Client()
 	analyticsRecords := []analytics.Record{}
+	accessLogs := []accesslog.AccessLog{}
 	eventRecords := []analytics.Event{}
 	logRecords := []*applog.Log{}
 	stats := map[string]map[string]int64{} // userId -> metric -> value
@@ -109,6 +112,10 @@ func IngestHandlerForward(ctx context.Context) error {
 			analyticsRecords = append(analyticsRecords, *record.Analytics)
 		}
 
+		if record.AccessLog != nil {
+			accessLogs = append(accessLogs, *record.AccessLog)
+		}
+
 		if len(record.Events) > 0 {
 			eventRecords = append(eventRecords, record.Events...)
 		}
@@ -146,6 +153,12 @@ func IngestHandlerForward(ctx context.Context) error {
 	if len(analyticsRecords) > 0 {
 		if err := analytics.NewStore().InsertRecords(analyticsContext, analyticsRecords); err != nil {
 			slog.Errorf("error while batch inserting analytic records: %v", err)
+		}
+	}
+
+	if len(accessLogs) > 0 {
+		if err := accesslog.NewStore().InsertLogs(ingestContext, accessLogs); err != nil {
+			slog.Errorf("error while batch inserting access logs: %v", err)
 		}
 	}
 

--- a/src/ce/workerserver/worker_scheduler.go
+++ b/src/ce/workerserver/worker_scheduler.go
@@ -81,6 +81,7 @@ func (s *Scheduler) RegisterMasterTasks(ctx context.Context) {
 		{Handler: InvokeDueFunctionTriggers, Def: dj(EVERY_MINUTE), Opt: immediate},
 		{Handler: RemoveOldLogs, Def: dj(EVERY_HOUR * 2), Opt: immediate},
 		{Handler: RemoveOldAnalytics, Def: dj(EVERY_6_HOURS), Opt: immediate},
+		{Handler: MaintainAccessLogPartitions, Def: daily, Opt: immediate},
 		{Handler: RemoveStaleEnvironments, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: RemoveDeploymentArtifacts, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: SyncAnalyticsVisitorsHourly, Def: dj(EVERY_MINUTE * 5), Opt: immediate},

--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -25,6 +25,7 @@ type statement struct {
 	selectUserIDsWithoutAPIKeys     string
 	selectStaleSchemas              string
 	clearSchemaConf                 string
+	selectAccessLogPartitions       string
 }
 
 var stmt = &statement{
@@ -62,6 +63,13 @@ var stmt = &statement{
 			WHERE event_ts < now() - make_interval(days => $1)
 			LIMIT $2
 		)
+	`,
+	selectAccessLogPartitions: `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		JOIN pg_class p ON p.oid = i.inhparent
+		WHERE p.relname = 'request_logs';
 	`,
 	deleteStaleEnvironments: fmt.Sprintf(`
 		DELETE FROM %s

--- a/src/ce/workerserver/ws_store.go
+++ b/src/ce/workerserver/ws_store.go
@@ -3,13 +3,23 @@ package jobs
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"regexp"
 	"text/template"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 )
+
+// accessLogPartitionName matches a dated request_logs partition (request_logs_YYYYMMDD),
+// guarding the DDL helpers — whose table names cannot be parameterized — against
+// anything but a name this code constructs itself.
+var accessLogPartitionName = regexp.MustCompile(`^request_logs_(\d{8})$`)
+
+const accessLogPartitionDateLayout = "20060102"
 
 // Store represents a store for the deployments and deployment logs.
 type Store struct {
@@ -55,6 +65,63 @@ func (s *Store) RemoveOldAnalyticsEvents(ctx context.Context, p RemoveOldAnalyti
 	}
 
 	return res.RowsAffected()
+}
+
+// CreateAccessLogPartition creates the daily request_logs partition covering the
+// given day, if it does not already exist. The day is normalized to its date.
+func (s *Store) CreateAccessLogPartition(ctx context.Context, day time.Time) error {
+	day = day.UTC().Truncate(24 * time.Hour)
+	name := "request_logs_" + day.Format(accessLogPartitionDateLayout)
+	from := day.Format("2006-01-02")
+	to := day.Add(24 * time.Hour).Format("2006-01-02")
+
+	query := fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s PARTITION OF request_logs FOR VALUES FROM ('%s') TO ('%s');",
+		name, from, to,
+	)
+
+	_, err := s.Exec(ctx, query)
+
+	return err
+}
+
+// AccessLogPartitions returns the names of all child partitions of request_logs
+// (including the DEFAULT partition).
+func (s *Store) AccessLogPartitions(ctx context.Context) ([]string, error) {
+	rows, err := s.Query(ctx, stmt.selectAccessLogPartitions)
+
+	if rows == nil || err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	names := []string{}
+
+	for rows.Next() {
+		var name string
+
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+
+		names = append(names, name)
+	}
+
+	return names, nil
+}
+
+// DropAccessLogPartition drops a dated request_logs partition by name. The name
+// must match the request_logs_YYYYMMDD pattern; anything else is rejected so the
+// non-parameterizable DROP cannot touch an arbitrary table.
+func (s *Store) DropAccessLogPartition(ctx context.Context, name string) error {
+	if !accessLogPartitionName.MatchString(name) {
+		return fmt.Errorf("refusing to drop unexpected partition name: %q", name)
+	}
+
+	_, err := s.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s;", name))
+
+	return err
 }
 
 // MarkDeploymentArtifactsDeleted marks the deployment and its artifacts as deleted.

--- a/src/migrations/0024_2026-06-27.up.sql
+++ b/src/migrations/0024_2026-06-27.up.sql
@@ -65,3 +65,80 @@ ALTER TABLE analytics ADD COLUMN IF NOT EXISTS source text;
 -- system variables (e.g. {{SK_REQUEST_ID}}) at inject time. Off by default; only
 -- flagged snippets are scanned, so unflagged user content is never rewritten.
 ALTER TABLE snippets ADD COLUMN IF NOT EXISTS snippet_interpolate boolean NOT NULL DEFAULT false;
+
+-- Raw, request-level access logs for every request hitting the hosting tier,
+-- including bots. This is intentionally NOT the analytics table: it keeps the
+-- raw client IP (unmasked), the full user-agent and path, and an is_bot flag
+-- instead of dropping bot traffic.
+--
+-- Named request_logs (not access_logs): a defunct, code-unreferenced legacy
+-- access_logs table from migration 0001 still exists and may hold historical
+-- data, and migrations here are forward-only — so a fresh name avoids any
+-- destructive drop while this feature owns the new partitioned table.
+--
+-- At ~200-500M rows/month the table is managed by native daily range
+-- partitioning + DROP PARTITION retention (see MaintainAccessLogPartitions),
+-- which makes 30-day purges instant and avoids the vacuum/bloat cost of the
+-- batched ctid-DELETE used for the analytics table.
+--
+-- No foreign keys: cascading deletes over hundreds of millions of rows on app
+-- deletion would be punishing, and the 30-day retention window bounds the data
+-- regardless. The partition key (request_timestamp) is part of the primary key
+-- because Postgres requires the partition column in every unique constraint.
+--
+-- NOTE: built non-concurrently for migration-runner compatibility (the runner
+-- executes each file in a single Exec). Creating the parent, its DEFAULT
+-- partition, a bootstrap window of daily partitions and the parent indexes in
+-- one file is fine; ongoing partition lifecycle lives in the gocron job.
+CREATE TABLE IF NOT EXISTS request_logs (
+    log_id            bigint GENERATED ALWAYS AS IDENTITY,
+    app_id            bigint NOT NULL,
+    env_id            bigint NOT NULL,
+    deployment_id     bigint,
+    domain_id         bigint,
+    host_name         text,
+    request_timestamp timestamp without time zone NOT NULL,
+    method            text,
+    request_path      text,
+    response_code     integer,
+    client_ip         text,
+    user_agent        text,
+    referrer          text,
+    is_bot            boolean NOT NULL DEFAULT false,
+    bytes_sent        bigint,
+    request_id        uuid,
+    PRIMARY KEY (log_id, request_timestamp)
+) PARTITION BY RANGE (request_timestamp);
+
+-- Safety net so an insert never fails if the maintenance job lags behind (and
+-- so tests with arbitrary timestamps insert cleanly). In steady state the
+-- create-ahead job keeps this empty.
+CREATE TABLE IF NOT EXISTS request_logs_default PARTITION OF request_logs DEFAULT;
+
+-- Lean index set: every index is write amplification against ~16M inserts/day.
+-- Defined on the parent so they propagate to existing and future partitions.
+-- Both lead with the scoping column and include request_timestamp, which the
+-- admin viewer always constrains (enabling partition pruning). Ad-hoc filters
+-- (ip, path, user-agent) scan within the already-pruned day partitions rather
+-- than carrying their own indexes.
+CREATE INDEX IF NOT EXISTS idx_request_logs_app_ts
+    ON request_logs (app_id, request_timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_request_logs_domain_ts
+    ON request_logs (domain_id, request_timestamp);
+
+-- Bootstrap daily partitions for a window around "now" so ingestion works
+-- before the gocron maintenance job first runs.
+DO $$
+DECLARE
+    d date;
+BEGIN
+    FOR d IN
+        SELECT generate_series(current_date - 1, current_date + 7, interval '1 day')::date
+    LOOP
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS request_logs_%s PARTITION OF request_logs FOR VALUES FROM (%L) TO (%L);',
+            to_char(d, 'YYYYMMDD'), d, d + 1
+        );
+    END LOOP;
+END $$;

--- a/src/ui/src/layouts/AdminLayout/AdminLayout.tsx
+++ b/src/ui/src/layouts/AdminLayout/AdminLayout.tsx
@@ -111,6 +111,14 @@ export default function AdminLayout({ children }: Props) {
               <MenuLink
                 inline
                 item={{
+                  path: "/admin/access-logs",
+                  text: "Access Logs",
+                  isActive: pathname.includes("/admin/access-logs"),
+                }}
+              />
+              <MenuLink
+                inline
+                item={{
                   path: "/admin/git",
                   text: "Git",
                   isActive: pathname.includes("/admin/git"),

--- a/src/ui/src/pages/admin/AccessLogs.tsx
+++ b/src/ui/src/pages/admin/AccessLogs.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useState } from "react";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import MenuItem from "@mui/material/MenuItem";
+import Table from "@mui/material/Table";
+import Head from "@mui/material/TableHead";
+import Body from "@mui/material/TableBody";
+import Tr from "@mui/material/TableRow";
+import Td from "@mui/material/TableCell";
+import Chip from "@mui/material/Chip";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardFooter from "~/components/CardFooter";
+import api from "~/utils/api/Api";
+
+interface AccessLogEntry {
+  id: string;
+  appId: string;
+  domainId: string;
+  hostName: string;
+  requestTimestamp: string;
+  method: string;
+  path: string;
+  statusCode: number;
+  clientIp: string;
+  userAgent: string;
+  referrer: string;
+  isBot: boolean;
+  bytesSent: number;
+}
+
+interface Filters {
+  hostName?: string;
+  clientIp?: string;
+  path?: string;
+  method?: string;
+  status?: string;
+  isBot?: string;
+}
+
+interface UseFetchAccessLogsProps {
+  filters: Filters;
+  beforeId?: string;
+  refreshToken: number;
+}
+
+const useFetchAccessLogs = ({
+  filters,
+  beforeId,
+  refreshToken,
+}: UseFetchAccessLogsProps) => {
+  const [logs, setLogs] = useState<AccessLogEntry[]>([]);
+  const [nextBeforeId, setNextBeforeId] = useState<string>();
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [error, setError] = useState<string>();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let unmounted = false;
+
+    setLoading(true);
+    setError(undefined);
+
+    const params = new URLSearchParams();
+
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+      }
+    });
+
+    if (beforeId) {
+      params.set("beforeId", beforeId);
+    }
+
+    api
+      .fetch<{
+        accessLogs: AccessLogEntry[];
+        pagination: { hasNextPage: boolean; beforeId?: string };
+      }>("/admin/access-logs?" + params.toString())
+      .then(res => {
+        if (unmounted) {
+          return;
+        }
+
+        setHasNextPage(res.pagination.hasNextPage);
+        setNextBeforeId(res.pagination.beforeId);
+        setLogs(beforeId ? prev => [...prev, ...res.accessLogs] : res.accessLogs);
+      })
+      .catch(() => {
+        if (!unmounted) {
+          setError("Something went wrong while fetching access logs.");
+        }
+      })
+      .finally(() => {
+        if (!unmounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      unmounted = true;
+    };
+  }, [refreshToken, beforeId]);
+
+  return { logs, error, loading, hasNextPage, nextBeforeId };
+};
+
+const formatTs = (ts: string) =>
+  ts ? new Date(Number(ts) * 1000).toLocaleString() : "";
+
+export default function AccessLogs() {
+  const [draft, setDraft] = useState<Filters>({});
+  const [filters, setFilters] = useState<Filters>({});
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [beforeId, setBeforeId] = useState<string>();
+  const { logs, error, loading, hasNextPage, nextBeforeId } = useFetchAccessLogs(
+    { filters, beforeId, refreshToken }
+  );
+
+  const search = () => {
+    setBeforeId(undefined);
+    setFilters(draft);
+    setRefreshToken(t => t + 1);
+  };
+
+  const set = (key: keyof Filters) => (value: string) =>
+    setDraft(prev => ({ ...prev, [key]: value }));
+
+  return (
+    <Card
+      error={error}
+      sx={{ backgroundColor: "container.transparent" }}
+      info={
+        !loading && logs.length === 0
+          ? "No access logs match your filters."
+          : undefined
+      }
+      contentPadding={false}
+    >
+      <CardHeader
+        title="Access Logs"
+        subtitle="Search raw request logs across all hosted applications. Defaults to the last 24 hours when no time range is set."
+      />
+      <Box
+        sx={{ px: 4, mb: 4, display: "flex", gap: 2, flexWrap: "wrap" }}
+        component="form"
+        onSubmit={e => {
+          e.preventDefault();
+          search();
+        }}
+      >
+        <TextField
+          variant="filled"
+          label="Host"
+          size="small"
+          onChange={e => set("hostName")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
+          label="Client IP"
+          size="small"
+          onChange={e => set("clientIp")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
+          label="Path"
+          size="small"
+          onChange={e => set("path")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
+          label="Method"
+          size="small"
+          onChange={e => set("method")(e.target.value.toUpperCase())}
+        />
+        <TextField
+          variant="filled"
+          label="Status"
+          size="small"
+          onChange={e => set("status")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
+          label="Bots"
+          size="small"
+          select
+          defaultValue=""
+          sx={{ minWidth: 120 }}
+          onChange={e => set("isBot")(e.target.value)}
+        >
+          <MenuItem value="">All</MenuItem>
+          <MenuItem value="false">Exclude bots</MenuItem>
+          <MenuItem value="true">Only bots</MenuItem>
+        </TextField>
+        <Button type="submit" variant="contained" disabled={loading}>
+          {loading ? <CircularProgress size={16} /> : "Search"}
+        </Button>
+      </Box>
+      <Box sx={{ px: 4 }}>
+        <Table size="small">
+          <Head>
+            <Tr>
+              <Td>Time</Td>
+              <Td>Method</Td>
+              <Td>Status</Td>
+              <Td>Host</Td>
+              <Td>Path</Td>
+              <Td>Client IP</Td>
+              <Td>Bot</Td>
+            </Tr>
+          </Head>
+          <Body>
+            {logs.map(log => (
+              <Tr key={log.id}>
+                <Td>{formatTs(log.requestTimestamp)}</Td>
+                <Td>{log.method}</Td>
+                <Td>{log.statusCode}</Td>
+                <Td>{log.hostName}</Td>
+                <Td sx={{ maxWidth: 280, wordBreak: "break-all" }}>
+                  {log.path}
+                </Td>
+                <Td>{log.clientIp}</Td>
+                <Td>
+                  {log.isBot && <Chip label="bot" size="small" color="warning" />}
+                </Td>
+              </Tr>
+            ))}
+          </Body>
+        </Table>
+        {hasNextPage && (
+          <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
+            <Button
+              variant="text"
+              disabled={loading}
+              onClick={() => setBeforeId(nextBeforeId)}
+            >
+              Load more
+            </Button>
+          </Box>
+        )}
+      </Box>
+      <CardFooter />
+    </Card>
+  );
+}

--- a/src/ui/src/pages/routes.tsx
+++ b/src/ui/src/pages/routes.tsx
@@ -145,6 +145,10 @@ const routes: Array<ExtendedRouterProps> = [
     element: Async(() => import("~/pages/admin/Proxies"), adminLayout),
   },
   {
+    path: "/admin/access-logs",
+    element: Async(() => import("~/pages/admin/AccessLogs"), adminLayout),
+  },
+  {
     path: "/admin/cloud/apps",
     element: Async(() => import("~/pages/admin/CloudApps"), adminLayout),
     cloudOnly: true,


### PR DESCRIPTION
## What

Stores raw, request-level **access logs for every request** hitting the hosting tier — **bots included** — in a new daily-partitioned `request_logs` table with **30-day `DROP PARTITION` retention**, queryable through a platform-admin viewer.

Unlike the `analytics` table (which drops bots, hashes the IP, skips XHR/non-HTML), this keeps the **raw unmasked client IP, full user-agent and path**, plus an `is_bot` flag so bot traffic can be included or excluded at query time. Sized for ~200–500M rows/month.

## Why partitioning

Native daily range partitioning makes 30-day purges an instant `DROP PARTITION` instead of the batched `ctid`-DELETE used for analytics — no vacuum/bloat cost at this volume. First use of declarative partitioning in the repo.

## Changes

- **Schema** (folded into the unreleased migration `0024`): `request_logs` `PARTITION BY RANGE(request_timestamp)`, a `DEFAULT` safety-net partition, lean `(app_id, ts)` / `(domain_id, ts)` indexes, no FKs (30-day retention bounds the data; cascading deletes over 500M rows would be punishing).
- **Ingestion**: reuses the existing buffer → Redis → worker pipeline (already sized for ~518M rows/month). `artifacts()` builds an access log unconditionally for every request (no bot/HTML/XHR filtering); the worker bulk-inserts via `accesslog.Store.InsertLogs`.
- **Retention**: `MaintainAccessLogPartitions` gocron master task — creates partitions ahead and drops those older than `STORMKIT_ACCESS_LOG_RETENTION_DAYS` (default 30).
- **Read API**: `GET /admin/access-logs` (gated by `user.WithAdmin`) with filters (app/domain/host/IP/method/path/status/isBot/from/to) + cursor pagination, always time-bounded for partition pruning.
- **UI**: `AccessLogs` admin page (filters + table + load-more) under `adminLayout`.

> Named `request_logs` (not `access_logs`): a defunct, code-unreferenced legacy `access_logs` table from migration 0001 still exists and may hold historical data; migrations are forward-only, so a fresh name avoids a destructive drop.

## Tests

All passing (`go test -p 1`):
- store insert/select (asserts raw IP/UA persisted)
- partition retention (drops old, keeps recent + DEFAULT, honors env window)
- admin handler (returns logs, bot filter, non-admin → 401)
- hosting wiring (bot request still produces a flagged access log)