### PR TITLE
fix: deploy step ordering + structured deployment logs

### DIFF
--- a/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_deploy_callback.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
@@ -72,9 +73,15 @@ func handlerDeployCallback(req *shttp.RequestContext) *shttp.Response {
 		return shttp.NotAllowed()
 	}
 
+	// Exit callbacks with migrations append a step to the logs, and the append
+	// format depends on the stored blob (structured vs legacy text), so the
+	// logs are loaded for them. All other callbacks leave the stored logs
+	// untouched and skip the load.
+	includeLogs := data.Outcome != "" && !data.Lock && data.Result.Migrations.Location != ""
+
 	depl, err := deploy.NewStore().MyDeployment(req.Context(), &deploy.DeploymentsQueryFilters{
 		DeploymentID: deployID,
-		IncludeLogs:  aws.Bool(false),
+		IncludeLogs:  aws.Bool(includeLogs),
 	})
 
 	if err != nil {
@@ -180,8 +187,13 @@ func UpdateExit(req *shttp.RequestContext, data deployCallbackRequest) *shttp.Re
 
 	// If the deployment branch == environment branch, it means we need to migrate the environment
 	if data.Result.Migrations.Location != "" {
-		logs := []string{}
-		logs = append(logs, deploy.LogStep("database migrations"))
+		step := deploy.StepRecord{
+			Title:     "database migrations",
+			StartedAt: time.Now().UnixMilli(),
+			Status:    deploy.StepStatusSuccess,
+		}
+
+		lines := []string{}
 
 		messages, results, err := RunMigrations(req.Context(), RunMigrationsArgs{
 			DeploymentID:   data.deployment.ID,
@@ -190,11 +202,12 @@ func UpdateExit(req *shttp.RequestContext, data deployCallbackRequest) *shttp.Re
 			MigrationsFile: data.Result.Migrations.Location,
 		})
 
-		logs = append(logs, messages...)
+		lines = append(lines, messages...)
 
 		// If there was an error and no migrations were applied, set the deployment error
 		if err != nil && len(results) == 0 {
 			data.deployment.Error = null.StringFrom(err.Error())
+			step.Status = deploy.StepStatusFailed
 		}
 
 		for _, result := range results {
@@ -209,16 +222,20 @@ func UpdateExit(req *shttp.RequestContext, data deployCallbackRequest) *shttp.Re
 				tickOrCross = "✗"
 				errorMsg = " - Error: " + result.Error
 				data.deployment.ExitCode = null.IntFrom(deploy.ExitCodeMigrationsFailed)
+				step.Status = deploy.StepStatusFailed
 			}
 
-			logs = append(logs, fmt.Sprintf("%s (%dms) %s%s", result.FileName, result.Duration.Milliseconds(), tickOrCross, errorMsg))
+			lines = append(lines, fmt.Sprintf("%s (%dms) %s%s", result.FileName, result.Duration.Milliseconds(), tickOrCross, errorMsg))
 		}
 
 		if len(results) == 0 && len(messages) == 0 {
-			logs = append(logs, "No new migrations to apply.")
+			lines = append(lines, "No new migrations to apply.")
 		}
 
-		data.deployment.AddLogs(logs)
+		step.Message = strings.Join(lines, "\n")
+		step.FinishedAt = time.Now().UnixMilli()
+
+		data.deployment.AddLogStep(step)
 	}
 
 	if err := deploy.NewStore().UpdateDeploymentResult(req.Context(), data.deployment, data.Result); err != nil {

--- a/src/ce/api/app/deploy/deployment_logs.go
+++ b/src/ce/api/app/deploy/deployment_logs.go
@@ -1,0 +1,175 @@
+package deploy
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const StepStatusSuccess = "success"
+const StepStatusFailed = "failed"
+
+// StepRecord is one deployment step in the structured log format. Logs in
+// this format are stored as NDJSON - one record per line - so a step can be
+// appended to the stored blob without re-parsing it. Timestamps are unix
+// milliseconds; a zero FinishedAt marks a step that is still running.
+//
+// The legacy format (raw build output interleaved with "[sk-step]" markers)
+// is still written by GitHub-action builds and read from old deployments.
+// PrepareLogs detects the format of the stored blob and picks the parser.
+type StepRecord struct {
+	Title      string         `json:"title"`
+	Message    string         `json:"message,omitempty"`
+	StartedAt  int64          `json:"startedAt"`
+	FinishedAt int64          `json:"finishedAt,omitempty"`
+	Status     string         `json:"status,omitempty"`
+	Payload    map[string]any `json:"payload,omitempty"`
+}
+
+// ParseStepLogs decodes an NDJSON log blob into step records. It returns
+// false when the blob is not in the structured format. A trailing line that
+// fails to decode is skipped rather than failing the whole blob, so a
+// partially written last record does not hide the completed steps.
+func ParseStepLogs(rawLogs string) ([]StepRecord, bool) {
+	trimmed := strings.TrimSpace(rawLogs)
+
+	if !strings.HasPrefix(trimmed, "{") {
+		return nil, false
+	}
+
+	steps := []StepRecord{}
+
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+
+		if line == "" {
+			continue
+		}
+
+		var step StepRecord
+
+		if err := json.Unmarshal([]byte(line), &step); err != nil {
+			continue
+		}
+
+		// A JSON line without a title is not a step record (e.g. JSON build
+		// output); skip it rather than rejecting the whole blob.
+		if step.Title == "" {
+			continue
+		}
+
+		steps = append(steps, step)
+	}
+
+	if len(steps) == 0 {
+		return nil, false
+	}
+
+	return steps, true
+}
+
+// MarshalStepLogs encodes step records as an NDJSON log blob. HTML escaping
+// is disabled so shell commands used as step titles (e.g. "a && b") stay
+// readable in the stored logs.
+func MarshalStepLogs(steps []StepRecord) string {
+	var sb strings.Builder
+
+	enc := json.NewEncoder(&sb)
+	enc.SetEscapeHTML(false)
+
+	for _, step := range steps {
+		if err := enc.Encode(step); err != nil {
+			continue
+		}
+	}
+
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+// AddLogStep appends a step to the deployment logs in whichever format the
+// stored blob uses: a structured record for NDJSON blobs, or a "[sk-step]"
+// marker plus message lines for legacy text blobs (old deployments and
+// GitHub-action builds).
+func (d *Deployment) AddLogStep(step StepRecord) {
+	if _, ok := ParseStepLogs(d.Logs.ValueOrZero()); ok || d.Logs.ValueOrZero() == "" {
+		blob := d.Logs.ValueOrZero()
+
+		if blob != "" {
+			blob += "\n"
+		}
+
+		d.Logs.SetValid(blob + MarshalStepLogs([]StepRecord{step}))
+
+		return
+	}
+
+	lines := []string{LogStep(step.Title)}
+
+	if step.Message != "" {
+		lines = append(lines, step.Message)
+	}
+
+	d.AddLogs(lines)
+}
+
+// prepareStepLogs renders structured step records into the log objects
+// returned by the API. Durations come straight from the recorded
+// start/finish timestamps, so ordering plays no role in the calculation.
+func (d *Deployment) prepareStepLogs(steps []StepRecord, isStatusChecks bool) []*Log {
+	logs := make([]*Log, 0, len(steps))
+
+	for _, step := range steps {
+		log := &Log{
+			Title:   step.Title,
+			Message: step.Message,
+			Status:  step.Status != StepStatusFailed,
+			Payload: step.Payload,
+		}
+
+		if step.Title == "deploy" && log.Message == "" {
+			if d.Error.ValueOrZero() != "" {
+				log.Message = d.Error.ValueOrZero()
+				log.Status = false
+			} else if d.UploadResult != nil {
+				log.Message = d.UploadResult.message()
+			}
+		}
+
+		finishedAt := step.FinishedAt
+
+		if finishedAt == 0 && d.StoppedAt.Valid {
+			finishedAt = d.StoppedAt.Unix() * 1000
+		}
+
+		if step.StartedAt > 0 && finishedAt > step.StartedAt {
+			log.Duration = (finishedAt - step.StartedAt + 500) / 1000
+		}
+
+		logs = append(logs, log)
+	}
+
+	if isStatusChecks && len(logs) > 0 && d.StatusChecksPassed.Valid {
+		logs[len(logs)-1].Status = d.StatusChecksPassed.Bool
+	}
+
+	// A stopped or crashed deployment kills the runner before it closes the
+	// current step, leaving the last record without a status. Reconcile it
+	// with the deployment outcome instead of rendering it as successful.
+	if !isStatusChecks && len(steps) > 0 {
+		last := steps[len(steps)-1]
+
+		if last.FinishedAt == 0 && last.Status == "" && d.ExitCode.Valid && d.ExitCode.ValueOrZero() != 0 {
+			lastLog := logs[len(logs)-1]
+			lastLog.Status = false
+
+			if d.ExitCode.ValueOrZero() == ExitCodeStopped {
+				if lastLog.Message != "" {
+					lastLog.Message += "\n"
+				}
+
+				lastLog.Message += "Deployment has been stopped manually."
+			}
+		}
+	}
+
+	return logs
+}

--- a/src/ce/api/app/deploy/deployment_logs_test.go
+++ b/src/ce/api/app/deploy/deployment_logs_test.go
@@ -1,0 +1,237 @@
+package deploy_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/guregu/null.v3"
+)
+
+type DeploymentLogsSuite struct {
+	suite.Suite
+}
+
+func (s *DeploymentLogsSuite) Test_MarshalAndParse_RoundTrip() {
+	steps := []deploy.StepRecord{
+		{Title: "npm install", Message: "added 12 packages\n", StartedAt: 1000, FinishedAt: 5000, Status: deploy.StepStatusSuccess},
+		{Title: "npm run build && echo done", StartedAt: 5000, FinishedAt: 9000, Status: deploy.StepStatusSuccess},
+	}
+
+	blob := deploy.MarshalStepLogs(steps)
+
+	// Shell commands used as titles must stay readable in the stored blob.
+	s.Contains(blob, `"title":"npm run build && echo done"`)
+
+	parsed, ok := deploy.ParseStepLogs(blob)
+
+	s.True(ok)
+	s.Equal(steps, parsed)
+}
+
+func (s *DeploymentLogsSuite) Test_ParseStepLogs_RejectsLegacyText() {
+	_, ok := deploy.ParseStepLogs("[sk-step] npm install [ts:1726053541]\nadded 12 packages")
+
+	s.False(ok)
+}
+
+func (s *DeploymentLogsSuite) Test_ParseStepLogs_SkipsPartialTrailingLine() {
+	blob := deploy.MarshalStepLogs([]deploy.StepRecord{
+		{Title: "npm install", StartedAt: 1000, FinishedAt: 2000},
+	}) + "\n{\"title\":\"npm run bui"
+
+	parsed, ok := deploy.ParseStepLogs(blob)
+
+	s.True(ok)
+	s.Len(parsed, 1)
+	s.Equal("npm install", parsed[0].Title)
+}
+
+func (s *DeploymentLogsSuite) Test_PrepareLogs_StructuredSteps() {
+	d := &deploy.Deployment{
+		ExitCode: null.IntFrom(0),
+		UploadResult: &deploy.UploadResult{
+			ServerBytes: 591919,
+		},
+		Logs: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "npm run build", Message: "compiled\n", StartedAt: 1_726_053_541_000, FinishedAt: 1_726_053_711_000, Status: deploy.StepStatusSuccess},
+			{Title: "saving build cache", Message: "saved build cache (193MB)\n", StartedAt: 1_726_053_711_000, FinishedAt: 1_726_053_756_000, Status: deploy.StepStatusSuccess},
+			{Title: "deploy", StartedAt: 1_726_053_756_000, FinishedAt: 1_726_053_767_400, Status: deploy.StepStatusSuccess},
+			{Title: "database migrations", Message: "No new migrations to apply.", StartedAt: 1_726_053_767_500, FinishedAt: 1_726_053_768_500, Status: deploy.StepStatusSuccess},
+		})),
+	}
+
+	b, err := json.Marshal(d.PrepareLogs(d.Logs.ValueOrZero(), false))
+	s.Nil(err)
+	s.JSONEq(`[
+		{
+			"title": "npm run build",
+			"duration": 170,
+			"message": "compiled\n",
+			"status": true,
+			"payload": null
+		},
+		{
+			"title": "saving build cache",
+			"duration": 45,
+			"message": "saved build cache (193MB)\n",
+			"status": true,
+			"payload": null
+		},
+		{
+			"title": "deploy",
+			"duration": 11,
+			"message": "\nSuccessfully deployed server side.\nPackage size: 591.9kB\n\n",
+			"status": true,
+			"payload": null
+		},
+		{
+			"title": "database migrations",
+			"duration": 1,
+			"message": "No new migrations to apply.",
+			"status": true,
+			"payload": null
+		}
+	]`, string(b))
+}
+
+func (s *DeploymentLogsSuite) Test_PrepareLogs_StructuredSteps_FailedStep() {
+	d := &deploy.Deployment{
+		ExitCode: null.IntFrom(1),
+		Logs: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "npm install", StartedAt: 1000, FinishedAt: 2000, Status: deploy.StepStatusSuccess},
+			{Title: "npm run build", Message: "type error\n", StartedAt: 2000, FinishedAt: 9000, Status: deploy.StepStatusFailed},
+		})),
+	}
+
+	logs := d.PrepareLogs(d.Logs.ValueOrZero(), false)
+
+	s.Len(logs, 2)
+	s.True(logs[0].Status)
+	s.False(logs[1].Status)
+}
+
+func (s *DeploymentLogsSuite) Test_PrepareLogs_StructuredSteps_DeployError() {
+	d := &deploy.Deployment{
+		Error: null.StringFrom("Error: cannot upload artifacts"),
+		Logs: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "deploy", StartedAt: 1000, Status: deploy.StepStatusSuccess},
+		})),
+	}
+
+	logs := d.PrepareLogs(d.Logs.ValueOrZero(), false)
+
+	s.Len(logs, 1)
+	s.Equal("Error: cannot upload artifacts", logs[0].Message)
+	s.False(logs[0].Status)
+}
+
+func (s *DeploymentLogsSuite) Test_PrepareLogs_StructuredSteps_RunningStep() {
+	stoppedAt := utils.Unix{Time: time.Unix(100, 0), Valid: true}
+
+	d := &deploy.Deployment{
+		StoppedAt: stoppedAt,
+		Logs: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "npm run build", StartedAt: 88_000},
+		})),
+	}
+
+	logs := d.PrepareLogs(d.Logs.ValueOrZero(), false)
+
+	s.Len(logs, 1)
+	// The step never recorded a finish; the deployment's stop time caps it.
+	s.Equal(int64(12), logs[0].Duration)
+	s.True(logs[0].Status)
+}
+
+func (s *DeploymentLogsSuite) Test_PrepareLogs_StructuredSteps_StoppedDeployment() {
+	d := &deploy.Deployment{
+		ExitCode:  null.IntFrom(deploy.ExitCodeStopped),
+		StoppedAt: utils.Unix{Time: time.Unix(100, 0), Valid: true},
+		Logs: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "npm install", StartedAt: 80_000, FinishedAt: 88_000, Status: deploy.StepStatusSuccess},
+			// The runner was killed by the stop before closing this step.
+			{Title: "npm run build", StartedAt: 88_000},
+		})),
+	}
+
+	logs := d.PrepareLogs(d.Logs.ValueOrZero(), false)
+
+	s.Len(logs, 2)
+	s.True(logs[0].Status)
+	s.False(logs[1].Status)
+	s.Contains(logs[1].Message, "Deployment has been stopped manually.")
+}
+
+func (s *DeploymentLogsSuite) Test_ParseStepLogs_SkipsUntitledRecords() {
+	blob := deploy.MarshalStepLogs([]deploy.StepRecord{
+		{Title: "npm install", StartedAt: 1000, FinishedAt: 2000},
+	}) + "\n{\"level\":\"info\",\"msg\":\"json build output without a title\"}"
+
+	parsed, ok := deploy.ParseStepLogs(blob)
+
+	s.True(ok)
+	s.Len(parsed, 1)
+	s.Equal("npm install", parsed[0].Title)
+}
+
+func (s *DeploymentLogsSuite) Test_PrepareLogs_StructuredSteps_StatusChecks() {
+	d := &deploy.Deployment{
+		StatusChecksPassed: null.BoolFrom(false),
+		StatusChecks: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "npm run e2e", StartedAt: 1000, FinishedAt: 2000, Status: deploy.StepStatusSuccess},
+		})),
+	}
+
+	logs := d.PrepareLogs(d.StatusChecks.ValueOrZero(), true)
+
+	s.Len(logs, 1)
+	s.False(logs[0].Status)
+}
+
+func (s *DeploymentLogsSuite) Test_AddLogStep_AppendsToStructuredBlob() {
+	d := &deploy.Deployment{
+		Logs: null.StringFrom(deploy.MarshalStepLogs([]deploy.StepRecord{
+			{Title: "deploy", StartedAt: 1000, FinishedAt: 2000, Status: deploy.StepStatusSuccess},
+		})),
+	}
+
+	d.AddLogStep(deploy.StepRecord{
+		Title:      "database migrations",
+		Message:    "No new migrations to apply.",
+		StartedAt:  3000,
+		FinishedAt: 4000,
+		Status:     deploy.StepStatusSuccess,
+	})
+
+	steps, ok := deploy.ParseStepLogs(d.Logs.ValueOrZero())
+
+	s.True(ok)
+	s.Len(steps, 2)
+	s.Equal("database migrations", steps[1].Title)
+	s.Equal(int64(3000), steps[1].StartedAt)
+}
+
+func (s *DeploymentLogsSuite) Test_AddLogStep_FallsBackToLegacyText() {
+	d := &deploy.Deployment{
+		Logs: null.StringFrom("[sk-step] npm install [ts:1726053541]\nadded 12 packages"),
+	}
+
+	d.AddLogStep(deploy.StepRecord{
+		Title:   "database migrations",
+		Message: "No new migrations to apply.",
+	})
+
+	logs := d.Logs.ValueOrZero()
+
+	s.Contains(logs, "[sk-step] database migrations [ts:")
+	s.Contains(logs, "No new migrations to apply.")
+	s.NotContains(logs, `"title"`)
+}
+
+func TestDeploymentLogsSuite(t *testing.T) {
+	suite.Run(t, new(DeploymentLogsSuite))
+}

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -414,6 +414,11 @@ func (d *Deployment) PrepareLogs(rawLogs string, isStatusChecks bool) []*Log {
 
 	}
 
+	// Structured logs written by the runner: one step record per line.
+	if steps, ok := ParseStepLogs(rawLogs); ok {
+		return d.prepareStepLogs(steps, isStatusChecks)
+	}
+
 	logs := []*Log{}
 
 	// This is a special case for old-style deployments
@@ -596,35 +601,43 @@ func (d *Deployment) deploymentsResult(startTimestamp int64) *Log {
 	}
 
 	log.Status = true
+	log.Message = d.UploadResult.message()
 
-	if d.UploadResult.ClientBytes != 0 {
-		log.Message = strings.Join([]string{
-			log.Message,
+	return log
+}
+
+// message summarizes the upload result for the deploy step's log output.
+func (ur *UploadResult) message() string {
+	msg := ""
+
+	if ur.ClientBytes != 0 {
+		msg = strings.Join([]string{
+			msg,
 			fmt.Sprintf(
 				"Successfully deployed client side.\n"+
 					"Total bytes uploaded: %s\n\n",
-				byteCountDecimal(d.UploadResult.ClientBytes),
+				byteCountDecimal(ur.ClientBytes),
 			),
 		}, "\n")
 	}
 
-	if d.UploadResult.ServerBytes != 0 {
-		log.Message = strings.Join([]string{
-			log.Message,
+	if ur.ServerBytes != 0 {
+		msg = strings.Join([]string{
+			msg,
 			"Successfully deployed server side.",
-			fmt.Sprintf("Package size: %s\n\n", byteCountDecimal(d.UploadResult.ServerBytes)),
+			fmt.Sprintf("Package size: %s\n\n", byteCountDecimal(ur.ServerBytes)),
 		}, "\n")
 	}
 
-	if d.UploadResult.ServerlessBytes != 0 {
-		log.Message = strings.Join([]string{
-			log.Message,
+	if ur.ServerlessBytes != 0 {
+		msg = strings.Join([]string{
+			msg,
 			"Successfully deployed api.",
-			fmt.Sprintf("Package size: %s", byteCountDecimal(d.UploadResult.ServerlessBytes)),
+			fmt.Sprintf("Package size: %s", byteCountDecimal(ur.ServerlessBytes)),
 		}, "\n")
 	}
 
-	return log
+	return msg
 }
 
 // byteCountDecimal converts the given bytes into a human readable format.

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -428,6 +428,7 @@ func (d *Deployment) PrepareLogs(rawLogs string, isStatusChecks bool) []*Log {
 
 	lastStepTimestamp := d.CreatedAt.Unix()
 	buildingFinished := len(lines) == 0 && d.ExitCode.Valid
+	buildingFinishedIdx := -1
 	deploymentComplete := false
 
 	for _, line := range lines {
@@ -457,6 +458,7 @@ func (d *Deployment) PrepareLogs(rawLogs string, isStatusChecks bool) []*Log {
 
 			if strings.Contains(line, "building finished") {
 				buildingFinished = true
+				buildingFinishedIdx = len(logs) - 1
 				lastStepTimestamp = timestamp
 			} else if strings.Contains(line, "deployment finished") {
 				deploymentComplete = true
@@ -494,7 +496,18 @@ func (d *Deployment) PrepareLogs(rawLogs string, isStatusChecks bool) []*Log {
 		if d.ExitCode.ValueOrZero() == ExitCodeMigrationsFailed && lastStep != nil {
 			lastStep.Status = false
 		} else if buildingFinished || isSuccess {
-			logs = append(logs, d.deploymentsResult(lastStepTimestamp))
+			result := d.deploymentsResult(lastStepTimestamp)
+
+			// Steps logged after the "building finished" marker (e.g. database
+			// migrations) carry later timestamps than the deploy step, which
+			// starts at the marker. Insert the deploy step right after the
+			// marker so the duration calculation below sees timestamps in
+			// chronological order.
+			if buildingFinishedIdx >= 0 && buildingFinishedIdx+1 < len(logs) {
+				logs = append(logs[:buildingFinishedIdx+1], append([]*Log{result}, logs[buildingFinishedIdx+1:]...)...)
+			} else {
+				logs = append(logs, result)
+			}
 		} else if !deploymentComplete && lastStep != nil {
 			// Let's sync the last step
 			lastStep.Status = isSuccess

--- a/src/ce/api/app/deploy/deployment_model_test.go
+++ b/src/ce/api/app/deploy/deployment_model_test.go
@@ -212,6 +212,51 @@ func (s *DeploymentModelSuite) Test_DeploymentLogs_WithMultipleSteps() {
 	]`, string(b))
 }
 
+func (s *DeploymentModelSuite) Test_DeploymentLogs_StepsAfterBuildingFinished() {
+	stoppedAt := utils.Unix{Time: time.Unix(1726053757, 0), Valid: true}
+
+	d := &deploy.Deployment{
+		UploadResult: &deploy.UploadResult{
+			ServerBytes: 591919,
+		},
+		ExitCode:  null.IntFrom(0),
+		StoppedAt: stoppedAt,
+		Logs: null.NewString(
+			"[sk-step] saving build cache [ts:1726053700]\n"+
+				"saved build cache (193MB)\n"+
+				"[sk-step] [system] building finished [ts:1726053745]\n"+
+				"[sk-step] database migrations [ts:1726053756]\n"+
+				"No new migrations to apply.",
+			true),
+	}
+
+	b, err := json.Marshal(d.PrepareLogs(d.Logs.ValueOrZero(), false))
+	s.Nil(err)
+	s.JSONEq(`[
+		{
+			"title": "saving build cache",
+			"duration": 45,
+			"message": "saved build cache (193MB)\n",
+			"status": true,
+			"payload": null
+		},
+		{
+			"title": "deploy",
+			"duration": 11,
+			"message": "\nSuccessfully deployed server side.\nPackage size: 591.9kB\n\n",
+			"status": true,
+			"payload": null
+		},
+		{
+			"title": "database migrations",
+			"duration": 1,
+			"message": "No new migrations to apply.\n",
+			"status": true,
+			"payload": null
+		}
+	]`, string(b))
+}
+
 func (s *DeploymentModelSuite) Test_PopulateFromEnv_SchemaDoNotInjectEnvVars() {
 	dep := &deploy.Deployment{}
 	env := &buildconf.Env{

--- a/src/ce/api/app/deploy/deployment_statements.go
+++ b/src/ce/api/app/deploy/deployment_statements.go
@@ -200,7 +200,7 @@ var stmt = &statement{
 			error = $2,
 			exit_code = $3,
 			build_manifest = $4,
-			logs = COALESCE(logs, '') || $5,
+			logs = CASE WHEN $5 = '' THEN logs ELSE $5 END,
 			stopped_at = NOW() AT TIME ZONE 'UTC'
 		WHERE
 			deployment_id = $6

--- a/src/ce/runner/builder_test.go
+++ b/src/ce/runner/builder_test.go
@@ -51,7 +51,7 @@ func (s *BuildManagerSuite) Test_Build_Chaining() {
 	s.NoError(bm.ExecCommands(context.Background()))
 
 	lines := []string{
-		fmt.Sprintf("[sk-step] %s", s.config.Build.BuildCmd),
+		fmt.Sprintf(`"title":%q`, s.config.Build.BuildCmd),
 		"hello world",
 		"hi world",
 	}
@@ -95,7 +95,7 @@ func (s *BuildManagerSuite) Test_Build_WithFlake() {
 
 	bm := runner.NewBuilder(s.config)
 	s.NoError(bm.ExecCommands(context.Background()))
-	s.Contains(s.config.Reporter.Logs(), "[sk-step] npm run build")
+	s.Contains(s.config.Reporter.Logs(), `"title":"npm run build"`)
 	mockCmd.AssertExpectations(s.T())
 }
 

--- a/src/ce/runner/custom_buffer.go
+++ b/src/ce/runner/custom_buffer.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"bytes"
-	"io"
 	"regexp"
 	"sync"
 
@@ -13,7 +12,6 @@ const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)
 
 type CustomBuffer struct {
 	output          []byte
-	readIndex       int
 	ansiRegexp      *regexp.Regexp
 	mu              sync.Mutex
 	isStormkitCloud bool
@@ -23,7 +21,6 @@ func NewCustomBuffer() *CustomBuffer {
 	return &CustomBuffer{
 		ansiRegexp:      regexp.MustCompile(ansi),
 		isStormkitCloud: config.IsStormkitCloud(),
-		readIndex:       0,
 	}
 }
 
@@ -59,15 +56,9 @@ func (cb *CustomBuffer) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (cb *CustomBuffer) Read(p []byte) (int, error) {
+func (cb *CustomBuffer) String() string {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
-	if cb.readIndex >= len(cb.output) {
-		return 0, io.EOF
-	}
-
-	n := copy(p, cb.output[cb.readIndex:])
-	cb.readIndex += n
-	return n, nil
+	return string(cb.output)
 }

--- a/src/ce/runner/custom_buffer_test.go
+++ b/src/ce/runner/custom_buffer_test.go
@@ -46,12 +46,7 @@ func (s *CustomBufferSuite) Test_Read_Write() {
 	s.Nil(err)
 	s.Equal(11, written)
 
-	// Read hello world
-	buffer := make([]byte, 11)
-	read, err := cb.Read(buffer)
-	s.Nil(err)
-	s.Equal(11, read)
-	s.Equal("Hello World", string(buffer))
+	s.Equal("Hello World\n", cb.String())
 }
 
 func (s *CustomBufferSuite) Test_GitLogs() {
@@ -62,12 +57,7 @@ func (s *CustomBufferSuite) Test_GitLogs() {
 	s.Nil(err)
 	s.Equal(len(gitLogs), written)
 
-	// Read the whole lorem ipsum
-	buffer := make([]byte, len(expectedGitLogs))
-	read, err := cb.Read(buffer)
-	s.Nil(err)
-	s.Equal(len(expectedGitLogs), read)
-	s.Equal(expectedGitLogs, string(buffer))
+	s.Equal(expectedGitLogs, cb.String()[:len(expectedGitLogs)])
 }
 
 func (s *CustomBufferSuite) Test_Write_CarriageReturn() {
@@ -79,14 +69,9 @@ func (s *CustomBufferSuite) Test_Write_CarriageReturn() {
 	s.Nil(err)
 	s.Equal(len(text), written)
 
-	// Read all
 	expected := "Let's see\nMy World"
 
-	buffer := make([]byte, len(expected))
-	read, err := cb.Read(buffer)
-	s.Nil(err)
-	s.Equal(len(expected), read)
-	s.Equal(expected, string(buffer))
+	s.Equal(expected, cb.String()[:len(expected)])
 }
 
 func TestCustomBufferSuite(t *testing.T) {

--- a/src/ce/runner/installer_test.go
+++ b/src/ce/runner/installer_test.go
@@ -176,7 +176,7 @@ func (s *InstallerSuite) Test_Install_Yarn() {
 	s.NoError(p.Install(context.Background()))
 
 	lines := []string{
-		"[sk-step] enable yarn workspaces",
+		`"title":"enable yarn workspaces"`,
 		"yarn",
 	}
 
@@ -216,7 +216,7 @@ func (s *InstallerSuite) Test_Install_Npm() {
 	s.NoError(p.Install(context.Background()))
 
 	lines := []string{
-		"[sk-step] npm ci",
+		`"title":"npm ci"`,
 	}
 
 	logs := s.config.Reporter.Logs()
@@ -258,7 +258,7 @@ func (s *InstallerSuite) Test_Install_Npm_Windows() {
 	s.NoError(p.Install(context.Background()))
 
 	lines := []string{
-		"[sk-step] npm ci",
+		`"title":"npm ci"`,
 	}
 
 	logs := s.config.Reporter.Logs()
@@ -291,7 +291,7 @@ func (s *InstallerSuite) Test_Install_Pnpm() {
 	s.NoError(p.Install(context.Background()))
 
 	lines := []string{
-		"[sk-step] pnpm install",
+		`"title":"pnpm install"`,
 		"pnpm install",
 	}
 
@@ -325,7 +325,7 @@ func (s *InstallerSuite) Test_Install_Bun() {
 	s.NoError(p.Install(context.Background()))
 
 	lines := []string{
-		"[sk-step] bun install",
+		`"title":"bun install"`,
 		"bun install",
 	}
 
@@ -357,7 +357,7 @@ func (s *InstallerSuite) TestInstall_Custom() {
 	s.NoError(p.Install(ctx))
 
 	lines := []string{
-		"[sk-step] npm install",
+		`"title":"npm install"`,
 		"npm install",
 	}
 
@@ -434,7 +434,7 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps() {
 	installed, err := p.InstallRuntimeDependencies(ctx)
 	s.Equal([]string{"go@1.24"}, installed)
 	s.NoError(err)
-	s.Contains(s.config.Reporter.Logs(), "[sk-step] install runtimes")
+	s.Contains(s.config.Reporter.Logs(), `"title":"install runtimes"`)
 
 	// Now let's try returning no runtimes installed
 	s.mockMise.On("InstallMise", ctx).Return(nil).Once()
@@ -450,7 +450,7 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps() {
 	installed, err = p.InstallRuntimeDependencies(ctx)
 	s.Equal([]string{"go"}, installed)
 	s.NoError(err)
-	s.Contains(s.config.Reporter.Logs(), "[sk-step] install runtimes")
+	s.Contains(s.config.Reporter.Logs(), `"title":"install runtimes"`)
 }
 
 func (s *InstallerSuite) Test_InstallingRuntimeDeps_WithFlake() {

--- a/src/ce/runner/print_env_test.go
+++ b/src/ce/runner/print_env_test.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -31,10 +30,7 @@ func (s *PrintEnvVariablesSuite) Test_MasksAllValues() {
 
 	s.NoError(printEnvVariables(opts))
 
-	out, err := io.ReadAll(reporter.File())
-	s.NoError(err)
-
-	log := string(out)
+	log := reporter.Logs()
 
 	// User-defined variable names are still listed so the build log stays
 	// useful, but their values are masked.

--- a/src/ce/runner/reporter.go
+++ b/src/ce/runner/reporter.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ReporterModel struct {
-	file        *CustomBuffer
+	steps       *stepLogger
 	baseURL     string
 	CallbackURL string
 	done        chan struct{}
@@ -30,7 +30,7 @@ var FlagPrintLogs bool
 
 func NewReporter(baseURL string) *ReporterModel {
 	return &ReporterModel{
-		file:        NewCustomBuffer(),
+		steps:       newStepLogger(),
 		done:        make(chan struct{}),
 		baseURL:     baseURL,
 		CallbackURL: baseURL + "/app/deploy/callback",
@@ -78,8 +78,13 @@ func (r *ReporterModel) request(payload map[string]any) error {
 	return err
 }
 
+// Logs returns the accumulated build logs in the structured NDJSON format.
 func (r *ReporterModel) Logs() string {
-	return string(r.file.output)
+	if r.steps == nil {
+		return ""
+	}
+
+	return r.steps.marshal()
 }
 
 func (r *ReporterModel) headers() http.Header {
@@ -99,12 +104,12 @@ func (r *ReporterModel) sendLogs() error {
 
 	return r.request(map[string]any{
 		"deployId": DeploymentIDEnc,
-		"logs":     r.Logs(),
+		"logs":     logs,
 	})
 }
 
 func (r *ReporterModel) SendLogs() {
-	if r.file == nil || r.baseURL == "" {
+	if r.steps == nil || r.baseURL == "" {
 		return
 	}
 
@@ -164,7 +169,7 @@ func (r *ReporterModel) LockDeployment(isSuccess bool) error {
 }
 
 func (r *ReporterModel) SendExit(manifest *deploy.BuildManifest, result *integrations.UploadResult, hasStatusChecks bool, uploadErr error) error {
-	if r.file == nil || r.baseURL == "" {
+	if r.steps == nil || r.baseURL == "" {
 		return nil
 	}
 
@@ -173,6 +178,10 @@ func (r *ReporterModel) SendExit(manifest *deploy.BuildManifest, result *integra
 	if manifest != nil && manifest.Success {
 		outcome = "success"
 	}
+
+	// The step that was open when the build ended carries the outcome:
+	// the deploy step on success, the failing step otherwise.
+	r.steps.closeStep(outcome == "success")
 
 	uploadErrStr := ""
 
@@ -183,8 +192,8 @@ func (r *ReporterModel) SendExit(manifest *deploy.BuildManifest, result *integra
 	// Send last remaining bits
 	r.sendLogs()
 
-	// Create a new buffer for status checks
-	r.file = NewCustomBuffer()
+	// Start over for the status check steps
+	r.steps = newStepLogger()
 
 	err := r.request(map[string]any{
 		"deployId":        DeploymentIDEnc,
@@ -203,25 +212,32 @@ func (r *ReporterModel) SendExit(manifest *deploy.BuildManifest, result *integra
 }
 
 func (r *ReporterModel) AddStep(title string) {
-	if r.file == nil {
+	if r.steps == nil {
 		return
 	}
 
-	_, err := r.file.Write([]byte(deploy.LogStep(title)))
-
-	if err != nil {
-		slog.Errorf("cannot add step: %s", title)
-	}
+	r.steps.addStep(title)
 }
 
 func (r *ReporterModel) AddLine(text string) {
-	if r.file != nil {
-		_, err := r.file.Write([]byte(fmt.Sprintf("%s\n", text)))
-
-		if err != nil {
-			slog.Errorf("cannot add line: %s", text)
-		}
+	if r.steps == nil {
+		return
 	}
+
+	if _, err := r.steps.Write([]byte(fmt.Sprintf("%s\n", text))); err != nil {
+		slog.Errorf("cannot add line: %s", text)
+	}
+}
+
+// CloseStep closes the current step with an explicit outcome. Steps closed
+// implicitly by the next AddStep are marked successful, so this is only
+// needed when a step can fail without ending the build (e.g. status checks).
+func (r *ReporterModel) CloseStep(success bool) {
+	if r.steps == nil {
+		return
+	}
+
+	r.steps.closeStep(success)
 }
 
 func (r *ReporterModel) Close(manifest *deploy.BuildManifest, result *integrations.UploadResult, err error) {
@@ -235,11 +251,18 @@ func (r *ReporterModel) Close(manifest *deploy.BuildManifest, result *integratio
 	r.isDone = true
 	close(r.done)
 
-	if r.file != nil {
-		r.file = nil
+	if r.steps != nil {
+		r.steps = nil
 	}
 }
 
-func (r *ReporterModel) File() *CustomBuffer {
-	return r.file
+// File returns the writer command output should stream into. The writer is
+// stable across steps: output is attributed to whichever step is current at
+// write time.
+func (r *ReporterModel) File() io.Writer {
+	if r.steps == nil {
+		return io.Discard
+	}
+
+	return r.steps
 }

--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -443,6 +443,8 @@ func Run(opts RunnerOpts) *RunResult {
 		manifest.CDNFiles = artifacts.CDNFiles()
 		manifest.APIFiles = artifacts.APIFiles()
 
+		opts.Reporter.AddStep("deploy")
+
 		result, err = NewUploader(opts.Uploader).Upload(UploadArgs{
 			MigrationsZip: artifacts.migrationsZip,
 			ClientZip:     artifacts.clientZip,

--- a/src/ce/runner/status_checks.go
+++ b/src/ce/runner/status_checks.go
@@ -60,7 +60,7 @@ func (s *StatusChecks) Run(ctx context.Context, command string) error {
 
 	err := cmd.Run()
 
-	rep.AddStep("[system] status check passed")
+	rep.CloseStep(err == nil)
 
 	return err
 }

--- a/src/ce/runner/step_logger.go
+++ b/src/ce/runner/step_logger.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+)
+
+// stepLogger accumulates the build output as structured steps. Command
+// output streams into the step that is current at write time, mirroring how
+// the legacy text format interleaved output with step markers. The logger
+// itself is a stable io.Writer, so call sites can hold on to it across step
+// boundaries.
+type stepLogger struct {
+	mu    sync.Mutex
+	steps []*loggedStep
+}
+
+type loggedStep struct {
+	title      string
+	startedAt  int64
+	finishedAt int64
+	status     string
+	buf        *CustomBuffer
+}
+
+func newStepLogger() *stepLogger {
+	return &stepLogger{}
+}
+
+// Write streams command output into the current step. Output arriving
+// before the first step is dropped, matching the legacy parser which
+// ignored lines preceding the first step marker.
+func (l *stepLogger) Write(p []byte) (int, error) {
+	l.mu.Lock()
+
+	var buf *CustomBuffer
+
+	if len(l.steps) > 0 {
+		buf = l.steps[len(l.steps)-1].buf
+	}
+
+	l.mu.Unlock()
+
+	if buf == nil {
+		return len(p), nil
+	}
+
+	return buf.Write(p)
+}
+
+// addStep closes the current step as successful and opens a new one. Titles
+// prefixed with "[system] " are markers rather than steps: they close the
+// current step without opening a new one. Empty titles are treated the same
+// way — ParseStepLogs skips untitled records.
+func (l *stepLogger) addStep(title string) {
+	now := time.Now().UnixMilli()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.closeCurrent(now, deploy.StepStatusSuccess)
+
+	if title == "" || strings.HasPrefix(title, "[system] ") {
+		return
+	}
+
+	l.steps = append(l.steps, &loggedStep{
+		title:     title,
+		startedAt: now,
+		buf:       NewCustomBuffer(),
+	})
+}
+
+// closeStep closes the current step with an explicit outcome.
+func (l *stepLogger) closeStep(success bool) {
+	status := deploy.StepStatusSuccess
+
+	if !success {
+		status = deploy.StepStatusFailed
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.closeCurrent(time.Now().UnixMilli(), status)
+}
+
+// closeCurrent stamps the current step's finish time and status. A step
+// that is already closed is left untouched.
+func (l *stepLogger) closeCurrent(finishedAt int64, status string) {
+	if len(l.steps) == 0 {
+		return
+	}
+
+	current := l.steps[len(l.steps)-1]
+
+	if current.finishedAt != 0 {
+		return
+	}
+
+	current.finishedAt = finishedAt
+	current.status = status
+}
+
+// marshal serializes the steps into the structured NDJSON log format.
+func (l *stepLogger) marshal() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	records := make([]deploy.StepRecord, 0, len(l.steps))
+
+	for _, step := range l.steps {
+		records = append(records, deploy.StepRecord{
+			Title:      step.title,
+			Message:    step.buf.String(),
+			StartedAt:  step.startedAt,
+			FinishedAt: step.finishedAt,
+			Status:     step.status,
+		})
+	}
+
+	return deploy.MarshalStepLogs(records)
+}

--- a/src/ce/runner/step_logger_test.go
+++ b/src/ce/runner/step_logger_test.go
@@ -1,0 +1,101 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stretchr/testify/suite"
+)
+
+type StepLoggerSuite struct {
+	suite.Suite
+}
+
+func (s *StepLoggerSuite) parse(reporter *ReporterModel) []deploy.StepRecord {
+	steps, ok := deploy.ParseStepLogs(reporter.Logs())
+
+	s.Require().True(ok)
+
+	return steps
+}
+
+func (s *StepLoggerSuite) Test_OutputIsAttributedToCurrentStep() {
+	reporter := NewReporter("")
+
+	// The writer is captured once and reused across steps, like the
+	// installer does: output must land in whichever step is current.
+	file := reporter.File()
+
+	reporter.AddStep("npm install")
+	_, err := file.Write([]byte("added 12 packages\n"))
+	s.NoError(err)
+
+	reporter.AddStep("npm run build")
+	_, err = file.Write([]byte("compiled\n"))
+	s.NoError(err)
+
+	steps := s.parse(reporter)
+
+	s.Len(steps, 2)
+	s.Equal("npm install", steps[0].Title)
+	s.Equal("added 12 packages\n", steps[0].Message)
+	s.Equal("npm run build", steps[1].Title)
+	s.Equal("compiled\n", steps[1].Message)
+
+	// The first step was closed by the second one.
+	s.Equal(deploy.StepStatusSuccess, steps[0].Status)
+	s.NotZero(steps[0].FinishedAt)
+	s.GreaterOrEqual(steps[0].FinishedAt, steps[0].StartedAt)
+
+	// The second step is still running.
+	s.Zero(steps[1].FinishedAt)
+}
+
+func (s *StepLoggerSuite) Test_OutputBeforeFirstStepIsDropped() {
+	reporter := NewReporter("")
+
+	_, err := reporter.File().Write([]byte("boot noise\n"))
+	s.NoError(err)
+
+	reporter.AddStep("checkout main")
+
+	steps := s.parse(reporter)
+
+	s.Len(steps, 1)
+	s.Empty(steps[0].Message)
+}
+
+func (s *StepLoggerSuite) Test_SystemMarkersCloseWithoutOpening() {
+	reporter := NewReporter("")
+
+	reporter.AddStep("saving build cache")
+	reporter.AddLine("saved build cache (193MB)")
+	reporter.AddStep("[system] building finished")
+
+	steps := s.parse(reporter)
+
+	s.Len(steps, 1)
+	s.Equal("saving build cache", steps[0].Title)
+	s.Equal("saved build cache (193MB)\n", steps[0].Message)
+	s.NotZero(steps[0].FinishedAt)
+}
+
+func (s *StepLoggerSuite) Test_CloseStep_MarksFailure() {
+	reporter := NewReporter("")
+
+	reporter.AddStep("npm run e2e")
+	reporter.CloseStep(false)
+
+	// A later close must not overwrite the recorded outcome.
+	reporter.CloseStep(true)
+	reporter.AddStep("[system] deployment finished")
+
+	steps := s.parse(reporter)
+
+	s.Len(steps, 1)
+	s.Equal(deploy.StepStatusFailed, steps[0].Status)
+}
+
+func TestStepLoggerSuite(t *testing.T) {
+	suite.Run(t, new(StepLoggerSuite))
+}


### PR DESCRIPTION
## Problem

Deployment logs showed a negative duration on the `database migrations` step (e.g. `-11s`) even after #348. Root cause: log steps are stored as a text blob with `[sk-step]` markers and all timing/status/structure is *inferred at read time* — durations from the next step's timestamp, statuses back-patched from exit codes, and the `deploy` step synthesized from the upload result and appended out of chronological order.

## Commit 1 — targeted fix

Insert the synthetic `deploy` step right after the `building finished` marker so timestamps stay chronological. Migrations show their real duration; the deploy step shows the upload time. Regression test reproduces deployment 422's exact timeline.

## Commit 2 — structured logs (kills the bug class)

The runner now records steps as structured NDJSON — one record per line with explicit `startedAt`/`finishedAt` (unix ms) and per-step `status`:

```json
{"title":"npm install","message":"...","startedAt":1783680123456,"finishedAt":1783680127890,"status":"success"}
```

- `deploy` is a real step recorded around the artifact upload; `database migrations` is timed by the API when it runs. No more synthesis, sentinels, or ordering-dependent duration math.
- `Reporter` keeps a per-step buffer behind a stable `io.Writer`, so command output is attributed to whichever step is current at write time — existing call sites unchanged.
- Live log streaming works as before (full blob posted every 5s); a step with `finishedAt: 0` renders as running.
- Status checks record real per-step outcomes via `CloseStep`.

### Backward compatibility

- `PrepareLogs` sniffs the stored blob: structured → new renderer; anything else → the existing text parser, unchanged. Old deployments never migrate.
- GitHub-action builds keep emitting the text format and keep working through the legacy parser (that producer can't be upgraded by us).
- The migrations append (`AddLogStep`) matches the stored blob's format, covering in-flight deployments during the upgrade. The exit callback now loads the logs to detect the format, so `updateDeploymentResult` replaces the logs column instead of concatenating (guarded to keep existing logs when nothing was appended).
- API response shape is unchanged — no UI changes needed.

## Testing

- New `DeploymentLogsSuite` (parse/marshal round-trip, structured render incl. running steps and failed migrations, format-sniffing append, legacy fallback).
- New `StepLoggerSuite` (output attribution across steps via a captured writer, system markers, explicit close outcomes).
- Full `go test ./src/... -p 1` passes.