### PR TITLE
fix: mobile responsive issues across ui

### DIFF
--- a/src/ui/src/components/AppName/AppName.tsx
+++ b/src/ui/src/components/AppName/AppName.tsx
@@ -27,7 +27,17 @@ export default function AppName({ app, imageSize = 20 }: Props) {
         >
           <BoltIcon sx={{ ml: 0, fontSize: 16, color: "container.paper" }} />
         </IconBg>
-        {app.displayName}
+        <Box
+          component="span"
+          sx={{
+            maxWidth: { xs: "35vw", md: "none" },
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {app.displayName}
+        </Box>
       </Typography>
     );
   }
@@ -53,7 +63,15 @@ export default function AppName({ app, imageSize = 20 }: Props) {
         alt={provider}
       />
 
-      <Typography component="div">
+      <Typography
+        component="div"
+        sx={{
+          maxWidth: { xs: "35vw", md: "none" },
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
         {app.displayName}
         <Dot />
         <Typography component="span" color="text.secondary">

--- a/src/ui/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/ui/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -37,7 +37,9 @@ export default function ButtonDropdown({ buttonText, children, items }: Props) {
                 setIsMenuOpen(false);
               }}
             >
-              <MenuList sx={{ minWidth: 250 }}>
+              <MenuList
+                sx={{ minWidth: 250, maxWidth: "calc(100vw - 32px)" }}
+              >
                 {items?.map(item => {
                   return (
                     <MenuItem

--- a/src/ui/src/components/DotDotDotV2/DotDotDot.tsx
+++ b/src/ui/src/components/DotDotDotV2/DotDotDot.tsx
@@ -38,6 +38,7 @@ export default function DotDotDot({ label, items }: Props) {
               flexDirection: "column",
               alignItems: "flex-start",
               minWidth: "185px",
+              maxWidth: "calc(100vw - 32px)",
             }}
           >
             {items.map((item, index) => (

--- a/src/ui/src/components/Help/Help.tsx
+++ b/src/ui/src/components/Help/Help.tsx
@@ -66,7 +66,13 @@ export default function Help({
         onClose={() => setIsDrawerOpen(false)}
         sx={{ zIndex: 1600 }}
       >
-        <Card sx={{ minHeight: "100vh", minWidth: "400px", maxWidth: "600px" }}>
+        <Card
+          sx={{
+            minHeight: "100vh",
+            minWidth: { xs: "100vw", sm: "400px" },
+            maxWidth: { xs: "100vw", sm: "600px" },
+          }}
+        >
           <CardHeader title={title} subtitle={subtitle} />
           <Box>{children}</Box>
         </Card>

--- a/src/ui/src/components/Modal/Modal.tsx
+++ b/src/ui/src/components/Modal/Modal.tsx
@@ -38,6 +38,7 @@ const Modal: React.FC<Props> = ({
           borderRadius: 1,
           height,
           maxHeight: "90vh",
+          mx: { xs: 2, md: 0 },
           overflow: "auto",
           border: `1px solid ${grey[900]}`,
         }}

--- a/src/ui/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/ui/src/components/MultiSelect/MultiSelect.tsx
@@ -121,7 +121,14 @@ export default function MultiSelect({
           );
         }}
       >
-        <ListSubheader sx={{ bgcolor: "transparent", p: 0, minWidth: 300 }}>
+        <ListSubheader
+          sx={{
+            bgcolor: "transparent",
+            p: 0,
+            minWidth: 300,
+            maxWidth: "calc(100vw - 32px)",
+          }}
+        >
           {onSearch && (
             <TextField
               variant="filled"

--- a/src/ui/src/layouts/AppLayout/AppMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/AppMenu.tsx
@@ -37,6 +37,7 @@ export default function AppMenu({ app, team }: Props) {
         sx={{
           display: "flex",
           alignItems: "center",
+          flexWrap: "wrap",
         }}
       >
         <Box

--- a/src/ui/src/layouts/AppLayout/AppSelector.tsx
+++ b/src/ui/src/layouts/AppLayout/AppSelector.tsx
@@ -38,6 +38,7 @@ const appLink = {
   p: 1,
   flex: 1,
   minWidth: "220px",
+  maxWidth: "calc(100vw - 32px)",
   borderRadius: 1,
   display: "flex",
   alignItems: "center",

--- a/src/ui/src/layouts/TopMenu/Teams/TeamMenu.tsx
+++ b/src/ui/src/layouts/TopMenu/Teams/TeamMenu.tsx
@@ -90,6 +90,7 @@ export default function TeamMenu({
                 sx={{
                   p: 1,
                   minWidth: "220px",
+                  maxWidth: "calc(100vw - 32px)",
                   borderRadius: 1,
                   display: "flex",
                   alignItems: "center",

--- a/src/ui/src/layouts/TopMenu/UserMenu.tsx
+++ b/src/ui/src/layouts/TopMenu/UserMenu.tsx
@@ -50,7 +50,11 @@ export default function UserMenu({ user, onClick }: Props) {
   const { mode, setMode } = useContext(RootContext);
 
   return (
-    <Box component="section" role="menu" sx={{ p: 2, minWidth: "250px" }}>
+    <Box
+      component="section"
+      role="menu"
+      sx={{ p: 2, minWidth: "250px", maxWidth: "calc(100vw - 32px)" }}
+    >
       <Box className="flex flex-col flex-1">
         <Box
           sx={{

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/_components/EnvironmentHeader.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/_components/EnvironmentHeader.tsx
@@ -1,3 +1,4 @@
+import type { SxProps } from "@mui/material";
 import React, { useContext } from "react";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
@@ -14,9 +15,10 @@ import DomainStatus from "./DomainStatus";
 
 interface ColumnProps {
   children: React.ReactNode;
+  sx?: SxProps;
 }
 
-function Column({ children }: ColumnProps) {
+function Column({ children, sx }: ColumnProps) {
   return (
     <Box
       sx={{
@@ -24,6 +26,7 @@ function Column({ children }: ColumnProps) {
         mr: 2,
         borderRight: "1px solid",
         borderColor: "container.transparent",
+        ...sx,
       }}
     >
       {children}
@@ -56,13 +59,12 @@ export default function EnvironmentHeader() {
         <Column>
           <DomainStatus loading={loading} status={status} />
         </Column>
-        <Column>
+        <Column sx={{ display: { xs: "none", md: "block" } }}>
           <Typography
             component="a"
             href={domainName}
             target="_blank"
             rel="noreferrer noopener"
-            sx={{ display: { xs: "none", md: "inline" } }}
           >
             {domainName.replace(/^https?:\/\//, "")}
           </Typography>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Analytics.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Analytics.tsx
@@ -69,7 +69,7 @@ export default function Analytics() {
                 if (domains?.[0]) {
                   setDomain(
                     domains.find(d => d.domainName === params.get("domain")) ||
-                      domains[0]
+                      domains[0],
                   );
 
                   setHasDomains(true);
@@ -97,6 +97,7 @@ export default function Analytics() {
         sx={{
           mt: 2,
           display: "flex",
+          flexDirection: { xs: "column", md: "row" },
           gap: 2,
         }}
       >

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/TopPaths.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/TopPaths.tsx
@@ -39,7 +39,7 @@ export default function TopPaths({ environment, domain }: Props) {
   return (
     <Card
       sx={{
-        width: "50%",
+        width: { xs: "100%", md: "50%" },
         margin: "",
         display: "flex",
         flexDirection: "column",

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/TopReferrers.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/TopReferrers.tsx
@@ -24,7 +24,7 @@ export default function TopReferrers({ environment, domain }: Props) {
       error={error}
       loading={loading}
       sx={{
-        width: "50%",
+        width: { xs: "100%", md: "50%" },
         margin: "",
         display: "flex",
         flexDirection: "column",

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
@@ -104,7 +104,11 @@ export default function ProviderSettings({
       <Card
         component="form"
         error={error}
-        sx={{ minHeight: "100vh", minWidth: "600px", maxWidth: "800px" }}
+        sx={{
+          minHeight: "100vh",
+          minWidth: { xs: "100vw", md: "600px" },
+          maxWidth: { xs: "100vw", md: "800px" },
+        }}
         onSubmit={e => {
           e.preventDefault();
           const form = e.target as HTMLFormElement;

--- a/src/ui/src/shared/deployments/CommitInfo.tsx
+++ b/src/ui/src/shared/deployments/CommitInfo.tsx
@@ -119,6 +119,7 @@ export default function CommitInfo({
           sx={{
             display: "flex",
             alignItems: "baseline",
+            flexWrap: "wrap",
             color: "text.secondary",
             fontSize: 12,
             my: 0.5,


### PR DESCRIPTION
## Summary

Fixes a batch of mobile/responsive UI bugs found during a sweep of the UI at a ~375px viewport:

- **Drawers wider than the screen**: the Help drawer (`minWidth: 400px`) and SkAuth ProviderSettings drawer (`minWidth: 600px`) now collapse to `100vw` on small screens.
- **Analytics cards never stacked**: Referrers/Paths were locked to `width: 50%` in a non-wrapping flex row, causing horizontal scroll; they now stack vertically below `md`.
- **App header overflow**: long app/repo names in `AppName` had no truncation and pushed the nav links off-screen; names now ellipsize on `xs` and the header row wraps as a fallback.
- **Deployment metadata overflow**: the `ID • branch • sha • author` row in `CommitInfo` didn't wrap; added `flexWrap`.
- **EnvironmentHeader stray separator**: the domain link was hidden on `xs` but its bordered `Column` wrapper still rendered, leaving an empty separator; the whole column is now hidden.
- **Edge-to-edge modals**: the shared `Modal` had no side margin on phones; added `mx: 2` on `xs`.
- **Dropdown menus with fixed min-widths** (UserMenu, TeamMenu, AppSelector, ButtonDropdown, DotDotDot, MultiSelect): added a `maxWidth: calc(100vw - 32px)` guard so they can't exceed the viewport.

## Testing

- `npm test` — 119 files, 659 tests passing
- `npm run build` — passes
- Prettier — clean