### PR TITLE
refactor: serve /_stormkit endpoints as routes

### DIFF
--- a/src/ce/hosting/analytics_script_test.go
+++ b/src/ce/hosting/analytics_script_test.go
@@ -41,9 +41,8 @@ func htmlResponse(body string) *shttp.Response {
 
 func (s *AnalyticsScriptSuite) Test_ServesScript() {
 	req := s.newRequest(&hosting.Host{Name: "x"}, "/_stormkit/analytics.js")
-	res, err := hosting.WithAnalyticsScript(req)
+	res := hosting.HandleAnalyticsScript(req)
 
-	s.NoError(err)
 	s.Require().NotNil(res)
 	s.Equal(http.StatusOK, res.Status)
 	s.Contains(res.Headers.Get("Content-Type"), "javascript")
@@ -55,21 +54,13 @@ func (s *AnalyticsScriptSuite) Test_ServesScript() {
 
 func (s *AnalyticsScriptSuite) Test_NotModifiedOnMatchingETag() {
 	req := s.newRequest(&hosting.Host{Name: "x"}, "/_stormkit/analytics.js")
-	first, _ := hosting.WithAnalyticsScript(req)
+	first := hosting.HandleAnalyticsScript(req)
 
 	req2 := s.newRequest(&hosting.Host{Name: "x"}, "/_stormkit/analytics.js")
 	req2.Header.Set("If-None-Match", first.Headers.Get("ETag"))
-	res, _ := hosting.WithAnalyticsScript(req2)
+	res := hosting.HandleAnalyticsScript(req2)
 
 	s.Equal(http.StatusNotModified, res.Status)
-}
-
-func (s *AnalyticsScriptSuite) Test_PassesThroughOtherPaths() {
-	req := s.newRequest(&hosting.Host{Name: "x"}, "/index.html")
-	res, err := hosting.WithAnalyticsScript(req)
-
-	s.NoError(err)
-	s.Nil(res)
 }
 
 func (s *AnalyticsScriptSuite) Test_ServesEmbeddedDefaultWhenNoOverride() {

--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -3,6 +3,7 @@ package hosting
 import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/pool"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -23,6 +24,43 @@ func ResolveAnalyticsScript(cfg admin.InstanceConfig) ([]byte, string) {
 // InjectSnippets exposes injectSnippets for tests.
 func InjectSnippets(req *RequestContext, res *shttp.Response) *shttp.Response {
 	return injectSnippets(req, res)
+}
+
+// HandleAuthVerify exposes the reserved /_stormkit/auth/verify route handler.
+// Reserved endpoints are unexported handlers now that they are routes rather
+// than middleware branches; this seam lets the existing tests drive the handler
+// directly without standing up the mux router.
+func HandleAuthVerify(req *RequestContext) *shttp.Response {
+	return handleAuthVerify(req)
+}
+
+// HandleAnalyticsScript exposes the reserved /_stormkit/analytics.js route
+// handler to the external hosting_test package.
+func HandleAnalyticsScript(req *RequestContext) *shttp.Response {
+	return handleAnalyticsScript(req)
+}
+
+// ServeAuth dispatches a /_stormkit/auth/* request to its route handler, the
+// same way registerReservedRoutes wires them into mux. It mirrors the WithSKAuth
+// (*shttp.Response, error) signature — always a nil error — so the terminal
+// endpoint tests migrate from WithSKAuth with a plain rename.
+func ServeAuth(req *RequestContext) (*shttp.Response, error) {
+	switch req.URL().Path {
+	case "/_stormkit/auth/register", "/_stormkit/auth/login":
+		return handleAuthRegisterLogin(req), nil
+	case "/_stormkit/auth/verify":
+		return handleAuthVerify(req), nil
+	case "/_stormkit/auth/magic":
+		return handleAuthMagic(req), nil
+	case "/_stormkit/auth/refresh":
+		return handleAuthRefresh(req), nil
+	case "/_stormkit/auth/me":
+		return handleAuthMe(req), nil
+	case skauth.CallbackPath:
+		return handleAuthOAuthCallback(req), nil
+	default:
+		return handleAuthProvider(req), nil
+	}
 }
 
 // EmbeddedScriptETag exposes the embedded default's ETag for tests.

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -68,9 +68,13 @@ func HandlerForward(req *RequestContext) (res *shttp.Response) {
 		return rs.NotFound()
 	}
 
+	// The reserved /_stormkit/* endpoints (analytics.js, collect, auth/*) are now
+	// declared as routes (see registerReservedRoutes) and short-circuit before
+	// this handler. What remains here is genuinely cross-cutting: WithSKAuth still
+	// injects verified-bearer identity headers on every app request and serves the
+	// bare one-time-code landing, and the auth-wall / redirect rules apply to any
+	// path.
 	middlewares := []func(req *RequestContext) (*shttp.Response, error){
-		WithAnalyticsScript,
-		WithCollect,
 		WithSKAuth,
 		WithAuthWall,
 		WithRedirect,

--- a/src/ce/hosting/middleware.analytics_script.go
+++ b/src/ce/hosting/middleware.analytics_script.go
@@ -15,8 +15,6 @@ import (
 //go:embed analytics.js
 var analyticsScript []byte
 
-const analyticsScriptPath = reservedPathPrefix + "analytics.js"
-
 // embeddedScriptETag is the content hash of the embedded default, served when no
 // admin override is configured so clients refetch only when the script changes.
 var embeddedScriptETag = etagFor(analyticsScript)
@@ -59,11 +57,12 @@ func resolveAnalyticsScript(cfg admin.InstanceConfig) ([]byte, string) {
 	return analyticsScript, embeddedScriptETag
 }
 
-// WithAnalyticsScript serves the client-side analytics script at a stable URL.
-func WithAnalyticsScript(req *RequestContext) (*shttp.Response, error) {
-	if req.URL().Path != analyticsScriptPath {
-		return nil, nil
-	}
+// handleAnalyticsScript serves the client-side analytics script at a stable URL.
+// It is wired as a route (see registerReservedRoutes), so the path is guaranteed
+// by the router and needs no guard here. finalizeReserved layers on the platform
+// response headers.
+func handleAnalyticsScript(req *RequestContext) (res *shttp.Response) {
+	defer func() { res = finalizeReserved(req, res) }()
 
 	content, etag := analyticsScriptContent(req.Context())
 
@@ -73,12 +72,12 @@ func WithAnalyticsScript(req *RequestContext) (*shttp.Response, error) {
 	headers.Set("ETag", etag)
 
 	if req.Header.Get("If-None-Match") == etag {
-		return &shttp.Response{Status: http.StatusNotModified, Headers: headers}, nil
+		return &shttp.Response{Status: http.StatusNotModified, Headers: headers}
 	}
 
 	return &shttp.Response{
 		Status:  http.StatusOK,
 		Headers: headers,
 		Data:    content,
-	}, nil
+	}
 }

--- a/src/ce/hosting/middleware.collect.go
+++ b/src/ce/hosting/middleware.collect.go
@@ -65,39 +65,37 @@ type collectPayload struct {
 	Pageviews []collectPageview `json:"pageviews"`
 }
 
-// WithCollect handles the client-side (and server-to-server) analytics beacon
+// handleCollect handles the client-side (and server-to-server) analytics beacon
 // at /_stormkit/collect. It resolves the app/env/domain from the host, computes
 // a cookieless visitor id, drops bots, and queues the events through the same
 // async pipeline as server-side analytics. Custom events are enterprise-only,
 // matching server-side analytics.
-func WithCollect(req *RequestContext) (*shttp.Response, error) {
-	if req.URL().Path != collectPath {
-		return nil, nil
-	}
+func handleCollect(req *RequestContext) (res *shttp.Response) {
+	defer func() { res = finalizeReserved(req, res) }()
 
 	if req.Method != http.MethodPost {
-		return &shttp.Response{Status: http.StatusMethodNotAllowed}, nil
+		return &shttp.Response{Status: http.StatusMethodNotAllowed}
 	}
 
 	if req.Host == nil || req.Host.Config == nil || !req.Host.Config.IsEnterprise {
-		return &shttp.Response{Status: http.StatusNotFound}, nil
+		return &shttp.Response{Status: http.StatusNotFound}
 	}
 
 	if !collectLimiter.Get(req.RemoteIP()).Limiter.Allow() {
-		return &shttp.Response{Status: http.StatusTooManyRequests}, nil
+		return &shttp.Response{Status: http.StatusTooManyRequests}
 	}
 
 	userAgent := req.UserAgent()
 
 	// Bots never reach human-facing aggregates; drop silently.
 	if analytics.IsBot(userAgent) || !analytics.IsUtf8(userAgent) {
-		return &shttp.Response{Status: http.StatusNoContent}, nil
+		return &shttp.Response{Status: http.StatusNoContent}
 	}
 
 	payload, ok := parseCollectBody(req.Body)
 
 	if !ok {
-		return &shttp.Response{Status: http.StatusBadRequest}, nil
+		return &shttp.Response{Status: http.StatusBadRequest}
 	}
 
 	cfg := req.Host.Config
@@ -174,7 +172,7 @@ func WithCollect(req *RequestContext) (*shttp.Response, error) {
 		})
 	}
 
-	return &shttp.Response{Status: http.StatusNoContent}, nil
+	return &shttp.Response{Status: http.StatusNoContent}
 }
 
 func parseCollectBody(body io.ReadCloser) (collectPayload, bool) {

--- a/src/ce/hosting/middleware.collect_handler_test.go
+++ b/src/ce/hosting/middleware.collect_handler_test.go
@@ -123,47 +123,41 @@ func (s *CollectHandlerSuite) waitForRecords(n int) []*jobs.HostingRecord {
 func (s *CollectHandlerSuite) Test_NonEnterprise_NotFound() {
 	s.host.Config.IsEnterprise = false
 
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.1", collectTestUA, `{"events":[{"name":"x"}]}`))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.1", collectTestUA, `{"events":[{"name":"x"}]}`))
 
-	s.NoError(err)
 	s.Equal(http.StatusNotFound, res.Status)
 }
 
 func (s *CollectHandlerSuite) Test_MethodNotAllowed() {
-	res, err := WithCollect(s.request(http.MethodGet, "203.0.113.2", collectTestUA, ""))
+	res := handleCollect(s.request(http.MethodGet, "203.0.113.2", collectTestUA, ""))
 
-	s.NoError(err)
 	s.Equal(http.StatusMethodNotAllowed, res.Status)
 }
 
 func (s *CollectHandlerSuite) Test_Bot_Dropped() {
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.3", "Googlebot/2.1", `{"events":[{"name":"x"}]}`))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.3", "Googlebot/2.1", `{"events":[{"name":"x"}]}`))
 
-	s.NoError(err)
 	s.Equal(http.StatusNoContent, res.Status)
 	s.Empty(s.waitForRecords(1))
 }
 
 func (s *CollectHandlerSuite) Test_BadBody() {
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.4", collectTestUA, `not-json`))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.4", collectTestUA, `not-json`))
 
-	s.NoError(err)
 	s.Equal(http.StatusBadRequest, res.Status)
 }
 
 func (s *CollectHandlerSuite) Test_EmptyPayload() {
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.5", collectTestUA, `{"events":[],"pageviews":[]}`))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.5", collectTestUA, `{"events":[],"pageviews":[]}`))
 
-	s.NoError(err)
 	s.Equal(http.StatusBadRequest, res.Status)
 }
 
 func (s *CollectHandlerSuite) Test_Events_Queued() {
 	body := `{"events":[{"name":"purchase","path":"/checkout","metadata":{"plan":"pro"}},{"name":""}]}`
 
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.6", collectTestUA, body))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.6", collectTestUA, body))
 
-	s.NoError(err)
 	s.Equal(http.StatusNoContent, res.Status)
 
 	records := s.waitForRecords(1)
@@ -180,9 +174,8 @@ func (s *CollectHandlerSuite) Test_Events_Queued() {
 func (s *CollectHandlerSuite) Test_Pageviews_TaggedClient() {
 	body := `{"pageviews":[{"path":"/pricing","referrer":"https://google.com"},{"path":""}]}`
 
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.7", collectTestUA, body))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.7", collectTestUA, body))
 
-	s.NoError(err)
 	s.Equal(http.StatusNoContent, res.Status)
 
 	records := s.waitForRecords(1)
@@ -208,9 +201,8 @@ func (s *CollectHandlerSuite) Test_Events_Truncated() {
 
 	b.WriteString(`]}`)
 
-	res, err := WithCollect(s.request(http.MethodPost, "203.0.113.8", collectTestUA, b.String()))
+	res := handleCollect(s.request(http.MethodPost, "203.0.113.8", collectTestUA, b.String()))
 
-	s.NoError(err)
 	s.Equal(http.StatusNoContent, res.Status)
 
 	records := s.waitForRecords(1)
@@ -223,8 +215,7 @@ func (s *CollectHandlerSuite) Test_RateLimited() {
 	statuses := make([]int, 0, 40)
 
 	for i := 0; i < 40; i++ {
-		res, err := WithCollect(s.request(http.MethodPost, "198.51.100.42", collectTestUA, body))
-		s.NoError(err)
+		res := handleCollect(s.request(http.MethodPost, "198.51.100.42", collectTestUA, body))
 		statuses = append(statuses, res.Status)
 	}
 

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
@@ -274,6 +272,11 @@ func (m *skAuthMiddleware) renderVerifyPage(status int, head, content string) *s
 	}
 }
 
+// WithSKAuth carries the cross-cutting auth concerns that must run for every app
+// request: the config-independent one-time-code login landing and the
+// verified-bearer -> identity header injection. The discrete /_stormkit/auth/*
+// endpoints (register, login, verify, magic, refresh, me, callback, provider)
+// are served by dedicated routes — see registerReservedRoutes.
 func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 	path := req.URL().Path
 
@@ -296,80 +299,66 @@ func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
 		return nil, nil
 	}
 
-	// Strip the headers to prevent clients from spoofing them.
-	req.Header.Del("X-User-Id")
-	req.Header.Del("X-User-Email")
+	injectUserHeaders(req)
 
-	if bearer := user.ParseBearer(req.Header.Get("Authorization")); bearer != "" {
-		secret := req.Host.Config.SKAuth.Secret
-
-		claims := user.ParseJWT(&user.ParseJWTArgs{
-			Bearer:  bearer,
-			Secret:  secret,
-			MaxMins: req.Host.Config.SKAuth.TTL,
-		})
-
-		if claims != nil {
-			if userID, ok := claims["uid"].(string); ok && userID != "" {
-				req.Header.Set("X-User-Id", userID)
-			}
-
-			if encEmail, ok := claims["eml"].(string); ok && encEmail != "" {
-				if email := utils.DecryptToString(encEmail, emlKey(secret)); email != "" {
-					req.Header.Set("X-User-Email", email)
-				}
-			}
-		}
-	}
-
-	if !strings.HasPrefix(path, "/_stormkit/auth") {
+	// Only the bare landing remains here; its terminal states (missing/unknown
+	// code) render the auth page. Everything under /_stormkit/auth/ is routed.
+	if path != "/_stormkit/auth" {
 		return nil, nil
 	}
 
-	// CORS preflight — respond 204 so the browser proceeds with the actual
-	// request. Per-path custom headers (e.g. Access-Control-Allow-Origin)
-	// are layered on by finalize() afterwards. Without this short-circuit
-	// the request would fall through to handlers that expect a JSON body
-	// and reject OPTIONS with 400, breaking the preflight.
 	if req.Method == http.MethodOptions {
 		return &shttp.Response{Status: http.StatusNoContent}, nil
 	}
 
-	m := &skAuthMiddleware{req: req}
+	return (&skAuthMiddleware{req: req}).handleCallback()
+}
 
-	if path == "/_stormkit/auth/register" || path == "/_stormkit/auth/login" {
-		return m.handleRegisterLogin(path)
+// injectUserHeaders strips any client-supplied identity headers and, when a
+// valid skauth bearer accompanies the request, re-injects the authenticated
+// X-User-Id / X-User-Email for downstream handlers and the customer app.
+func injectUserHeaders(req *RequestContext) {
+	// Strip the headers to prevent clients from spoofing them.
+	req.Header.Del("X-User-Id")
+	req.Header.Del("X-User-Email")
+
+	bearer := user.ParseBearer(req.Header.Get("Authorization"))
+
+	if bearer == "" {
+		return
 	}
 
-	if path == "/_stormkit/auth/verify" {
-		return m.handleVerify()
+	secret := req.Host.Config.SKAuth.Secret
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer:  bearer,
+		Secret:  secret,
+		MaxMins: req.Host.Config.SKAuth.TTL,
+	})
+
+	if claims == nil {
+		return
 	}
 
-	if path == "/_stormkit/auth/magic" {
-		if m.req.Query().Get("token") != "" {
-			return m.handleMagicLinkVerify()
+	if userID, ok := claims["uid"].(string); ok && userID != "" {
+		req.Header.Set("X-User-Id", userID)
+	}
+
+	if encEmail, ok := claims["eml"].(string); ok && encEmail != "" {
+		if email := utils.DecryptToString(encEmail, emlKey(secret)); email != "" {
+			req.Header.Set("X-User-Email", email)
 		}
+	}
+}
 
-		return m.handleMagicLinkRequest()
+// handleMagic dispatches the magic-link endpoint: a token query parameter means
+// the user is following a link (verify), otherwise it's a request to send one.
+func (m *skAuthMiddleware) handleMagic() (*shttp.Response, error) {
+	if m.req.Query().Get("token") != "" {
+		return m.handleMagicLinkVerify()
 	}
 
-	if path == "/_stormkit/auth/refresh" {
-		return m.handleRefresh()
-	}
-
-	if path == "/_stormkit/auth/me" {
-		return m.handleMe()
-	}
-
-	if path == skauth.CallbackPath {
-		return m.handleOAuthCallback()
-	}
-
-	if provider, ok := isOAuthProviderPath(path); ok {
-		return m.handleOAuthInitiate(provider)
-	}
-
-	return m.handleCallback()
+	return m.handleMagicLinkRequest()
 }
 
 // handleRefresh trades a currently-valid skauth bearer for a freshly signed

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -163,7 +163,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_InvalidEmail() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=not-an-email"))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=not-an-email"))
 
 	s.NoError(err)
 	s.Equal(http.StatusBadRequest, res.Status)
@@ -172,7 +172,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_InvalidEmail() {
 func (s *WithSKAuthMagicLinkSuite) Test_Request_ProviderNotEnabled() {
 	env := s.MockEnv(s.app, nil)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com"))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com"))
 
 	s.NoError(err)
 	s.Equal(http.StatusNotFound, res.Status)
@@ -182,7 +182,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_Success() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com"))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com"))
 
 	s.NoError(err)
 	s.Equal(http.StatusCreated, res.Status)
@@ -198,7 +198,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_CreatesNewUser() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=newuser@example.com"))
+	_, err = hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=newuser@example.com"))
 	s.Require().NoError(err)
 
 	store, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeAppUser)
@@ -220,7 +220,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_InvalidToken() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?token=bad-token"))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?token=bad-token"))
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -233,13 +233,13 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_Success() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=verify@example.com"))
+	_, err = hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=verify@example.com"))
 	s.Require().NoError(err)
 
 	token := s.captureToken(env.ID)
 	s.Require().NotEmpty(token)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 
 	s.NoError(err)
 	s.Equal(http.StatusOK, res.Status)
@@ -253,13 +253,13 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_UIDClaimIsUUID() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=uuidcheck@example.com"))
+	_, err = hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=uuidcheck@example.com"))
 	s.Require().NoError(err)
 
 	token := s.captureToken(env.ID)
 	s.Require().NotEmpty(token)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 	s.Require().NoError(err)
 	s.Require().Equal(http.StatusOK, res.Status)
 
@@ -294,7 +294,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_TokenConsumedOnce() {
 	env, err := s.setupEnv()
 	s.Require().NoError(err)
 
-	_, err = hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=once@example.com"))
+	_, err = hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), "/_stormkit/auth/magic?email=once@example.com"))
 	s.Require().NoError(err)
 
 	token := s.captureToken(env.ID)
@@ -302,12 +302,12 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_TokenConsumedOnce() {
 
 	path := fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)
 
-	first, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	first, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.NoError(err)
 	s.Equal(http.StatusOK, first.Status)
 
 	// Reusing a consumed token bounces back to the app with a login_error.
-	second, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	second, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.NoError(err)
 	s.Equal(http.StatusFound, second.Status)
 	s.Require().NotNil(second.Redirect)
@@ -322,7 +322,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_Error_CrossOrigin_RedirectsToInit
 	s.Require().NoError(err)
 
 	post := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=err@example.com", http.MethodPost, "https://app.example.com")
-	_, err = hosting.WithSKAuth(post)
+	_, err = hosting.ServeAuth(post)
 	s.Require().NoError(err)
 
 	token := s.captureToken(env.ID)
@@ -330,13 +330,13 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_Error_CrossOrigin_RedirectsToInit
 
 	path := fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)
 
-	first, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	first, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.Require().NoError(err)
 	s.Require().Equal(http.StatusOK, first.Status)
 
 	// Replaying the consumed token: the error redirect must target the initiating
 	// origin, not the verify host.
-	second, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), path))
+	second, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.NoError(err)
 	s.Equal(http.StatusFound, second.Status)
 	s.Require().NotNil(second.Redirect)
@@ -348,7 +348,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_NoOriginCheck_WhenAllowListEmpty
 	s.Require().NoError(err)
 
 	rq := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com", http.MethodPost, "https://other.example.com")
-	res, err := hosting.WithSKAuth(rq)
+	res, err := hosting.ServeAuth(rq)
 
 	s.NoError(err)
 	s.Equal(http.StatusCreated, res.Status)
@@ -359,7 +359,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_AllowedOrigin_Accepted() {
 	s.Require().NoError(err)
 
 	rq := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com", http.MethodPost, "https://app.example.com")
-	res, err := hosting.WithSKAuth(rq)
+	res, err := hosting.ServeAuth(rq)
 
 	s.NoError(err)
 	s.Equal(http.StatusCreated, res.Status)
@@ -370,7 +370,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Request_DisallowedOrigin_Returns403() {
 	s.Require().NoError(err)
 
 	rq := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=user@example.com", http.MethodPost, "https://evil.example.com")
-	res, err := hosting.WithSKAuth(rq)
+	res, err := hosting.ServeAuth(rq)
 
 	s.NoError(err)
 	s.Equal(http.StatusForbidden, res.Status)
@@ -381,13 +381,13 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_CrossOrigin_RedirectsToInitiator(
 	s.Require().NoError(err)
 
 	post := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=cross@example.com", http.MethodPost, "https://app.example.com")
-	_, err = hosting.WithSKAuth(post)
+	_, err = hosting.ServeAuth(post)
 	s.Require().NoError(err)
 
 	token := s.captureToken(env.ID)
 	s.Require().NotEmpty(token)
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 
 	s.NoError(err)
 	s.Equal(http.StatusOK, res.Status)
@@ -406,7 +406,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() 
 	s.Require().NoError(err)
 
 	post := s.magicRequestWith(s.hostFor(env.ID), "/_stormkit/auth/magic?email=stale@example.com", http.MethodPost, "https://app.example.com")
-	_, err = hosting.WithSKAuth(post)
+	_, err = hosting.ServeAuth(post)
 	s.Require().NoError(err)
 
 	token := s.captureToken(env.ID)
@@ -420,7 +420,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() 
 	stored.AuthConf.AllowedOrigins = nil
 	s.Require().NoError(envStore.SaveAuthConf(context.Background(), env.ID, stored.AuthConf))
 
-	res, err := hosting.WithSKAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 
 	s.NoError(err)
 	s.Equal(http.StatusOK, res.Status)

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -85,7 +85,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
 		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
 		nil,
@@ -135,7 +135,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_LinksToExistingMagicLinkUser() {
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
 		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
 		nil,
@@ -163,7 +163,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_LinksToExistingMagicLinkUser() {
 func (s *WithSKAuthOAuthSuite) Test_Callback_InvalidState() {
 	host := s.setupCallbackEnv(true)
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
 		"/_stormkit/auth/callback?state=not-a-jwt&code=test-code",
 		nil,
@@ -181,7 +181,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ProviderDisabled_RedirectsWithError
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
 		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
 		nil,
@@ -203,7 +203,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ProviderDenied_RedirectsWithError()
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
 		fmt.Sprintf("/_stormkit/auth/callback?state=%s&error=access_denied", state),
 		nil,
@@ -227,7 +227,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ExchangeFails_RedirectsWithError() 
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
 		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=bad-code", state),
 		nil,

--- a/src/ce/hosting/middleware.skauth_oauth_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_test.go
@@ -123,7 +123,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_AllowedRedirect_Redirects() {
 		Referrer:     "https://app.example.com",
 	}).Return("https://accounts.google.com/o/oauth2/auth", nil)
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		s.hostFor(env.ID),
 		"/_stormkit/auth/google?redirect=https://app.example.com",
 		nil,
@@ -139,7 +139,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_AllowedRedirect_Redirects() {
 func (s *WithSKAuthOAuthSuite) Test_Initiate_DisallowedRedirect_Returns403() {
 	env := s.setupEnv([]string{"https://app.example.com"}, true)
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		s.hostFor(env.ID),
 		"/_stormkit/auth/google?redirect=https://evil.example.com",
 		nil,
@@ -160,7 +160,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_NoAllowList_FallsBackToOwnOrigin() 
 		Referrer:     "https://api.example.com",
 	}).Return("https://accounts.google.com/o/oauth2/auth", nil)
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		s.hostFor(env.ID),
 		"/_stormkit/auth/google?redirect=https://other.example.com",
 		nil,
@@ -180,7 +180,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_FallsBackToRefererHeader() {
 		Referrer:     "https://app.example.com",
 	}).Return("https://accounts.google.com/o/oauth2/auth", nil)
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		s.hostFor(env.ID),
 		"/_stormkit/auth/google",
 		map[string]string{"Referer": "https://app.example.com/login"},
@@ -193,7 +193,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_FallsBackToRefererHeader() {
 func (s *WithSKAuthOAuthSuite) Test_Initiate_ProviderDisabled_NotFound() {
 	env := s.setupEnv([]string{"https://app.example.com"}, false)
 
-	res, err := hosting.WithSKAuth(s.oauthRequest(
+	res, err := hosting.ServeAuth(s.oauthRequest(
 		s.hostFor(env.ID),
 		"/_stormkit/auth/google?redirect=https://app.example.com",
 		nil,

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -120,7 +120,7 @@ func (s *WithSKAuthSuite) Test_CORSPreflight() {
 	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic")
 	req.RequestContext.Method = http.MethodOptions
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -249,7 +249,7 @@ func (s *WithSKAuthSuite) Test_RegisterPath_SKAuthDisabled() {
 // Test_RegisterPath_MethodNotAllowed checks that /_stormkit/auth/register rejects non-POST requests.
 func (s *WithSKAuthSuite) Test_RegisterPath_MethodNotAllowed() {
 	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth/register")
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -263,7 +263,7 @@ func (s *WithSKAuthSuite) Test_RegisterPath_MissingEnv() {
 		"email":    "test@example.com",
 		"password": "supersecret123",
 	})
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -290,7 +290,7 @@ func (s *WithSKAuthSuite) Test_LoginPath_SKAuthDisabled() {
 // Test_LoginPath_MethodNotAllowed checks that /_stormkit/auth/login rejects non-POST requests.
 func (s *WithSKAuthSuite) Test_LoginPath_MethodNotAllowed() {
 	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth/login")
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -304,7 +304,7 @@ func (s *WithSKAuthSuite) Test_LoginPath_MissingEnv() {
 		"email":    "test@example.com",
 		"password": "supersecret123",
 	})
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -314,9 +314,8 @@ func (s *WithSKAuthSuite) Test_LoginPath_MissingEnv() {
 // Test_VerifyPath_MethodNotAllowed checks that /_stormkit/auth/verify rejects non-GET requests.
 func (s *WithSKAuthSuite) Test_VerifyPath_MethodNotAllowed() {
 	req := s.newPostRequest(s.hostWithSKAuth(), "/_stormkit/auth/verify", nil)
-	res, err := hosting.WithSKAuth(req)
+	res := hosting.HandleAuthVerify(req)
 
-	s.NoError(err)
 	s.NotNil(res)
 	s.Equal(http.StatusMethodNotAllowed, res.Status)
 }
@@ -324,9 +323,8 @@ func (s *WithSKAuthSuite) Test_VerifyPath_MethodNotAllowed() {
 // Test_VerifyPath_MissingToken checks that /_stormkit/auth/verify returns 400 when no token is provided.
 func (s *WithSKAuthSuite) Test_VerifyPath_MissingToken() {
 	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/verify")
-	res, err := hosting.WithSKAuth(req)
+	res := hosting.HandleAuthVerify(req)
 
-	s.NoError(err)
 	s.NotNil(res)
 	s.Equal(http.StatusBadRequest, res.Status)
 }
@@ -335,9 +333,8 @@ func (s *WithSKAuthSuite) Test_VerifyPath_MissingToken() {
 // has no EnvID configured — the env lookup finds nothing and auth is unavailable.
 func (s *WithSKAuthSuite) Test_VerifyPath_MissingEnv() {
 	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/verify?token=some-token")
-	res, err := hosting.WithSKAuth(req)
+	res := hosting.HandleAuthVerify(req)
 
-	s.NoError(err)
 	s.NotNil(res)
 	s.Equal(http.StatusNotFound, res.Status)
 }
@@ -346,7 +343,7 @@ func (s *WithSKAuthSuite) Test_VerifyPath_MissingEnv() {
 // the host has no EnvID configured — the zero-envId guard fires first.
 func (s *WithSKAuthSuite) Test_MagicPath_MissingEnv() {
 	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic?email=user@example.com")
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -357,7 +354,7 @@ func (s *WithSKAuthSuite) Test_MagicPath_MissingEnv() {
 // EnvID configured returns 404 — the zero-envId guard fires before token validation.
 func (s *WithSKAuthSuite) Test_MagicPath_VerifyInvalidToken() {
 	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/magic?token=bad-token")
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.NotNil(res)
@@ -521,7 +518,7 @@ func (s *WithSKAuthSuite) Test_Refresh_ValidToken() {
 	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
 	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -551,7 +548,7 @@ func (s *WithSKAuthSuite) Test_Refresh_PreservesEmail() {
 	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
 	req.Header.Set("Authorization", s.generateBearerWithEmail(types.ID(42), "user@example.com", secret))
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -579,7 +576,7 @@ func (s *WithSKAuthSuite) Test_Refresh_ExpiredToken() {
 	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
 	req.Header.Set("Authorization", s.generateBearerIssuedAt(types.ID(7), "test-secret-padded-to-32-chars!!", time.Now().Add(-30*time.Minute)))
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -592,7 +589,7 @@ func (s *WithSKAuthSuite) Test_Refresh_MissingBearer() {
 	host := s.hostWithSKAuth()
 	req := s.newPostRequest(host, "/_stormkit/auth/refresh", nil)
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -605,7 +602,7 @@ func (s *WithSKAuthSuite) Test_Refresh_WrongMethod() {
 	req := s.newGetRequest(host, "/_stormkit/auth/refresh")
 	req.Header.Set("Authorization", s.generateBearer(types.ID(1), "test-secret-padded-to-32-chars!!"))
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -617,7 +614,7 @@ func (s *WithSKAuthSuite) Test_Refresh_WrongMethod() {
 func (s *WithSKAuthSuite) Test_Me_MissingBearer() {
 	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/me")
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -629,7 +626,7 @@ func (s *WithSKAuthSuite) Test_Me_WrongMethod() {
 	req := s.newPostRequest(s.hostWithSKAuth(), "/_stormkit/auth/me", nil)
 	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)
@@ -642,7 +639,7 @@ func (s *WithSKAuthSuite) Test_Me_MissingEnv() {
 	req := s.newGetRequest(s.hostWithSKAuth(), "/_stormkit/auth/me")
 	req.Header.Set("Authorization", s.generateBearer(types.ID(42), "test-secret-padded-to-32-chars!!"))
 
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(req)
 
 	s.NoError(err)
 	s.Require().NotNil(res)

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -1,0 +1,118 @@
+package hosting
+
+import (
+	"net/http"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+// registerReservedRoutes attaches Stormkit's platform auth endpoints (the
+// discrete /_stormkit/auth/* handlers) as explicit routes instead of path-prefix
+// branches inside WithSKAuth. Each handler is wrapped with WithHost to resolve
+// the per-app config and applies finalizeReserved rather than the full
+// RequestServer.finalize(): reserved endpoints are platform pages, so customer
+// snippets and page-view analytics must not bleed into them.
+//
+// The cross-cutting parts of the old middleware stay in WithSKAuth: the verified
+// bearer -> identity header injection (which runs for every app request) and the
+// bare /_stormkit/auth one-time-code landing (which must work even on hosts with
+// no auth config of their own).
+//
+// Ordering matters. gorilla/mux matches in registration order, so these routes
+// must be registered before the catch-all in Services(); the dynamic {provider}
+// route is registered last so the fixed endpoints above take precedence.
+func registerReservedRoutes(s *shttp.Service) {
+	sk := s.NewEndpoint("/_stormkit")
+	sk.Handler(http.MethodGet, "/analytics.js", WithHost(handleAnalyticsScript))
+	// GET is registered too so the handler's own POST-only check returns the 405,
+	// matching the pre-route middleware behaviour.
+	sk.Handler(http.MethodGet, "/collect", WithHost(handleCollect))
+	sk.Handler(http.MethodPost, "/collect", WithHost(handleCollect))
+
+	auth := s.NewEndpoint("/_stormkit/auth")
+
+	// Every path is registered for GET, POST and OPTIONS regardless of the
+	// method it ultimately accepts: the handlers do their own method validation
+	// (returning a JSON 405), and serveReservedAuth answers OPTIONS preflights.
+	// This keeps behaviour identical to the old prefix-matching middleware, which
+	// never filtered by method at the routing layer.
+	add := func(path string, h func(*RequestContext) *shttp.Response) {
+		for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodOptions} {
+			auth.Handler(method, path, WithHost(h))
+		}
+	}
+
+	add("/register", handleAuthRegisterLogin)
+	add("/login", handleAuthRegisterLogin)
+	add("/verify", handleAuthVerify)
+	add("/magic", handleAuthMagic)
+	add("/refresh", handleAuthRefresh)
+	add("/me", handleAuthMe)
+	add("/callback", handleAuthOAuthCallback)
+	add("/{provider}", handleAuthProvider)
+}
+
+// serveReservedAuth wraps a skAuthMiddleware handler with the concerns the
+// WithSKAuth chain used to apply around every /_stormkit/auth/* branch: fall
+// through to normal app serving when the host has no auth configured, answer
+// CORS preflights, inject the verified-bearer identity headers, and finalize
+// with platform headers only.
+func serveReservedAuth(fn func(*skAuthMiddleware) (*shttp.Response, error)) func(*RequestContext) *shttp.Response {
+	return func(req *RequestContext) *shttp.Response {
+		// No auth configured -> this path is not reserved for the host; serve the
+		// app exactly as the old middleware's nil return did.
+		if req.Host.Config.SKAuth == nil {
+			return HandlerForward(req)
+		}
+
+		if req.Method == http.MethodOptions {
+			return finalizeReserved(req, &shttp.Response{Status: http.StatusNoContent})
+		}
+
+		injectUserHeaders(req)
+
+		resp, err := fn(&skAuthMiddleware{req: req})
+
+		if err != nil {
+			return NewRequestServer(req).Error(err)
+		}
+
+		return finalizeReserved(req, resp)
+	}
+}
+
+var (
+	handleAuthVerify        = serveReservedAuth((*skAuthMiddleware).handleVerify)
+	handleAuthRefresh       = serveReservedAuth((*skAuthMiddleware).handleRefresh)
+	handleAuthMe            = serveReservedAuth((*skAuthMiddleware).handleMe)
+	handleAuthMagic         = serveReservedAuth((*skAuthMiddleware).handleMagic)
+	handleAuthOAuthCallback = serveReservedAuth((*skAuthMiddleware).handleOAuthCallback)
+
+	handleAuthRegisterLogin = serveReservedAuth(func(m *skAuthMiddleware) (*shttp.Response, error) {
+		return m.handleRegisterLogin(m.req.URL().Path)
+	})
+
+	// handleAuthProvider serves /_stormkit/auth/{provider}. A known provider
+	// starts the OAuth flow; anything else falls to the one-time-code landing's
+	// terminal state, matching the old middleware fall-through.
+	handleAuthProvider = serveReservedAuth(func(m *skAuthMiddleware) (*shttp.Response, error) {
+		if provider, ok := isOAuthProviderPath(m.req.URL().Path); ok {
+			return m.handleOAuthInitiate(provider)
+		}
+
+		return m.handleCallback()
+	})
+)
+
+// finalizeReserved is the reserved-endpoint counterpart to
+// RequestServer.finalize. It applies the platform response headers
+// (x-sk-version, Server, and the user-configured CustomHeaders that carry CORS)
+// but deliberately skips snippet injection and page-view analytics, which
+// belong to customer traffic only.
+func finalizeReserved(req *RequestContext, res *shttp.Response) *shttp.Response {
+	if res == nil || req.Host == nil || req.Host.Config == nil {
+		return res
+	}
+
+	return injectHeaders(req, res)
+}

--- a/src/ce/hosting/services.go
+++ b/src/ce/hosting/services.go
@@ -58,6 +58,11 @@ func Services(r *shttp.Router) *shttp.Service {
 	}
 
 	s := r.NewService()
+
+	// Reserved /_stormkit/* endpoints are declared as explicit routes and MUST
+	// be registered before the catch-all so mux matches them first.
+	registerReservedRoutes(s)
+
 	s.NewEndpoint("/").CatchAll(WithHost(HandlerForward), devDomain)
 
 	return s

--- a/src/ce/hosting/skauth_email_test.go
+++ b/src/ce/hosting/skauth_email_test.go
@@ -177,7 +177,7 @@ func (s *WithSKAuthEmailSuite) setupEnv(withMailer bool) (*factory.MockEnv, erro
 }
 
 func (s *WithSKAuthEmailSuite) register(host *hosting.Host, email, password string) *shttp.Response {
-	res, err := hosting.WithSKAuth(s.postRequest(host, "/_stormkit/auth/register", map[string]any{
+	res, err := hosting.ServeAuth(s.postRequest(host, "/_stormkit/auth/register", map[string]any{
 		"email":    email,
 		"password": password,
 	}))
@@ -186,7 +186,7 @@ func (s *WithSKAuthEmailSuite) register(host *hosting.Host, email, password stri
 }
 
 func (s *WithSKAuthEmailSuite) login(host *hosting.Host, email, password string) *shttp.Response {
-	res, err := hosting.WithSKAuth(s.postRequest(host, "/_stormkit/auth/login", map[string]any{
+	res, err := hosting.ServeAuth(s.postRequest(host, "/_stormkit/auth/login", map[string]any{
 		"email":    email,
 		"password": password,
 	}))
@@ -219,7 +219,7 @@ func (s *WithSKAuthEmailSuite) Test_Register_BodyEnvIdIgnored() {
 	s.Require().NoError(err)
 
 	// Post with a different envId in the body — should still succeed using the host's env.
-	res, err := hosting.WithSKAuth(s.postRequest(s.hostFor(env.ID), "/_stormkit/auth/register", map[string]any{
+	res, err := hosting.ServeAuth(s.postRequest(s.hostFor(env.ID), "/_stormkit/auth/register", map[string]any{
 		"envId":    "9999999",
 		"email":    "crossenv@example.com",
 		"password": "supersecret123",
@@ -465,9 +465,8 @@ func (s *WithSKAuthEmailSuite) Test_Verify_Success() {
 	s.Require().Equal(http.StatusCreated, s.register(host, "willverify@example.com", "supersecret123").Status)
 	s.Require().NotEmpty(capturedToken)
 
-	res, err := hosting.WithSKAuth(s.getRequest(host, fmt.Sprintf("/_stormkit/auth/verify?token=%s&envId=%d", capturedToken, env.ID)))
+	res := hosting.HandleAuthVerify(s.getRequest(host, fmt.Sprintf("/_stormkit/auth/verify?token=%s&envId=%d", capturedToken, env.ID)))
 
-	s.Require().NoError(err)
 	s.Equal(http.StatusOK, res.Status)
 
 	body := string(res.Data.([]byte))
@@ -478,9 +477,8 @@ func (s *WithSKAuthEmailSuite) Test_Verify_InvalidToken() {
 	env, err := s.setupEnv(true)
 	s.Require().NoError(err)
 
-	res, err := hosting.WithSKAuth(s.getRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/verify?token=not-a-real-token&envId=%d", env.ID)))
+	res := hosting.HandleAuthVerify(s.getRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/verify?token=not-a-real-token&envId=%d", env.ID)))
 
-	s.Require().NoError(err)
 	s.Equal(http.StatusBadRequest, res.Status)
 	s.Contains(string(res.Data.([]byte)), "invalid or expired verification token")
 }
@@ -515,8 +513,7 @@ func (s *WithSKAuthEmailSuite) Test_Verify_AfterVerification_LoginSucceeds() {
 	s.Require().Equal(http.StatusCreated, s.register(host, "loginafter@example.com", "supersecret123").Status)
 	s.Require().NotEmpty(capturedToken)
 
-	_, err = hosting.WithSKAuth(s.getRequest(host, fmt.Sprintf("/_stormkit/auth/verify?token=%s&envId=%d", capturedToken, env.ID)))
-	s.Require().NoError(err)
+	hosting.HandleAuthVerify(s.getRequest(host, fmt.Sprintf("/_stormkit/auth/verify?token=%s&envId=%d", capturedToken, env.ID)))
 
 	res := s.login(host, "loginafter@example.com", "supersecret123")
 


### PR DESCRIPTION
## What

Move Stormkit's reserved `/_stormkit/*` endpoints off the forwarding middleware chain and onto explicit mux routes.

**Routed now:** `analytics.js`, `collect`, and every auth endpoint — `register`, `login`, `verify`, `magic`, `refresh`, `me`, `callback`, and the `{provider}` OAuth initiator.

## Why

Reserved endpoints were served by `if path == "/_stormkit/..."` checks scattered across the middleware chain in `HandlerForward`. Declaring them as routes is more self-documenting, and — with the OAuth 2.1 authorization server for MCP connectors coming in #314 — makes new platform endpoints first-class routes rather than another prefix branch. It also cleanly separates terminal platform endpoints from genuinely cross-cutting middleware.

## How

- **`reserved_routes.go`** — `registerReservedRoutes()` declares the routes; `serveReservedAuth` wraps each auth handler with the concerns the old chain applied per branch (disabled-host fall-through, CORS preflight, bearer→header injection, `finalizeReserved`). Registered before the catch-all so mux matches them first; the dynamic `{provider}` route is registered last so fixed endpoints win.
- **`WithAnalyticsScript` / `WithCollect` are removed** — their bodies moved into the `handleAnalyticsScript` / `handleCollect` route handlers. The router guarantees the path, so the old prefix guards are dropped.
- **`WithSKAuth` slims down** to the cross-cutting work it still owns: injecting verified-bearer identity headers on every app request, and serving the config-independent one-time-code login landing at the bare `/_stormkit/auth`.

### Behaviour preserved deliberately

1. **Fall-through when auth is disabled** — `serveReservedAuth` delegates to `HandlerForward` when the host has no auth config, matching the old `nil` return.
2. **`finalizeReserved` instead of `finalize()`** — reserved pages get platform headers (`x-sk-version`, `Server`, CustomHeaders/CORS) but not snippet injection, which today leaks customer snippets into Stormkit's own pages. Page-view analytics already skipped reserved paths.
3. **Method handling & CORS** — handlers keep their own method checks (405); OPTIONS preflights answer 204.

## Tests

Terminal-endpoint tests drive the routed handlers through `export_test.go` seams (`ServeAuth`, `HandleAuthVerify`, `HandleAnalyticsScript`); collect tests (internal package) call `handleCollect` directly. The bearer-injection and one-time-code landing tests keep exercising `WithSKAuth`. Full hosting suite passes.