### PR TITLE
feat: collapse events help to icon once tracked

### DIFF
--- a/src/ui/src/components/Help/Help.tsx
+++ b/src/ui/src/components/Help/Help.tsx
@@ -1,6 +1,8 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
+import Tooltip from "@mui/material/Tooltip";
 import QuestionMarkOutlined from "@mui/icons-material/HelpCenter";
 import Drawer from "@mui/material/Drawer";
 import { useState } from "react";
@@ -14,6 +16,7 @@ interface Props {
   subtitle?: React.ReactNode;
   buttonText?: string;
   buttonVariant?: "text" | "contained" | "outlined" | "link";
+  iconOnly?: boolean;
 }
 
 export default function Help({
@@ -22,12 +25,22 @@ export default function Help({
   subtitle,
   buttonText = "Help",
   buttonVariant = "text",
+  iconOnly = false,
 }: Props) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   return (
     <>
-      {buttonVariant === "link" ? (
+      {iconOnly ? (
+        <Tooltip title={buttonText} arrow>
+          <IconButton
+            aria-label={buttonText}
+            onClick={() => setIsDrawerOpen(true)}
+          >
+            <QuestionMarkOutlined />
+          </IconButton>
+        </Tooltip>
+      ) : buttonVariant === "link" ? (
         <Link
           href="#"
           onClick={e => {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.spec.tsx
@@ -75,6 +75,27 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx", () => {
     });
   });
 
+  it("shows the full 'How to track' button when there are no events", async () => {
+    createWrapper({ response: [] });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByText("How to track")).toBeTruthy();
+    });
+  });
+
+  it("collapses 'How to track' to an icon button once events exist", async () => {
+    createWrapper({
+      response: [{ name: "trip_creation", total: 1, unique: 1 }],
+    });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.queryByText("How to track")).toBeNull();
+      expect(wrapper.getByLabelText("How to track")).toBeTruthy();
+    });
+  });
+
   it("opens the help drawer with client and server examples", async () => {
     createWrapper({
       response: [{ name: "trip_creation", total: 1, unique: 1 }],
@@ -84,7 +105,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx", () => {
       expect(scope.isDone()).toBe(true);
     });
 
-    fireEvent.click(wrapper.getByText("How to track"));
+    fireEvent.click(wrapper.getByLabelText("How to track"));
 
     // The drawer renders in a portal, so query the whole document.
     expect(screen.getByText("Track events")).toBeTruthy();

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Events.tsx
@@ -68,6 +68,7 @@ export default function Events({ environment, domain, ts }: Props) {
               subtitle={helpSubtitle}
               buttonText="How to track"
               buttonVariant="text"
+              iconOnly={!isEmpty}
             >
               <EventsHelpContent domain={domain} />
             </Help>


### PR DESCRIPTION
## What

The **Events** analytics section always showed a prominent "How to track" button. Once a domain has events flowing, that onboarding CTA no longer needs to compete with the data.

- **No events** → full "How to track" button (onboarding stays loud), plus the existing "Learn how to send events." link in the empty-state banner.
- **Events present** → the button collapses to a quiet `?` icon (tooltip + `aria-label` = "How to track"), still opening the same tracking docs drawer.

Implemented via a new `iconOnly` prop on the shared `Help` component, driven by `!isEmpty` in `Events.tsx`.

## Tests

- Updated the existing drawer test to target the icon button by label.
- Added coverage for full-button (empty) vs icon-only (populated) states.

All 6 `Events.spec.tsx` tests pass.