### PR TITLE
feat: add optional from address to mailer config

### DIFF
--- a/src/ce/api/app/buildconf/mailer_model.go
+++ b/src/ce/api/app/buildconf/mailer_model.go
@@ -17,17 +17,18 @@ var SendMailFunc = smtp.SendMail
 
 type SendEmailParams struct {
 	To      string // semicolon-separated list of recipients
-	From    string // falls back to mc.Username when empty
+	From    string // falls back to mc.DefaultFrom() when empty
 	Subject string
 	Body    string
 }
 
 type MailerConf struct {
-	EnvID    types.ID `json:"-"`
-	Host     string   `json:"host"`
-	Port     string   `json:"port"`
-	Username string   `json:"username"`
-	Password string   `json:"password"`
+	EnvID       types.ID `json:"-"`
+	Host        string   `json:"host"`
+	Port        string   `json:"port"`
+	Username    string   `json:"username"`
+	Password    string   `json:"password"`
+	FromAddress string   `json:"fromAddress,omitempty"`
 }
 
 // Bytes uses the json marshaler to return the byte representation.
@@ -75,8 +76,16 @@ func (mc *MailerConf) UnmarshalJSON(data []byte) error {
 	mc.Password = utils.DecryptToString(hash["password"])
 	mc.Host = hash["host"]
 	mc.Port = hash["port"]
+	mc.FromAddress = hash["fromAddress"]
 
 	return nil
+}
+
+// DefaultFrom returns the address used as the From header when a send
+// request does not specify one: the configured FromAddress, falling back
+// to the SMTP username.
+func (mc *MailerConf) DefaultFrom() string {
+	return utils.GetString(mc.FromAddress, mc.Username)
 }
 
 // SanitizeHeader strips carriage returns and newlines from an SMTP header value
@@ -91,7 +100,7 @@ func SanitizeHeader(v string) string {
 // forms like `Acme <foo@bar.com>` are rejected by many SMTP servers with
 // a 501.
 func (mc *MailerConf) Send(p SendEmailParams) error {
-	fromHeader := SanitizeHeader(utils.GetString(p.From, mc.Username))
+	fromHeader := SanitizeHeader(utils.GetString(p.From, mc.DefaultFrom()))
 	port := utils.GetString(mc.Port, "587")
 	mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 	msg := []byte(

--- a/src/ce/api/app/buildconf/mailer_model_test.go
+++ b/src/ce/api/app/buildconf/mailer_model_test.go
@@ -89,6 +89,41 @@ func (s *MailerModelSuite) Test_Send_EnvelopeUsesParamsFromAddress() {
 	s.Equal("noreply@acme.com", capturedFrom)
 }
 
+func (s *MailerModelSuite) Test_Send_FallsBackToConfiguredFromAddress() {
+	mailer := &buildconf.MailerConf{
+		Host:        "smtp.example.com",
+		Username:    "smtp-user@example.com",
+		Password:    "secret",
+		FromAddress: "no-reply@acme.com",
+	}
+
+	var capturedFrom string
+	var capturedMsg []byte
+
+	buildconf.SendMailFunc = func(_ string, _ smtp.Auth, from string, _ []string, msg []byte) error {
+		capturedFrom = from
+		capturedMsg = msg
+		return nil
+	}
+
+	s.NoError(mailer.Send(buildconf.SendEmailParams{
+		To:      "user@example.com",
+		Subject: "Hello",
+		Body:    "Body",
+	}))
+
+	s.Equal("no-reply@acme.com", capturedFrom, "FromAddress takes precedence over Username")
+	s.Contains(string(capturedMsg), "From: no-reply@acme.com")
+}
+
+func (s *MailerModelSuite) Test_DefaultFrom() {
+	mailer := &buildconf.MailerConf{Username: "smtp-user@example.com"}
+	s.Equal("smtp-user@example.com", mailer.DefaultFrom())
+
+	mailer.FromAddress = "no-reply@acme.com"
+	s.Equal("no-reply@acme.com", mailer.DefaultFrom())
+}
+
 func TestMailerModel(t *testing.T) {
 	suite.Run(t, &MailerModelSuite{})
 }

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
@@ -48,7 +48,7 @@ func HandlerMail(req *app.RequestContext) *shttp.Response {
 	from := data.From
 
 	if config != nil {
-		from = utils.GetString(data.From, config.Username)
+		from = utils.GetString(data.From, config.DefaultFrom())
 
 		if err := config.Send(buildconf.SendEmailParams{
 			To:      data.To,

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get.go
@@ -21,10 +21,11 @@ func HandlerMailerConfigGet(req *app.RequestContext) *shttp.Response {
 
 	if env.MailerConf != nil {
 		response["config"] = map[string]any{
-			"host":     env.MailerConf.Host,
-			"port":     env.MailerConf.Port,
-			"username": env.MailerConf.Username,
-			"password": env.MailerConf.Password,
+			"host":        env.MailerConf.Host,
+			"port":        env.MailerConf.Port,
+			"username":    env.MailerConf.Username,
+			"password":    env.MailerConf.Password,
+			"fromAddress": env.MailerConf.FromAddress,
 		}
 	}
 

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get_test.go
@@ -37,10 +37,11 @@ func (s *HandlerMailerConfigGetSuite) Test_Success() {
 	app := s.MockApp(usr)
 	env := s.MockEnv(app, map[string]any{
 		"MailerConf": &buildconf.MailerConf{
-			Host:     "smtp.gmail.com",
-			Port:     "587",
-			Username: "test",
-			Password: "testpwd",
+			Host:        "smtp.gmail.com",
+			Port:        "587",
+			Username:    "test",
+			Password:    "testpwd",
+			FromAddress: "no-reply@example.com",
 		},
 	})
 
@@ -54,12 +55,13 @@ func (s *HandlerMailerConfigGetSuite) Test_Success() {
 		},
 	)
 
-	expected := `{ 
-		"config": { 
+	expected := `{
+		"config": {
 			"host": "smtp.gmail.com",
 			"port": "587",
 			"password": "testpwd",
-			"username": "test"
+			"username": "test",
+			"fromAddress": "no-reply@example.com"
 		}
 	}`
 

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set.go
@@ -2,6 +2,7 @@ package mailerhandlers
 
 import (
 	"net/http"
+	"net/mail"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -31,6 +32,12 @@ func validateConfig(data ConfigRequestData) map[string]string {
 		errors["host"] = "SMTP Host is a required field."
 	}
 
+	if data.FromAddress != "" {
+		if _, err := mail.ParseAddress(data.FromAddress); err != nil {
+			errors["fromAddress"] = "From Address must be a valid email address."
+		}
+	}
+
 	if len(errors) == 0 {
 		return nil
 	}
@@ -55,11 +62,12 @@ func HandlerMailerConfigSet(req *app.RequestContext) *shttp.Response {
 	}
 
 	config := &buildconf.MailerConf{
-		Host:     data.SMTPHost,
-		Port:     data.SMTPPort,
-		Username: data.Username,
-		Password: data.Password,
-		EnvID:    req.EnvID,
+		Host:        data.SMTPHost,
+		Port:        data.SMTPPort,
+		Username:    data.Username,
+		Password:    data.Password,
+		FromAddress: data.FromAddress,
+		EnvID:       req.EnvID,
 	}
 
 	if err := buildconf.MailerStore().UpsertConfig(req.Context(), config); err != nil {

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set_test.go
@@ -42,12 +42,13 @@ func (s *HandlerMailerConfigSetSuite) Test_Success() {
 		shttp.MethodPost,
 		"/mailer/config",
 		map[string]string{
-			"appId":    app.ID.String(),
-			"envId":    env.ID.String(),
-			"smtpHost": "smtp.gmail.com",
-			"smtpPort": "587",
-			"username": "test-user",
-			"password": "test-pwd",
+			"appId":       app.ID.String(),
+			"envId":       env.ID.String(),
+			"smtpHost":    "smtp.gmail.com",
+			"smtpPort":    "587",
+			"username":    "test-user",
+			"password":    "test-pwd",
+			"fromAddress": "no-reply@example.com",
 		},
 		map[string]string{
 			"Authorization": usertest.Authorization(usr.ID),
@@ -60,11 +61,45 @@ func (s *HandlerMailerConfigSetSuite) Test_Success() {
 	s.NoError(err)
 	s.NotNil(envUpdated)
 	s.Equal(&buildconf.MailerConf{
-		Host:     "smtp.gmail.com",
-		Port:     "587",
-		Username: "test-user",
-		Password: "test-pwd",
+		Host:        "smtp.gmail.com",
+		Port:        "587",
+		Username:    "test-user",
+		Password:    "test-pwd",
+		FromAddress: "no-reply@example.com",
 	}, envUpdated.MailerConf)
+}
+
+func (s *HandlerMailerConfigSetSuite) Test_InvalidFromAddress() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/mailer/config",
+		map[string]string{
+			"appId":       app.ID.String(),
+			"envId":       env.ID.String(),
+			"smtpHost":    "smtp.gmail.com",
+			"smtpPort":    "587",
+			"username":    "test-user",
+			"password":    "test-pwd",
+			"fromAddress": "not-an-email",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	expected := `{
+		"errors": {
+			"fromAddress": "From Address must be a valid email address."
+		}
+	}`
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.JSONEq(expected, response.String())
 }
 
 func (s *HandlerMailerConfigSetSuite) Test_BadRequest() {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
@@ -81,6 +81,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
     const password = "my-app-token";
     const smtpHost = "smtp.example.org";
     const smtpPort = "587";
+    const fromAddress = "no-reply@example.org";
 
     const scope = mockSetMailerConfig({
       appId: currentApp.id,
@@ -89,6 +90,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
       password,
       smtpHost,
       smtpPort,
+      fromAddress,
     });
 
     await waitFor(() => {
@@ -100,6 +102,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
     await userEvent.type(wrapper.getByLabelText("SMTP Port"), smtpPort);
     await userEvent.type(wrapper.getByLabelText("Username"), username);
     await userEvent.type(wrapper.getByLabelText("Password"), password);
+    await userEvent.type(wrapper.getByLabelText("From Address"), fromAddress);
 
     setupFetchScope();
 
@@ -112,6 +115,50 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
 
     // Should re-fetch
     expect(fetchScope.isDone()).toBe(true);
+  });
+
+  it("should display an error when saving the configuration fails", async () => {
+    createWrapper({});
+
+    const scope = mockSetMailerConfig({
+      appId: currentApp.id,
+      envId: currentEnv.id,
+      username: "joe@example.org",
+      password: "my-app-token",
+      smtpHost: "smtp.example.org",
+      smtpPort: "587",
+      fromAddress: "not-an-email",
+      status: 400,
+      response: {
+        errors: { fromAddress: "From Address must be a valid email address." },
+      },
+    });
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+      expect(wrapper.getByLabelText("SMTP Host")).toBeTruthy();
+    });
+
+    await userEvent.type(
+      wrapper.getByLabelText("SMTP Host"),
+      "smtp.example.org",
+    );
+    await userEvent.type(wrapper.getByLabelText("SMTP Port"), "587");
+    await userEvent.type(wrapper.getByLabelText("Username"), "joe@example.org");
+    await userEvent.type(wrapper.getByLabelText("Password"), "my-app-token");
+    await userEvent.type(
+      wrapper.getByLabelText("From Address"),
+      "not-an-email",
+    );
+
+    fireEvent.click(wrapper.getByText("Save"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(
+        wrapper.getByText("From Address must be a valid email address."),
+      ).toBeTruthy();
+    });
   });
 
   it("should send a test email", async () => {
@@ -132,6 +179,35 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
       appId: currentApp.id,
       envId: currentEnv.id!,
       from: "joe@example.org",
+      to: "joe@example.org",
+    });
+
+    fireEvent.click(wrapper.getByText("Send test email"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  it("should send a test email from the configured from address", async () => {
+    createWrapper({
+      config: {
+        host: "smtp.example.org",
+        port: "587",
+        username: "joe@example.org",
+        password: "123",
+        fromAddress: "no-reply@example.org",
+      },
+    });
+
+    await waitFor(() => {
+      expect(wrapper.getByDisplayValue("no-reply@example.org")).toBeTruthy();
+    });
+
+    const scope = mockSendTestEmail({
+      appId: currentApp.id,
+      envId: currentEnv.id!,
+      from: "no-reply@example.org",
       to: "joe@example.org",
     });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
@@ -46,6 +46,9 @@ export default function TabMailer() {
       .then(() => {
         setSuccess("Mailer configuration saved successfully.");
         setRefreshToken(Date.now());
+      })
+      .catch(async res => {
+        setFormError((await api.errors(res)).join(" "));
       });
   };
 
@@ -189,6 +192,19 @@ export default function TabMailer() {
         />
       </Box>
 
+      <Box sx={{ mb: 4 }}>
+        <TextField
+          label="From Address"
+          name="fromAddress"
+          fullWidth
+          defaultValue={config?.fromAddress || ""}
+          variant="filled"
+          autoComplete="off"
+          placeholder="sender@example.com"
+          helperText="Optional. Default sender address for outgoing emails. Falls back to the username when empty."
+        />
+      </Box>
+
       <CardFooter>
         {config && (
           <Button
@@ -207,7 +223,7 @@ export default function TabMailer() {
                   body: JSON.stringify({
                     appId: app.id,
                     envId: env.id!,
-                    from: config.username,
+                    from: config.fromAddress || config.username,
                     to: config.username,
                     body: "Test email body",
                     subject: "Test email subject",

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
@@ -6,6 +6,7 @@ interface MailerConfig {
   port: string;
   username: string;
   password: string;
+  fromAddress?: string;
 }
 
 export interface Email {

--- a/src/ui/src/testing/nocks/nock_mailer.ts
+++ b/src/ui/src/testing/nocks/nock_mailer.ts
@@ -7,6 +7,7 @@ export interface MockMailerConfig {
   port: string;
   username: string;
   password: string;
+  fromAddress?: string;
 }
 
 interface MockFetchMailerConfigProps {
@@ -35,8 +36,9 @@ interface MockSetMailerConfigProps {
   smtpPort?: string;
   username?: string;
   password?: string;
+  fromAddress?: string;
   status?: number;
-  response?: { ok: boolean };
+  response?: { ok: boolean } | { errors: Record<string, string> };
 }
 
 export const mockSetMailerConfig = ({
@@ -46,6 +48,7 @@ export const mockSetMailerConfig = ({
   smtpPort,
   username,
   password,
+  fromAddress = "",
   status = 200,
   response = { ok: true },
 }: MockSetMailerConfigProps) => {
@@ -57,6 +60,7 @@ export const mockSetMailerConfig = ({
       smtpPort,
       username,
       password,
+      fromAddress,
     })
     .reply(status, response);
 };


### PR DESCRIPTION
## Summary

Adds an optional, configurable **From Address** to the Mailer Configuration.

### Backend
- `MailerConf` gains a `FromAddress` field, persisted in the existing `mailer_conf` JSON (stored plain — not a secret).
- New `DefaultFrom()` method: configured FromAddress, falling back to the SMTP username. Used by `Send()` and the `/mailer` handler, so emails without an explicit From automatically use the configured address.
- The set handler now stores `fromAddress` (it previously accepted it but silently dropped it) and validates the format with `mail.ParseAddress` when non-empty. The get handler returns it.

### Frontend
- New optional **From Address** field on the Mailer form with helper text explaining the username fallback.
- "Send test email" sends from the configured address when set.
- Save errors (e.g. invalid from address, 400 responses) are now surfaced via the Card's error property — previously they were silently swallowed.

### Tests
- Fallback behavior in `Send`, `DefaultFrom()`, invalid-address rejection, get/set roundtrip with the new field.
- Frontend specs for saving with a from address, sending test email from the configured address, and displaying backend validation errors.

Existing saved configs are unaffected: they unmarshal with an empty `FromAddress` and keep falling back to the username.