### PR TITLE
feat: add skauth /me endpoint with user metadata

### DIFF
--- a/docs/features/15-authentication.md
+++ b/docs/features/15-authentication.md
@@ -143,6 +143,35 @@ headers:
 - `X-User-Id` — the user's external identifier.
 - `X-User-Email` — the user's email address.
 
+These two headers are kept intentionally minimal so they stay cheap to forward on
+every request. For the richer profile, use the user-info endpoint below.
+
+### Fetching the full profile
+
+`GET /_stormkit/auth/me` with the current `Authorization: Bearer <token>` header
+returns the full profile for the signed-in user:
+
+```json
+{
+  "id": "…",
+  "email": "user@example.com",
+  "firstName": "John",
+  "lastName": "Doe",
+  "avatar": "https://…",
+  "username": "johndoe",
+  "profileUrl": "https://x.com/johndoe",
+  "createdAt": 0,
+  "lastLoginAt": 0
+}
+```
+
+`username` and `profileUrl` are populated from the provider when available (for
+example, the X handle and a link to the public profile); they are empty for
+providers that don't supply them. The endpoint only ever returns the caller's own
+record — identity is taken from the token, not from any parameter. Typically your
+backend calls it once, on first sight of a new `X-User-Id`, to sync the profile
+into its own store.
+
 ### Refreshing the token
 
 To keep an active user signed in without forcing a new sign-in, exchange a still

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -135,6 +135,14 @@ func (Env) TableName() string {
 	return "apps_build_conf"
 }
 
+// AuthReady reports whether authentication is fully provisioned for this
+// environment: enabled auth config and a schema to back it. Auth handlers guard
+// on this before touching the auth store, so the check lives here once instead
+// of being spelled out (in varying orders) at every call site.
+func (e *Env) AuthReady() bool {
+	return e != nil && e.AuthConf != nil && e.AuthConf.Status && e.SchemaConf != nil
+}
+
 // DomainInfo represents a domainInfo struct returned by the database.
 // It is used by the store's DomainInfo method.
 type DomainInfo struct {

--- a/src/ce/api/app/buildconf/schema_model.go
+++ b/src/ce/api/app/buildconf/schema_model.go
@@ -1,6 +1,7 @@
 package buildconf
 
 import (
+	"context"
 	"database/sql/driver"
 	"fmt"
 	"sync"
@@ -14,6 +15,12 @@ import (
 // unlike the per-request SchemaConf structs that are deserialized fresh from
 // the database each time.
 var schemaStoreCache sync.Map
+
+// authSchemaEnsured tracks, per process, which schemas have had their auth
+// tables reconciled (CreateAuthTable, including idempotent column ALTERs) since
+// boot, so EnsureAuthSchema runs the DDL at most once per schema. Keyed like
+// schemaStoreCache.
+var authSchemaEnsured sync.Map
 
 type SchemaTable struct {
 	Name string
@@ -93,6 +100,31 @@ func (sc *SchemaConf) Store(accessType string) (*schemaStore, error) {
 
 	schemaStoreCache.Store(cacheKey, store)
 	return store, nil
+}
+
+// EnsureAuthSchema guarantees the auth tables in this schema match the current
+// DDL, including columns (e.g. metadata) added after the tenant first enabled
+// auth. It runs the idempotent CreateAuthTable through the migration role once
+// per schema per process; a failure is not cached, so the next call retries.
+func (sc *SchemaConf) EnsureAuthSchema(ctx context.Context) error {
+	key := sc.storeKey(SchemaAccessTypeMigrations)
+
+	if _, ok := authSchemaEnsured.Load(key); ok {
+		return nil
+	}
+
+	store, err := sc.Store(SchemaAccessTypeMigrations)
+
+	if err != nil {
+		return err
+	}
+
+	if err := store.CreateAuthTable(ctx); err != nil {
+		return err
+	}
+
+	authSchemaEnsured.Store(key, struct{}{})
+	return nil
 }
 
 // URL returns the psql connection URL.

--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -18,20 +18,21 @@ import (
 )
 
 var schemaStmt = struct {
-	selectSchema          string
-	selectTables          string
-	createAuthTable       string
-	createMigrationsTable string
-	selectMigrations      string
-	insertOAuth           string
-	upsertProvider        string
-	insertAuthUser        string
-	selectUserIDByEmail   string
-	verifyEmailUser       string
-	consumeMagicLinkToken string
-	updateAuthUser        string
-	deleteAuthUser        string
-	updateLastLogin       string
+	selectSchema           string
+	selectTables           string
+	createAuthTable        string
+	createMigrationsTable  string
+	selectMigrations       string
+	insertOAuth            string
+	upsertProvider         string
+	insertAuthUser         string
+	selectUserIDByEmail    string
+	verifyEmailUser        string
+	consumeMagicLinkToken  string
+	updateAuthUser         string
+	updateAuthUserMetadata string
+	deleteAuthUser         string
+	updateLastLogin        string
 }{
 	updateAuthUser: `
 		UPDATE stormkit_auth_users
@@ -46,6 +47,12 @@ var schemaStmt = struct {
 			COALESCE(avatar, '') AS avatar,
 			created_at,
 			last_login_at;
+	`,
+
+	updateAuthUserMetadata: `
+		UPDATE stormkit_auth_users
+		SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb
+		WHERE uuid = $1;
 	`,
 
 	deleteAuthUser: `
@@ -68,6 +75,11 @@ var schemaStmt = struct {
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			last_login_at TIMESTAMPTZ
 		);
+
+		-- Retroactively add columns introduced after a tenant first enabled auth.
+		-- Idempotent (no-op once present); runs as the schema's migration_user,
+		-- which owns the table, so ALTER is permitted. See SchemaConf.EnsureAuthSchema.
+		ALTER TABLE stormkit_auth_users ADD COLUMN IF NOT EXISTS metadata JSONB;
 
 		CREATE TABLE IF NOT EXISTS stormkit_auth_providers (
 			auth_id SERIAL PRIMARY KEY NOT NULL,
@@ -199,6 +211,7 @@ var sqlTemplates = struct {
 			COALESCE(u.avatar, '') AS avatar,
 			u.created_at,
 			u.last_login_at
+			{{- if .WithMetadata}}, COALESCE(u.metadata, '{}'::jsonb) AS metadata{{end}}
 			{{- if .WithHash}}, p.access_token AS password_hash, p.verified_at{{end}}
 		FROM
 			stormkit_auth_users u
@@ -783,6 +796,76 @@ func (s *schemaStore) AuthUser(ctx context.Context, authID types.ID) (*skauth.Us
 	}
 
 	return authUser, nil
+}
+
+// AuthUserByUUID retrieves the authentication user by its external UUID,
+// including the metadata JSONB column. This is what the /_stormkit/auth/me
+// endpoint uses. Returns nil when no user matches. The metadata column is
+// reconciled off the request path by the EnsureAuthSchemas startup job (and by
+// saveProvider when auth config is saved); on a schema not yet reconciled this
+// query errors, which is why /me is best-effort until the sweep converges it.
+func (s *schemaStore) AuthUserByUUID(ctx context.Context, uuid string) (*skauth.User, error) {
+	if s.conf == nil {
+		return nil, fmt.Errorf("schema configuration is required to retrieve auth user")
+	}
+
+	buf := bytes.Buffer{}
+
+	err := sqlTemplates.selectAuthUsers.Execute(&buf, map[string]any{
+		"WhereField":   "uuid",
+		"WithHash":     false,
+		"WithMetadata": true,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to render selectAuthUsers template: %w", err)
+	}
+
+	row, err := s.QueryRow(ctx, buf.String(), uuid)
+
+	if err != nil {
+		return nil, err
+	}
+
+	authUser := &skauth.User{}
+
+	err = row.Scan(
+		&authUser.ID,
+		&authUser.UUID,
+		&authUser.FirstName,
+		&authUser.LastName,
+		&authUser.Email,
+		&authUser.Avatar,
+		&authUser.CreatedAt,
+		&authUser.LastLoginAt,
+		&authUser.Metadata,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return authUser, nil
+}
+
+// UpdateAuthUserMetadata merges the provider metadata (handle, profile link)
+// for the user identified by UUID. It runs on every OAuth login so the values
+// stay fresh, using a JSONB merge so a provider that supplies no handle (e.g.
+// Google) does not clobber values a previous provider (e.g. X) stored on the
+// shared, email-linked user row. The metadata column is reconciled off the
+// request path (EnsureAuthSchemas startup job / saveProvider); this write is
+// best-effort and no-ops on a schema not yet reconciled.
+func (s *schemaStore) UpdateAuthUserMetadata(ctx context.Context, uuid string, metadata skauth.UserMetadata) error {
+	if s.conf == nil {
+		return fmt.Errorf("schema configuration is required to update auth user metadata")
+	}
+
+	_, err := s.Exec(ctx, schemaStmt.updateAuthUserMetadata, uuid, metadata)
+	return err
 }
 
 // ListAuthUsers returns a paginated list of authentication users.

--- a/src/ce/api/app/buildconf/schema_store_test.go
+++ b/src/ce/api/app/buildconf/schema_store_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -396,6 +397,146 @@ func (s *SchemaStoreSuite) Test_SchemaConf_URL() {
 
 	expected := "postgresql://app_user:app_password@localhost:5432/test_db?options=-csearch_path=test_schema&sslmode=require"
 	s.Equal(expected, conf.URL())
+}
+
+// authSchemaConf creates the schema and returns a migration-role SchemaConf
+// wired to the test transaction, mirroring Test_Migrations_Success. Callers
+// build the store with SchemaStoreFor via := so the unexported store type is
+// never named in this external test package.
+func (s *SchemaStoreSuite) authSchemaConf(ctx context.Context) *buildconf.SchemaConf {
+	result, err := buildconf.SchemaStore().CreateSchema(ctx, s.schemaName)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	result.MigrationPassword = database.Config.Password
+	result.MigrationUserName = database.Config.User
+	result.DriverName = "txdb"
+
+	return result
+}
+
+func (s *SchemaStoreSuite) Test_AuthUserMetadata_RoundTrip() {
+	ctx := context.Background()
+
+	store, err := buildconf.SchemaStoreFor(s.authSchemaConf(ctx), buildconf.SchemaAccessTypeMigrations)
+	s.Require().NoError(err)
+	defer store.Close()
+
+	s.NoError(store.CreateAuthTable(ctx))
+	s.NoError(store.CreateAuthTable(ctx), "CreateAuthTable must be idempotent")
+
+	oauth := &skauth.OAuth{AccountID: "acct-1", ProviderName: skauth.ProviderX, AccessToken: "access", TokenType: "bearer"}
+	usr := &skauth.User{Email: "roundtrip@example.com", FirstName: "John"}
+	s.Require().NoError(store.InsertAuthUser(ctx, oauth, usr))
+	s.Require().NotEmpty(usr.UUID)
+
+	// Before any metadata is written, the column reads back as an empty struct.
+	fetched, err := store.AuthUserByUUID(ctx, usr.UUID)
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched)
+	s.Equal(skauth.UserMetadata{}, fetched.Metadata)
+
+	meta := skauth.UserMetadata{Username: "johndoe", ProfileURL: "https://x.com/johndoe"}
+	s.NoError(store.UpdateAuthUserMetadata(ctx, usr.UUID, meta))
+
+	fetched, err = store.AuthUserByUUID(ctx, usr.UUID)
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched)
+	s.Equal(meta, fetched.Metadata)
+	s.Equal("johndoe", fetched.JSON()["username"])
+	s.Equal("https://x.com/johndoe", fetched.JSON()["profileUrl"])
+
+	// A later login from a provider that supplies no handle (e.g. Google)
+	// merges rather than overwrites, so the X values survive on the shared,
+	// email-linked user row.
+	s.NoError(store.UpdateAuthUserMetadata(ctx, usr.UUID, skauth.UserMetadata{}))
+
+	fetched, err = store.AuthUserByUUID(ctx, usr.UUID)
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched)
+	s.Equal(meta, fetched.Metadata, "empty metadata must not clobber stored values")
+}
+
+func (s *SchemaStoreSuite) Test_AuthUserByUUID_NotFound() {
+	ctx := context.Background()
+
+	store, err := buildconf.SchemaStoreFor(s.authSchemaConf(ctx), buildconf.SchemaAccessTypeMigrations)
+	s.Require().NoError(err)
+	defer store.Close()
+
+	s.NoError(store.CreateAuthTable(ctx))
+
+	fetched, err := store.AuthUserByUUID(ctx, "00000000-0000-0000-0000-000000000000")
+	s.NoError(err)
+	s.Nil(fetched)
+}
+
+// Test_CreateAuthTable_AddsMetadataColumnRetroactively proves the rollout path:
+// a schema whose users table predates the metadata column gets it added by the
+// idempotent CreateAuthTable, so EnsureAuthSchema converges existing tenants.
+func (s *SchemaStoreSuite) Test_CreateAuthTable_AddsMetadataColumnRetroactively() {
+	ctx := context.Background()
+
+	store, err := buildconf.SchemaStoreFor(s.authSchemaConf(ctx), buildconf.SchemaAccessTypeMigrations)
+	s.Require().NoError(err)
+	defer store.Close()
+
+	// Simulate a legacy schema: create the users table WITHOUT the metadata
+	// column (the shape before this change shipped). Everything goes through the
+	// store's connection so the assertions observe the same transaction.
+	_, err = store.Exec(ctx, `
+		CREATE TABLE stormkit_auth_users (
+			user_id SERIAL PRIMARY KEY NOT NULL,
+			uuid UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+			email TEXT NOT NULL UNIQUE,
+			first_name TEXT,
+			last_name TEXT,
+			avatar TEXT,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			last_login_at TIMESTAMPTZ
+		);
+	`)
+	s.Require().NoError(err)
+
+	// Scope the check to current_schema() rather than a fixed name: under the
+	// shared txdb session the store's unqualified DDL lands in the session's
+	// active schema, which is where the legacy table and the ALTER both go. A
+	// deliberate error probe would abort the shared transaction, so avoid it.
+	metadataColumnExists := `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = 'stormkit_auth_users'
+			  AND column_name = 'metadata'
+		)`
+
+	var hasColumn bool
+
+	row, err := store.QueryRow(ctx, metadataColumnExists)
+	s.Require().NoError(err)
+	s.Require().NoError(row.Scan(&hasColumn))
+	s.Require().False(hasColumn, "legacy table starts without the metadata column")
+
+	// Reconcile — this is what EnsureAuthSchema runs.
+	s.NoError(store.CreateAuthTable(ctx))
+
+	row, err = store.QueryRow(ctx, metadataColumnExists)
+	s.Require().NoError(err)
+	s.NoError(row.Scan(&hasColumn))
+	s.True(hasColumn, "metadata column is added retroactively")
+
+	oauth := &skauth.OAuth{AccountID: "acct-legacy", ProviderName: skauth.ProviderX, AccessToken: "access", TokenType: "bearer"}
+	usr := &skauth.User{Email: "legacy@example.com", FirstName: "John"}
+	s.Require().NoError(store.InsertAuthUser(ctx, oauth, usr))
+	s.Require().NotEmpty(usr.UUID)
+
+	meta := skauth.UserMetadata{Username: "legacy", ProfileURL: "https://x.com/legacy"}
+	s.NoError(store.UpdateAuthUserMetadata(ctx, usr.UUID, meta))
+
+	fetched, err := store.AuthUserByUUID(ctx, usr.UUID)
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched)
+	s.Equal(meta, fetched.Metadata)
 }
 
 func TestSchemaStore(t *testing.T) {

--- a/src/ce/api/app/skauth/client_x.go
+++ b/src/ce/api/app/skauth/client_x.go
@@ -17,8 +17,7 @@ var TwitterAuthBase = "https://x.com/i/oauth2/authorize"
 // Step 1: https://developer.x.com/en/portal/dashboard
 // Step 2: Create a new project and app
 // Step 3: Enable OAuth 2.0 and set the callback URL
-// Step 4: In User authentication settings, enable "Request email address from
-//         users" so the users.email scope returns confirmed_email
+// Step 4: In User authentication settings, enable "Request email address from users" so the users.email scope returns confirmed_email
 // Step 5: Callback URL: http://sample.stormkit:8888/api/auth/callback/x
 // Step 6: Obtain client ID and client secret
 type XClient struct {
@@ -78,12 +77,21 @@ func (x *XClient) UserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo,
 		return nil, err
 	}
 
+	var profileURL string
+
+	if userInfo.Data.Username != "" {
+		profileURL = "https://x.com/" + userInfo.Data.Username
+	}
+
 	return &UserInfo{
 		AccountID: userInfo.Data.ID,
 		Email:     userInfo.Data.ConfirmedEmail,
 		Avatar:    userInfo.Data.ProfileImageURL,
 		FirstName: userInfo.Data.Name,
-		LastName:  "",
+		UserMetadata: UserMetadata{
+			Username:   userInfo.Data.Username,
+			ProfileURL: profileURL,
+		},
 	}, nil
 }
 

--- a/src/ce/api/app/skauth/client_x_test.go
+++ b/src/ce/api/app/skauth/client_x_test.go
@@ -90,6 +90,32 @@ func (s *ClientXSuite) Test_UserInfo_Success() {
 	s.Equal("https://example.com/avatar.jpg", userInfo.Avatar)
 	s.Equal("John Doe", userInfo.FirstName)
 	s.Equal("", userInfo.LastName)
+	s.Equal("johndoe", userInfo.Username)
+	s.Equal("https://x.com/johndoe", userInfo.ProfileURL)
+}
+
+func (s *ClientXSuite) Test_UserInfo_NoUsername_NoProfileURL() {
+	s.mockServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"data": {
+				"id": "123456789",
+				"name": "John Doe",
+				"confirmed_email": "john@example.com"
+			}
+		}`))
+	}))
+
+	token := &oauth2.Token{AccessToken: "test-access-token", TokenType: "Bearer"}
+
+	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback")
+	userInfo, err := client.UserInfo(context.Background(), token)
+
+	s.NoError(err)
+	s.Require().NotNil(userInfo)
+	s.Equal("", userInfo.Username)
+	s.Equal("", userInfo.ProfileURL, "no handle means no profile URL is constructed")
 }
 
 func (s *ClientXSuite) Test_UserInfo_InvalidJSON() {

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -2,6 +2,9 @@ package skauth
 
 import (
 	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -44,6 +47,55 @@ type UserInfo struct {
 	Avatar    string `json:"avatar,omitempty"`
 	FirstName string `json:"firstName,omitempty"`
 	LastName  string `json:"lastName,omitempty"`
+	// Provider profile extras (handle, profile link). Embedded so a client can
+	// hand its whole UserMetadata to the stored User in one assignment.
+	UserMetadata
+}
+
+// UserMetadata holds provider-specific profile extras that not every provider
+// supplies (currently the handle and a link to the public profile). It is
+// stored as a JSONB column so new fields can be added without a schema change.
+type UserMetadata struct {
+	Username   string `json:"username,omitempty"`   // provider handle, e.g. an X @handle (empty when the provider has none)
+	ProfileURL string `json:"profileUrl,omitempty"` // link to the public profile, e.g. https://x.com/<handle>
+}
+
+// Value serialises the metadata as plain JSON for the JSONB column. Unlike
+// utils.ByteaValue it does not encrypt: these are public profile fields and
+// benefit from staying queryable as JSON in Postgres.
+func (m UserMetadata) Value() (driver.Value, error) {
+	b, err := json.Marshal(m)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return string(b), nil
+}
+
+// Scan reads the JSONB column back into the struct. A NULL or empty value
+// leaves the zero struct.
+func (m *UserMetadata) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var b []byte
+
+	switch v := value.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("failed to scan UserMetadata: unexpected type %T", value)
+	}
+
+	if len(b) == 0 {
+		return nil
+	}
+
+	return json.Unmarshal(b, m)
 }
 
 type ProviderData struct {
@@ -132,16 +184,17 @@ type OAuth struct {
 }
 
 type User struct {
-	ID           types.ID   `json:"-"`  // Internal numeric primary key. Used for joins; not exposed externally.
-	UUID         string     `json:"id"` // External identifier surfaced via the X-User-Id header and API responses.
-	FirstName    string     `json:"firstName"`
-	LastName     string     `json:"lastName"`
-	Email        string     `json:"email"`
-	Avatar       string     `json:"avatar,omitempty"`
-	CreatedAt    utils.Unix `json:"createdAt"`
-	LastLoginAt  utils.Unix `json:"lastLoginAt,omitempty"`
-	VerifiedAt   utils.Unix `json:"verifiedAt,omitempty"`
-	PasswordHash string     `json:"-"`
+	ID           types.ID     `json:"-"`  // Internal numeric primary key. Used for joins; not exposed externally.
+	UUID         string       `json:"id"` // External identifier surfaced via the X-User-Id header and API responses.
+	FirstName    string       `json:"firstName"`
+	LastName     string       `json:"lastName"`
+	Email        string       `json:"email"`
+	Avatar       string       `json:"avatar,omitempty"`
+	CreatedAt    utils.Unix   `json:"createdAt"`
+	LastLoginAt  utils.Unix   `json:"lastLoginAt,omitempty"`
+	VerifiedAt   utils.Unix   `json:"verifiedAt,omitempty"`
+	PasswordHash string       `json:"-"`
+	Metadata     UserMetadata `json:"-"` // provider extras; surfaced flattened by JSON(), stored as the metadata JSONB column
 }
 
 // JSON returns a map representation of the user for API responses.
@@ -152,6 +205,8 @@ func (u *User) JSON() map[string]any {
 		"lastName":    u.LastName,
 		"email":       u.Email,
 		"avatar":      u.Avatar,
+		"username":    u.Metadata.Username,
+		"profileUrl":  u.Metadata.ProfileURL,
 		"createdAt":   u.CreatedAt,
 		"lastLoginAt": u.LastLoginAt,
 	}

--- a/src/ce/api/app/skauth/sk_auth_model_test.go
+++ b/src/ce/api/app/skauth/sk_auth_model_test.go
@@ -1,0 +1,82 @@
+package skauth_test
+
+import (
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
+	"github.com/stretchr/testify/suite"
+)
+
+type UserModelSuite struct {
+	suite.Suite
+}
+
+func (s *UserModelSuite) Test_UserMetadata_ValueScan_RoundTrip() {
+	original := skauth.UserMetadata{
+		Username:   "johndoe",
+		ProfileURL: "https://x.com/johndoe",
+	}
+
+	value, err := original.Value()
+	s.Require().NoError(err)
+
+	// Value() must return a JSON string (not encrypted bytea) so Postgres can
+	// store it as queryable JSONB.
+	str, ok := value.(string)
+	s.Require().True(ok, "Value() should return a string for the JSONB column")
+	s.Equal(`{"username":"johndoe","profileUrl":"https://x.com/johndoe"}`, str)
+
+	var scanned skauth.UserMetadata
+	s.NoError(scanned.Scan([]byte(str)))
+	s.Equal(original, scanned)
+
+	// Scanning the string form works too.
+	var scannedStr skauth.UserMetadata
+	s.NoError(scannedStr.Scan(str))
+	s.Equal(original, scannedStr)
+}
+
+func (s *UserModelSuite) Test_UserMetadata_Scan_NullAndEmpty() {
+	var m skauth.UserMetadata
+
+	s.NoError(m.Scan(nil), "NULL leaves the zero struct")
+	s.Equal(skauth.UserMetadata{}, m)
+
+	s.NoError(m.Scan([]byte(`{}`)), "empty object leaves the zero struct")
+	s.Equal(skauth.UserMetadata{}, m)
+
+	s.NoError(m.Scan([]byte(``)), "empty bytes are a no-op")
+	s.Equal(skauth.UserMetadata{}, m)
+}
+
+func (s *UserModelSuite) Test_User_JSON_IncludesMetadataOmitsSecrets() {
+	u := &skauth.User{
+		UUID:         "user-uuid",
+		FirstName:    "John",
+		LastName:     "Doe",
+		Email:        "john@example.com",
+		Avatar:       "https://example.com/a.jpg",
+		PasswordHash: "should-not-leak",
+		Metadata: skauth.UserMetadata{
+			Username:   "johndoe",
+			ProfileURL: "https://x.com/johndoe",
+		},
+	}
+
+	j := u.JSON()
+
+	s.Equal("user-uuid", j["id"])
+	s.Equal("john@example.com", j["email"])
+	s.Equal("johndoe", j["username"])
+	s.Equal("https://x.com/johndoe", j["profileUrl"])
+
+	_, hasHash := j["passwordHash"]
+	s.False(hasHash, "password hash must never be serialised")
+
+	_, hasInternalID := j["ID"]
+	s.False(hasInternalID, "internal numeric id must never be serialised")
+}
+
+func TestUserModelSuite(t *testing.T) {
+	suite.Run(t, new(UserModelSuite))
+}

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
@@ -356,6 +357,10 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 		return m.handleRefresh()
 	}
 
+	if path == "/_stormkit/auth/me" {
+		return m.handleMe()
+	}
+
 	if path == skauth.CallbackPath {
 		return m.handleOAuthCallback()
 	}
@@ -425,5 +430,68 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Data:   map[string]any{"token": token},
+	}, nil
+}
+
+// handleMe returns the full profile for the user identified by the bearer token
+// — the OIDC-style userinfo endpoint. Per-request headers stay limited to
+// X-User-Id / X-User-Email; richer, sync-once fields (name, avatar, provider
+// username and profile link) are served here instead of bloating every request.
+func (m *skAuthMiddleware) handleMe() (*shttp.Response, error) {
+	if m.req.Method != http.MethodGet {
+		return &shttp.Response{
+			Status: http.StatusMethodNotAllowed,
+			Data:   map[string]any{"errors": []string{"method not allowed"}},
+		}, nil
+	}
+
+	// X-User-Id is injected by WithSKAuth from the verified bearer before
+	// dispatch, so a value here is already authenticated. Empty means no valid
+	// token accompanied the request. Identity comes solely from the token — the
+	// endpoint can only ever return the caller's own record.
+	uid := m.req.Header.Get("X-User-Id")
+
+	if uid == "" {
+		return &shttp.Response{
+			Status: http.StatusUnauthorized,
+			Data:   map[string]any{"errors": []string{"missing or invalid token"}},
+		}, nil
+	}
+
+	envID := m.req.Host.Config.EnvID
+
+	if envID == 0 {
+		return shttp.NotFound(), nil
+	}
+
+	env, err := buildconf.NewStore().EnvironmentByID(m.req.Context(), envID)
+
+	if err != nil {
+		return shttp.Error(err, "handleMe: failed to get environment"), nil
+	}
+
+	if !env.AuthReady() {
+		return shttp.NotFound(), nil
+	}
+
+	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
+
+	if err != nil {
+		return shttp.Error(err, "handleMe: failed to get schema store"), nil
+	}
+
+	usr, err := store.AuthUserByUUID(m.req.Context(), uid)
+
+	if err != nil {
+		return shttp.Error(err, "handleMe: failed to get auth user"), nil
+	}
+
+	if usr == nil {
+		return shttp.NotFound(), nil
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   usr.JSON(),
 	}, nil
 }

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -612,6 +612,43 @@ func (s *WithSKAuthSuite) Test_Refresh_WrongMethod() {
 	s.Equal(http.StatusMethodNotAllowed, res.Status)
 }
 
+// Test_Me_MissingBearer checks that GET /_stormkit/auth/me without a bearer is
+// rejected: no X-User-Id gets injected, so the handler returns 401.
+func (s *WithSKAuthSuite) Test_Me_MissingBearer() {
+	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/me")
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusUnauthorized, res.Status)
+}
+
+// Test_Me_WrongMethod checks that a non-GET request to /me returns 405.
+func (s *WithSKAuthSuite) Test_Me_WrongMethod() {
+	req := s.newPostRequest(s.hostWithSKAuth(), "/_stormkit/auth/me", nil)
+	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusMethodNotAllowed, res.Status)
+}
+
+// Test_Me_MissingEnv checks that a valid bearer whose env can't be resolved
+// (the test host has EnvID == 0) returns 404 rather than leaking a user.
+func (s *WithSKAuthSuite) Test_Me_MissingEnv() {
+	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/me")
+	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusNotFound, res.Status)
+}
+
 func TestWithSKAuth(t *testing.T) {
 	suite.Run(t, new(WithSKAuthSuite))
 }

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -142,7 +142,7 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return m.loginErrorRedirect(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
 	}
 
-	if env == nil || env.SchemaConf == nil || env.AuthConf == nil || !env.AuthConf.Status {
+	if !env.AuthReady() {
 		return m.loginErrorRedirect(referOrigin, "Sign-in is not available right now."), nil
 	}
 
@@ -202,11 +202,21 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		Avatar:    info.Avatar,
 		FirstName: info.FirstName,
 		LastName:  info.LastName,
+		Metadata:  info.UserMetadata,
 	}
 
 	if err := store.UpsertAuthUser(req.Context(), &oauth, &usr); err != nil {
 		slog.Errorf("oauth callback: failed to upsert auth user: %s", err.Error())
 		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
+	}
+
+	// Metadata lives on the user row and is merged on every login, so a provider
+	// that supplies no handle can't clobber values another provider stored on the
+	// shared, email-linked row. Non-fatal: it must not block sign-in if the write
+	// fails, and if the metadata column isn't reconciled yet (see EnsureAuthSchemas
+	// job) this simply no-ops until it is.
+	if err := store.UpdateAuthUserMetadata(req.Context(), usr.UUID, usr.Metadata); err != nil {
+		slog.Errorf("oauth callback: failed to update user metadata: %s", err.Error())
 	}
 
 	if err := store.UpdateLastLogin(req.Context(), usr.ID); err != nil {

--- a/src/ce/workerserver/job_auth_schema.go
+++ b/src/ce/workerserver/job_auth_schema.go
@@ -1,0 +1,96 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+type authSchemaTarget struct {
+	EnvID types.ID
+	Conf  buildconf.SchemaConf
+}
+
+// EnsureAuthSchemas reconciles the per-tenant auth tables for every auth-enabled
+// environment, adding columns (e.g. metadata) introduced after a tenant first
+// enabled auth. It runs off the request path so sign-in and /me never trigger
+// migration-role DDL themselves.
+//
+// It is a backfill for tenants that enabled auth before a column was introduced;
+// new tenants and auth-config edits are reconciled inline by saveProvider. Each
+// call is idempotent — SchemaConf.EnsureAuthSchema no-ops on schemas already
+// reconciled this process — so the recurring run converges to near-zero work.
+// Per-env failures are logged and skipped so one broken schema never blocks the
+// batch (and, being uncached, retry on the next run).
+func EnsureAuthSchemas(ctx context.Context) error {
+	store := NewStore()
+
+	targets, err := collectAuthSchemaTargets(ctx, store)
+
+	if err != nil {
+		return err
+	}
+
+	for _, t := range targets {
+		if err := t.Conf.EnsureAuthSchema(ctx); err != nil {
+			slog.Errorf("ensure auth schema for env %d: %v", t.EnvID, err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// collectAuthSchemaTargets loads and decodes every non-deleted environment that
+// has auth configured and a provisioned schema, keeping only those with auth
+// enabled. auth_conf is an opaque bytea blob, so the enabled check happens in Go
+// rather than SQL. The primary-DB cursor is drained fully before any per-tenant
+// connection is opened, mirroring dropStaleSchemas.
+func collectAuthSchemaTargets(ctx context.Context, store *Store) ([]authSchemaTarget, error) {
+	rows, err := store.Query(ctx, stmt.selectAuthEnabledEnvs)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var targets []authSchemaTarget
+
+	for rows.Next() {
+		var (
+			envID     types.ID
+			rawAuth   []byte
+			rawSchema []byte
+		)
+
+		if err := rows.Scan(&envID, &rawAuth, &rawSchema); err != nil {
+			return nil, err
+		}
+
+		var authConf buildconf.SKAuthConf
+
+		if err := utils.ByteaScan(rawAuth, &authConf); err != nil {
+			slog.Errorf("failed to decode auth_conf for env %d: %v", envID, err)
+			continue
+		}
+
+		if !authConf.Status {
+			continue
+		}
+
+		var schemaConf buildconf.SchemaConf
+
+		if err := utils.ByteaScan(rawSchema, &schemaConf); err != nil {
+			slog.Errorf("failed to decode schema_conf for env %d: %v", envID, err)
+			continue
+		}
+
+		targets = append(targets, authSchemaTarget{EnvID: envID, Conf: schemaConf})
+	}
+
+	return targets, rows.Err()
+}

--- a/src/ce/workerserver/job_auth_schema_test.go
+++ b/src/ce/workerserver/job_auth_schema_test.go
@@ -1,0 +1,80 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+type JobAuthSchemaSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *JobAuthSchemaSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *JobAuthSchemaSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+// Test_CollectAuthSchemaTargets_SelectsOnlyEnabled proves the sweep only picks
+// up non-deleted environments that have auth enabled and a provisioned schema —
+// disabled-auth, unconfigured, and deleted envs are skipped. This is the
+// selection logic that keeps the backfill off unrelated tenants.
+func (s *JobAuthSchemaSuite) Test_CollectAuthSchemaTargets_SelectsOnlyEnabled() {
+	app := s.MockApp(nil)
+
+	enabled := s.MockEnv(app, map[string]any{
+		"Name":       "enabled",
+		"AuthConf":   &buildconf.SKAuthConf{Status: true},
+		"SchemaConf": &buildconf.SchemaConf{SchemaName: "schema_enabled"},
+	})
+
+	// Auth configured but disabled — nothing to reconcile.
+	s.MockEnv(app, map[string]any{
+		"Name":       "disabled",
+		"AuthConf":   &buildconf.SKAuthConf{Status: false},
+		"SchemaConf": &buildconf.SchemaConf{SchemaName: "schema_disabled"},
+	})
+
+	// Auth enabled but soft-deleted env — must be ignored.
+	s.MockEnv(app, map[string]any{
+		"Name":       "deleted",
+		"AuthConf":   &buildconf.SKAuthConf{Status: true},
+		"SchemaConf": &buildconf.SchemaConf{SchemaName: "schema_deleted"},
+		"DeletedAt":  utils.Unix{Time: time.Now(), Valid: true},
+	})
+
+	// No auth configured at all — filtered out by the query.
+	s.MockEnv(app, map[string]any{
+		"Name":       "no_auth",
+		"SchemaConf": &buildconf.SchemaConf{SchemaName: "schema_no_auth"},
+	})
+
+	targets, err := collectAuthSchemaTargets(context.Background(), NewStore())
+	s.Require().NoError(err)
+
+	ids := make([]types.ID, 0, len(targets))
+	for _, t := range targets {
+		ids = append(ids, t.EnvID)
+	}
+
+	s.Equal([]types.ID{enabled.ID}, ids)
+	s.Require().Len(targets, 1)
+	s.Equal("schema_enabled", targets[0].Conf.SchemaName)
+}
+
+func TestJobAuthSchemaSuite(t *testing.T) {
+	suite.Run(t, &JobAuthSchemaSuite{})
+}

--- a/src/ce/workerserver/worker_scheduler.go
+++ b/src/ce/workerserver/worker_scheduler.go
@@ -83,6 +83,7 @@ func (s *Scheduler) RegisterMasterTasks(ctx context.Context) {
 		{Handler: RemoveOldAnalytics, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: MaintainAccessLogPartitions, Def: daily, Opt: immediate},
 		{Handler: RemoveStaleEnvironments, Def: dj(EVERY_6_HOURS), Opt: immediate},
+		{Handler: EnsureAuthSchemas, Def: daily, Opt: immediate},
 		{Handler: RemoveDeploymentArtifacts, Def: dj(EVERY_6_HOURS), Opt: immediate},
 		{Handler: SyncAnalyticsVisitorsHourly, Def: dj(EVERY_MINUTE * 5), Opt: immediate},
 		{Handler: SyncAnalyticsVisitorsDaily, Def: daily, Opt: immediate},

--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -26,6 +26,7 @@ type statement struct {
 	selectStaleSchemas              string
 	clearSchemaConf                 string
 	selectAccessLogPartitions       string
+	selectAuthEnabledEnvs           string
 }
 
 var stmt = &statement{
@@ -270,6 +271,21 @@ var stmt = &statement{
 
 	clearSchemaConf: `
 		UPDATE apps_build_conf SET schema_conf = NULL WHERE env_id = $1;
+	`,
+
+	// auth_conf is an opaque bytea blob, so its Status can't be filtered in SQL;
+	// callers decode each row and skip envs where auth is disabled.
+	selectAuthEnabledEnvs: `
+		SELECT
+			env_id, auth_conf, schema_conf
+		FROM
+			apps_build_conf
+		WHERE
+			deleted_at IS NULL AND
+			auth_conf IS NOT NULL AND
+			schema_conf IS NOT NULL
+		ORDER BY
+			env_id ASC;
 	`,
 
 	selectUserIDsWithoutAPIKeys: `


### PR DESCRIPTION
## What

Adds `GET /_stormkit/auth/me`, an OIDC-style user-info endpoint that returns the full profile for the bearer's user, plus a new `metadata JSONB` column on the per-tenant `stormkit_auth_users` table to carry the provider handle and public profile link.

Per-request headers stay minimal and unchanged (`X-User-Id`, `X-User-Email`); richer, sync-once fields (name, avatar, `username`, `profileUrl`) are served from `/me` instead of bloating every request or the JWT.

## Why

Apps want more than id/email (e.g. the X `@handle` and a link to the profile), but that data is needed once at first sync, not on every request. A user-info endpoint keeps the hot path cheap while making the profile extensible.

## How

- **`UserInfo` → `User`**: new `Username`/`ProfileURL` fields. The X client previously fetched the handle and dropped it — now it maps it and builds `https://x.com/<handle>`. Google/email/magic-link leave it empty.
- **Storage**: new `metadata JSONB` column on `stormkit_auth_users`, modeled as a typed `UserMetadata` with a plain-JSON `driver.Valuer`/`sql.Scanner` (not the encrypting `ByteaValue` path). Written on every OAuth login (last-login-wins, on the user row).
- **Rollout to existing tenants**: the users table is created by a Go DDL constant, so `CREATE TABLE IF NOT EXISTS` only helps new tenants. `SchemaConf.EnsureAuthSchema` runs the idempotent `CreateAuthTable` (now with `ALTER … ADD COLUMN IF NOT EXISTS metadata JSONB`) through the migration role once per schema per process, before any metadata read/write. Metadata queries are isolated from the login hot-path SELECTs so an un-reconciled schema can never break sign-in.
- **`/me` handler**: bearer-only (identity from the verified token via the injected `X-User-Id`), env-guarded, `EnsureAuthSchema` → `AuthUserByUUID`, returns `usr.JSON()`. CORS/OPTIONS handled by the existing `/_stormkit/auth/*` machinery.

## Tests

- Model: `UserMetadata` value/scan round-trip; `User.JSON()` includes the new fields and still omits secrets.
- X client: `UserInfo` maps `username`/`profileUrl`, and constructs no URL when there's no handle.
- Store (DB-backed): metadata round-trip via `AuthUserByUUID`; **retroactive column add** on a legacy table proving the rollout path; `AuthUserByUUID` not-found.
- Hosting: `/me` returns 401 (no bearer), 405 (wrong method), 404 (missing env).

## Notes / follow-ups

- Already-signed-up users get `username`/`profileUrl` on their next login (no backfill without re-auth); the column is backfilled lazily.
- `X-User-Email` is intentionally kept as a header (free, already in the token) — not removed.