### PR TITLE
feat: ask from/to when sending test email

### DIFF
--- a/src/ce/api/app/buildconf/mailer_model.go
+++ b/src/ce/api/app/buildconf/mailer_model.go
@@ -17,18 +17,17 @@ var SendMailFunc = smtp.SendMail
 
 type SendEmailParams struct {
 	To      string // semicolon-separated list of recipients
-	From    string // falls back to mc.DefaultFrom() when empty
+	From    string // falls back to mc.Username when empty
 	Subject string
 	Body    string
 }
 
 type MailerConf struct {
-	EnvID       types.ID `json:"-"`
-	Host        string   `json:"host"`
-	Port        string   `json:"port"`
-	Username    string   `json:"username"`
-	Password    string   `json:"password"`
-	FromAddress string   `json:"fromAddress,omitempty"`
+	EnvID    types.ID `json:"-"`
+	Host     string   `json:"host"`
+	Port     string   `json:"port"`
+	Username string   `json:"username"`
+	Password string   `json:"password"`
 }
 
 // Bytes uses the json marshaler to return the byte representation.
@@ -76,16 +75,8 @@ func (mc *MailerConf) UnmarshalJSON(data []byte) error {
 	mc.Password = utils.DecryptToString(hash["password"])
 	mc.Host = hash["host"]
 	mc.Port = hash["port"]
-	mc.FromAddress = hash["fromAddress"]
 
 	return nil
-}
-
-// DefaultFrom returns the address used as the From header when a send
-// request does not specify one: the configured FromAddress, falling back
-// to the SMTP username.
-func (mc *MailerConf) DefaultFrom() string {
-	return utils.GetString(mc.FromAddress, mc.Username)
 }
 
 // SanitizeHeader strips carriage returns and newlines from an SMTP header value
@@ -100,7 +91,7 @@ func SanitizeHeader(v string) string {
 // forms like `Acme <foo@bar.com>` are rejected by many SMTP servers with
 // a 501.
 func (mc *MailerConf) Send(p SendEmailParams) error {
-	fromHeader := SanitizeHeader(utils.GetString(p.From, mc.DefaultFrom()))
+	fromHeader := SanitizeHeader(utils.GetString(p.From, mc.Username))
 	port := utils.GetString(mc.Port, "587")
 	mime := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 	msg := []byte(

--- a/src/ce/api/app/buildconf/mailer_model_test.go
+++ b/src/ce/api/app/buildconf/mailer_model_test.go
@@ -89,41 +89,6 @@ func (s *MailerModelSuite) Test_Send_EnvelopeUsesParamsFromAddress() {
 	s.Equal("noreply@acme.com", capturedFrom)
 }
 
-func (s *MailerModelSuite) Test_Send_FallsBackToConfiguredFromAddress() {
-	mailer := &buildconf.MailerConf{
-		Host:        "smtp.example.com",
-		Username:    "smtp-user@example.com",
-		Password:    "secret",
-		FromAddress: "no-reply@acme.com",
-	}
-
-	var capturedFrom string
-	var capturedMsg []byte
-
-	buildconf.SendMailFunc = func(_ string, _ smtp.Auth, from string, _ []string, msg []byte) error {
-		capturedFrom = from
-		capturedMsg = msg
-		return nil
-	}
-
-	s.NoError(mailer.Send(buildconf.SendEmailParams{
-		To:      "user@example.com",
-		Subject: "Hello",
-		Body:    "Body",
-	}))
-
-	s.Equal("no-reply@acme.com", capturedFrom, "FromAddress takes precedence over Username")
-	s.Contains(string(capturedMsg), "From: no-reply@acme.com")
-}
-
-func (s *MailerModelSuite) Test_DefaultFrom() {
-	mailer := &buildconf.MailerConf{Username: "smtp-user@example.com"}
-	s.Equal("smtp-user@example.com", mailer.DefaultFrom())
-
-	mailer.FromAddress = "no-reply@acme.com"
-	s.Equal("no-reply@acme.com", mailer.DefaultFrom())
-}
-
 func TestMailerModel(t *testing.T) {
 	suite.Run(t, &MailerModelSuite{})
 }

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
@@ -48,7 +48,7 @@ func HandlerMail(req *app.RequestContext) *shttp.Response {
 	from := data.From
 
 	if config != nil {
-		from = utils.GetString(data.From, config.DefaultFrom())
+		from = utils.GetString(data.From, config.Username)
 
 		if err := config.Send(buildconf.SendEmailParams{
 			To:      data.To,

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get.go
@@ -21,11 +21,10 @@ func HandlerMailerConfigGet(req *app.RequestContext) *shttp.Response {
 
 	if env.MailerConf != nil {
 		response["config"] = map[string]any{
-			"host":        env.MailerConf.Host,
-			"port":        env.MailerConf.Port,
-			"username":    env.MailerConf.Username,
-			"password":    env.MailerConf.Password,
-			"fromAddress": env.MailerConf.FromAddress,
+			"host":     env.MailerConf.Host,
+			"port":     env.MailerConf.Port,
+			"username": env.MailerConf.Username,
+			"password": env.MailerConf.Password,
 		}
 	}
 

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get_test.go
@@ -37,11 +37,10 @@ func (s *HandlerMailerConfigGetSuite) Test_Success() {
 	app := s.MockApp(usr)
 	env := s.MockEnv(app, map[string]any{
 		"MailerConf": &buildconf.MailerConf{
-			Host:        "smtp.gmail.com",
-			Port:        "587",
-			Username:    "test",
-			Password:    "testpwd",
-			FromAddress: "no-reply@example.com",
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "test",
+			Password: "testpwd",
 		},
 	})
 
@@ -55,13 +54,12 @@ func (s *HandlerMailerConfigGetSuite) Test_Success() {
 		},
 	)
 
-	expected := `{
-		"config": {
+	expected := `{ 
+		"config": { 
 			"host": "smtp.gmail.com",
 			"port": "587",
 			"password": "testpwd",
-			"username": "test",
-			"fromAddress": "no-reply@example.com"
+			"username": "test"
 		}
 	}`
 

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set.go
@@ -2,7 +2,6 @@ package mailerhandlers
 
 import (
 	"net/http"
-	"net/mail"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -32,12 +31,6 @@ func validateConfig(data ConfigRequestData) map[string]string {
 		errors["host"] = "SMTP Host is a required field."
 	}
 
-	if data.FromAddress != "" {
-		if _, err := mail.ParseAddress(data.FromAddress); err != nil {
-			errors["fromAddress"] = "From Address must be a valid email address."
-		}
-	}
-
 	if len(errors) == 0 {
 		return nil
 	}
@@ -62,12 +55,11 @@ func HandlerMailerConfigSet(req *app.RequestContext) *shttp.Response {
 	}
 
 	config := &buildconf.MailerConf{
-		Host:        data.SMTPHost,
-		Port:        data.SMTPPort,
-		Username:    data.Username,
-		Password:    data.Password,
-		FromAddress: data.FromAddress,
-		EnvID:       req.EnvID,
+		Host:     data.SMTPHost,
+		Port:     data.SMTPPort,
+		Username: data.Username,
+		Password: data.Password,
+		EnvID:    req.EnvID,
 	}
 
 	if err := buildconf.MailerStore().UpsertConfig(req.Context(), config); err != nil {

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set_test.go
@@ -42,13 +42,12 @@ func (s *HandlerMailerConfigSetSuite) Test_Success() {
 		shttp.MethodPost,
 		"/mailer/config",
 		map[string]string{
-			"appId":       app.ID.String(),
-			"envId":       env.ID.String(),
-			"smtpHost":    "smtp.gmail.com",
-			"smtpPort":    "587",
-			"username":    "test-user",
-			"password":    "test-pwd",
-			"fromAddress": "no-reply@example.com",
+			"appId":    app.ID.String(),
+			"envId":    env.ID.String(),
+			"smtpHost": "smtp.gmail.com",
+			"smtpPort": "587",
+			"username": "test-user",
+			"password": "test-pwd",
 		},
 		map[string]string{
 			"Authorization": usertest.Authorization(usr.ID),
@@ -61,45 +60,11 @@ func (s *HandlerMailerConfigSetSuite) Test_Success() {
 	s.NoError(err)
 	s.NotNil(envUpdated)
 	s.Equal(&buildconf.MailerConf{
-		Host:        "smtp.gmail.com",
-		Port:        "587",
-		Username:    "test-user",
-		Password:    "test-pwd",
-		FromAddress: "no-reply@example.com",
+		Host:     "smtp.gmail.com",
+		Port:     "587",
+		Username: "test-user",
+		Password: "test-pwd",
 	}, envUpdated.MailerConf)
-}
-
-func (s *HandlerMailerConfigSetSuite) Test_InvalidFromAddress() {
-	usr := s.MockUser()
-	app := s.MockApp(usr)
-	env := s.MockEnv(app)
-
-	response := shttptest.RequestWithHeaders(
-		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
-		shttp.MethodPost,
-		"/mailer/config",
-		map[string]string{
-			"appId":       app.ID.String(),
-			"envId":       env.ID.String(),
-			"smtpHost":    "smtp.gmail.com",
-			"smtpPort":    "587",
-			"username":    "test-user",
-			"password":    "test-pwd",
-			"fromAddress": "not-an-email",
-		},
-		map[string]string{
-			"Authorization": usertest.Authorization(usr.ID),
-		},
-	)
-
-	expected := `{
-		"errors": {
-			"fromAddress": "From Address must be a valid email address."
-		}
-	}`
-
-	s.Equal(http.StatusBadRequest, response.Code)
-	s.JSONEq(expected, response.String())
 }
 
 func (s *HandlerMailerConfigSetSuite) Test_BadRequest() {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
@@ -81,7 +81,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
     const password = "my-app-token";
     const smtpHost = "smtp.example.org";
     const smtpPort = "587";
-    const fromAddress = "no-reply@example.org";
 
     const scope = mockSetMailerConfig({
       appId: currentApp.id,
@@ -90,7 +89,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
       password,
       smtpHost,
       smtpPort,
-      fromAddress,
     });
 
     await waitFor(() => {
@@ -102,7 +100,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
     await userEvent.type(wrapper.getByLabelText("SMTP Port"), smtpPort);
     await userEvent.type(wrapper.getByLabelText("Username"), username);
     await userEvent.type(wrapper.getByLabelText("Password"), password);
-    await userEvent.type(wrapper.getByLabelText("From Address"), fromAddress);
 
     setupFetchScope();
 
@@ -115,50 +112,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
 
     // Should re-fetch
     expect(fetchScope.isDone()).toBe(true);
-  });
-
-  it("should display an error when saving the configuration fails", async () => {
-    createWrapper({});
-
-    const scope = mockSetMailerConfig({
-      appId: currentApp.id,
-      envId: currentEnv.id,
-      username: "joe@example.org",
-      password: "my-app-token",
-      smtpHost: "smtp.example.org",
-      smtpPort: "587",
-      fromAddress: "not-an-email",
-      status: 400,
-      response: {
-        errors: { fromAddress: "From Address must be a valid email address." },
-      },
-    });
-
-    await waitFor(() => {
-      expect(fetchScope.isDone()).toBe(true);
-      expect(wrapper.getByLabelText("SMTP Host")).toBeTruthy();
-    });
-
-    await userEvent.type(
-      wrapper.getByLabelText("SMTP Host"),
-      "smtp.example.org",
-    );
-    await userEvent.type(wrapper.getByLabelText("SMTP Port"), "587");
-    await userEvent.type(wrapper.getByLabelText("Username"), "joe@example.org");
-    await userEvent.type(wrapper.getByLabelText("Password"), "my-app-token");
-    await userEvent.type(
-      wrapper.getByLabelText("From Address"),
-      "not-an-email",
-    );
-
-    fireEvent.click(wrapper.getByText("Save"));
-
-    await waitFor(() => {
-      expect(scope.isDone()).toBe(true);
-      expect(
-        wrapper.getByText("From Address must be a valid email address."),
-      ).toBeTruthy();
-    });
   });
 
   it("should send a test email", async () => {
@@ -179,35 +132,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
       appId: currentApp.id,
       envId: currentEnv.id!,
       from: "joe@example.org",
-      to: "joe@example.org",
-    });
-
-    fireEvent.click(wrapper.getByText("Send test email"));
-
-    await waitFor(() => {
-      expect(scope.isDone()).toBe(true);
-    });
-  });
-
-  it("should send a test email from the configured from address", async () => {
-    createWrapper({
-      config: {
-        host: "smtp.example.org",
-        port: "587",
-        username: "joe@example.org",
-        password: "123",
-        fromAddress: "no-reply@example.org",
-      },
-    });
-
-    await waitFor(() => {
-      expect(wrapper.getByDisplayValue("no-reply@example.org")).toBeTruthy();
-    });
-
-    const scope = mockSendTestEmail({
-      appId: currentApp.id,
-      envId: currentEnv.id!,
-      from: "no-reply@example.org",
       to: "joe@example.org",
     });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
@@ -132,13 +132,33 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
       appId: currentApp.id,
       envId: currentEnv.id!,
       from: "joe@example.org",
-      to: "joe@example.org",
+      to: "jane@example.org",
     });
 
     fireEvent.click(wrapper.getByText("Send test email"));
 
+    // The modal pre-fills From and To with the configured username
+    await waitFor(() => {
+      expect(wrapper.getByLabelText("From")).toBeTruthy();
+    });
+
+    expect((wrapper.getByLabelText("From") as HTMLInputElement).value).toBe(
+      "joe@example.org",
+    );
+    expect((wrapper.getByLabelText("To") as HTMLInputElement).value).toBe(
+      "joe@example.org",
+    );
+
+    await userEvent.clear(wrapper.getByLabelText("To"));
+    await userEvent.type(wrapper.getByLabelText("To"), "jane@example.org");
+
+    fireEvent.click(wrapper.getByText("Send"));
+
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
+      expect(
+        wrapper.getByText("Test email sent to jane@example.org"),
+      ).toBeTruthy();
     });
   });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
@@ -46,9 +46,6 @@ export default function TabMailer() {
       .then(() => {
         setSuccess("Mailer configuration saved successfully.");
         setRefreshToken(Date.now());
-      })
-      .catch(async res => {
-        setFormError((await api.errors(res)).join(" "));
       });
   };
 
@@ -192,19 +189,6 @@ export default function TabMailer() {
         />
       </Box>
 
-      <Box sx={{ mb: 4 }}>
-        <TextField
-          label="From Address"
-          name="fromAddress"
-          fullWidth
-          defaultValue={config?.fromAddress || ""}
-          variant="filled"
-          autoComplete="off"
-          placeholder="sender@example.com"
-          helperText="Optional. Default sender address for outgoing emails. Falls back to the username when empty."
-        />
-      </Box>
-
       <CardFooter>
         {config && (
           <Button
@@ -223,7 +207,7 @@ export default function TabMailer() {
                   body: JSON.stringify({
                     appId: app.id,
                     envId: env.id!,
-                    from: config.fromAddress || config.username,
+                    from: config.username,
                     to: config.username,
                     body: "Test email body",
                     subject: "Test email subject",

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
@@ -12,13 +12,14 @@ import Help, { HelpTable } from "~/components/Help";
 import { AppContext } from "~/pages/apps/[id]/App.context";
 import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
 import { useFetchMailerConfig } from "./actions";
+import SendTestEmailModal from "./SendTestEmailModal";
 
 export default function TabMailer() {
   const { app } = useContext(AppContext);
   const { environment: env } = useContext(EnvironmentContext);
   const [refreshToken, setRefreshToken] = useState<number>();
   const [formError, setFormError] = useState<string>();
-  const [sendLoading, setSendLoading] = useState<boolean>(false);
+  const [isTestModalOpen, setIsTestModalOpen] = useState<boolean>(false);
   const [success, setSuccess] = useState<string>();
   const { loading, error, config } = useFetchMailerConfig({
     appId: app.id,
@@ -195,35 +196,9 @@ export default function TabMailer() {
             type="button"
             variant="text"
             color="info"
-            loading={sendLoading}
             sx={{ mr: 2 }}
             onClick={() => {
-              setSendLoading(true);
-
-              api
-                .post("/mailer", {
-                  // fetch treats the `body` argument as a json string so we
-                  // need to stringify the parameters to make this api call work.
-                  body: JSON.stringify({
-                    appId: app.id,
-                    envId: env.id!,
-                    from: config.username,
-                    to: config.username,
-                    body: "Test email body",
-                    subject: "Test email subject",
-                  }),
-                })
-                .then(() => {
-                  setSuccess("Test email sent to " + config.username);
-                })
-                .catch(() => {
-                  setFormError(
-                    "Something went wrong while sending test email.",
-                  );
-                })
-                .finally(() => {
-                  setSendLoading(false);
-                });
+              setIsTestModalOpen(true);
             }}
           >
             Send test email
@@ -234,6 +209,18 @@ export default function TabMailer() {
           Save
         </Button>
       </CardFooter>
+
+      {isTestModalOpen && config && (
+        <SendTestEmailModal
+          appId={app.id}
+          envId={env.id!}
+          defaultFrom={config.username}
+          defaultTo={config.username}
+          onClose={() => {
+            setIsTestModalOpen(false);
+          }}
+        />
+      )}
     </Card>
   );
 }

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SendTestEmailModal.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SendTestEmailModal.tsx
@@ -1,0 +1,126 @@
+import type { FormEventHandler } from "react";
+import { useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Modal from "~/components/Modal";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardFooter from "~/components/CardFooter";
+import api from "~/utils/api/Api";
+
+interface Props {
+  appId: string;
+  envId: string;
+  defaultFrom: string;
+  defaultTo: string;
+  onClose: () => void;
+}
+
+export default function SendTestEmailModal({
+  appId,
+  envId,
+  defaultFrom,
+  defaultTo,
+  onClose,
+}: Props) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState<string>();
+
+  const handleSubmit: FormEventHandler<HTMLElement> = e => {
+    e.preventDefault();
+    // The modal is portaled from within the parent configuration form;
+    // without this the submit event bubbles up the React tree and
+    // triggers the parent form's submit handler as well.
+    e.stopPropagation();
+
+    const form = e.target as HTMLFormElement;
+    const data = Object.fromEntries(new FormData(form).entries()) as Record<
+      string,
+      string
+    >;
+
+    if (data.from === "" || data.to === "") {
+      return setError("From and To are required fields.");
+    }
+
+    setIsLoading(true);
+    setError(undefined);
+    setSuccess(undefined);
+
+    api
+      .post("/mailer", {
+        // fetch treats the `body` argument as a json string so we
+        // need to stringify the parameters to make this api call work.
+        body: JSON.stringify({
+          appId,
+          envId,
+          from: data.from,
+          to: data.to,
+          body: "Test email body",
+          subject: "Test email subject",
+        }),
+      })
+      .then(() => {
+        setSuccess("Test email sent to " + data.to);
+      })
+      .catch(() => {
+        setError("Something went wrong while sending test email.");
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  return (
+    <Modal open onClose={onClose}>
+      <Card
+        component="form"
+        error={error}
+        success={success}
+        onSubmit={handleSubmit}
+      >
+        <CardHeader
+          title="Send test email"
+          subtitle="Verify your mailer configuration by sending a test email."
+        />
+
+        <Box sx={{ mb: 4 }}>
+          <TextField
+            label="From"
+            name="from"
+            fullWidth
+            defaultValue={defaultFrom}
+            variant="filled"
+            autoComplete="off"
+            placeholder="sender@example.com"
+          />
+        </Box>
+
+        <Box sx={{ mb: 4 }}>
+          <TextField
+            label="To"
+            name="to"
+            fullWidth
+            defaultValue={defaultTo}
+            variant="filled"
+            autoComplete="off"
+            placeholder="recipient@example.com"
+          />
+        </Box>
+
+        <CardFooter>
+          <Button
+            variant="contained"
+            color="secondary"
+            type="submit"
+            loading={isLoading}
+          >
+            Send
+          </Button>
+        </CardFooter>
+      </Card>
+    </Modal>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
@@ -6,7 +6,6 @@ interface MailerConfig {
   port: string;
   username: string;
   password: string;
-  fromAddress?: string;
 }
 
 export interface Email {

--- a/src/ui/src/testing/nocks/nock_mailer.ts
+++ b/src/ui/src/testing/nocks/nock_mailer.ts
@@ -7,7 +7,6 @@ export interface MockMailerConfig {
   port: string;
   username: string;
   password: string;
-  fromAddress?: string;
 }
 
 interface MockFetchMailerConfigProps {
@@ -36,9 +35,8 @@ interface MockSetMailerConfigProps {
   smtpPort?: string;
   username?: string;
   password?: string;
-  fromAddress?: string;
   status?: number;
-  response?: { ok: boolean } | { errors: Record<string, string> };
+  response?: { ok: boolean };
 }
 
 export const mockSetMailerConfig = ({
@@ -48,7 +46,6 @@ export const mockSetMailerConfig = ({
   smtpPort,
   username,
   password,
-  fromAddress = "",
   status = 200,
   response = { ok: true },
 }: MockSetMailerConfigProps) => {
@@ -60,7 +57,6 @@ export const mockSetMailerConfig = ({
       smtpPort,
       username,
       password,
-      fromAddress,
     })
     .reply(status, response);
 };


### PR DESCRIPTION
## What

- Reverts #340 (`fromAddress` in the mailer config) — the From Address does not belong in the persisted configuration.
- Instead, clicking **Send test email** now opens a modal that asks for the **From** and **To** addresses (both pre-filled with the configured username) and sends the test email with those values.

## Why

The mailer config should only hold SMTP connection settings. The sender/recipient for a test email is a per-send concern, so it is now collected at send time.