### PR TITLE
feat: add app selector with recent apps to layout

### DIFF
--- a/src/ui/src/components/AppName/AppName.tsx
+++ b/src/ui/src/components/AppName/AppName.tsx
@@ -6,12 +6,12 @@ import IconBg from "~/components/IconBg";
 import { getLogoForProvider, parseRepo } from "~/utils/helpers/providers";
 
 interface Props {
-  app: App;
+  app: Pick<App, "displayName" | "repo" | "isBare">;
   imageSize?: number;
 }
 
 export default function AppName({ app, imageSize = 20 }: Props) {
-  if (app.isBare) {
+  if (app.isBare || !app.repo) {
     return (
       <Typography
         component="div"

--- a/src/ui/src/layouts/AppLayout/AppMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/AppMenu.tsx
@@ -4,6 +4,7 @@ import Box from "@mui/material/Box";
 import ArrowBack from "@mui/icons-material/ArrowBack";
 import AppName from "~/components/AppName";
 import MenuLink from "~/components/MenuLink";
+import AppSelector from "./AppSelector";
 import { appMenuItems } from "./menu_items";
 
 interface Props {
@@ -67,6 +68,7 @@ export default function AppMenu({ app, team }: Props) {
               isActive: pathname.includes(`/environments/${app.defaultEnvId}`),
             }}
           />
+          <AppSelector app={app} team={team} />
         </Box>
         <Box>
           {appMenu.map(item => (

--- a/src/ui/src/layouts/AppLayout/AppSelector.spec.tsx
+++ b/src/ui/src/layouts/AppLayout/AppSelector.spec.tsx
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AuthContext } from "~/pages/auth/Auth.context";
+import mockApp from "~/testing/data/mock_app";
+import mockTeams from "~/testing/data/mock_teams";
+import mockUser from "~/testing/data/mock_user";
+import { mockFetchTeamApps } from "~/testing/nocks/nock_app";
+import LocalStorage from "~/utils/storage/LocalStorage";
+import AppSelector from "./AppSelector";
+
+describe("~/layouts/AppLayout/AppSelector.tsx", () => {
+  let currentApp: App;
+  let teams: Team[];
+  let team: Team;
+
+  const createWrapper = () => {
+    currentApp = mockApp();
+    teams = mockTeams();
+    team = teams[0];
+
+    render(
+      <AuthContext.Provider value={{ user: mockUser(), teams }}>
+        <AppSelector app={currentApp} team={team} />
+      </AuthContext.Provider>,
+    );
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("should record the visited app in recent apps", () => {
+    createWrapper();
+
+    expect(LocalStorage.get("recent_apps")).toEqual([
+      {
+        id: currentApp.id,
+        displayName: currentApp.displayName,
+        repo: currentApp.repo,
+      },
+    ]);
+  });
+
+  it("should list team apps when the arrow is clicked", async () => {
+    const otherApp = mockApp({ id: "6421", displayName: "other-app" });
+
+    createWrapper();
+
+    const scope = mockFetchTeamApps({
+      teamId: team.id,
+      response: { apps: [currentApp, otherApp], hasNextPage: false },
+    });
+
+    fireEvent.click(screen.getByLabelText("Select app"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(screen.getByText("other-app")).toBeTruthy();
+    });
+
+    expect(
+      screen.getByText("other-app").closest("a")?.getAttribute("href"),
+    ).toBe("/apps/6421");
+  });
+
+  it("should list apps from another team when switched", async () => {
+    createWrapper();
+
+    mockFetchTeamApps({
+      teamId: team.id,
+      response: { apps: [currentApp], hasNextPage: false },
+    });
+
+    fireEvent.click(screen.getByLabelText("Select app"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeTruthy();
+    });
+
+    const otherTeamApp = mockApp({ id: "8151", displayName: "other-team-app" });
+
+    const scope = mockFetchTeamApps({
+      teamId: teams[1].id,
+      response: { apps: [otherTeamApp], hasNextPage: false },
+    });
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText(teams[1].name));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(screen.getByText("other-team-app")).toBeTruthy();
+    });
+  });
+
+  it("should list recently visited apps excluding the current app", async () => {
+    LocalStorage.set("recent_apps", [
+      {
+        id: "9911",
+        displayName: "recent-app",
+        repo: "github/stormkit-io/recent-app",
+      },
+    ]);
+
+    createWrapper();
+
+    mockFetchTeamApps({
+      teamId: team.id,
+      response: { apps: [], hasNextPage: false },
+    });
+
+    fireEvent.click(screen.getByLabelText("Select app"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Recent apps")).toBeTruthy();
+      expect(screen.getByText("recent-app")).toBeTruthy();
+    });
+
+    expect(
+      screen.getByText("recent-app").closest("a")?.getAttribute("href"),
+    ).toBe("/apps/9911");
+
+    expect(screen.queryByTestId(`recent-app-${currentApp.id}`)).toBeNull();
+  });
+
+  it("should exclude legacy entries recorded without repo info", async () => {
+    LocalStorage.set("recent_apps", [{ id: "9911", displayName: "legacy-app" }]);
+
+    createWrapper();
+
+    mockFetchTeamApps({
+      teamId: team.id,
+      response: { apps: [], hasNextPage: false },
+    });
+
+    fireEvent.click(screen.getByLabelText("Select app"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("legacy-app")).toBeNull();
+      expect(screen.getByText("No recently visited apps.")).toBeTruthy();
+    });
+  });
+
+  it("should display a message when there are no recent apps", async () => {
+    createWrapper();
+
+    mockFetchTeamApps({
+      teamId: team.id,
+      response: { apps: [], hasNextPage: false },
+    });
+
+    fireEvent.click(screen.getByLabelText("Select app"));
+
+    await waitFor(() => {
+      expect(screen.getByText("No recently visited apps.")).toBeTruthy();
+    });
+  });
+});

--- a/src/ui/src/layouts/AppLayout/AppSelector.tsx
+++ b/src/ui/src/layouts/AppLayout/AppSelector.tsx
@@ -1,0 +1,179 @@
+import { useContext, useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
+import Check from "@mui/icons-material/Check";
+import KeyboardArrowDown from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUp from "@mui/icons-material/KeyboardArrowUp";
+import { AuthContext } from "~/pages/auth/Auth.context";
+import AppName from "~/components/AppName";
+import { useFetchAppList } from "~/pages/apps/actions";
+import { recentApps, recordRecentApp } from "./recent_apps";
+
+interface Props {
+  app: App;
+  team?: Team;
+}
+
+interface MenuProps {
+  app: App;
+  teamId?: string;
+  onClickAway: () => void;
+}
+
+const sectionHeader = {
+  height: "50px",
+  borderBottom: "1px solid",
+  borderColor: "container.transparent",
+  display: "flex",
+  alignItems: "center",
+};
+
+const appLink = {
+  p: 1,
+  flex: 1,
+  minWidth: "220px",
+  borderRadius: 1,
+  display: "flex",
+  alignItems: "center",
+  ":hover": {
+    bgcolor: "container.transparent",
+    cursor: "pointer",
+    color: "inherit",
+  },
+};
+
+function AppSelectorMenu({ app, teamId, onClickAway }: MenuProps) {
+  const { teams } = useContext(AuthContext);
+  const [selectedTeamId, setSelectedTeamId] = useState(teamId);
+  const { apps } = useFetchAppList({ teamId: selectedTeamId });
+  const recent = recentApps().filter(a => a.id !== app.id);
+
+  return (
+    <ClickAwayListener onClickAway={onClickAway}>
+      <Box>
+        <Box sx={sectionHeader}>
+          {/* disablePortal: a portal-based menu would trigger the
+              ClickAwayListener and close the whole dropdown. */}
+          <Select
+            fullWidth
+            size="small"
+            variant="outlined"
+            value={selectedTeamId || ""}
+            inputProps={{ "aria-label": "Select team" }}
+            MenuProps={{ disablePortal: true }}
+            onChange={e => setSelectedTeamId(e.target.value as string)}
+          >
+            {teams?.map(t => (
+              <MenuItem key={t.id} value={t.id}>
+                {t.isDefault ? "Personal" : t.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+        <Box role="list">
+          {apps.map(a => (
+            <Box
+              key={a.id}
+              data-testid={`app-${a.id}`}
+              sx={{ display: "flex", alignItems: "center", my: 2 }}
+            >
+              <Check
+                sx={{
+                  fontSize: 14,
+                  mr: 1,
+                  cursor: "default",
+                  visibility: a.id === app.id ? "visible" : "hidden",
+                }}
+              />
+              <Link href={`/apps/${a.id}`} onClick={onClickAway} sx={appLink}>
+                <AppName app={a} imageSize={18} />
+              </Link>
+            </Box>
+          ))}
+        </Box>
+        <Box sx={sectionHeader}>
+          <Typography variant="h2" sx={{ flex: 1, pl: 1 }} color="text.primary">
+            Recent apps
+          </Typography>
+        </Box>
+        {recent.length > 0 ? (
+          <Box role="list">
+            {recent.map(a => (
+              <Box
+                key={a.id}
+                data-testid={`recent-app-${a.id}`}
+                sx={{ display: "flex", alignItems: "center", my: 2 }}
+              >
+                <Box sx={{ width: 14, mr: 1 }} />
+                <Link href={`/apps/${a.id}`} onClick={onClickAway} sx={appLink}>
+                  <AppName app={a} imageSize={18} />
+                </Link>
+              </Box>
+            ))}
+          </Box>
+        ) : (
+          <Typography sx={{ p: 1, my: 1 }} color="text.secondary">
+            No recently visited apps.
+          </Typography>
+        )}
+      </Box>
+    </ClickAwayListener>
+  );
+}
+
+export default function AppSelector({ app, team }: Props) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const Arrow = isMenuOpen ? KeyboardArrowUp : KeyboardArrowDown;
+
+  useEffect(() => {
+    recordRecentApp(app);
+  }, [app.id]);
+
+  return (
+    <Tooltip
+      arrow
+      open={isMenuOpen}
+      placement="bottom-start"
+      slotProps={{
+        popper: {
+          modifiers: [
+            { name: "offset", options: { offset: [0, 12] } },
+            // Position with top/left instead of a CSS transform: the
+            // select menu inside is position fixed, and a transformed
+            // ancestor would offset it to the wrong place.
+            { name: "computeStyles", options: { gpuAcceleration: false } },
+          ],
+        },
+        tooltip: { sx: { maxWidth: "none" } },
+      }}
+      title={
+        <Box sx={{ p: 1 }}>
+          <AppSelectorMenu
+            app={app}
+            teamId={team?.id}
+            onClickAway={() => {
+              setIsMenuOpen(false);
+            }}
+          />
+        </Box>
+      }
+    >
+      <IconButton
+        aria-label="Select app"
+        type="button"
+        onClick={e => {
+          e.preventDefault();
+          setIsMenuOpen(!isMenuOpen);
+        }}
+      >
+        <Arrow sx={{ fontSize: 16 }} />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/src/ui/src/layouts/AppLayout/recent_apps.ts
+++ b/src/ui/src/layouts/AppLayout/recent_apps.ts
@@ -1,0 +1,26 @@
+import LocalStorage from "~/utils/storage/LocalStorage";
+
+export type RecentApp = Pick<App, "id" | "displayName" | "repo" | "isBare">;
+
+const STORAGE_KEY = "recent_apps";
+const MAX_RECENT_APPS = 10;
+
+// Entries with neither a repo nor the isBare flag were recorded by an
+// older version of this feature and would render as bare apps; drop them.
+export const recentApps = (): RecentApp[] =>
+  (LocalStorage.get<RecentApp[]>(STORAGE_KEY, []) || []).filter(
+    a => a.repo || a.isBare,
+  );
+
+export const recordRecentApp = (app: App) => {
+  const entry: RecentApp = {
+    id: app.id,
+    displayName: app.displayName,
+    repo: app.repo,
+    isBare: app.isBare,
+  };
+
+  const visited = [entry, ...recentApps().filter(a => a.id !== app.id)];
+
+  LocalStorage.set(STORAGE_KEY, visited.slice(0, MAX_RECENT_APPS));
+};

--- a/src/ui/src/testing/nocks/nock_app.ts
+++ b/src/ui/src/testing/nocks/nock_app.ts
@@ -44,6 +44,25 @@ export const mockFetchApps = ({
     .get(`/v1/apps?from=${from}&filter=${filter}&teamId=${teamId}`)
     .reply(status, response);
 
+interface MockFetchTeamAppsProps {
+  from?: number;
+  teamId?: string;
+  status?: number;
+  response: { apps: App[]; hasNextPage: boolean };
+}
+
+// Same endpoint as mockFetchApps, but without the `filter` query
+// parameter, which is omitted from the request when undefined.
+export const mockFetchTeamApps = ({
+  from = 0,
+  teamId = "",
+  status = 200,
+  response,
+}: MockFetchTeamAppsProps) =>
+  nock(endpoint)
+    .get(`/v1/apps?teamId=${teamId}&from=${from}`)
+    .reply(status, response);
+
 interface DeleteAppProps {
   appId: string;
   status?: number;


### PR DESCRIPTION
## Summary

Adds an app selector dropdown to the App Layout header. The app name still links to the app's home page; a new arrow button next to it opens a dropdown instead of navigating.

### Features
- **Team selector**: the dropdown header is an outlined `Select` listing all teams (default team shown as "Personal"), pre-selected to the current app's team. Switching teams lists that team's apps via the existing `useFetchAppList` hook (fetched lazily when the dropdown opens).
- **Apps list**: apps of the selected team rendered with `AppName` (provider logo + display name + repo), check mark on the current app, linking to `/apps/:id`.
- **Recent apps**: up to 10 recently visited apps stored in localStorage (`recent_apps` key), most-recent first, deduped, excluding the current app. Shows "No recently visited apps." when empty.

### Implementation notes
- The team select keeps its menu inside the tooltip (`MenuProps.disablePortal`) — a portalled menu would trigger the surrounding `ClickAwayListener` and close the dropdown. The tooltip popper positions with `top`/`left` instead of a CSS transform (`computeStyles.gpuAcceleration: false`) so the fixed-position select menu anchors correctly.
- `AppName` prop type widened to `Pick<App, "displayName" | "repo" | "isBare">` and it now falls back to the bare-app rendering when `repo` is missing instead of crashing in `parseRepo`.
- Recent-app entries store `repo`/`isBare` so the provider logo renders; entries with neither are treated as legacy-format and dropped on read.
- New `mockFetchTeamApps` nock helper: the existing `mockFetchApps` hardcodes a `filter=` query param the hook omits when the filter is undefined.

### Tests
Six specs covering: recording visits, listing team apps, switching teams, recent apps (incl. current-app exclusion and legacy-entry filtering), and the empty state.