### PR TITLE
feat: inject snippets into gzipped ssr responses

### DIFF
--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -1,8 +1,12 @@
 package hosting
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -327,13 +331,26 @@ func (r *RequestServer) Dynamic() *shttp.Response {
 		arn = cnf.APILocation
 	}
 
+	// When snippets are configured we want the origin to hand back uncompressed
+	// HTML so it can be injected into. Ask the upstream not to compress: if it
+	// honours the header (most servers do) injectSnippets works on the plain
+	// body directly; if it ignores it, injectSnippets still decompresses as a
+	// fallback. Either way the edge gzip middleware re-compresses the final
+	// response for the client.
+	headers := r.req.Headers()
+
+	if cnf.Snippets != nil {
+		headers = headers.Clone()
+		headers.Set("Accept-Encoding", "identity")
+	}
+
 	result, err := integrations.Client().Invoke(integrations.InvokeArgs{
 		URL:           url,
 		ARN:           arn,
 		Body:          r.req.Body,
 		ContentLength: r.req.ContentLength,
 		Method:        r.req.Method,
-		Headers:       r.req.Headers(),
+		Headers:       headers,
 		HostName:      r.req.Host.Name,
 		AppID:         cnf.AppID,
 		EnvID:         cnf.EnvID,
@@ -604,47 +621,117 @@ func (r *RequestServer) OptimizeImage(content []byte) ([]byte, error) {
 }
 
 func shouldInject(_ *RequestContext, res *shttp.Response) bool {
-	// We only need to inject the snippets to the html files.
-	// We also skip if the `Content-Encoding` header is given because
-	// we're not going to unzip and re-zip.
-	if !strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html") ||
-		res == nil ||
-		res.Headers.Get("Content-Encoding") != "" {
+	// We only inject snippets into HTML responses. Encoding is handled by
+	// injectSnippets, which decompresses gzip/deflate bodies before injecting.
+	if res == nil || !strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html") {
 		return false
 	}
 
 	return true
 }
 
-func responseBody(res *shttp.Response) string {
-	switch res.Data.(type) {
+// responseBytes returns the raw (possibly still-encoded) response body bytes.
+func responseBytes(res *shttp.Response) ([]byte, bool) {
+	switch data := res.Data.(type) {
 	case string:
-		return res.Data.(string)
+		return []byte(data), true
 	case []byte:
-		return string(res.Data.([]byte))
+		return data, true
 	default:
-		return ""
+		return nil, false
 	}
 }
 
-// injectSnippets injects the snippets to the response data.
+// decodeBody returns the body as plaintext, transparently decompressing gzip
+// and deflate payloads. The bool is false when the encoding is one we can't
+// decode (e.g. brotli), so the caller can leave the response untouched rather
+// than corrupt it.
+func decodeBody(encoding string, data []byte) ([]byte, bool) {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "", "identity":
+		return data, true
+	case "gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(data))
+
+		if err != nil {
+			return nil, false
+		}
+
+		defer zr.Close()
+
+		out, err := io.ReadAll(zr)
+
+		if err != nil {
+			return nil, false
+		}
+
+		return out, true
+	case "deflate":
+		fr := flate.NewReader(bytes.NewReader(data))
+		defer fr.Close()
+
+		out, err := io.ReadAll(fr)
+
+		if err != nil {
+			return nil, false
+		}
+
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// injectSnippets injects the configured snippets into the HTML response body.
+// It transparently decodes gzip/deflate-encoded bodies before injecting, then
+// drops the now-stale Content-Encoding and Content-Length headers so the edge
+// gzip middleware can re-compress the modified response for the client.
 func injectSnippets(req *RequestContext, res *shttp.Response) *shttp.Response {
 	if req.Host.Config.Snippets == nil || !shouldInject(req, res) {
+		return res
+	}
+
+	raw, ok := responseBytes(res)
+
+	if !ok {
+		return res
+	}
+
+	decoded, ok := decodeBody(res.Headers.Get("Content-Encoding"), raw)
+
+	if !ok {
+		// Encoding we can't decode (e.g. brotli); leave the response as-is
+		// rather than risk corrupting it.
+		return res
+	}
+
+	body := string(decoded)
+
+	if body == "" {
 		return res
 	}
 
 	// We need to use the original path because of path rewrites.
 	filters := appconf.SnippetFilters{RequestPath: req.OriginalPath, RequestID: req.RequestID}
 	snpt := appconf.SnippetsHTML(req.Host.Config.Snippets, filters)
-	body := responseBody(res)
 
-	if body != "" {
-		body = insertAfter(body, "<head>", snpt.HeadPrepend)
-		body = insertAfter(body, "<body>", snpt.BodyPrepend)
-		body = insertBefore(body, "</head>", snpt.HeadAppend)
-		body = insertBefore(body, "</body>", snpt.BodyAppend)
-		res.Data = body
+	injected := body
+	injected = insertAfter(injected, "<head>", snpt.HeadPrepend)
+	injected = insertAfter(injected, "<body>", snpt.BodyPrepend)
+	injected = insertBefore(injected, "</head>", snpt.HeadAppend)
+	injected = insertBefore(injected, "</body>", snpt.BodyAppend)
+
+	if injected == body {
+		// Nothing matched; keep the original response (and its encoding) as-is.
+		return res
 	}
+
+	res.Data = injected
+
+	// The body is now plaintext and a different length. Drop the stale framing
+	// and encoding; the edge gzip middleware re-compresses from scratch.
+	res.Headers.Del("Content-Encoding")
+	res.Headers.Del("Content-Length")
 
 	return res
 }

--- a/src/ce/hosting/snippet_inject_test.go
+++ b/src/ce/hosting/snippet_inject_test.go
@@ -1,0 +1,156 @@
+package hosting_test
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	hosting "github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stretchr/testify/suite"
+)
+
+type SnippetInjectSuite struct {
+	suite.Suite
+}
+
+func (s *SnippetInjectSuite) request(host *hosting.Host, path string) *hosting.RequestContext {
+	rq := &hosting.RequestContext{
+		Host: host,
+		RequestContext: shttp.NewRequestContext(&http.Request{
+			Header: http.Header{},
+			URL:    &url.URL{Path: path},
+		}),
+	}
+
+	rq.OriginalPath = path
+
+	return rq
+}
+
+func snippetHost(snippets appconf.Snippets) *hosting.Host {
+	return &hosting.Host{
+		Name:   "x",
+		Config: &appconf.Config{Snippets: snippets},
+	}
+}
+
+func gzipBytes(s string) []byte {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, _ = w.Write([]byte(s))
+	_ = w.Close()
+
+	return buf.Bytes()
+}
+
+func deflateBytes(s string) []byte {
+	var buf bytes.Buffer
+	w, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+	_, _ = w.Write([]byte(s))
+	_ = w.Close()
+
+	return buf.Bytes()
+}
+
+func encodedResponse(encoding string, data []byte) *shttp.Response {
+	headers := http.Header{"Content-Type": []string{"text/html"}}
+
+	if encoding != "" {
+		headers.Set("Content-Encoding", encoding)
+	}
+
+	return &shttp.Response{
+		Status:  http.StatusOK,
+		Headers: headers,
+		Data:    data,
+	}
+}
+
+const sampleHTML = "<html><head></head><body></body></html>"
+
+func headAppendSnippet() appconf.Snippets {
+	return appconf.Snippets{{Content: "<!--sk-head-->", Location: "head"}}
+}
+
+func (s *SnippetInjectSuite) Test_InjectsIntoGzipHTML() {
+	res := encodedResponse("gzip", gzipBytes(sampleHTML))
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	body, ok := out.Data.(string)
+	s.Require().True(ok, "body should be decoded to a plaintext string")
+	s.Contains(body, "<!--sk-head--></head>")
+
+	// Stale framing/encoding must be dropped so the edge can re-compress.
+	s.Empty(out.Headers.Get("Content-Encoding"))
+	s.Empty(out.Headers.Get("Content-Length"))
+}
+
+func (s *SnippetInjectSuite) Test_InjectsIntoDeflateHTML() {
+	res := encodedResponse("deflate", deflateBytes(sampleHTML))
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	body, ok := out.Data.(string)
+	s.Require().True(ok)
+	s.Contains(body, "<!--sk-head--></head>")
+	s.Empty(out.Headers.Get("Content-Encoding"))
+}
+
+func (s *SnippetInjectSuite) Test_PlainHTMLStripsStaleContentLength() {
+	res := encodedResponse("", []byte(sampleHTML))
+	res.Headers.Set("Content-Length", "40") // original length, stale after injection
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	body, ok := out.Data.(string)
+	s.Require().True(ok)
+	s.Contains(body, "<!--sk-head--></head>")
+	s.Empty(out.Headers.Get("Content-Length"))
+}
+
+func (s *SnippetInjectSuite) Test_SkipsUndecodableEncoding() {
+	original := []byte("this-is-brotli-or-something")
+	res := encodedResponse("br", original)
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	// Undecodable encoding: response left completely untouched.
+	s.Equal("br", out.Headers.Get("Content-Encoding"))
+	data, ok := out.Data.([]byte)
+	s.Require().True(ok)
+	s.Equal(original, data)
+}
+
+func (s *SnippetInjectSuite) Test_NoMatchingTagsKeepsEncoding() {
+	// Valid gzip HTML but without <head>/<body> tags to inject around.
+	res := encodedResponse("gzip", gzipBytes("<html>no tags here</html>"))
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	// Nothing matched, so the original (still-gzipped) response is preserved.
+	s.Equal("gzip", out.Headers.Get("Content-Encoding"))
+	_, ok := out.Data.([]byte)
+	s.True(ok, "body should remain the original encoded bytes")
+}
+
+func (s *SnippetInjectSuite) Test_SkipsNonHTML() {
+	res := &shttp.Response{
+		Status:  http.StatusOK,
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Data:    `{"ok":true}`,
+	}
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	s.Equal(`{"ok":true}`, out.Data)
+}
+
+func TestSnippetInjectSuite(t *testing.T) {
+	suite.Run(t, &SnippetInjectSuite{})
+}


### PR DESCRIPTION
## Problem

Snippet injection was silently skipped whenever the origin returned a `Content-Encoding` header. For server-side-rendered apps whose function compresses its own output (Express `compression()`, many Node servers), snippets were never injected. The `shouldInject` guard explicitly bailed out (*"we're not going to unzip and re-zip"*).

I also confirmed that snippets **do** work for SSR when the origin returns plain HTML — but found a latent bug: `Content-Length` was never recomputed after injection, so a non-gzip client against a fixed-length origin could get truncated HTML.

## Fix

Two complementary approaches:

1. **Ask the origin not to compress.** In `Dynamic()`, when snippets are configured, the upstream SSR request is sent with `Accept-Encoding: identity`, so most servers return plain HTML that injects directly.
2. **Decompress fallback.** If the origin compresses anyway, `injectSnippets` now transparently decodes `gzip`/`deflate`, injects, and drops the stale `Content-Encoding`/`Content-Length` so the existing edge gzip middleware re-compresses for the client. An encoding we can't decode (e.g. `brotli`, not a current dependency) falls back to today's skip behavior — no regression.
3. **Content-Length staleness fix.** `Content-Length` is now stripped whenever injection changes the body, including the plain (non-encoded) path.

## Tests

`snippet_inject_test.go`: gzip inject, deflate inject, plain-path Content-Length strip, undecodable-encoding skip, no-matching-tags keeps original encoding, non-HTML skip. Full `hosting` suite green.

## Notes

- Also includes a one-line `gofmt` fix to `client_x.go`'s doc comment that was missing on main.