### PR TITLE
feat: add build cache for deployments

### DIFF
--- a/docs/api/3-environments.md
+++ b/docs/api/3-environments.md
@@ -93,6 +93,7 @@ Creates a new environment for an application.
 | `autoDeployCommits`  | string                  | No       | Glob/regex pattern to filter which commit messages trigger auto-deploys. Setting this enables `autoDeploy`. |
 | `autoPublish`        | boolean                 | No       | Whether to automatically publish successful deployments.                                                    |
 | `buildCmd`           | string                  | No       | Command to build the application.                                                                           |
+| `cacheDirs`          | `string[]`              | No       | Directories (relative to `workDir`) restored before the install step and snapshotted after a successful build. Best for compiler caches like `.next/cache` or `.turbo`. Requires a premium or ultimate subscription on Stormkit Cloud; always enabled on self-hosted. |
 | `distFolder`         | string                  | No       | Output folder containing the build artifacts.                                                               |
 | `envVars`            | `Record<string,string>` | No       | Environment variables to inject into deployments.                                                           |
 | `errorFile`          | string                  | No       | File served on errors. Must be inside `distFolder`.                                                         |
@@ -173,6 +174,7 @@ All fields are **optional**. Only the fields you include will be updated.
 | `autoDeployCommits`  | string                  | Glob/regex pattern to filter which commit messages trigger auto-deploys. Setting this enables `autoDeploy`.                                  |
 | `autoPublish`        | boolean                 | Whether to automatically publish successful deployments.                                                                                     |
 | `buildCmd`           | string                  | Command to build the application.                                                                                                            |
+| `cacheDirs`          | `string[]`              | Directories (relative to `workDir`) restored before the install step and snapshotted after a successful build. Replaces the existing list; pass `[]` to disable caching. Requires a premium or ultimate subscription on Stormkit Cloud; always enabled on self-hosted. |
 | `distFolder`         | string                  | Output folder containing the build artifacts.                                                                                                |
 | `envVars`            | `Record<string,string>` | Environment variables to inject into deployments. Replaces all existing variables.                                                           |
 | `errorFile`          | string                  | File served on errors. Must be inside `distFolder`.                                                                                          |

--- a/src/ce/api/app/buildconf/cache_dirs_test.go
+++ b/src/ce/api/app/buildconf/cache_dirs_test.go
@@ -1,0 +1,35 @@
+package buildconf_test
+
+import (
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stretchr/testify/suite"
+)
+
+type ValidateCacheDirsSuite struct {
+	suite.Suite
+}
+
+func (s *ValidateCacheDirsSuite) Test_ValidDirs() {
+	s.Empty(buildconf.ValidateCacheDirs(nil))
+	s.Empty(buildconf.ValidateCacheDirs([]string{}))
+	s.Empty(buildconf.ValidateCacheDirs([]string{"node_modules", ".next/cache", "./dist", "a/b/c"}))
+}
+
+func (s *ValidateCacheDirsSuite) Test_InvalidDirs() {
+	for _, dir := range []string{"", " ", "/absolute", "~/home", "..", "../escape", "a/../../b", "."} {
+		s.NotEmpty(buildconf.ValidateCacheDirs([]string{dir}), "expected %q to be invalid", dir)
+	}
+}
+
+func (s *ValidateCacheDirsSuite) Test_MixedDirs_ReportsOnlyInvalid() {
+	errs := buildconf.ValidateCacheDirs([]string{"node_modules", "../escape"})
+
+	s.Len(errs, 1)
+	s.Contains(errs[0], "../escape")
+}
+
+func TestValidateCacheDirsSuite(t *testing.T) {
+	suite.Run(t, new(ValidateCacheDirsSuite))
+}

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
@@ -295,6 +296,7 @@ type BuildConf struct {
 	Vars            map[string]string    `json:"vars,omitempty"`            // The environment variables that will be injected to the application.
 	StatusChecks    []StatusCheck        `json:"statusChecks,omitempty"`    // StatusChecks is an array of commands that will be executed after the deployment is complete.
 	PriorityPattern string               `json:"priorityPattern,omitempty"` // PriorityPattern is a regex matched against the commit message to auto-prioritize deployments.
+	CacheDirs       []string             `json:"cacheDirs,omitempty"`       // CacheDirs is a list of directories (relative to the working directory) restored before install and snapshotted after a successful build.
 }
 
 type InterpolatedVarsOpts struct {
@@ -414,8 +416,62 @@ func Validate(env *Env) []string {
 		}
 	}
 
+	if env.Data != nil {
+		errors = append(errors, ValidateCacheDirs(env.Data.CacheDirs)...)
+	}
+
 	if len(errors) == 0 {
 		return nil
+	}
+
+	return errors
+}
+
+// NormalizeCacheDirs trims each entry and drops empty ones, so callers can
+// accept a raw list (e.g. a textarea split by newlines) before validation.
+func NormalizeCacheDirs(dirs []string) []string {
+	normalized := make([]string, 0, len(dirs))
+
+	for _, dir := range dirs {
+		if dir = strings.TrimSpace(dir); dir != "" {
+			normalized = append(normalized, dir)
+		}
+	}
+
+	return normalized
+}
+
+// ValidateCacheDirs ensures every cache directory is a relative path that
+// stays inside the build working directory. The runner extracts cache
+// archives with these paths, so anything escaping the workdir is rejected.
+func ValidateCacheDirs(dirs []string) []string {
+	errors := []string{}
+
+	for _, dir := range dirs {
+		dir = strings.TrimSpace(dir)
+
+		if dir == "" {
+			errors = append(errors, "Cache directories cannot be empty")
+			continue
+		}
+
+		if strings.HasPrefix(dir, "/") || strings.HasPrefix(dir, "~") {
+			errors = append(errors, fmt.Sprintf("Cache directory %q must be relative to the working directory", dir))
+			continue
+		}
+
+		// A leading dash would be interpreted as a flag when the directory is
+		// passed to tar during snapshot/restore.
+		if strings.HasPrefix(dir, "-") {
+			errors = append(errors, fmt.Sprintf("Cache directory %q cannot start with a dash", dir))
+			continue
+		}
+
+		cleaned := path.Clean(dir)
+
+		if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			errors = append(errors, fmt.Sprintf("Cache directory %q must point inside the working directory", dir))
+		}
 	}
 
 	return errors

--- a/src/ce/api/app/deployservice/deployer.go
+++ b/src/ce/api/app/deployservice/deployer.go
@@ -38,8 +38,13 @@ func New() Deployer {
 }
 
 func (dd *DefaultDeployer) Deploy(ctx context.Context, a *app.App, d *deploy.Deployment) error {
+	// Build caching is available to everyone on self-hosted instances. On
+	// Stormkit Cloud it is an enterprise feature: premium and ultimate only.
+	cacheEnabled := !config.IsStormkitCloud()
+
 	if config.IsStormkitCloud() {
-		usr, err := user.NewStore().UserMetrics(ctx, user.UserMetricsArgs{AppID: a.ID})
+		store := user.NewStore()
+		usr, err := store.UserMetrics(ctx, user.UserMetricsArgs{AppID: a.ID})
 
 		if err != nil {
 			return err
@@ -48,6 +53,23 @@ func (dd *DefaultDeployer) Deploy(ctx context.Context, a *app.App, d *deploy.Dep
 		if usr != nil && !usr.HasBuildMinutes() {
 			return ErrBuildMinutesExceeded
 		}
+
+		// UserMetrics already carries the owner's package, but it returns no
+		// row until the first usage entry of the month exists; fall back to a
+		// dedicated lookup in that case. Build caching is best-effort, so a
+		// failed entitlement lookup disables caching instead of failing the
+		// deployment.
+		tier := ""
+
+		if usr != nil {
+			tier = usr.Metadata.PackageName
+		} else if t, err := store.PackageNameByAppID(ctx, a.ID); err != nil {
+			slog.Errorf("could not resolve package for app %d: %v", a.ID, err)
+		} else {
+			tier = t
+		}
+
+		cacheEnabled = tier == config.PackagePremium || tier == config.PackageUltimate
 	}
 
 	// Get git credentials
@@ -89,6 +111,14 @@ func (dd *DefaultDeployer) Deploy(ctx context.Context, a *app.App, d *deploy.Dep
 		}
 	}
 
+	// When caching is not allowed the runner receives no cache directories,
+	// which is how it decides whether to restore and snapshot the cache.
+	cacheDirs := d.BuildConfig.CacheDirs
+
+	if !cacheEnabled {
+		cacheDirs = nil
+	}
+
 	payload := DeploymentMessage{
 		Client: ClientConfig{
 			Repo:        d.RepoCloneURL(),
@@ -114,6 +144,7 @@ func (dd *DefaultDeployer) Deploy(ctx context.Context, a *app.App, d *deploy.Dep
 			APIFolder:        utils.GetString(d.BuildConfig.APIFolder, "/api"),
 			StatusChecks:     d.BuildConfig.StatusChecks,
 			MigrationsFolder: d.MigrationsFolder.ValueOrZero(),
+			CacheDirs:        cacheDirs,
 			Vars: d.BuildConfig.InterpolatedVars(
 				buildconf.InterpolatedVarsOpts{
 					DeploymentID: d.ID.String(),

--- a/src/ce/api/app/deployservice/deployer_service.go
+++ b/src/ce/api/app/deployservice/deployer_service.go
@@ -96,6 +96,13 @@ type BuildConfig struct {
 
 	// MigrationsFolder is the path to the migrations folder, if any.
 	MigrationsFolder string `json:"migrationsFolder"`
+
+	// CacheDirs is the list of directories (relative to the working directory)
+	// that are restored before install and snapshotted after a successful
+	// build. It is empty when caching is not allowed for the deployment (on
+	// Stormkit Cloud this requires a premium or ultimate subscription;
+	// self-hosted instances always have it enabled).
+	CacheDirs []string `json:"cacheDirs,omitempty"`
 }
 
 // DeploymentMessage represents a deployment payload.

--- a/src/ce/api/app/deployservice/deployer_test.go
+++ b/src/ce/api/app/deployservice/deployer_test.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hibiken/asynq"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deployservice"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -123,6 +126,116 @@ func (s *DeploySuite) Test_Deployment() {
 	s.NoError(err)
 	s.Equal(depl.ID, d.ID)
 	s.Equal(depl.Branch, d.Branch)
+}
+
+// enqueueCapture is a TaskClient that records the enqueued task instead of
+// sending it to Redis, so tests can inspect the deployment message without
+// relying on shared queue state.
+type enqueueCapture struct {
+	task *asynq.Task
+}
+
+func (c *enqueueCapture) Enqueue(task *asynq.Task, opts ...asynq.Option) (*asynq.TaskInfo, error) {
+	c.task = task
+	return &asynq.TaskInfo{}, nil
+}
+
+func (s *DeploySuite) deployAndReadMessage(a *app.App, d *deploy.Deployment) *deployservice.DeploymentMessage {
+	capture := &enqueueCapture{}
+	prevClient := tasks.Client
+	tasks.Client = func() tasks.TaskClient { return capture }
+
+	defer func() { tasks.Client = prevClient }()
+
+	deployer := &deployservice.DefaultDeployer{}
+	s.Require().NoError(deployer.Deploy(context.Background(), a, d))
+	s.Require().NotNil(capture.task)
+
+	message, err := deployservice.FromEncrypted(string(capture.task.Payload()))
+	s.Require().NoError(err)
+
+	return message
+}
+
+func (s *DeploySuite) Test_Deployment_BuildCache_SelfHosted() {
+	config.SetIsSelfHosted(true)
+
+	defer config.SetIsSelfHosted(false)
+
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	depl := s.MockDeployment(env, map[string]any{
+		"BuildConfig": &buildconf.BuildConf{
+			CacheDirs: []string{".next/cache", "node_modules"},
+		},
+	})
+
+	message := s.deployAndReadMessage(app.App, depl.Deployment)
+
+	s.Equal([]string{".next/cache", "node_modules"}, message.Build.CacheDirs)
+}
+
+func (s *DeploySuite) Test_Deployment_BuildCache_Cloud_PremiumTier() {
+	config.SetIsStormkitCloud(true)
+
+	defer config.SetIsStormkitCloud(false)
+
+	usr := s.MockUser() // Mock users are premium by default.
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	depl := s.MockDeployment(env, map[string]any{
+		"BuildConfig": &buildconf.BuildConf{
+			CacheDirs: []string{".next/cache"},
+		},
+	})
+
+	message := s.deployAndReadMessage(app.App, depl.Deployment)
+
+	s.Equal([]string{".next/cache"}, message.Build.CacheDirs)
+}
+
+func (s *DeploySuite) Test_Deployment_BuildCache_Cloud_FreeTier() {
+	config.SetIsStormkitCloud(true)
+
+	defer config.SetIsStormkitCloud(false)
+
+	usr := s.MockUser(map[string]any{
+		"Metadata": user.UserMeta{
+			SeatsPurchased: 1,
+			PackageName:    config.PackageFree,
+		},
+	})
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	depl := s.MockDeployment(env, map[string]any{
+		"BuildConfig": &buildconf.BuildConf{
+			CacheDirs: []string{".next/cache"},
+		},
+	})
+
+	message := s.deployAndReadMessage(app.App, depl.Deployment)
+
+	// Free tier users on the cloud get no cache directories, which disables
+	// caching in the runner.
+	s.Empty(message.Build.CacheDirs)
+}
+
+func (s *DeploySuite) Test_Deployment_BuildCache_NoDirs() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	depl := s.MockDeployment(env, map[string]any{
+		"BuildConfig": &buildconf.BuildConf{},
+	})
+
+	message := s.deployAndReadMessage(app.App, depl.Deployment)
+
+	s.Empty(message.Build.CacheDirs)
 }
 
 func (s *DeploySuite) Test_Deployment_NoMoreBuildMinutes() {

--- a/src/ce/api/public/v1/handler_env_add.go
+++ b/src/ce/api/public/v1/handler_env_add.go
@@ -36,6 +36,7 @@ type EnvAddRequest struct {
 	ServerCmd          string                  `json:"serverCmd,omitempty"`
 	ServerFolder       string                  `json:"serverFolder,omitempty"`
 	StatusChecks       []buildconf.StatusCheck `json:"statusChecks,omitempty"`
+	CacheDirs          []string                `json:"cacheDirs,omitempty"`
 }
 
 func handlerEnvAdd(req *RequestContext) *shttp.Response {
@@ -69,6 +70,7 @@ func handlerEnvAdd(req *RequestContext) *shttp.Response {
 			Redirects:     data.Redirects,
 			Vars:          data.EnvVars,
 			StatusChecks:  data.StatusChecks,
+			CacheDirs:     buildconf.NormalizeCacheDirs(data.CacheDirs),
 		},
 		Name:        data.Name,
 		AppID:       req.App.ID,

--- a/src/ce/api/public/v1/handler_env_add_test.go
+++ b/src/ce/api/public/v1/handler_env_add_test.go
@@ -104,6 +104,7 @@ func (s *HandlerEnvAddSuite) Test_Success() {
 			"redirects": []map[string]any{
 				{"from": "/old", "to": "/new", "status": 301},
 			},
+			"cacheDirs": []string{".next/cache", " node_modules ", ""},
 		},
 		map[string]string{
 			"Authorization": key.Value,
@@ -133,6 +134,8 @@ func (s *HandlerEnvAddSuite) Test_Success() {
 	s.Equal("/error.html", env.Data.ErrorFile)
 	s.Equal("/headers.json", env.Data.HeadersFile)
 	s.Equal("production", env.Data.Vars["NODE_ENV"])
+	// Entries are trimmed and empty ones dropped.
+	s.Equal([]string{".next/cache", "node_modules"}, env.Data.CacheDirs)
 
 	audits, err := audit.NewStore().SelectAudits(context.Background(), audit.AuditFilters{
 		AppID: app.ID,

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -39,6 +39,7 @@ type EnvUpdateRequest struct {
 	StatusChecks       []buildconf.StatusCheck `json:"statusChecks,omitempty"`
 	PriorityPattern    *string                 `json:"priorityPattern,omitempty"`
 	EnvVars            map[string]string       `json:"envVars,omitempty"`
+	CacheDirs          *[]string               `json:"cacheDirs,omitempty"`
 }
 
 func handlerEnvUpdate(req *RequestContext) *shttp.Response {
@@ -169,6 +170,10 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 
 	if data.EnvVars != nil {
 		env.Data.Vars = data.EnvVars
+	}
+
+	if data.CacheDirs != nil {
+		env.Data.CacheDirs = buildconf.NormalizeCacheDirs(*data.CacheDirs)
 	}
 
 	if errs := buildconf.Validate(env); len(errs) > 0 {

--- a/src/ce/api/public/v1/handler_env_update_test.go
+++ b/src/ce/api/public/v1/handler_env_update_test.go
@@ -147,6 +147,61 @@ func (s *HandlerEnvUpdateSuite) Test_Success_PartialUpdate_OnlyBuildCmd() {
 	s.Equal("npm run build:staging", updated.Data.BuildCmd)
 }
 
+func (s *HandlerEnvUpdateSuite) Test_Success_CacheDirs() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	key := s.MockAPIKey(nil, env, map[string]any{
+		"Scope": apikey.SCOPE_ENV,
+		"EnvID": env.ID,
+	})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodPut,
+		fmt.Sprintf("/v1/env?envId=%s", env.ID),
+		map[string]any{
+			"cacheDirs": []string{".next/cache", " node_modules ", ""},
+		},
+		map[string]string{
+			"Authorization": key.Value,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), env.ID)
+
+	s.NoError(err)
+	s.NotNil(updated)
+	// Entries are trimmed and empty ones dropped.
+	s.Equal([]string{".next/cache", "node_modules"}, updated.Data.CacheDirs)
+}
+
+func (s *HandlerEnvUpdateSuite) Test_BadRequest_InvalidCacheDirs() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	key := s.MockAPIKey(nil, env, map[string]any{
+		"Scope": apikey.SCOPE_ENV,
+		"EnvID": env.ID,
+	})
+
+	for _, dir := range []string{"/absolute", "../escape", "a/../../b", "~/home"} {
+		response := shttptest.RequestWithHeaders(
+			shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+			shttp.MethodPut,
+			fmt.Sprintf("/v1/env?envId=%s", env.ID),
+			map[string]any{
+				"cacheDirs": []string{dir},
+			},
+			map[string]string{
+				"Authorization": key.Value,
+			},
+		)
+
+		s.Equal(http.StatusBadRequest, response.Code, "expected %q to be rejected", dir)
+	}
+}
+
 func (s *HandlerEnvUpdateSuite) Test_BadRequest_InvalidHeaders() {
 	app := s.MockApp(nil)
 	env := s.MockEnv(app)

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -235,6 +235,11 @@ func mcpAllTools() []mcpToolDef {
 							"required": []string{"name", "cmd"},
 						},
 					},
+					"cacheDirs": map[string]any{
+						"type":        "array",
+						"description": "Directories (relative to the build working directory) restored before install and snapshotted after a successful build. Best for compiler caches like .next/cache or .turbo. Requires a premium or ultimate subscription on Stormkit Cloud; always enabled on self-hosted.",
+						"items":       map[string]any{"type": "string"},
+					},
 				},
 				"required":             []string{"appId", "name", "branch"},
 				"additionalProperties": false,
@@ -296,6 +301,11 @@ func mcpAllTools() []mcpToolDef {
 								"description": map[string]any{"type": "string"},
 							},
 						},
+					},
+					"cacheDirs": map[string]any{
+						"type":        "array",
+						"description": "Directories (relative to the build working directory) restored before install and snapshotted after a successful build. Best for compiler caches like .next/cache or .turbo. Pass an empty array to disable caching. Requires a premium or ultimate subscription on Stormkit Cloud; always enabled on self-hosted.",
+						"items":       map[string]any{"type": "string"},
 					},
 				},
 				"required":             []string{"envId"},
@@ -711,6 +721,7 @@ func mcpCreateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	}
 
 	body.StatusChecks = parseStatusChecksArg(args)
+	body.CacheDirs, _ = stringArrayArg(args, "cacheDirs")
 
 	resp := req.setBody(id, body)
 
@@ -796,6 +807,27 @@ func parseStatusChecksArg(args map[string]any) []buildconf.StatusCheck {
 	return out
 }
 
+// stringArrayArg reads a JSON string array argument. The second return value
+// reports whether the key was present as an array, so callers can tell an
+// omitted argument (leave unchanged) from an empty one (clear the list).
+func stringArrayArg(args map[string]any, key string) ([]string, bool) {
+	raw, ok := args[key].([]any)
+
+	if !ok {
+		return nil, false
+	}
+
+	out := make([]string, 0, len(raw))
+
+	for _, item := range raw {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+
+	return out, true
+}
+
 // stringArgMap and boolArgMap are like stringArg/boolArg but operate on a
 // plain map[string]any instead of the top-level args map.
 func stringArgMap(m map[string]any, key string) string {
@@ -857,6 +889,10 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	}
 
 	update.StatusChecks = parseStatusChecksArg(args)
+
+	if dirs, ok := stringArrayArg(args, "cacheDirs"); ok {
+		update.CacheDirs = &dirs
+	}
 
 	resp := req.setBody(id, update)
 

--- a/src/ce/api/user/user_statements.go
+++ b/src/ce/api/user/user_statements.go
@@ -26,6 +26,7 @@ type userStatement struct {
 	deleteLicense             string
 	updateLastLogin           string
 	userMetrics               string
+	packageNameByAppID        string
 	updateUsageMetrics        string
 	updateApprovalStatus      string
 }
@@ -236,6 +237,19 @@ var ustmt = &userStatement{
 			um.user_id = {{ .where }} AND
 			um.year = EXTRACT(YEAR FROM CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::INTEGER AND
 			um.month = EXTRACT(MONTH FROM CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::INTEGER;
+	`,
+
+	packageNameByAppID: `
+		SELECT
+			u.metadata
+		FROM
+			users u
+		JOIN
+			teams t ON t.user_id = u.user_id
+		JOIN
+			apps a ON a.team_id = t.team_id
+		WHERE
+			a.app_id = $1;
 	`,
 
 	updateUsageMetrics: `

--- a/src/ce/api/user/user_store.go
+++ b/src/ce/api/user/user_store.go
@@ -561,6 +561,29 @@ func (s *Store) UserMetrics(ctx context.Context, args UserMetricsArgs) (*UserMet
 	return metrics, nil
 }
 
+// PackageNameByAppID returns the subscription package of the user owning the
+// team the given app belongs to. It falls back to the free package when the
+// user metadata does not specify one.
+func (s *Store) PackageNameByAppID(ctx context.Context, appID types.ID) (string, error) {
+	row, err := s.QueryRow(ctx, ustmt.packageNameByAppID, appID)
+
+	if err != nil {
+		return "", err
+	}
+
+	meta := UserMeta{}
+
+	if err := row.Scan(&meta); err != nil {
+		if err == sql.ErrNoRows {
+			return config.PackageFree, nil
+		}
+
+		return "", err
+	}
+
+	return utils.GetString(meta.PackageName, config.PackageFree), nil
+}
+
 // MustUser inserts an auth user if it is not inserted yet.
 func (s *Store) MustUser(authUser *oauth.User) (*User, error) {
 	var user *User

--- a/src/ce/runner/cache.go
+++ b/src/ce/runner/cache.go
@@ -1,0 +1,210 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+)
+
+// maxCacheArchiveSize caps the snapshot size so a misconfigured cacheDirs
+// cannot fill up the storage with multi-gigabyte archives.
+const maxCacheArchiveSize = 2 << 30 // 2GiB
+
+// DefaultCacheStore overrides the storage client used for build caches.
+// It is meant for tests.
+var DefaultCacheStore integrations.CacheStore
+
+// cacheManager restores and snapshots the build cache archive around a
+// build. All of its operations are best-effort: a cache failure is reported
+// to the build log but never fails the deployment.
+type cacheManager struct {
+	opts        RunnerOpts
+	archivePath string
+}
+
+func newCacheManager(opts RunnerOpts) *cacheManager {
+	return &cacheManager{
+		opts:        opts,
+		archivePath: path.Join(opts.RootDir, "build-cache.tar.gz"),
+	}
+}
+
+// dirs returns the sanitized cache directories. The API validates these on
+// save; this re-validation keeps a forged deployment message from extracting
+// or archiving paths outside the working directory.
+func (c *cacheManager) dirs() []string {
+	valid := []string{}
+
+	for _, dir := range c.opts.Build.CacheDirs {
+		if len(buildconf.ValidateCacheDirs([]string{dir})) == 0 {
+			valid = append(valid, path.Clean(dir))
+		}
+	}
+
+	return valid
+}
+
+// enabled reports whether caching should run. The deployer clears CacheDirs
+// when caching is not allowed, so a non-empty (valid) list is the signal.
+func (c *cacheManager) enabled() bool {
+	return len(c.dirs()) > 0
+}
+
+func (c *cacheManager) store() integrations.CacheStore {
+	if DefaultCacheStore != nil {
+		return DefaultCacheStore
+	}
+
+	if c.opts.Uploader == nil {
+		return nil
+	}
+
+	client := integrations.Client(integrations.ClientArgs{
+		Provider:  c.opts.Uploader.Provider,
+		AccessKey: c.opts.Uploader.AccessKey,
+		SecretKey: c.opts.Uploader.SecretKey,
+		Region:    c.opts.Uploader.Region,
+	})
+
+	if store, ok := client.(integrations.CacheStore); ok {
+		return store
+	}
+
+	return nil
+}
+
+func (c *cacheManager) artifactArgs() integrations.CacheArtifactArgs {
+	args := integrations.CacheArtifactArgs{
+		AppID:     utils.StringToID(c.opts.Build.AppID),
+		EnvID:     utils.StringToID(c.opts.Build.EnvID),
+		LocalPath: c.archivePath,
+	}
+
+	if c.opts.Uploader != nil {
+		args.BucketName = c.opts.Uploader.BucketName
+	}
+
+	return args
+}
+
+// Restore downloads the environment's cache archive and extracts it into
+// the working directory. It runs before the install step.
+func (c *cacheManager) Restore(ctx context.Context) {
+	if !c.enabled() {
+		return
+	}
+
+	store := c.store()
+
+	if store == nil {
+		return
+	}
+
+	c.opts.Reporter.AddStep("restoring build cache")
+
+	found, err := store.DownloadCacheArtifact(ctx, c.artifactArgs())
+
+	if err != nil {
+		c.reportError("could not download build cache", err)
+		return
+	}
+
+	if !found {
+		c.opts.Reporter.AddLine("no build cache found - starting from a clean state")
+		return
+	}
+
+	defer os.Remove(c.archivePath)
+
+	cmd := sys.Command(ctx, sys.CommandOpts{
+		Name: "tar",
+		Args: []string{"-xzf", c.archivePath, "-C", c.opts.WorkDir},
+		Dir:  c.opts.RootDir,
+	})
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		c.reportError(fmt.Sprintf("could not extract build cache: %s", string(out)), err)
+		return
+	}
+
+	c.opts.Reporter.AddLine(fmt.Sprintf("restored cached directories: %v", c.dirs()))
+}
+
+// Snapshot archives the cache directories and uploads them, replacing the
+// environment's previous cache. It runs after a successful build.
+func (c *cacheManager) Snapshot(ctx context.Context) {
+	if !c.enabled() {
+		return
+	}
+
+	store := c.store()
+
+	if store == nil {
+		return
+	}
+
+	dirs := []string{}
+
+	for _, dir := range c.dirs() {
+		if stat, err := os.Stat(path.Join(c.opts.WorkDir, dir)); err == nil && stat.IsDir() {
+			dirs = append(dirs, dir)
+		}
+	}
+
+	if len(dirs) == 0 {
+		c.opts.Reporter.AddLine("no cache directories found after the build - skipping")
+		return
+	}
+
+	c.opts.Reporter.AddStep("saving build cache")
+
+	defer os.Remove(c.archivePath)
+
+	cmd := sys.Command(ctx, sys.CommandOpts{
+		Name: "tar",
+		Args: append([]string{"-czf", c.archivePath, "-C", c.opts.WorkDir}, dirs...),
+		Dir:  c.opts.RootDir,
+	})
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		c.reportError(fmt.Sprintf("could not archive build cache: %s", string(out)), err)
+		return
+	}
+
+	stat, err := os.Stat(c.archivePath)
+
+	if err != nil {
+		c.reportError("could not stat build cache archive", err)
+		return
+	}
+
+	if stat.Size() > maxCacheArchiveSize {
+		c.opts.Reporter.AddLine(
+			fmt.Sprintf(
+				"build cache is too large (%dMB > %dMB) - reduce the cache directories to enable caching",
+				stat.Size()>>20,
+				int64(maxCacheArchiveSize)>>20,
+			),
+		)
+		return
+	}
+
+	if err := store.UploadCacheArtifact(ctx, c.artifactArgs()); err != nil {
+		c.reportError("could not upload build cache", err)
+		return
+	}
+
+	c.opts.Reporter.AddLine(fmt.Sprintf("saved build cache (%dMB): %v", stat.Size()>>20, dirs))
+}
+
+func (c *cacheManager) reportError(msg string, err error) {
+	slog.Errorf("%s: %v", msg, err)
+	c.opts.Reporter.AddLine(fmt.Sprintf("%s - continuing without cache", msg))
+}

--- a/src/ce/runner/cache_test.go
+++ b/src/ce/runner/cache_test.go
@@ -1,0 +1,179 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/file"
+	"github.com/stretchr/testify/suite"
+)
+
+// mockCacheStore keeps cache archives in a local directory so Snapshot and
+// Restore can round-trip without a real storage provider.
+type mockCacheStore struct {
+	storeDir  string
+	uploads   int
+	downloads int
+}
+
+func (m *mockCacheStore) archivePath() string {
+	return path.Join(m.storeDir, "cache.tar.gz")
+}
+
+func (m *mockCacheStore) UploadCacheArtifact(_ context.Context, args integrations.CacheArtifactArgs) error {
+	m.uploads++
+	return file.Copy(args.LocalPath, m.archivePath(), 0664)
+}
+
+func (m *mockCacheStore) DownloadCacheArtifact(_ context.Context, args integrations.CacheArtifactArgs) (bool, error) {
+	m.downloads++
+
+	if _, err := os.Stat(m.archivePath()); err != nil {
+		return false, nil
+	}
+
+	return true, file.Copy(m.archivePath(), args.LocalPath, 0664)
+}
+
+func (m *mockCacheStore) DeleteCacheArtifact(_ context.Context, _ integrations.CacheArtifactArgs) error {
+	return os.Remove(m.archivePath())
+}
+
+type CacheManagerSuite struct {
+	suite.Suite
+
+	store *mockCacheStore
+	opts  RunnerOpts
+}
+
+func (s *CacheManagerSuite) SetupTest() {
+	rootDir := s.T().TempDir()
+	workDir := path.Join(rootDir, "repo")
+
+	s.Require().NoError(os.MkdirAll(workDir, 0775))
+
+	s.store = &mockCacheStore{storeDir: s.T().TempDir()}
+	DefaultCacheStore = s.store
+
+	s.opts = RunnerOpts{
+		RootDir:  rootDir,
+		WorkDir:  workDir,
+		Reporter: NewReporter(""),
+		Build: BuildOpts{
+			AppID:     "1",
+			EnvID:     "2",
+			CacheDirs: []string{"node_modules", ".next/cache"},
+		},
+	}
+}
+
+func (s *CacheManagerSuite) TearDownTest() {
+	DefaultCacheStore = nil
+}
+
+func (s *CacheManagerSuite) writeWorkDirFile(relPath, content string) {
+	fullPath := path.Join(s.opts.WorkDir, relPath)
+
+	s.Require().NoError(os.MkdirAll(path.Dir(fullPath), 0775))
+	s.Require().NoError(os.WriteFile(fullPath, []byte(content), 0664))
+}
+
+func (s *CacheManagerSuite) Test_SnapshotAndRestore_RoundTrip() {
+	ctx := context.Background()
+
+	s.writeWorkDirFile("node_modules/pkg/index.js", "module.exports = {}")
+	s.writeWorkDirFile(".next/cache/build.json", "{}")
+	s.writeWorkDirFile("src/app.js", "should not be cached")
+
+	newCacheManager(s.opts).Snapshot(ctx)
+
+	s.Equal(1, s.store.uploads)
+
+	// Simulate a fresh checkout: wipe the working directory.
+	s.Require().NoError(os.RemoveAll(s.opts.WorkDir))
+	s.Require().NoError(os.MkdirAll(s.opts.WorkDir, 0775))
+
+	newCacheManager(s.opts).Restore(ctx)
+
+	content, err := os.ReadFile(path.Join(s.opts.WorkDir, "node_modules/pkg/index.js"))
+
+	s.NoError(err)
+	s.Equal("module.exports = {}", string(content))
+	s.FileExists(path.Join(s.opts.WorkDir, ".next/cache/build.json"))
+	s.NoFileExists(path.Join(s.opts.WorkDir, "src/app.js"))
+}
+
+func (s *CacheManagerSuite) Test_Restore_CacheMiss() {
+	newCacheManager(s.opts).Restore(context.Background())
+
+	s.Equal(1, s.store.downloads)
+
+	entries, err := os.ReadDir(s.opts.WorkDir)
+
+	s.NoError(err)
+	s.Empty(entries)
+}
+
+// The deployer clears CacheDirs when caching is not allowed, so an empty
+// list is how the runner sees a disabled cache.
+func (s *CacheManagerSuite) Test_Disabled_WhenNoCacheDirs() {
+	s.writeWorkDirFile("node_modules/pkg/index.js", "cached")
+	s.opts.Build.CacheDirs = nil
+
+	cache := newCacheManager(s.opts)
+	cache.Snapshot(context.Background())
+	cache.Restore(context.Background())
+
+	s.Equal(0, s.store.uploads)
+	s.Equal(0, s.store.downloads)
+}
+
+func (s *CacheManagerSuite) Test_Disabled_WhenNoDirs() {
+	s.opts.Build.CacheDirs = nil
+
+	newCacheManager(s.opts).Snapshot(context.Background())
+
+	s.Equal(0, s.store.uploads)
+}
+
+func (s *CacheManagerSuite) Test_InvalidDirs_AreSkipped() {
+	s.opts.Build.CacheDirs = []string{"../escape", "/absolute", "node_modules"}
+
+	s.Equal([]string{"node_modules"}, newCacheManager(s.opts).dirs())
+}
+
+func (s *CacheManagerSuite) Test_Disabled_WhenAllDirsInvalid() {
+	s.opts.Build.CacheDirs = []string{"../escape", "/absolute"}
+
+	s.False(newCacheManager(s.opts).enabled())
+}
+
+func (s *CacheManagerSuite) Test_Snapshot_SkipsMissingDirs() {
+	s.writeWorkDirFile("node_modules/pkg/index.js", "cached")
+
+	// .next/cache does not exist; only node_modules should be archived.
+	newCacheManager(s.opts).Snapshot(context.Background())
+
+	s.Equal(1, s.store.uploads)
+
+	s.Require().NoError(os.RemoveAll(s.opts.WorkDir))
+	s.Require().NoError(os.MkdirAll(s.opts.WorkDir, 0775))
+
+	newCacheManager(s.opts).Restore(context.Background())
+
+	s.FileExists(path.Join(s.opts.WorkDir, "node_modules/pkg/index.js"))
+	s.NoDirExists(path.Join(s.opts.WorkDir, ".next"))
+}
+
+func (s *CacheManagerSuite) Test_Snapshot_NoUpload_WhenNoDirsExist() {
+	newCacheManager(s.opts).Snapshot(context.Background())
+
+	s.Equal(0, s.store.uploads)
+}
+
+func TestCacheManagerSuite(t *testing.T) {
+	suite.Run(t, new(CacheManagerSuite))
+}

--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -194,6 +194,7 @@ type BuildOpts struct {
 	EnvID            string
 	MigrationsFolder string
 	StatusChecks     []buildconf.StatusCheck
+	CacheDirs        []string // Directories (relative to WorkDir) restored before install and snapshotted after a successful build; empty disables caching
 }
 
 type RunnerOpts struct {
@@ -287,6 +288,7 @@ func Start(payload, rootDir string) error {
 			MigrationsFolder: trim(msg.Build.MigrationsFolder),
 			StatusChecks:     msg.Build.StatusChecks,
 			EnvVars:          msg.Build.Vars,
+			CacheDirs:        msg.Build.CacheDirs,
 		},
 		Uploader:    &msg.Config.RunnerConfig,
 		AutoInstall: msg.Config.AutoInstall,
@@ -386,6 +388,9 @@ func Run(opts RunnerOpts) *RunResult {
 		return &RunResult{opts: opts, err: err}
 	}
 
+	cache := newCacheManager(opts)
+	cache.Restore(ctx)
+
 	if err := installer.Install(ctx); err != nil {
 		return &RunResult{opts: opts, err: err}
 	}
@@ -423,6 +428,8 @@ func Run(opts RunnerOpts) *RunResult {
 	}
 
 	opts.Reporter.AddStep("[system] building finished")
+
+	cache.Snapshot(ctx)
 
 	manifest = &deploy.BuildManifest{
 		Success:  err == nil,

--- a/src/lib/integrations/cache_store.go
+++ b/src/lib/integrations/cache_store.go
@@ -1,0 +1,35 @@
+package integrations
+
+import (
+	"context"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+// CacheArtifactArgs identifies a build cache archive. Cache archives are
+// scoped per environment: previews deploying to the same environment share
+// a cache, while environments and applications never share one.
+type CacheArtifactArgs struct {
+	AppID      types.ID
+	EnvID      types.ID
+	BucketName string // Optional bucket override. Falls back to the provider's configured bucket.
+	LocalPath  string // Absolute path of the local archive to upload from or download to.
+}
+
+// CacheStore is implemented by storage clients that can persist build cache
+// archives between deployments. The runner type-asserts the configured client
+// against this interface; providers that do not implement it simply skip
+// build caching.
+type CacheStore interface {
+	// UploadCacheArtifact stores the archive at LocalPath, replacing any
+	// previous cache for the same environment.
+	UploadCacheArtifact(context.Context, CacheArtifactArgs) error
+
+	// DownloadCacheArtifact fetches the environment's cache archive into
+	// LocalPath. It returns false with a nil error on a cache miss.
+	DownloadCacheArtifact(context.Context, CacheArtifactArgs) (bool, error)
+
+	// DeleteCacheArtifact removes the environment's cache archive. Deleting
+	// a missing cache is not an error.
+	DeleteCacheArtifact(context.Context, CacheArtifactArgs) error
+}

--- a/src/lib/integrations/client_aws_cache.go
+++ b/src/lib/integrations/client_aws_cache.go
@@ -1,0 +1,98 @@
+package integrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+const cacheContentType = "application/gzip"
+
+// cacheKey returns the S3 key for an environment's build cache archive.
+// It lives under the app prefix (next to `{appID}/{deploymentID}/...`
+// deployment artifacts) so deleting the app prefix also removes caches.
+// The literal "cache" segment cannot collide with numeric deployment IDs.
+func (a *AWSClient) cacheKey(args CacheArtifactArgs) string {
+	return fmt.Sprintf("%d/cache/env-%d.tar.gz", args.AppID, args.EnvID)
+}
+
+func (a *AWSClient) cacheBucket(args CacheArtifactArgs) string {
+	bucketName := args.BucketName
+
+	if bucketName == "" && config.Get().AWS != nil {
+		bucketName = config.Get().AWS.StorageBucket
+	}
+
+	return bucketName
+}
+
+// UploadCacheArtifact implements CacheStore by streaming the archive to S3,
+// replacing any previous cache for the environment.
+func (a *AWSClient) UploadCacheArtifact(ctx context.Context, args CacheArtifactArgs) error {
+	f, err := os.Open(args.LocalPath)
+
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = a.uploader.Upload(ctx, &s3.PutObjectInput{
+		Bucket:               utils.Ptr(a.cacheBucket(args)),
+		Key:                  utils.Ptr(a.cacheKey(args)),
+		Body:                 f,
+		ContentType:          utils.Ptr(cacheContentType),
+		ServerSideEncryption: s3types.ServerSideEncryptionAes256,
+		ACL:                  s3types.ObjectCannedACLPrivate,
+	})
+
+	return err
+}
+
+// DownloadCacheArtifact implements CacheStore by downloading the archive
+// into LocalPath. It returns false with a nil error on a cache miss.
+func (a *AWSClient) DownloadCacheArtifact(ctx context.Context, args CacheArtifactArgs) (bool, error) {
+	f, err := os.Create(args.LocalPath)
+
+	if err != nil {
+		return false, err
+	}
+
+	defer f.Close()
+
+	_, err = a.downloader.Download(ctx, f, &s3.GetObjectInput{
+		Bucket: utils.Ptr(a.cacheBucket(args)),
+		Key:    utils.Ptr(a.cacheKey(args)),
+	})
+
+	if err != nil {
+		os.Remove(args.LocalPath)
+
+		var nsk *s3types.NoSuchKey
+
+		if errors.As(err, &nsk) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+// DeleteCacheArtifact implements CacheStore. Deleting a missing cache is a
+// no-op on S3, so this is safe to call unconditionally.
+func (a *AWSClient) DeleteCacheArtifact(ctx context.Context, args CacheArtifactArgs) error {
+	_, err := a.S3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: utils.Ptr(a.cacheBucket(args)),
+		Key:    utils.Ptr(a.cacheKey(args)),
+	})
+
+	return err
+}

--- a/src/lib/integrations/client_filesystem_cache.go
+++ b/src/lib/integrations/client_filesystem_cache.go
@@ -1,0 +1,68 @@
+package integrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/file"
+)
+
+// cachePath returns the on-disk location of an environment's build cache
+// archive, stored under the deployer's storage directory next to the
+// deployment artifacts.
+func (c *FilesysClient) cachePath(args CacheArtifactArgs) string {
+	return path.Join(
+		config.Get().Deployer.StorageDir,
+		"cache",
+		fmt.Sprintf("app-%d", args.AppID),
+		fmt.Sprintf("env-%d.tar.gz", args.EnvID),
+	)
+}
+
+// UploadCacheArtifact implements CacheStore by copying the archive into the
+// storage directory, replacing any previous cache for the environment.
+func (c *FilesysClient) UploadCacheArtifact(ctx context.Context, args CacheArtifactArgs) error {
+	dest := c.cachePath(args)
+
+	if err := os.MkdirAll(path.Dir(dest), 0774); err != nil {
+		return err
+	}
+
+	return file.Copy(args.LocalPath, dest, 0664)
+}
+
+// DownloadCacheArtifact implements CacheStore by copying the archive to
+// LocalPath. It returns false with a nil error on a cache miss.
+func (c *FilesysClient) DownloadCacheArtifact(ctx context.Context, args CacheArtifactArgs) (bool, error) {
+	src := c.cachePath(args)
+
+	if _, err := os.Stat(src); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if err := file.Copy(src, args.LocalPath, 0664); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// DeleteCacheArtifact implements CacheStore. Deleting a missing cache is
+// not an error.
+func (c *FilesysClient) DeleteCacheArtifact(ctx context.Context, args CacheArtifactArgs) error {
+	err := os.Remove(c.cachePath(args))
+
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return nil
+}

--- a/src/lib/integrations/client_filesystem_cache_test.go
+++ b/src/lib/integrations/client_filesystem_cache_test.go
@@ -1,0 +1,107 @@
+package integrations_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
+	"github.com/stretchr/testify/suite"
+)
+
+type FilesysCacheStoreSuite struct {
+	suite.Suite
+
+	prevStorageDir string
+	localDir       string
+}
+
+func (s *FilesysCacheStoreSuite) SetupTest() {
+	s.prevStorageDir = config.Get().Deployer.StorageDir
+	config.Get().Deployer.StorageDir = s.T().TempDir()
+	s.localDir = s.T().TempDir()
+}
+
+func (s *FilesysCacheStoreSuite) TearDownTest() {
+	config.Get().Deployer.StorageDir = s.prevStorageDir
+}
+
+func (s *FilesysCacheStoreSuite) args(localPath string) integrations.CacheArtifactArgs {
+	return integrations.CacheArtifactArgs{
+		AppID:     1,
+		EnvID:     2,
+		LocalPath: localPath,
+	}
+}
+
+func (s *FilesysCacheStoreSuite) Test_UploadDownloadDelete_RoundTrip() {
+	ctx := context.Background()
+	client := integrations.Filesys()
+
+	archive := path.Join(s.localDir, "cache.tar.gz")
+	s.Require().NoError(os.WriteFile(archive, []byte("archive-content"), 0664))
+
+	s.NoError(client.UploadCacheArtifact(ctx, s.args(archive)))
+
+	downloaded := path.Join(s.localDir, "downloaded.tar.gz")
+	found, err := client.DownloadCacheArtifact(ctx, s.args(downloaded))
+
+	s.NoError(err)
+	s.True(found)
+
+	content, err := os.ReadFile(downloaded)
+
+	s.NoError(err)
+	s.Equal("archive-content", string(content))
+
+	s.NoError(client.DeleteCacheArtifact(ctx, s.args(archive)))
+
+	found, err = client.DownloadCacheArtifact(ctx, s.args(downloaded))
+
+	s.NoError(err)
+	s.False(found)
+}
+
+func (s *FilesysCacheStoreSuite) Test_Download_CacheMiss() {
+	found, err := integrations.Filesys().DownloadCacheArtifact(
+		context.Background(),
+		s.args(path.Join(s.localDir, "missing.tar.gz")),
+	)
+
+	s.NoError(err)
+	s.False(found)
+}
+
+func (s *FilesysCacheStoreSuite) Test_Delete_MissingCache_IsNotAnError() {
+	s.NoError(integrations.Filesys().DeleteCacheArtifact(
+		context.Background(),
+		s.args(""),
+	))
+}
+
+func (s *FilesysCacheStoreSuite) Test_CachesAreScopedPerEnvironment() {
+	ctx := context.Background()
+	client := integrations.Filesys()
+
+	archive := path.Join(s.localDir, "cache.tar.gz")
+	s.Require().NoError(os.WriteFile(archive, []byte("env-2-cache"), 0664))
+
+	s.NoError(client.UploadCacheArtifact(ctx, s.args(archive)))
+
+	otherEnv := integrations.CacheArtifactArgs{
+		AppID:     1,
+		EnvID:     3,
+		LocalPath: path.Join(s.localDir, "other.tar.gz"),
+	}
+
+	found, err := client.DownloadCacheArtifact(ctx, otherEnv)
+
+	s.NoError(err)
+	s.False(found)
+}
+
+func TestFilesysCacheStoreSuite(t *testing.T) {
+	suite.Run(t, new(FilesysCacheStoreSuite))
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
@@ -2,8 +2,11 @@ import { RenderResult, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, type Mock, beforeEach } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { AuthContext } from "~/pages/auth/Auth.context";
+import { RootContext } from "~/pages/Root.context";
 import mockApp from "~/testing/data/mock_app";
 import mockEnvironments from "~/testing/data/mock_environments";
+import mockUser from "~/testing/data/mock_user";
 import { mockUpdateEnvironment } from "~/testing/nocks/nock_environment";
 import TabConfigBuild from "./TabConfigBuild";
 
@@ -11,6 +14,8 @@ interface WrapperProps {
   app?: App;
   environment?: Environment;
   setRefreshToken?: () => void;
+  user?: User;
+  edition?: InstanceDetails["stormkit"]["edition"];
 }
 
 describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx", () => {
@@ -19,17 +24,32 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
   let currentEnv: Environment;
   let setRefreshToken: Mock;
 
-  const createWrapper = ({ app, environment }: WrapperProps) => {
+  const createWrapper = ({
+    app,
+    environment,
+    user,
+    edition = "self-hosted",
+  }: WrapperProps) => {
     setRefreshToken = vi.fn();
     currentApp = app || mockApp();
     currentEnv = environment || mockEnvironments({ app: currentApp })[0];
 
     wrapper = render(
-      <TabConfigBuild
-        app={currentApp}
-        environment={currentEnv}
-        setRefreshToken={setRefreshToken}
-      />
+      <RootContext.Provider
+        value={{
+          mode: "dark",
+          setMode: () => {},
+          details: { stormkit: { edition, apiCommit: "", apiVersion: "" } },
+        }}
+      >
+        <AuthContext.Provider value={{ user: user || mockUser() }}>
+          <TabConfigBuild
+            app={currentApp}
+            environment={currentEnv}
+            setRefreshToken={setRefreshToken}
+          />
+        </AuthContext.Provider>
+      </RootContext.Provider>
     );
   };
 
@@ -57,6 +77,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
       expect(wrapper.getByLabelText("Build command")).toBeTruthy();
       expect(wrapper.getByLabelText("Output folder")).toBeTruthy();
       expect(wrapper.getByLabelText("Build root")).toBeTruthy();
+      expect(wrapper.getByLabelText("Cache directories")).toBeTruthy();
     });
 
     it("should update the environment", async () => {
@@ -72,12 +93,17 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
 
       await userEvent.type(wrapper.getByLabelText("Output folder"), "dist");
 
+      fireEvent.change(wrapper.getByLabelText("Cache directories"), {
+        target: { value: ".next/cache\nnode_modules" },
+      });
+
       const scope = mockUpdateEnvironment({
         payload: {
           installCmd: "go get .",
           buildCmd: "go build .",
           distFolder: "./dist",
           workDir: "./",
+          cacheDirs: [".next/cache", "node_modules"],
         },
         status: 200,
         response: { ok: true },
@@ -92,6 +118,33 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
     });
   });
 
+  describe("build cache gating", () => {
+    it("is editable for premium users on cloud", () => {
+      createWrapper({ user: mockUser({ packageId: "premium" }), edition: "cloud" });
+
+      const field = wrapper.getByLabelText("Cache directories");
+
+      expect(field.hasAttribute("disabled")).toBe(false);
+    });
+
+    it("is disabled with an upsell for free users on cloud", () => {
+      createWrapper({ user: mockUser({ packageId: "free" }), edition: "cloud" });
+
+      const field = wrapper.getByLabelText("Cache directories");
+
+      expect(field.hasAttribute("disabled")).toBe(true);
+      expect(wrapper.getByText("Upgrade to enterprise")).toBeTruthy();
+    });
+
+    it("is editable on self-hosted regardless of package", () => {
+      createWrapper({ user: mockUser({ packageId: "free" }), edition: "self-hosted" });
+
+      const field = wrapper.getByLabelText("Cache directories");
+
+      expect(field.hasAttribute("disabled")).toBe(false);
+    });
+  });
+
   it("pre-configured state", () => {
     currentApp = mockApp();
     currentEnv = mockEnvironments({ app: currentApp })[0];
@@ -99,6 +152,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
     currentEnv.build.buildCmd = "go build main.go";
     currentEnv.build.distFolder = "./";
     currentEnv.build.workDir = "./root";
+    currentEnv.build.cacheDirs = [".next/cache", "node_modules"];
 
     createWrapper({ environment: currentEnv });
 
@@ -106,5 +160,10 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
     expect(wrapper.getByDisplayValue("go build main.go")).toBeTruthy();
     expect(wrapper.getByDisplayValue("./")).toBeTruthy();
     expect(wrapper.getByDisplayValue("./root")).toBeTruthy();
+    const cacheField = wrapper.getByLabelText(
+      "Cache directories"
+    ) as HTMLTextAreaElement;
+
+    expect(cacheField.value).toBe(".next/cache\nnode_modules");
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
@@ -1,11 +1,14 @@
 import type { FormValues } from "../actions";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import { AuthContext } from "~/pages/auth/Auth.context";
+import { RootContext } from "~/pages/Root.context";
 import Card from "~/components/Card";
 import CardHeader from "~/components/CardHeader";
 import CardFooter from "~/components/CardFooter";
+import UpgradeButton from "~/components/UpgradeButton";
 import {
   updateEnvironment,
   buildFormValues,
@@ -23,10 +26,19 @@ export default function TabConfigGeneral({
   app,
   setRefreshToken,
 }: Props) {
+  const { user } = useContext(AuthContext);
+  const { details } = useContext(RootContext);
   const [error, setError] = useState<string>();
   const [success, setSuccess] = useState<string>();
   const [isLoading, setLoading] = useState(false);
   const [root, setRoot] = useState(env?.build?.workDir || "./");
+
+  // Build caching is available on self-hosted instances and for premium or
+  // ultimate subscriptions on Stormkit Cloud.
+  const isCacheAllowed =
+    details?.stormkit?.edition !== "cloud" ||
+    user?.package.id === "premium" ||
+    user?.package.id === "ultimate";
 
   if (!env) {
     return <></>;
@@ -59,6 +71,7 @@ export default function TabConfigGeneral({
             buildCmd: build.buildCmd,
             distFolder: build.distFolder,
             workDir: build.workDir,
+            cacheDirs: build.cacheDirs,
           },
           setError,
           setLoading,
@@ -143,6 +156,33 @@ export default function TabConfigGeneral({
           fullWidth
           placeholder="Defaults to `./`"
           helperText={"The working directory relative to the Repository root."}
+        />
+      </Box>
+      <Box sx={{ mb: 4 }}>
+        <TextField
+          label="Cache directories"
+          variant="filled"
+          autoComplete="off"
+          multiline
+          minRows={2}
+          disabled={!isCacheAllowed}
+          defaultValue={env?.build.cacheDirs?.join("\n") || ""}
+          fullWidth
+          name="build.cacheDirs"
+          placeholder={".next/cache\n.turbo"}
+          helperText={
+            isCacheAllowed ? (
+              "One directory per line, relative to the build root. Restored before the install step and saved after a successful build. Best for compiler caches like .next/cache, .turbo or node's build cache; caching node_modules helps incremental installs but not `npm ci`, which wipes it first. Leave empty to disable caching."
+            ) : (
+              <>
+                Build caching speeds up deployments by reusing directories like{" "}
+                <Box component="code" sx={{ fontSize: 11, px: 0.5, py: 0.25 }}>
+                  .next/cache
+                </Box>{" "}
+                between builds. <UpgradeButton variant="text" /> to enable it.
+              </>
+            )
+          }
         />
       </Box>
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -63,6 +63,16 @@ export const prepareBuildObject = (values: FormValues): BuildConfig => {
     } catch {}
   }
 
+  // One directory per line; an empty textarea clears the list.
+  let cacheDirs: string[] | undefined;
+
+  if (values["build.cacheDirs"] !== undefined) {
+    cacheDirs = values["build.cacheDirs"]
+      .split("\n")
+      .map(dir => dir.trim())
+      .filter(Boolean);
+  }
+
   const build: BuildConfig = {
     buildCmd: values["build.buildCmd"]?.trim() || "",
     serverCmd: values["build.serverCmd"]?.trim() || "",
@@ -79,6 +89,7 @@ export const prepareBuildObject = (values: FormValues): BuildConfig => {
     priorityPattern: values["build.priorityPattern"]?.trim() || "",
     statusChecks,
     redirects,
+    cacheDirs,
     vars,
   };
 
@@ -184,6 +195,7 @@ export interface EnvUpdatePayload {
   statusChecks?: StatusCheck[];
   redirects?: Redirect[];
   envVars?: Record<string, string>;
+  cacheDirs?: string[];
 }
 
 export interface FormValues {
@@ -201,6 +213,7 @@ export interface FormValues {
   "build.installCmd"?: string;
   "build.distFolder"?: string;
   "build.workDir"?: string;
+  "build.cacheDirs"?: string;
   "build.headers"?: string;
   "build.headersFile"?: string;
   "build.errorFile"?: string;

--- a/src/ui/src/types/environment.d.ts
+++ b/src/ui/src/types/environment.d.ts
@@ -21,6 +21,7 @@ declare type BuildConfig = {
   serverFolder?: string; // @deprecated: use distFolder instead.
   statusChecks?: StatusCheck[];
   priorityPattern?: string;
+  cacheDirs?: string[]; // Directories restored before install and snapshotted after a successful build
   vars: Record<string, string>;
 };
 


### PR DESCRIPTION
## What

Adds a per-environment **build cache**: directories listed in the new `cacheDirs` build config (e.g. `.next/cache`, `node_modules`) are restored before the install step and snapshotted after a successful build, making subsequent deployments significantly faster.

## How it works

- **Config**: new `cacheDirs` field on the environment build config (`PUT /v1/env`), validated so every entry stays inside the build working directory (no absolute paths, no `..`).
- **Storage**: a new `CacheStore` abstraction in `lib/integrations`, implemented for AWS S3 and the filesystem provider. Caches are stored per app/environment (`{appID}/cache/env-{envID}.tar.gz` on S3, `{StorageDir}/cache/app-{appID}/env-{envID}.tar.gz` on disk) and overwritten on each successful build, so storage stays bounded at one archive per environment. Providers that don't implement the interface simply skip caching.
- **Runner**: a `cacheManager` restores the archive after checkout (before install) and snapshots after a successful build. All cache operations are best-effort: failures are logged to the build output but never fail the deployment. Snapshots are capped at 2GiB.
- **Gating**: on Stormkit Cloud the feature requires a premium or ultimate subscription (enforced server-side at deploy time via the team owner's package; free users get a normal uncached build). Self-hosted instances always have it enabled. The UI shows the field disabled with an upgrade hint for free cloud users.

## Notes

- The deployer now resolves the owner's package via a dedicated `PackageNameByAppID` query instead of `UserMetrics`, which returns no row until the first usage entry of the month exists.
- The new deployer tests capture the enqueued task with a mock `TaskClient` instead of round-tripping through Redis — asynq's client caches queue registrations, so `DeleteQueue`-based cleanup makes subsequent enqueues invisible to the inspector.

## Follow-ups (separate PRs)

- "Clear cache & redeploy" action (storage delete exists already via `DeleteCacheArtifact`)
- Cache eviction for idle environments (S3 lifecycle rule / cleanup job)

## Testing

- Go: new suites for cache dir validation, the deployer gate (cloud premium/free/self-hosted), the runner snapshot/restore round-trip (real tar), and the filesystem cache store. Affected packages pass with `-p 1`.
- UI: TabConfigBuild specs extended for the new field and gating (6 passing).