### PR TITLE
feat: add maintenance mode toggle

### DIFF
--- a/src/ce/api/app/appconf/appconf_model.go
+++ b/src/ce/api/app/appconf/appconf_model.go
@@ -39,5 +39,6 @@ type Config struct {
 	CustomHeaders    []deploy.CustomHeader `json:"-"` // Parsed user-configured header rules; matched against request path at response time.
 	SKAuth           *buildconf.SKAuthConf `json:"-"`
 	AuthWall         string                `json:"authWall,omitempty"`     // Whether to display an auth wall or not. Possible values: dev | all
+	Maintenance      string                `json:"maintenance,omitempty"`  // Whether the environment is in maintenance mode. Possible values: on
 	IsEnterprise     bool                  `json:"isEnterprise,omitempty"` // Whether the app is running in enterprise mode
 }

--- a/src/ce/api/app/appconf/appconf_model_test.go
+++ b/src/ce/api/app/appconf/appconf_model_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/authwall"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/redirects"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -125,6 +126,22 @@ func (s *appconfSuite) SetupSuite() {
 
 func (s *appconfSuite) AfterTest(_, _ string) {
 	authwall.Store().SetAuthWallConfig(context.Background(), s.env.ID, nil)
+	maintenance.Store().SetConfig(context.Background(), s.env.ID, nil)
+}
+
+func (s *appconfSuite) Test_ByDeploymentID_Maintenance() {
+	s.NoError(maintenance.Store().SetConfig(context.Background(), s.env.ID, &maintenance.Config{
+		Status: "on",
+	}))
+
+	configs, err := appconf.NewStore().Configs(s.ctx, appconf.ConfigFilters{
+		DeploymentID: s.depl.ID,
+		DisplayName:  s.app.DisplayName,
+	})
+
+	s.NoError(err)
+	s.Len(configs, 1)
+	s.Equal("on", configs[0].Maintenance)
 }
 
 func (s *appconfSuite) TearDownSuite() {

--- a/src/ce/api/app/appconf/appconf_store.go
+++ b/src/ce/api/app/appconf/appconf_store.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/authwall"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
@@ -83,6 +84,7 @@ var stmt = &statement{
 				e.build_conf							 			 as build_conf,
 				e.auth_wall_conf						 			 as auth_wall_conf,
 				e.auth_conf											 as auth_conf,
+				e.maintenance_conf									 as maintenance_conf,
 				coalesce(dp.percentage_released, 0)		 			 as percentage,
 				a.display_name,
 				coalesce(u.metadata->>'package', 'free') 			 as subscription_tier,
@@ -136,7 +138,7 @@ var stmt = &statement{
 			d.manifest, d.build_conf_snapshot, d.env_updated, d.build_conf, d.percentage,
 			coalesce(d.cert_value, '') as cert_value,
 			coalesce(d.cert_key, '') as cert_key,
-			d.domain_id, d.auth_wall_conf, d.auth_conf,
+			d.domain_id, d.auth_wall_conf, d.auth_conf, d.maintenance_conf,
 			(SELECT json_data FROM snippets) as snippets,
 			d.display_name, d.env_name, d.subscription_tier, d.billing_user_id
 		FROM deployment d
@@ -312,6 +314,7 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 		var envName string
 		var tier string
 		authwall := authwall.Config{}
+		maintenanceCnf := maintenance.Config{}
 		cnf := &Config{}
 		err := rows.Scan(
 			&cnf.AppID, &cnf.DeploymentID, &cnf.EnvID,
@@ -319,7 +322,7 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 			&cnf.APILocation, &cnf.APIPathPrefix,
 			&buildManifest, &buildConfSnapshot, &cnf.UpdatedAt, &buildConf,
 			&cnf.Percentage, &certVal, &certKey, &cnf.DomainID,
-			&authwall, &authConf, &cnf.Snippets, &displayName, &envName, &tier,
+			&authwall, &authConf, &maintenanceCnf, &cnf.Snippets, &displayName, &envName, &tier,
 			&cnf.BillingUserID,
 		)
 
@@ -408,6 +411,10 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 
 		if authwall.Status != "" {
 			cnf.AuthWall = authwall.Status
+		}
+
+		if maintenanceCnf.Status != "" {
+			cnf.Maintenance = maintenanceCnf.Status
 		}
 
 		if authConf != nil {

--- a/src/ce/api/app/maintenance/maintenance_model.go
+++ b/src/ce/api/app/maintenance/maintenance_model.go
@@ -1,0 +1,38 @@
+package maintenance
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+)
+
+const StatusOn = "on"
+const StatusDisabled = ""
+
+// Config is the per-environment maintenance mode configuration. It is stored
+// as jsonb so future iterations (custom redirect, custom HTML) can extend it
+// without a schema change.
+type Config struct {
+	Status string `json:"status"`
+}
+
+// Scan implements the Scanner interface.
+func (cnf *Config) Scan(value any) error {
+	if value != nil {
+		if b, ok := value.([]byte); ok {
+			if err := json.Unmarshal(b, &cnf); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Value implements the Sql Driver interface.
+func (cnf *Config) Value() (driver.Value, error) {
+	if cnf == nil {
+		return nil, nil
+	}
+
+	return json.Marshal(cnf)
+}

--- a/src/ce/api/app/maintenance/maintenance_store.go
+++ b/src/ce/api/app/maintenance/maintenance_store.go
@@ -1,0 +1,56 @@
+package maintenance
+
+import (
+	"context"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/database"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+var stmt = struct {
+	setConfig    string
+	selectConfig string
+}{
+	setConfig: `
+		UPDATE apps_build_conf SET maintenance_conf = $1 WHERE env_id = $2;
+	`,
+	selectConfig: `
+		SELECT maintenance_conf FROM apps_build_conf WHERE env_id = $1;
+	`,
+}
+
+type store struct {
+	*database.Store
+}
+
+// Store returns a store instance.
+func Store() *store {
+	return &store{database.NewStore()}
+}
+
+// SetConfig stores the maintenance configuration for the environment.
+func (s *store) SetConfig(ctx context.Context, envID types.ID, cfg *Config) error {
+	_, err := s.Exec(ctx, stmt.setConfig, cfg, envID)
+	return err
+}
+
+// Config returns the maintenance configuration associated with the environment.
+func (s *store) Config(ctx context.Context, envID types.ID) (*Config, error) {
+	row, err := s.QueryRow(ctx, stmt.selectConfig, envID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if row == nil {
+		return nil, nil
+	}
+
+	cfg := &Config{}
+
+	if err := row.Scan(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/src/ce/api/app/maintenance/maintenancehandlers/handler_config_get.go
+++ b/src/ce/api/app/maintenance/maintenancehandlers/handler_config_get.go
@@ -1,0 +1,24 @@
+package maintenancehandlers
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+func handlerConfigGet(req *app.RequestContext) *shttp.Response {
+	cnf, err := maintenance.Store().Config(req.Context(), req.EnvID)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data: map[string]any{
+			"maintenance": cnf.Status,
+		},
+	}
+}

--- a/src/ce/api/app/maintenance/maintenancehandlers/handler_config_get_test.go
+++ b/src/ce/api/app/maintenance/maintenancehandlers/handler_config_get_test.go
@@ -1,0 +1,80 @@
+package maintenancehandlers_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance/maintenancehandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerConfigGetSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn databasetest.TestDB
+}
+
+func (s *HandlerConfigGetSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+	admin.SetMockLicense()
+}
+
+func (s *HandlerConfigGetSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+	admin.ResetMockLicense()
+}
+
+func (s *HandlerConfigGetSuite) Test_ConfigGet_Success() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	s.NoError(maintenance.Store().SetConfig(context.Background(), env.ID, &maintenance.Config{
+		Status: "on",
+	}))
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(maintenancehandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/maintenance/config?envId="+env.ID.String(),
+		nil,
+		map[string]string{
+			"authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(`{ "maintenance": "on" }`, response.String())
+}
+
+func (s *HandlerConfigGetSuite) Test_ConfigGet_SuccessEmptyState() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(maintenancehandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/maintenance/config?envId="+env.ID.String(),
+		nil,
+		map[string]string{
+			"authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(`{ "maintenance": "" }`, response.String())
+}
+
+func TestHandlerConfigGetSuite(t *testing.T) {
+	suite.Run(t, &HandlerConfigGetSuite{})
+}

--- a/src/ce/api/app/maintenance/maintenancehandlers/handler_config_set.go
+++ b/src/ce/api/app/maintenance/maintenancehandlers/handler_config_set.go
@@ -1,0 +1,83 @@
+package maintenancehandlers
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+type ConfigSetRequest struct {
+	Maintenance string `json:"maintenance"`
+}
+
+func handlerConfigSet(req *app.RequestContext) *shttp.Response {
+	data := ConfigSetRequest{}
+
+	if err := req.Post(&data); err != nil {
+		return shttp.Error(err)
+	}
+
+	cnf := &maintenance.Config{
+		Status: data.Maintenance,
+	}
+
+	availableOptions := []string{
+		maintenance.StatusOn,
+		maintenance.StatusDisabled,
+	}
+
+	if !utils.InSliceString(availableOptions, cnf.Status) {
+		return shttp.BadRequest(map[string]any{
+			"error": "Invalid maintenance status. Available options are: on | ''",
+		})
+	}
+
+	store := maintenance.Store()
+	current, err := store.Config(req.Context(), req.EnvID)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	if err := store.SetConfig(req.Context(), req.EnvID, cnf); err != nil {
+		return shttp.Error(err)
+	}
+
+	if err := appcache.Service().Reset(req.EnvID); err != nil {
+		return shttp.Error(err)
+	}
+
+	diff := &audit.Diff{
+		Old: audit.DiffFields{
+			MaintenanceStatus: "off",
+		},
+		New: audit.DiffFields{
+			MaintenanceStatus: "off",
+		},
+	}
+
+	if current != nil && current.Status != "" {
+		diff.Old.MaintenanceStatus = current.Status
+	}
+
+	if data.Maintenance != "" {
+		diff.New.MaintenanceStatus = data.Maintenance
+	}
+
+	if req.License().IsEnterprise() {
+		err = audit.FromRequestContext(req).
+			WithAction(audit.UpdateAction, audit.TypeMaintenance).
+			WithDiff(diff).
+			WithEnvID(req.EnvID).
+			Insert()
+
+		if err != nil {
+			return shttp.Error(err)
+		}
+	}
+
+	return shttp.OK()
+}

--- a/src/ce/api/app/maintenance/maintenancehandlers/handler_config_set_test.go
+++ b/src/ce/api/app/maintenance/maintenancehandlers/handler_config_set_test.go
@@ -1,0 +1,156 @@
+package maintenancehandlers_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance/maintenancehandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerConfigSetSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn             databasetest.TestDB
+	mockCacheService *mocks.CacheInterface
+}
+
+func (s *HandlerConfigSetSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+	s.mockCacheService = &mocks.CacheInterface{}
+	appcache.DefaultCacheService = s.mockCacheService
+	admin.SetMockLicense()
+}
+
+func (s *HandlerConfigSetSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+	appcache.DefaultCacheService = nil
+	admin.ResetMockLicense()
+}
+
+func (s *HandlerConfigSetSuite) Test_ConfigSet_Success() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	s.mockCacheService.On("Reset", types.ID(env.ID)).Return(nil).Once()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(maintenancehandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/maintenance/config",
+		map[string]any{
+			"envId":       env.ID.String(),
+			"maintenance": "on",
+		},
+		map[string]string{
+			"authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	config, err := maintenance.Store().Config(context.Background(), env.ID)
+	s.NoError(err)
+	s.NotNil(config)
+	s.Equal("on", config.Status)
+
+	audits, err := audit.NewStore().SelectAudits(context.Background(), audit.AuditFilters{
+		EnvID: env.ID,
+	})
+
+	s.NoError(err)
+	s.Len(audits, 1)
+	s.Equal(audit.Audit{
+		ID:          audits[0].ID,
+		Timestamp:   audits[0].Timestamp,
+		Action:      "UPDATE:MAINTENANCE",
+		EnvName:     env.Name,
+		EnvID:       env.ID,
+		AppID:       app.ID,
+		TeamID:      app.TeamID,
+		UserID:      usr.ID,
+		UserDisplay: usr.Display(),
+		Diff: &audit.Diff{
+			Old: audit.DiffFields{
+				MaintenanceStatus: "off",
+			},
+			New: audit.DiffFields{
+				MaintenanceStatus: maintenance.StatusOn,
+			},
+		},
+	}, audits[0])
+}
+
+func (s *HandlerConfigSetSuite) Test_ConfigSet_ResetSuccess() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	s.NoError(maintenance.Store().SetConfig(context.Background(), env.ID, &maintenance.Config{
+		Status: "on",
+	}))
+
+	s.mockCacheService.On("Reset", types.ID(env.ID)).Return(nil).Once()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(maintenancehandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/maintenance/config",
+		map[string]any{
+			"envId":       env.ID.String(),
+			"maintenance": "",
+		},
+		map[string]string{
+			"authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	config, err := maintenance.Store().Config(context.Background(), env.ID)
+	s.NoError(err)
+	s.NotNil(config)
+	s.Equal("", config.Status)
+}
+
+func (s *HandlerConfigSetSuite) Test_ConfigSet_InvalidOption() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(maintenancehandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/maintenance/config",
+		map[string]any{
+			"envId":       env.ID.String(),
+			"maintenance": "not-allowed",
+		},
+		map[string]string{
+			"authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	expected := `{ "error": "Invalid maintenance status. Available options are: on | ''" }`
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.JSONEq(expected, response.String())
+}
+
+func TestHandlerConfigSetSuite(t *testing.T) {
+	suite.Run(t, &HandlerConfigSetSuite{})
+}

--- a/src/ce/api/app/maintenance/maintenancehandlers/services.go
+++ b/src/ce/api/app/maintenance/maintenancehandlers/services.go
@@ -1,0 +1,20 @@
+package maintenancehandlers
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+// Services sets the handlers for this service. Maintenance mode is available
+// on all editions, so the endpoints are not gated behind a license check.
+func Services(r *shttp.Router) *shttp.Service {
+	s := r.NewService()
+
+	opts := &app.Opts{Env: true}
+
+	s.NewEndpoint("/maintenance").
+		Handler(shttp.MethodGet, "/config", app.WithApp(handlerConfigGet, opts)).
+		Handler(shttp.MethodPost, "/config", app.WithApp(handlerConfigSet, opts))
+
+	return s
+}

--- a/src/ce/api/router/router.go
+++ b/src/ce/api/router/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/mailerhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/snippetshandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy/deployhandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance/maintenancehandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/providerhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/redirects/redirectshandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
@@ -59,6 +60,7 @@ func Get() *shttp.Router {
 	r.RegisterService(providerhandlers.Services)
 	r.RegisterService(snippetshandlers.Services)
 	r.RegisterService(volumeshandlers.Services)
+	r.RegisterService(maintenancehandlers.Services)
 
 	// Enterprise handlers
 	r.RegisterService(authwallhandlers.Services)

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -71,6 +71,7 @@ func HandlerForward(req *RequestContext) (res *shttp.Response) {
 	middlewares := []func(req *RequestContext) (*shttp.Response, error){
 		WithAnalyticsScript,
 		WithCollect,
+		WithMaintenance,
 		WithSKAuth,
 		WithAuthWall,
 		WithRedirect,

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -1042,6 +1042,43 @@ func (s *HandlerForwardSuite) Test_ImageOptimization_PreviouslyCached() {
 	s.Equal([]byte("Image Content"), res.Data.([]byte))
 }
 
+func (s *HandlerForwardSuite) Test_Maintenance_Page() {
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			Maintenance: "on",
+		},
+	}
+
+	req := s.newRequest(host, "/my-page?with=query")
+	res := hosting.HandlerForward(req)
+	data := string(res.Data.([]byte))
+
+	s.Equal(http.StatusServiceUnavailable, res.Status)
+	s.Equal("text/html; charset=utf-8", res.Headers.Get("Content-Type"))
+	s.Equal("300", res.Headers.Get("Retry-After"))
+	s.Contains(data, "Under maintenance")
+	s.Contains(data, "temporarily unavailable")
+}
+
+func (s *HandlerForwardSuite) Test_Maintenance_TakesPrecedenceOverAuthWall() {
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			AuthWall:    "all",
+			Maintenance: "on",
+		},
+	}
+
+	req := s.newRequest(host, "/my-page")
+	res := hosting.HandlerForward(req)
+	data := string(res.Data.([]byte))
+
+	s.Equal(http.StatusServiceUnavailable, res.Status)
+	s.NotContains(data, `method="POST"`)
+	s.Contains(data, "Under maintenance")
+}
+
 func (s *HandlerForwardSuite) Test_AuthWall_LoginPage() {
 	admin.MustConfig().SetURL("http://stormkit:8888")
 

--- a/src/ce/hosting/middleware.maintenance.go
+++ b/src/ce/hosting/middleware.maintenance.go
@@ -1,0 +1,32 @@
+package hosting
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/maintenance"
+	"github.com/stormkit-io/stormkit-io/src/lib/html"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+// WithMaintenance blocks public traffic with a maintenance page while the
+// environment's maintenance mode is turned on. It returns a 503 so search
+// engines treat the downtime as temporary.
+func WithMaintenance(req *RequestContext) (*shttp.Response, error) {
+	if req.Host.Config.Maintenance != maintenance.StatusOn {
+		return nil, nil
+	}
+
+	content := html.MustRender(html.RenderArgs{
+		PageTitle:   "Under maintenance",
+		PageContent: html.Templates["maintenance"],
+	})
+
+	return &shttp.Response{
+		Status: http.StatusServiceUnavailable,
+		Data:   content,
+		Headers: http.Header{
+			"Content-Type": []string{"text/html; charset=utf-8"},
+			"Retry-After":  []string{"300"},
+		},
+	}, nil
+}

--- a/src/ee/api/audit/audit_model.go
+++ b/src/ee/api/audit/audit_model.go
@@ -22,15 +22,16 @@ const (
 )
 
 const (
-	TypeUser       string = "USER"
-	TypeApp        string = "APP"
-	TypeEnv        string = "ENV"
-	TypeTeam       string = "TEAM"
-	TypeDomain     string = "DOMAIN"
-	TypeSnippet    string = "SNIPPET"
-	TypeAuthWall   string = "AUTHWALL"
-	TypeSchema     string = "SCHEMA"
-	TypeDeployment string = "DEPLOYMENT"
+	TypeUser        string = "USER"
+	TypeApp         string = "APP"
+	TypeEnv         string = "ENV"
+	TypeTeam        string = "TEAM"
+	TypeDomain      string = "DOMAIN"
+	TypeSnippet     string = "SNIPPET"
+	TypeAuthWall    string = "AUTHWALL"
+	TypeMaintenance string = "MAINTENANCE"
+	TypeSchema      string = "SCHEMA"
+	TypeDeployment  string = "DEPLOYMENT"
 )
 
 // AuditData is the data extracted from a request context for auditing.
@@ -76,6 +77,7 @@ type DiffFields struct {
 	AuthWallCreateLoginEmail string                 `json:"authWallCreateLoginEmail,omitempty"`
 	AuthWallCreateLoginID    string                 `json:"authWallCreateLoginId,omitempty"`
 	AuthWallDeleteLoginIDs   string                 `json:"authWallDeleteLoginIds,omitempty"`
+	MaintenanceStatus        string                 `json:"maintenanceStatus,omitempty"`
 	SchemaName               string                 `json:"schemaName,omitempty"`
 	DeploymentID             string                 `json:"deploymentId,omitempty"`
 	AutoPublished            *bool                  `json:"autoPublished,omitempty"`

--- a/src/lib/html/html.go
+++ b/src/lib/html/html.go
@@ -232,6 +232,12 @@ var Templates = map[string]string{
 		</div>
 	</form>`,
 
+	"maintenance": `
+	<div class="container">
+		<h1>Under maintenance</h1>
+		<h3>This site is temporarily unavailable while we make some updates.<br/>Please check back again shortly.</h3>
+	</div>`,
+
 	"404": `
 	<div class="container">
 		<h1>4 oh 4</h1>

--- a/src/migrations/0025_2026-07-10.up.sql
+++ b/src/migrations/0025_2026-07-10.up.sql
@@ -1,0 +1,4 @@
+-- Maintenance mode (issue #21): a per-environment toggle that blocks public
+-- traffic and serves a maintenance page. Stored as jsonb so follow-up
+-- iterations (custom redirect, custom HTML) extend the same config object.
+ALTER TABLE apps_build_conf ADD COLUMN IF NOT EXISTS maintenance_conf jsonb;

--- a/src/migrations/structure.sql
+++ b/src/migrations/structure.sql
@@ -427,7 +427,8 @@ CREATE TABLE skitapi.apps_build_conf (
     mailer_conf jsonb,
     auth_wall_conf jsonb,
     auth_conf bytea,
-    schema_conf bytea
+    schema_conf bytea,
+    maintenance_conf jsonb
 );
 
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.spec.tsx
@@ -74,6 +74,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx",
     expect(wrapper.getByText("Headers")).toBeTruthy();
     expect(wrapper.getByText("Redirects")).toBeTruthy();
     expect(wrapper.getByText("Auth wall")).toBeTruthy();
+    expect(wrapper.getByText("Maintenance mode")).toBeTruthy();
     expect(wrapper.getByText("Domains")).toBeTruthy();
   });
 
@@ -83,6 +84,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx",
     ${""}          | ${"These variables will be available to build time, status checks and serverless runtime."}
     ${""}          | ${"Use these settings to configure your build options."}
     ${"#authwall"} | ${"Limit access to your deployments with an authentication wall."}
+    ${"#maintenance"} | ${"Take your site offline temporarily and display a maintenance page to visitors."}
     ${"#api-keys"} | ${"This key will allow you to interact with our API and modify this environment."}
   `(
     "should load different tab based on hash: $hash",

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx
@@ -19,6 +19,7 @@ import TabConfigServerless from "./_components/TabConfigServerless";
 import TabStatusChecks from "./_components/TabStatusChecks";
 import TabAPIKey from "./_components/TabAPIKey";
 import TabAuthWall from "./_components/TabAuthWall";
+import TabMaintenance from "./_components/TabMaintenance";
 
 interface NavItem {
   path: string;
@@ -56,6 +57,7 @@ const generateListItems = (
       { path: "#headers", text: "Headers" },
       { path: "#redirects", text: "Redirects" },
       { path: "#authwall", text: "Auth wall" },
+      { path: "#maintenance", text: "Maintenance mode" },
     ],
   },
   {
@@ -97,6 +99,10 @@ export default function EnvironmentConfig() {
       case "#authwall":
         return ({ app, environment }: TabProps) => (
           <TabAuthWall app={app} environment={environment} />
+        );
+      case "#maintenance":
+        return ({ app, environment }: TabProps) => (
+          <TabMaintenance app={app} environment={environment} />
         );
       case "":
       case "#general":

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/Maintenance.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/Maintenance.spec.tsx
@@ -1,0 +1,127 @@
+import type { RenderResult } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import mockApp from "~/testing/data/mock_app";
+import mockEnvironment from "~/testing/data/mock_environment";
+import * as actions from "~/testing/nocks/nock_maintenance";
+import Maintenance from "./Maintenance";
+
+const { mockFetchMaintenanceConfig, mockUpdateMaintenanceConfig } = actions;
+
+describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/Maintenance.tsx", () => {
+  let wrapper: RenderResult;
+  let app: App;
+  let env: Environment;
+
+  beforeEach(() => {
+    app = mockApp();
+    env = mockEnvironment({ app });
+  });
+
+  const createWrapper = () => {
+    wrapper = render(<Maintenance app={app} environment={env} />);
+  };
+
+  it.each`
+    config  | expectedStatus | checked
+    ${""}   | ${"Disabled"}  | ${false}
+    ${"on"} | ${"Enabled"}   | ${true}
+  `(
+    "reflects the API response in the toggle and status",
+    async ({ config, expectedStatus, checked }) => {
+      const scope = mockFetchMaintenanceConfig({
+        appId: app.id,
+        envId: env.id!,
+        response: { maintenance: config },
+      });
+
+      createWrapper();
+      expect(wrapper.getByTestId("card-loading")).toBeTruthy();
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
+        expect(() => wrapper.getByTestId("card-loading")).toThrow();
+        expect(wrapper.getByText(expectedStatus)).toBeTruthy();
+
+        const toggle = wrapper.getByLabelText(
+          "Turn on maintenance mode"
+        ) as HTMLInputElement;
+
+        expect(toggle.checked).toBe(checked);
+      });
+    }
+  );
+
+  it("turns on maintenance mode", async () => {
+    const fetchScope = mockFetchMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      response: { maintenance: "" },
+    });
+
+    createWrapper();
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+    });
+
+    const updateScope = mockUpdateMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      maintenance: "on",
+    });
+
+    // The refetch after a successful update
+    mockFetchMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      response: { maintenance: "on" },
+    });
+
+    fireEvent.click(wrapper.getByLabelText("Turn on maintenance mode"));
+    fireEvent.click(wrapper.getByText("Save"));
+
+    await waitFor(() => {
+      expect(updateScope.isDone()).toBe(true);
+      expect(
+        wrapper.getByText("Maintenance mode configuration updated successfully.")
+      ).toBeTruthy();
+    });
+  });
+
+  it("turns off maintenance mode", async () => {
+    const fetchScope = mockFetchMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      response: { maintenance: "on" },
+    });
+
+    createWrapper();
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+    });
+
+    const updateScope = mockUpdateMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      maintenance: "",
+    });
+
+    mockFetchMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      response: { maintenance: "" },
+    });
+
+    fireEvent.click(wrapper.getByLabelText("Turn on maintenance mode"));
+    fireEvent.click(wrapper.getByText("Save"));
+
+    await waitFor(() => {
+      expect(updateScope.isDone()).toBe(true);
+      expect(
+        wrapper.getByText("Maintenance mode configuration updated successfully.")
+      ).toBeTruthy();
+    });
+  });
+});

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/Maintenance.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/Maintenance.tsx
@@ -1,0 +1,120 @@
+import type { MaintenanceConfig } from "./actions";
+import { FormEventHandler, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+import LensIcon from "@mui/icons-material/Lens";
+import Card from "~/components/Card";
+import CardHeader from "~/components/CardHeader";
+import CardFooter from "~/components/CardFooter";
+import { useFetchMaintenanceConfig, updateMaintenanceConfig } from "./actions";
+
+interface Props {
+  app: App;
+  environment: Environment;
+}
+
+export default function Maintenance({ app, environment: env }: Props) {
+  const [refreshToken, setRefreshToken] = useState<number>();
+  const [formError, setFormError] = useState<string>();
+  const [sendLoading, setSendLoading] = useState<boolean>(false);
+  const [success, setSuccess] = useState<string>();
+  const { loading, error, config } = useFetchMaintenanceConfig({
+    appId: app.id,
+    envId: env.id!,
+    refreshToken,
+  });
+
+  const isActive = config === "on";
+
+  const submitHandler: FormEventHandler = e => {
+    e.preventDefault();
+    const form = e.target as HTMLFormElement;
+    const data = Object.fromEntries(new FormData(form).entries()) as Record<
+      string,
+      string
+    >;
+
+    const maintenance = data.maintenance === "on" ? "on" : "";
+
+    setSendLoading(true);
+
+    updateMaintenanceConfig({
+      appId: app.id,
+      envId: env.id!,
+      maintenance: maintenance as MaintenanceConfig,
+    })
+      .then(() => {
+        setRefreshToken(Date.now());
+        setSuccess("Maintenance mode configuration updated successfully.");
+        setFormError(undefined);
+      })
+      .catch(async e => {
+        const data = await e.json();
+
+        setFormError(
+          data.error ||
+            "Something went wrong while updating maintenance mode configuration."
+        );
+      })
+      .finally(() => {
+        setSendLoading(false);
+      });
+  };
+
+  return (
+    <Card
+      id="maintenance"
+      component="form"
+      loading={loading}
+      error={error || formError}
+      success={success}
+      onSubmit={submitHandler}
+      sx={{ mb: 4 }}
+    >
+      <CardHeader
+        title="Maintenance mode"
+        subtitle="Take your site offline temporarily and display a maintenance page to visitors."
+        actions={
+          <Box sx={{ alignSelf: "flex-start" }}>
+            <LensIcon
+              color={isActive ? "success" : "error"}
+              sx={{ width: 12 }}
+            />
+            <Typography component="span" sx={{ ml: 1, fontSize: 12 }}>
+              {isActive ? "Enabled" : "Disabled"}
+            </Typography>
+          </Box>
+        }
+      />
+      <Box sx={{ mb: 4 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              name="maintenance"
+              color="secondary"
+              defaultChecked={isActive}
+            />
+          }
+          label="Turn on maintenance mode"
+        />
+        <Typography sx={{ color: "text.secondary", fontSize: 12, mt: 1 }}>
+          While turned on, public traffic receives a maintenance page with a
+          503 status code. Deployments and settings remain untouched.
+        </Typography>
+      </Box>
+      <CardFooter>
+        <Button
+          type="submit"
+          variant="contained"
+          color="secondary"
+          loading={sendLoading}
+        >
+          Save
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/actions.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import api from "~/utils/api/Api";
+
+export type MaintenanceConfig = "on" | "";
+
+interface UseFetchMaintenanceConfig {
+  appId: string;
+  envId: string;
+  refreshToken?: number;
+}
+
+export const useFetchMaintenanceConfig = ({
+  appId,
+  envId,
+  refreshToken,
+}: UseFetchMaintenanceConfig) => {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>();
+  const [config, setConfig] = useState<MaintenanceConfig>();
+
+  useEffect(() => {
+    api
+      .fetch<{ maintenance: MaintenanceConfig }>(
+        `/maintenance/config?appId=${appId}&envId=${envId}`
+      )
+      .then(({ maintenance }) => {
+        setConfig(maintenance);
+      })
+      .catch(() => {
+        setError("Something went wrong while fetching the maintenance config");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [appId, envId, refreshToken]);
+
+  return { loading, error, config };
+};
+
+interface UpdateMaintenanceConfigProps {
+  appId: string;
+  envId: string;
+  maintenance: MaintenanceConfig;
+}
+
+export const updateMaintenanceConfig = ({
+  appId,
+  envId,
+  maintenance,
+}: UpdateMaintenanceConfigProps) => {
+  return api.post("/maintenance/config", {
+    appId,
+    envId,
+    maintenance,
+  });
+};

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/index.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabMaintenance/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Maintenance";

--- a/src/ui/src/shared/feed/AuditMessage.tsx
+++ b/src/ui/src/shared/feed/AuditMessage.tsx
@@ -235,6 +235,16 @@ export default function AuditMessage({ audit }: Props) {
         </AuditRow>
       );
 
+    case "UPDATE:MAINTENANCE":
+      return (
+        <AuditRow audit={audit} forceDiff>
+          {audit.diff.new.maintenanceStatus === "off"
+            ? "Disabled"
+            : "Enabled"}{" "}
+          maintenance mode in <EnvLink audit={audit} /> environment
+        </AuditRow>
+      );
+
     case "CREATE:AUTHWALL":
       return (
         <AuditRow audit={audit} forceDiff>

--- a/src/ui/src/testing/nocks/nock_maintenance.ts
+++ b/src/ui/src/testing/nocks/nock_maintenance.ts
@@ -1,0 +1,39 @@
+import nock from "nock";
+
+const endpoint = process.env.API_DOMAIN || "";
+
+interface MockFetchMaintenanceConfigProps {
+  appId: string;
+  envId: string;
+  response: { maintenance: "on" | "" };
+  status?: number;
+}
+
+export const mockFetchMaintenanceConfig = ({
+  envId,
+  appId,
+  status = 200,
+  response,
+}: MockFetchMaintenanceConfigProps) =>
+  nock(endpoint)
+    .get(`/maintenance/config?appId=${appId}&envId=${envId}`)
+    .reply(status, response);
+
+interface MockUpdateMaintenanceConfigProps {
+  appId: string;
+  envId: string;
+  maintenance: "on" | "";
+  response?: { ok: boolean };
+  status?: number;
+}
+
+export const mockUpdateMaintenanceConfig = ({
+  envId,
+  appId,
+  maintenance,
+  status = 200,
+  response = { ok: true },
+}: MockUpdateMaintenanceConfigProps) =>
+  nock(endpoint)
+    .post("/maintenance/config", { appId, envId, maintenance })
+    .reply(status, response);

--- a/src/ui/src/types/audit.d.ts
+++ b/src/ui/src/types/audit.d.ts
@@ -22,6 +22,7 @@ declare interface DiffFields {
   authWallCreateLoginEmail?: string;
   authWallCreateLoginID?: string;
   authWallDeleteLoginIDs?: string;
+  maintenanceStatus?: string;
   deploymentId?: string;
   autoPublished?: boolean;
   restarted?: boolean;


### PR DESCRIPTION
## Summary

First step of #21: a per-environment **ON/OFF maintenance mode toggle**. When turned on, all public traffic receives a built-in maintenance page with a **503** status code and a `Retry-After: 300` header (so search engines treat the downtime as temporary). Deployments and settings remain untouched.

Custom redirect and custom HTML upload (steps 2 and 3 from the issue discussion) will follow in separate PRs — the config is stored as jsonb so those extend the same object without another schema change.

## Implementation

Mirrors the Auth Wall structure end to end:

- **Data**: new `apps_build_conf.maintenance_conf` jsonb column (migration 0025) + a `maintenance` package with the `Config{Status}` model and store.
- **API**: `GET/POST /maintenance/config`. Available on **all editions** (no EE gate). Updates reset the app cache and write an `UPDATE:MAINTENANCE` audit entry on enterprise.
- **Hosting**: `WithMaintenance` middleware, placed before `WithSKAuth`/`WithAuthWall` so maintenance takes precedence over other gates. Renders a new embedded `maintenance` HTML template.
- **UI**: "Maintenance mode" card under Runtime Settings, next to Auth wall, with a switch, status indicator and save button. Audit feed shows "Enabled/Disabled maintenance mode in {env} environment".

## Tests

- Handler suites for get/set (round-trip, reset, invalid value, audit diff)
- `appconf` test verifying `maintenance_conf` flows into the hosting config
- Hosting tests: 503 + Retry-After + page content; maintenance takes precedence over auth wall
- UI: component specs for toggle on/off flows + nav/tab wiring in `EnvironmentConfig`

Full Go suite (`-p 1`) and UI vitest suite pass. (One pre-existing flaky spec, `analytics/Events.spec.tsx`, fails under the full parallel run on main as well and passes in isolation — unrelated.)

Closes nothing yet — issue #21 stays open for the follow-up PRs. Refs #21.