### PR TITLE
fix: skip cache upload when contents unchanged

### DIFF
--- a/src/ce/runner/cache.go
+++ b/src/ce/runner/cache.go
@@ -2,9 +2,15 @@ package runner
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
+	"sort"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
@@ -27,6 +33,11 @@ var DefaultCacheStore integrations.CacheStore
 type cacheManager struct {
 	opts        RunnerOpts
 	archivePath string
+
+	// restoredHash is the content hash of the cache directories right after
+	// Restore extracted them. Snapshot compares against it to skip the upload
+	// when the build did not change the cached contents.
+	restoredHash string
 }
 
 func newCacheManager(opts RunnerOpts) *cacheManager {
@@ -135,10 +146,93 @@ func (c *cacheManager) Restore(ctx context.Context) {
 	}
 
 	c.opts.Reporter.AddLine(fmt.Sprintf("restored cached directories: %v", c.dirs()))
+
+	if hash, err := c.contentHash(ctx); err != nil {
+		slog.Errorf("could not hash restored build cache: %v", err)
+	} else {
+		c.restoredHash = hash
+	}
+}
+
+// contentHash digests the paths and contents of all files inside the cache
+// directories. It hashes contents rather than modification times, which
+// package managers rewrite on every install even when nothing changed.
+func (c *cacheManager) contentHash(ctx context.Context) (string, error) {
+	hash := sha256.New()
+	dirs := c.dirs()
+
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		root := path.Join(c.opts.WorkDir, dir)
+
+		if stat, err := os.Stat(root); err != nil || !stat.IsDir() {
+			continue
+		}
+
+		err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			rel, err := filepath.Rel(c.opts.WorkDir, p)
+
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(hash, "%s\x00", rel)
+
+			if d.Type()&fs.ModeSymlink != 0 {
+				target, err := os.Readlink(p)
+
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintf(hash, "->%s\x00", target)
+
+				return nil
+			}
+
+			if !d.Type().IsRegular() {
+				return nil
+			}
+
+			f, err := os.Open(p)
+
+			if err != nil {
+				return err
+			}
+
+			defer f.Close()
+
+			if _, err := io.Copy(hash, f); err != nil {
+				return err
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // Snapshot archives the cache directories and uploads them, replacing the
-// environment's previous cache. It runs after a successful build.
+// environment's previous cache. It runs after a successful build. When the
+// contents are unchanged since Restore, the archive and upload are skipped.
 func (c *cacheManager) Snapshot(ctx context.Context) {
 	if !c.enabled() {
 		return
@@ -164,6 +258,13 @@ func (c *cacheManager) Snapshot(ctx context.Context) {
 	}
 
 	c.opts.Reporter.AddStep("saving build cache")
+
+	if hash, err := c.contentHash(ctx); err != nil {
+		slog.Errorf("could not hash build cache: %v", err)
+	} else if c.restoredHash != "" && hash == c.restoredHash {
+		c.opts.Reporter.AddLine("build cache unchanged - skipping upload")
+		return
+	}
 
 	defer os.Remove(c.archivePath)
 

--- a/src/ce/runner/cache_test.go
+++ b/src/ce/runner/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/file"
@@ -166,6 +167,85 @@ func (s *CacheManagerSuite) Test_Snapshot_SkipsMissingDirs() {
 
 	s.FileExists(path.Join(s.opts.WorkDir, "node_modules/pkg/index.js"))
 	s.NoDirExists(path.Join(s.opts.WorkDir, ".next"))
+}
+
+func (s *CacheManagerSuite) Test_Snapshot_SkipsUpload_WhenUnchanged() {
+	ctx := context.Background()
+
+	s.writeWorkDirFile("node_modules/pkg/index.js", "module.exports = {}")
+
+	newCacheManager(s.opts).Snapshot(ctx)
+
+	s.Equal(1, s.store.uploads)
+
+	s.Require().NoError(os.RemoveAll(s.opts.WorkDir))
+	s.Require().NoError(os.MkdirAll(s.opts.WorkDir, 0775))
+
+	cache := newCacheManager(s.opts)
+	cache.Restore(ctx)
+
+	// Package managers rewrite modification times on every install; only a
+	// content change should trigger a re-upload.
+	newTime := time.Now().Add(time.Hour)
+	s.Require().NoError(os.Chtimes(path.Join(s.opts.WorkDir, "node_modules/pkg/index.js"), newTime, newTime))
+
+	cache.Snapshot(ctx)
+
+	s.Equal(1, s.store.uploads)
+}
+
+func (s *CacheManagerSuite) Test_Snapshot_Uploads_WhenContentChanged() {
+	ctx := context.Background()
+
+	s.writeWorkDirFile("node_modules/pkg/index.js", "module.exports = {}")
+
+	newCacheManager(s.opts).Snapshot(ctx)
+
+	s.Require().NoError(os.RemoveAll(s.opts.WorkDir))
+	s.Require().NoError(os.MkdirAll(s.opts.WorkDir, 0775))
+
+	cache := newCacheManager(s.opts)
+	cache.Restore(ctx)
+
+	// Same byte length as the original content: a size check would miss this.
+	s.writeWorkDirFile("node_modules/pkg/index.js", "module.exports = []")
+
+	cache.Snapshot(ctx)
+
+	s.Equal(2, s.store.uploads)
+}
+
+func (s *CacheManagerSuite) Test_Snapshot_Uploads_WhenNewDirAppears() {
+	ctx := context.Background()
+
+	s.writeWorkDirFile("node_modules/pkg/index.js", "module.exports = {}")
+
+	newCacheManager(s.opts).Snapshot(ctx)
+
+	s.Require().NoError(os.RemoveAll(s.opts.WorkDir))
+	s.Require().NoError(os.MkdirAll(s.opts.WorkDir, 0775))
+
+	cache := newCacheManager(s.opts)
+	cache.Restore(ctx)
+
+	s.writeWorkDirFile(".next/cache/build.json", "{}")
+
+	cache.Snapshot(ctx)
+
+	s.Equal(2, s.store.uploads)
+}
+
+func (s *CacheManagerSuite) Test_Snapshot_Uploads_OnCacheMiss() {
+	ctx := context.Background()
+
+	cache := newCacheManager(s.opts)
+	cache.Restore(ctx)
+
+	s.writeWorkDirFile("node_modules/pkg/index.js", "module.exports = {}")
+
+	cache.Snapshot(ctx)
+
+	s.Equal(1, s.store.uploads)
 }
 
 func (s *CacheManagerSuite) Test_Snapshot_NoUpload_WhenNoDirsExist() {


### PR DESCRIPTION
## Summary

The build cache snapshot re-archived and re-uploaded the cache directories on every successful build, even when nothing changed — a same-commit rebuild paid the full tar + upload cost for a byte-identical cache.

The cache manager now records a content hash of the cache directories right after `Restore` extracts them, and recomputes it before `Snapshot`. When the hashes match, both the archive and the upload are skipped, and the build log shows `build cache unchanged - skipping upload`.

## Design notes

- The hash covers file paths, symlink targets, and file **contents** — not modification times, which package managers rewrite on every install even when nothing changed. A content change of identical size is still detected (covered by a test).
- The hash lives in memory on the `cacheManager`: the same runner process performs both `Restore` and `Snapshot`, so no storage-interface changes or sidecar objects are needed.
- Hashing stays best-effort, consistent with the rest of the cache manager: any hashing error is logged and falls back to uploading, never failing the deployment.
- On a cache miss (no previous archive) the recorded hash is empty and the snapshot always uploads.

## Tests

- unchanged contents after restore → upload skipped, even with rewritten mtimes
- content change of identical byte length → re-uploads
- new cache directory appearing after the build → re-uploads
- cache miss → uploads