### PR TITLE
fix: log building finished after cache snapshot

### DIFF
--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -427,9 +427,9 @@ func Run(opts RunnerOpts) *RunResult {
 		return &RunResult{opts: opts, err: err}
 	}
 
-	opts.Reporter.AddStep("[system] building finished")
-
 	cache.Snapshot(ctx)
+
+	opts.Reporter.AddStep("[system] building finished")
 
 	manifest = &deploy.BuildManifest{
 		Success:  err == nil,


### PR DESCRIPTION
## Problem

After adding the build-cache steps (#346), the `database migrations` step showed a negative duration (e.g. -50s) in the deployment logs UI.

## Cause

Step durations are computed as `next step ts − current step ts`, and the synthetic `deploy` step takes its timestamp from the `[system] building finished` marker. The runner emitted that marker *before* `cache.Snapshot()`, so:

- `saving build cache` absorbed ~50s (correct by coincidence)
- `database migrations` (stamped server-side after upload) ended up *later* than the deploy step's timestamp → negative duration
- `deploy` was inflated by the cache-save time

## Fix

Emit the `building finished` marker after the cache snapshot, so the deploy phase start is stamped once the snapshot is done.