### PR TITLE
fix: close migration store in ensure auth schema

### DIFF
--- a/src/ce/api/app/buildconf/schema_model.go
+++ b/src/ce/api/app/buildconf/schema_model.go
@@ -86,6 +86,13 @@ func (sc *SchemaConf) storeKey(accessType string) string {
 }
 
 func (sc *SchemaConf) Store(accessType string) (*schemaStore, error) {
+	// Migration stores are never cached: migration roles have CONNECTION LIMIT 1,
+	// so a pooled idle connection would permanently occupy the role's only slot.
+	// Callers open them for short-lived DDL and must Close them when done.
+	if accessType == SchemaAccessTypeMigrations {
+		return SchemaStoreFor(sc, accessType)
+	}
+
 	cacheKey := sc.storeKey(accessType)
 
 	if cached, ok := schemaStoreCache.Load(cacheKey); ok {
@@ -118,6 +125,8 @@ func (sc *SchemaConf) EnsureAuthSchema(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	defer store.Close()
 
 	if err := store.CreateAuthTable(ctx); err != nil {
 		return err

--- a/src/ce/api/app/buildconf/schema_model_test.go
+++ b/src/ce/api/app/buildconf/schema_model_test.go
@@ -1,0 +1,109 @@
+package buildconf
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/database"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stretchr/testify/suite"
+)
+
+// SchemaModelSuite is an internal (package buildconf) suite so it can assert
+// against the unexported schemaStoreCache and authSchemaEnsured maps. Migration
+// roles are created with CONNECTION LIMIT 1, so a migration store lingering in
+// the cache permanently occupies the role's only connection slot — these tests
+// guard against reintroducing that leak.
+type SchemaModelSuite struct {
+	suite.Suite
+
+	conn       databasetest.TestDB
+	schemaName string
+}
+
+func (s *SchemaModelSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.schemaName = "schema_model_test"
+}
+
+func (s *SchemaModelSuite) AfterTest(_, _ string) {
+	if err := SchemaStore().DropSchema(context.Background(), s.schemaName); err != nil {
+		fmt.Printf("cleanup error (ignored): %v\n", err)
+	}
+
+	s.conn.CloseTx()
+}
+
+// migrationConf creates the schema and returns a SchemaConf wired to the test
+// transaction, mirroring the helper in schema_store_test.go.
+func (s *SchemaModelSuite) migrationConf(ctx context.Context) *SchemaConf {
+	conf, err := SchemaStore().CreateSchema(ctx, s.schemaName)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(conf)
+
+	conf.MigrationUserName = database.Config.User
+	conf.MigrationPassword = database.Config.Password
+	conf.AppUserName = database.Config.User
+	conf.AppPassword = database.Config.Password
+	conf.DriverName = "txdb"
+
+	return conf
+}
+
+func (s *SchemaModelSuite) Test_Store_MigrationsAccessNotCached() {
+	ctx := context.Background()
+	conf := s.migrationConf(ctx)
+
+	first, err := conf.Store(SchemaAccessTypeMigrations)
+	s.Require().NoError(err)
+	defer first.Close()
+
+	second, err := conf.Store(SchemaAccessTypeMigrations)
+	s.Require().NoError(err)
+	defer second.Close()
+
+	s.NotSame(first, second, "migration stores must not be shared between callers")
+
+	_, cached := schemaStoreCache.Load(conf.storeKey(SchemaAccessTypeMigrations))
+	s.False(cached, "migration stores must never enter the cache")
+}
+
+func (s *SchemaModelSuite) Test_Store_AppUserAccessCached() {
+	ctx := context.Background()
+	conf := s.migrationConf(ctx)
+
+	first, err := conf.Store(SchemaAccessTypeAppUser)
+	s.Require().NoError(err)
+
+	second, err := conf.Store(SchemaAccessTypeAppUser)
+	s.Require().NoError(err)
+
+	s.Same(first, second, "app-user stores are pooled via the cache")
+
+	s.NoError(first.Close())
+
+	_, cached := schemaStoreCache.Load(conf.storeKey(SchemaAccessTypeAppUser))
+	s.False(cached, "Close must evict the store from the cache")
+}
+
+func (s *SchemaModelSuite) Test_EnsureAuthSchema_DoesNotLeakStore() {
+	ctx := context.Background()
+	conf := s.migrationConf(ctx)
+	key := conf.storeKey(SchemaAccessTypeMigrations)
+
+	s.Require().NoError(conf.EnsureAuthSchema(ctx))
+
+	_, cached := schemaStoreCache.Load(key)
+	s.False(cached, "EnsureAuthSchema must not leave a migration store behind")
+
+	_, ensured := authSchemaEnsured.Load(key)
+	s.True(ensured, "successful runs are marked so later calls no-op")
+
+	s.NoError(conf.EnsureAuthSchema(ctx), "second call must no-op")
+}
+
+func TestSchemaModelSuite(t *testing.T) {
+	suite.Run(t, &SchemaModelSuite{})
+}

--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -344,10 +344,19 @@ func SchemaStore() *schemaStore {
 func SchemaStoreFor(conf *SchemaConf, accessType string) (*schemaStore, error) {
 	var username, password string
 
+	maxOpenConns := database.Config.MaxOpenConns
+	maxIdleConns := database.Config.MaxIdleConns
+
 	switch accessType {
 	case SchemaAccessTypeMigrations:
 		username = conf.MigrationUserName
 		password = conf.MigrationPassword
+
+		// Migration roles are created with CONNECTION LIMIT 1, so cap the pool
+		// to a single connection reused for the store's lifetime. Callers must
+		// Close the store when done to release the role's only slot.
+		maxOpenConns = 1
+		maxIdleConns = 1
 	case SchemaAccessTypeAppUser:
 		username = conf.AppUserName
 		password = conf.AppPassword
@@ -365,8 +374,8 @@ func SchemaStoreFor(conf *SchemaConf, accessType string) (*schemaStore, error) {
 		SSLMode:      conf.SSLMode,
 		DriverName:   conf.DriverName,
 		MaxLifetime:  database.Config.MaxLifetime,
-		MaxOpenConns: database.Config.MaxOpenConns,
-		MaxIdleConns: database.Config.MaxIdleConns,
+		MaxOpenConns: maxOpenConns,
+		MaxIdleConns: maxIdleConns,
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Problem

Deploys fail with per-app migration roles (e.g. `a8e8_migration_user`) hitting their Postgres connection limit.

Root cause: the `EnsureAuthSchemas` worker job introduced in 58b6115 (#336) opens a migration-role connection per auth-enabled environment via the caching `SchemaConf.Store()` and never closes it. With `MaxLifetime: 0` and `MaxIdleConns: 2`, the worker process parks one idle connection per schema forever. Migration roles are created with `CONNECTION LIMIT 1`, so that lingering connection occupies the role's only slot — and the next deploy's `RunMigrations` (a different process) can't connect.

Every other migration-store caller (`RunMigrations`, `saveProvider`) already does `defer store.Close()`; `EnsureAuthSchema` was the only one that didn't.

## Fix

- **Stop caching migration-access stores** in `schemaStoreCache`. All migration-store callers are short-lived DDL that must close their store; caching was also racy — `Close()` deletes the cache entry, so two concurrent users of the same cached store could close it out from under each other. App-user stores stay cached (intended request-path pooling).
- **Add the missing `defer store.Close()`** in `EnsureAuthSchema`.
- **Cap the migration pool** to a single reused connection (`MaxOpenConns: 1, MaxIdleConns: 1`) to match the role's `CONNECTION LIMIT 1`; the slot is released when the caller closes the store.

## Tests

New internal `SchemaModelSuite` asserts migration stores never enter the cache, app-user stores remain cached (and are evicted on `Close`), and `EnsureAuthSchema` leaves nothing cached behind while remaining idempotent.

Ran sequentially (`-p 1`): `buildconf/...`, `workerserver/...`, `deploy/...`, `skauth/...`, `hosting/...` — all green.

## Prod note

Existing leaked connections persist until the worker process is restarted (or the idle `*_migration_user` sessions are terminated via `pg_terminate_backend`); the fix prevents new ones.