### PR TITLE
feat: add oauth 2.1 authorization server (phase 1)

### DIFF
--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -40,6 +40,26 @@ type SKAuthConf struct {
 	// carry a matching Origin header and the user is redirected back to
 	// that origin after clicking the email link.
 	AllowedOrigins []string
+
+	// OAuth, when enabled, turns this environment into an OAuth 2.1
+	// authorization server for MCP connectors (see /_stormkit/oauth and the
+	// .well-known discovery documents). It builds on the SkAuth identity above;
+	// redirect_uri targets are validated against AllowedOrigins.
+	OAuth *OAuthConf
+}
+
+// OAuthConf configures the OAuth 2.1 authorization server layered on SkAuth.
+type OAuthConf struct {
+	// Enabled turns the /_stormkit/oauth/* endpoints and the .well-known
+	// discovery documents on for this environment.
+	Enabled bool
+}
+
+// OAuthEnabled reports whether the OAuth authorization server is active. It
+// requires SkAuth itself to be enabled, since OAuth reuses its signing secret
+// and app-user identities.
+func (ac *SKAuthConf) OAuthEnabled() bool {
+	return ac != nil && ac.Status && ac.OAuth != nil && ac.OAuth.Enabled
 }
 
 // Value implements the Sql Driver interface.

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -41,25 +41,29 @@ type SKAuthConf struct {
 	// that origin after clicking the email link.
 	AllowedOrigins []string
 
-	// OAuth, when enabled, turns this environment into an OAuth 2.1
+	// OAuthServer, when enabled, turns this environment into an OAuth 2.1
 	// authorization server for MCP connectors (see /_stormkit/oauth and the
-	// .well-known discovery documents). It builds on the SkAuth identity above;
+	// .well-known discovery documents). Note this is the opposite role from the
+	// Google/X provider logins above: here the app IS the OAuth server that
+	// external clients connect to. It builds on the SkAuth identity;
 	// redirect_uri targets are validated against AllowedOrigins.
-	OAuth *OAuthConf
+	OAuthServer *OAuthServerConf
 }
 
-// OAuthConf configures the OAuth 2.1 authorization server layered on SkAuth.
-type OAuthConf struct {
+// OAuthServerConf configures the OAuth 2.1 authorization server layered on
+// SkAuth. Distinct from the OAuth *provider* logins (Google, X), where the app
+// is instead an OAuth client of an external identity provider.
+type OAuthServerConf struct {
 	// Enabled turns the /_stormkit/oauth/* endpoints and the .well-known
 	// discovery documents on for this environment.
 	Enabled bool
 }
 
-// OAuthEnabled reports whether the OAuth authorization server is active. It
-// requires SkAuth itself to be enabled, since OAuth reuses its signing secret
-// and app-user identities.
-func (ac *SKAuthConf) OAuthEnabled() bool {
-	return ac != nil && ac.Status && ac.OAuth != nil && ac.OAuth.Enabled
+// OAuthServerEnabled reports whether the OAuth authorization server is active.
+// It requires SkAuth itself to be enabled, since the server reuses its signing
+// secret and app-user identities.
+func (ac *SKAuthConf) OAuthServerEnabled() bool {
+	return ac != nil && ac.Status && ac.OAuthServer != nil && ac.OAuthServer.Enabled
 }
 
 // Value implements the Sql Driver interface.

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -13,11 +13,11 @@ import (
 )
 
 type AuthConfigUpdateRequest struct {
-	SuccessURL     string   `json:"successUrl"`
-	TTL            int      `json:"tokenTtl"`
-	Status         bool     `json:"status"`
-	AllowedOrigins []string `json:"allowedOrigins"`
-	OAuthEnabled   bool     `json:"oauthEnabled"`
+	SuccessURL         string   `json:"successUrl"`
+	TTL                int      `json:"tokenTtl"`
+	Status             bool     `json:"status"`
+	AllowedOrigins     []string `json:"allowedOrigins"`
+	OAuthServerEnabled bool     `json:"oauthServerEnabled"`
 }
 
 func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
@@ -93,7 +93,7 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	env.AuthConf.TTL = data.TTL
 	env.AuthConf.Status = data.Status
 	env.AuthConf.AllowedOrigins = allowedOrigins
-	env.AuthConf.OAuth = &buildconf.OAuthConf{Enabled: data.OAuthEnabled}
+	env.AuthConf.OAuthServer = &buildconf.OAuthServerConf{Enabled: data.OAuthServerEnabled}
 
 	err = store.SaveAuthConf(req.Context(), req.EnvID, env.AuthConf)
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -13,11 +13,15 @@ import (
 )
 
 type AuthConfigUpdateRequest struct {
-	SuccessURL         string   `json:"successUrl"`
-	TTL                int      `json:"tokenTtl"`
-	Status             bool     `json:"status"`
-	AllowedOrigins     []string `json:"allowedOrigins"`
-	OAuthServerEnabled bool     `json:"oauthServerEnabled"`
+	SuccessURL     string   `json:"successUrl"`
+	TTL            int      `json:"tokenTtl"`
+	Status         bool     `json:"status"`
+	AllowedOrigins []string `json:"allowedOrigins"`
+
+	// OAuthServerEnabled is a pointer so an omitted field leaves the stored
+	// setting untouched: a client that saves other fields (or an older UI that
+	// doesn't know the field) must not silently disable a live OAuth server.
+	OAuthServerEnabled *bool `json:"oauthServerEnabled"`
 }
 
 func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
@@ -93,7 +97,10 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	env.AuthConf.TTL = data.TTL
 	env.AuthConf.Status = data.Status
 	env.AuthConf.AllowedOrigins = allowedOrigins
-	env.AuthConf.OAuthServer = &buildconf.OAuthServerConf{Enabled: data.OAuthServerEnabled}
+
+	if data.OAuthServerEnabled != nil {
+		env.AuthConf.OAuthServer = &buildconf.OAuthServerConf{Enabled: *data.OAuthServerEnabled}
+	}
 
 	err = store.SaveAuthConf(req.Context(), req.EnvID, env.AuthConf)
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -17,6 +17,7 @@ type AuthConfigUpdateRequest struct {
 	TTL            int      `json:"tokenTtl"`
 	Status         bool     `json:"status"`
 	AllowedOrigins []string `json:"allowedOrigins"`
+	OAuthEnabled   bool     `json:"oauthEnabled"`
 }
 
 func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
@@ -92,6 +93,7 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	env.AuthConf.TTL = data.TTL
 	env.AuthConf.Status = data.Status
 	env.AuthConf.AllowedOrigins = allowedOrigins
+	env.AuthConf.OAuth = &buildconf.OAuthConf{Enabled: data.OAuthEnabled}
 
 	err = store.SaveAuthConf(req.Context(), req.EnvID, env.AuthConf)
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -51,7 +51,7 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 	if env.AuthConf != nil {
 		successURL = env.AuthConf.SuccessURL
 		ttl = env.AuthConf.TTL
-		oauthServerEnabled = env.AuthConf.OAuthServer != nil && env.AuthConf.OAuthServer.Enabled
+		oauthServerEnabled = env.AuthConf.OAuthServerEnabled()
 
 		if env.AuthConf.AllowedOrigins != nil {
 			allowedOrigins = env.AuthConf.AllowedOrigins

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -46,12 +46,12 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 	successURL := ""
 	ttl := 0
 	allowedOrigins := []string{}
-	oauthEnabled := false
+	oauthServerEnabled := false
 
 	if env.AuthConf != nil {
 		successURL = env.AuthConf.SuccessURL
 		ttl = env.AuthConf.TTL
-		oauthEnabled = env.AuthConf.OAuth != nil && env.AuthConf.OAuth.Enabled
+		oauthServerEnabled = env.AuthConf.OAuthServer != nil && env.AuthConf.OAuthServer.Enabled
 
 		if env.AuthConf.AllowedOrigins != nil {
 			allowedOrigins = env.AuthConf.AllowedOrigins
@@ -60,13 +60,13 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 
 	return &shttp.Response{
 		Data: map[string]any{
-			"providers":      returnValue,
-			"successUrl":     successURL,
-			"tokenTtl":       ttl,
-			"allowedOrigins": allowedOrigins,
-			"oauthEnabled":   oauthEnabled,
-			"redirectUrl":    skauth.RedirectURL(),
-			"authUrl":        skauth.AuthURL(),
+			"providers":          returnValue,
+			"successUrl":         successURL,
+			"tokenTtl":           ttl,
+			"allowedOrigins":     allowedOrigins,
+			"oauthServerEnabled": oauthServerEnabled,
+			"redirectUrl":        skauth.RedirectURL(),
+			"authUrl":            skauth.AuthURL(),
 		},
 	}
 }

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -46,10 +46,12 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 	successURL := ""
 	ttl := 0
 	allowedOrigins := []string{}
+	oauthEnabled := false
 
 	if env.AuthConf != nil {
 		successURL = env.AuthConf.SuccessURL
 		ttl = env.AuthConf.TTL
+		oauthEnabled = env.AuthConf.OAuth != nil && env.AuthConf.OAuth.Enabled
 
 		if env.AuthConf.AllowedOrigins != nil {
 			allowedOrigins = env.AuthConf.AllowedOrigins
@@ -62,6 +64,7 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 			"successUrl":     successURL,
 			"tokenTtl":       ttl,
 			"allowedOrigins": allowedOrigins,
+			"oauthEnabled":   oauthEnabled,
 			"redirectUrl":    skauth.RedirectURL(),
 			"authUrl":        skauth.AuthURL(),
 		},

--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -40,6 +40,15 @@ func HandleAnalyticsScript(req *RequestContext) *shttp.Response {
 	return handleAnalyticsScript(req)
 }
 
+// OAuth route handler seams for the external hosting_test package.
+func HandleOAuthMetadataAS(req *RequestContext) *shttp.Response { return handleOAuthMetadataAS(req) }
+func HandleOAuthMetadataResource(req *RequestContext) *shttp.Response {
+	return handleOAuthMetadataResource(req)
+}
+func HandleOAuthAuthorize(req *RequestContext) *shttp.Response { return handleOAuthAuthorize(req) }
+func HandleOAuthGrant(req *RequestContext) *shttp.Response     { return handleOAuthGrant(req) }
+func HandleOAuthToken(req *RequestContext) *shttp.Response     { return handleOAuthToken(req) }
+
 // ServeAuth dispatches a /_stormkit/auth/* request to its route handler, the
 // same way registerReservedRoutes wires them into mux. It mirrors the WithSKAuth
 // (*shttp.Response, error) signature — always a nil error — so the terminal

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -2,7 +2,6 @@ package hosting
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,7 +11,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
-	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
@@ -161,21 +159,20 @@ type sessionCode struct {
 	Redirect string `json:"redirect"`
 }
 
+// magicLinkCodeStore holds the one-time login codes for the magic-link landing.
+// The empty prefix keeps the bare-code keyspace the landing URL embeds; OAuth
+// codes live under their own prefix so the two never collide.
+var magicLinkCodeStore = oneTimeCode{prefix: "", ttl: 2 * time.Minute}
+
 // stashSessionToken stores the session token and its post-login redirect under a
 // fresh one-time code and returns the landing URL on the destination origin. The
 // browser is sent there; codeLanding reads the payload back and injects the token
 // into localStorage on that origin. origin is scheme+host (no trailing slash);
 // successURL is validated at config time to start with '/'.
 func stashSessionToken(ctx context.Context, origin, successURL, token string) (string, error) {
-	payload, err := json.Marshal(sessionCode{Token: token, Redirect: origin + successURL})
+	code, err := magicLinkCodeStore.issue(ctx, sessionCode{Token: token, Redirect: origin + successURL})
 
 	if err != nil {
-		return "", err
-	}
-
-	code := utils.RandomToken(64)
-
-	if err := rediscache.Client().Set(ctx, code, payload, time.Minute*2).Err(); err != nil {
 		return "", err
 	}
 
@@ -211,15 +208,9 @@ func (m *skAuthMiddleware) codeLanding() *shttp.Response {
 		return nil
 	}
 
-	raw, err := rediscache.Client().GetDel(m.req.Context(), code).Result()
-
-	if err != nil || raw == "" {
-		return nil
-	}
-
 	var sc sessionCode
 
-	if err := json.Unmarshal([]byte(raw), &sc); err != nil {
+	if err := magicLinkCodeStore.redeem(m.req.Context(), code, &sc); err != nil {
 		return nil
 	}
 

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -4,22 +4,23 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
-	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
-	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
-// oauthCodePrefix namespaces authorization codes in Redis so they can't collide
-// with the bare one-time login codes used by the magic-link landing.
-const oauthCodePrefix = "oauth:code:"
+// oauthCodeStore holds the OAuth authorization codes. The "oauth:code:" prefix
+// namespaces them in Redis so they can't collide with the bare one-time login
+// codes used by the magic-link landing.
+var oauthCodeStore = oneTimeCode{prefix: "oauth:code:", ttl: 5 * time.Minute}
 
 // oauthServer implements the OAuth 2.1 authorization server layered on SkAuth.
 // The end user (an app's own SkAuth user) is the resource owner; access tokens
@@ -58,6 +59,17 @@ var (
 
 func (o *oauthServer) secret() string {
 	return o.req.Host.Config.SKAuth.Secret
+}
+
+// tokenTTLMinutes is the effective access-token lifetime. It mirrors the edge's
+// user.ParseJWT default (24h when the env TTL is unset), so the advertised
+// expires_in matches how long the token is actually accepted.
+func (o *oauthServer) tokenTTLMinutes() int {
+	if ttl := o.req.Host.Config.SKAuth.TTL; ttl > 0 {
+		return ttl
+	}
+
+	return 24 * 60
 }
 
 // issuer is the app's own origin; every AS/RS URL hangs off it.
@@ -127,7 +139,9 @@ func (o *oauthServer) redirectAllowed(redirectURI string) bool {
 		return false
 	}
 
-	return o.req.Host.Config.SKAuth.IsAllowedOrigin(u.Scheme + "://" + u.Host)
+	// Host is compared case-insensitively: url.Parse lowercases the scheme but
+	// preserves host case, and DNS names are case-insensitive.
+	return o.req.Host.Config.SKAuth.IsAllowedOrigin(u.Scheme + "://" + strings.ToLower(u.Host))
 }
 
 // authorize serves GET /_stormkit/oauth/authorize — the consent screen. Because
@@ -188,9 +202,8 @@ func (o *oauthServer) grant() *shttp.Response {
 	}
 
 	eml, _ := claims["eml"].(string)
-	code := utils.RandomToken(64)
 
-	payload, err := json.Marshal(oauthAuthCode{
+	code, err := oauthCodeStore.issue(o.req.Context(), oauthAuthCode{
 		UID:           uid,
 		EML:           eml,
 		ClientID:      p.clientID,
@@ -200,10 +213,6 @@ func (o *oauthServer) grant() *shttp.Response {
 	})
 
 	if err != nil {
-		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
-	}
-
-	if err := rediscache.Client().Set(o.req.Context(), oauthCodePrefix+code, payload, 5*time.Minute).Err(); err != nil {
 		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
 	}
 
@@ -237,20 +246,25 @@ func (o *oauthServer) token() *shttp.Response {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "code and code_verifier are required"))
 	}
 
-	raw, err := rediscache.Client().GetDel(o.req.Context(), oauthCodePrefix+code).Result()
-
-	if err != nil || raw == "" {
-		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "authorization code is invalid or expired"))
-	}
-
 	var ac oauthAuthCode
 
-	if err := json.Unmarshal([]byte(raw), &ac); err != nil {
-		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", ""))
+	if err := oauthCodeStore.redeem(o.req.Context(), code, &ac); err != nil {
+		if errors.Is(err, errCodeNotFound) {
+			return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "authorization code is invalid or expired"))
+		}
+
+		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
 	}
 
 	if o.req.PostFormValue("redirect_uri") != ac.RedirectURI {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "redirect_uri mismatch"))
+	}
+
+	// Bind the code to the client_id it was issued for. Without this, origin-level
+	// redirect_uri matching alone would let a different client on an allowed
+	// origin redeem a code minted for another.
+	if o.req.PostFormValue("client_id") != ac.ClientID {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "client_id mismatch"))
 	}
 
 	if !verifyPKCE(verifier, ac.CodeChallenge) {
@@ -276,7 +290,7 @@ func (o *oauthServer) token() *shttp.Response {
 	return oauthJSON(http.StatusOK, map[string]any{
 		"access_token": accessToken,
 		"token_type":   "Bearer",
-		"expires_in":   o.req.Host.Config.SKAuth.TTL * 60,
+		"expires_in":   o.tokenTTLMinutes() * 60,
 		"scope":        ac.Scope,
 	})
 }
@@ -306,8 +320,13 @@ func (o *oauthServer) redirectError(p authzParams, code, desc string) *shttp.Res
 
 func (o *oauthServer) errorPage(msg string) *shttp.Response {
 	return &shttp.Response{
-		Status:  http.StatusBadRequest,
-		Headers: shttp.HeadersFromMap(map[string]string{"Content-Type": "text/html", "Cache-Control": "no-store"}),
+		Status: http.StatusBadRequest,
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Content-Type":            "text/html",
+			"Cache-Control":           "no-store",
+			"X-Frame-Options":         "DENY",
+			"Content-Security-Policy": "frame-ancestors 'none'",
+		}),
 		Data: html.MustRender(html.RenderArgs{
 			PageTitle:   "Stormkit - Authorize",
 			PageContent: `<div class="container"><h1>Authorization error</h1><p>{{ .message }}</p></div>`,
@@ -373,9 +392,11 @@ func (o *oauthServer) consentPage(p authzParams) *shttp.Response {
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Headers: shttp.HeadersFromMap(map[string]string{
-			"Content-Type":    "text/html",
-			"Referrer-Policy": "no-referrer",
-			"Cache-Control":   "no-store",
+			"Content-Type":            "text/html",
+			"Referrer-Policy":         "no-referrer",
+			"Cache-Control":           "no-store",
+			"X-Frame-Options":         "DENY",
+			"Content-Security-Policy": "frame-ancestors 'none'",
 		}),
 		Data: html.MustRender(html.RenderArgs{
 			PageTitle:   "Stormkit - Authorize",

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -1,0 +1,428 @@
+package hosting
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/html"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// oauthCodePrefix namespaces authorization codes in Redis so they can't collide
+// with the bare one-time login codes used by the magic-link landing.
+const oauthCodePrefix = "oauth:code:"
+
+// oauthServer implements the OAuth 2.1 authorization server layered on SkAuth.
+// The end user (an app's own SkAuth user) is the resource owner; access tokens
+// are signed with the environment's SkAuth secret, so the existing edge
+// validation accepts them and injects X-User-Id with no app-side changes.
+type oauthServer struct {
+	req *RequestContext
+}
+
+// serveOAuth wraps an oauthServer handler with the shared gate: when OAuth is
+// disabled for the host the path is not reserved, so we fall through to normal
+// app serving (this also keeps an app's own /.well-known files reachable).
+func serveOAuth(fn func(*oauthServer) *shttp.Response) func(*RequestContext) *shttp.Response {
+	return func(req *RequestContext) *shttp.Response {
+		if req.Host.Config == nil || !req.Host.Config.SKAuth.OAuthEnabled() {
+			return HandlerForward(req)
+		}
+
+		if req.Method == http.MethodOptions {
+			return finalizeReserved(req, &shttp.Response{Status: http.StatusNoContent})
+		}
+
+		return finalizeReserved(req, fn(&oauthServer{req: req}))
+	}
+}
+
+// OAuth route handlers, wired in registerReservedRoutes and exercised by tests
+// through export_test seams.
+var (
+	handleOAuthMetadataAS       = serveOAuth((*oauthServer).metadataAS)
+	handleOAuthMetadataResource = serveOAuth((*oauthServer).metadataResource)
+	handleOAuthAuthorize        = serveOAuth((*oauthServer).authorize)
+	handleOAuthGrant            = serveOAuth((*oauthServer).grant)
+	handleOAuthToken            = serveOAuth((*oauthServer).token)
+)
+
+func (o *oauthServer) secret() string {
+	return o.req.Host.Config.SKAuth.Secret
+}
+
+// issuer is the app's own origin; every AS/RS URL hangs off it.
+func (o *oauthServer) issuer() string {
+	return "https://" + o.req.Host.Name
+}
+
+// metadataAS serves the RFC 8414 authorization-server metadata document.
+func (o *oauthServer) metadataAS() *shttp.Response {
+	iss := o.issuer()
+
+	return oauthJSON(http.StatusOK, map[string]any{
+		"issuer":                                iss,
+		"authorization_endpoint":                iss + "/_stormkit/oauth/authorize",
+		"token_endpoint":                        iss + "/_stormkit/oauth/token",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+	})
+}
+
+// metadataResource serves the RFC 9728 protected-resource metadata document.
+// It points MCP clients at this same host as the authorization server and binds
+// the resource identity, which the access-token audience is stamped with.
+func (o *oauthServer) metadataResource() *shttp.Response {
+	iss := o.issuer()
+
+	return oauthJSON(http.StatusOK, map[string]any{
+		"resource":                 iss,
+		"authorization_servers":    []string{iss},
+		"bearer_methods_supported": []string{"header"},
+	})
+}
+
+type authzParams struct {
+	responseType        string
+	clientID            string
+	redirectURI         string
+	codeChallenge       string
+	codeChallengeMethod string
+	state               string
+	scope               string
+}
+
+func (o *oauthServer) parseAuthzParams() authzParams {
+	q := o.req.Query()
+
+	return authzParams{
+		responseType:        q.Get("response_type"),
+		clientID:            q.Get("client_id"),
+		redirectURI:         q.Get("redirect_uri"),
+		codeChallenge:       q.Get("code_challenge"),
+		codeChallengeMethod: q.Get("code_challenge_method"),
+		state:               q.Get("state"),
+		scope:               q.Get("scope"),
+	}
+}
+
+// redirectAllowed reports whether redirectURI is an absolute URL whose origin is
+// in the environment's SkAuth AllowedOrigins list. Reusing that list means an
+// operator declares the trusted connector origins in one place.
+func (o *oauthServer) redirectAllowed(redirectURI string) bool {
+	u, err := url.Parse(redirectURI)
+
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return false
+	}
+
+	return o.req.Host.Config.SKAuth.IsAllowedOrigin(u.Scheme + "://" + u.Host)
+}
+
+// authorize serves GET /_stormkit/oauth/authorize — the consent screen. Because
+// the SkAuth session lives in localStorage (no server-readable cookie), the page
+// is client-assisted: its script reads the token and POSTs back to grant().
+func (o *oauthServer) authorize() *shttp.Response {
+	p := o.parseAuthzParams()
+
+	// redirect_uri must be validated before we can safely bounce any error to
+	// it; an unvalidated redirect is an open-redirect vector.
+	if !o.redirectAllowed(p.redirectURI) {
+		return o.errorPage("The redirect_uri is not allowed for this application.")
+	}
+
+	if p.responseType != "code" {
+		return o.redirectError(p, "unsupported_response_type", "only response_type=code is supported")
+	}
+
+	if p.codeChallenge == "" || p.codeChallengeMethod != "S256" {
+		return o.redirectError(p, "invalid_request", "a PKCE code_challenge using S256 is required")
+	}
+
+	return o.consentPage(p)
+}
+
+// grant serves POST /_stormkit/oauth/authorize. The consent page calls it with
+// the user's SkAuth bearer; it validates identity + params and mints a one-time
+// authorization code bound to the PKCE challenge.
+func (o *oauthServer) grant() *shttp.Response {
+	p := o.parseAuthzParams()
+
+	if !o.redirectAllowed(p.redirectURI) {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "invalid redirect_uri"))
+	}
+
+	if p.responseType != "code" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("unsupported_response_type", ""))
+	}
+
+	if p.codeChallenge == "" || p.codeChallengeMethod != "S256" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "PKCE S256 required"))
+	}
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer:  user.ParseBearer(o.req.Header.Get("Authorization")),
+		Secret:  o.secret(),
+		MaxMins: o.req.Host.Config.SKAuth.TTL,
+	})
+
+	if claims == nil {
+		return oauthJSON(http.StatusUnauthorized, oauthErr("access_denied", "authentication required"))
+	}
+
+	uid, _ := claims["uid"].(string)
+
+	if uid == "" {
+		return oauthJSON(http.StatusUnauthorized, oauthErr("access_denied", "invalid session"))
+	}
+
+	eml, _ := claims["eml"].(string)
+	code := utils.RandomToken(64)
+
+	payload, err := json.Marshal(oauthAuthCode{
+		UID:           uid,
+		EML:           eml,
+		ClientID:      p.clientID,
+		RedirectURI:   p.redirectURI,
+		CodeChallenge: p.codeChallenge,
+		Scope:         p.scope,
+	})
+
+	if err != nil {
+		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
+	}
+
+	if err := rediscache.Client().Set(o.req.Context(), oauthCodePrefix+code, payload, 5*time.Minute).Err(); err != nil {
+		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
+	}
+
+	return oauthJSON(http.StatusOK, map[string]any{
+		"redirect": appendQuery(p.redirectURI, map[string]string{"code": code, "state": p.state}),
+	})
+}
+
+// oauthAuthCode is the Redis-stashed authorization code payload.
+type oauthAuthCode struct {
+	UID           string `json:"uid"`
+	EML           string `json:"eml"`
+	ClientID      string `json:"clientId"`
+	RedirectURI   string `json:"redirectUri"`
+	CodeChallenge string `json:"codeChallenge"`
+	Scope         string `json:"scope"`
+}
+
+// token serves POST /_stormkit/oauth/token — the authorization_code exchange.
+// It verifies the PKCE proof and mints an access token in the SkAuth format, so
+// the edge validates it like any session token.
+func (o *oauthServer) token() *shttp.Response {
+	if o.req.PostFormValue("grant_type") != "authorization_code" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("unsupported_grant_type", ""))
+	}
+
+	code := o.req.PostFormValue("code")
+	verifier := o.req.PostFormValue("code_verifier")
+
+	if code == "" || verifier == "" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "code and code_verifier are required"))
+	}
+
+	raw, err := rediscache.Client().GetDel(o.req.Context(), oauthCodePrefix+code).Result()
+
+	if err != nil || raw == "" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "authorization code is invalid or expired"))
+	}
+
+	var ac oauthAuthCode
+
+	if err := json.Unmarshal([]byte(raw), &ac); err != nil {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", ""))
+	}
+
+	if o.req.PostFormValue("redirect_uri") != ac.RedirectURI {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "redirect_uri mismatch"))
+	}
+
+	if !verifyPKCE(verifier, ac.CodeChallenge) {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "PKCE verification failed"))
+	}
+
+	claims := jwt.MapClaims{"uid": ac.UID, "aud": o.issuer()}
+
+	if ac.EML != "" {
+		claims["eml"] = ac.EML
+	}
+
+	if ac.Scope != "" {
+		claims["scope"] = ac.Scope
+	}
+
+	accessToken, err := user.JWT(claims, o.secret())
+
+	if err != nil {
+		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
+	}
+
+	return oauthJSON(http.StatusOK, map[string]any{
+		"access_token": accessToken,
+		"token_type":   "Bearer",
+		"expires_in":   o.req.Host.Config.SKAuth.TTL * 60,
+		"scope":        ac.Scope,
+	})
+}
+
+// verifyPKCE checks the S256 proof: base64url(sha256(verifier)) == challenge.
+func verifyPKCE(verifier, challenge string) bool {
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	return subtle.ConstantTimeCompare([]byte(computed), []byte(challenge)) == 1
+}
+
+// redirectError bounces an authorization error back to the (already validated)
+// redirect_uri per the OAuth spec, preserving state.
+func (o *oauthServer) redirectError(p authzParams, code, desc string) *shttp.Response {
+	params := map[string]string{"error": code, "error_description": desc}
+
+	if p.state != "" {
+		params["state"] = p.state
+	}
+
+	return &shttp.Response{
+		Redirect: utils.Ptr(appendQuery(p.redirectURI, params)),
+		Status:   http.StatusFound,
+	}
+}
+
+func (o *oauthServer) errorPage(msg string) *shttp.Response {
+	return &shttp.Response{
+		Status:  http.StatusBadRequest,
+		Headers: shttp.HeadersFromMap(map[string]string{"Content-Type": "text/html", "Cache-Control": "no-store"}),
+		Data: html.MustRender(html.RenderArgs{
+			PageTitle:   "Stormkit - Authorize",
+			PageContent: `<div class="container"><h1>Authorization error</h1><p>{{ .message }}</p></div>`,
+			ContentData: map[string]any{"message": msg},
+		}),
+	}
+}
+
+// consentPage renders the client-assisted consent screen. The script pulls the
+// SkAuth token from localStorage and POSTs it back to grant(); when signed out
+// it prompts the user to sign in first. html/template escapes the injected
+// values in both HTML and JS contexts.
+func (o *oauthServer) consentPage(p authzParams) *shttp.Response {
+	client := p.clientID
+
+	if client == "" {
+		client = "An application"
+	}
+
+	deny := appendQuery(p.redirectURI, map[string]string{"error": "access_denied", "state": p.state})
+
+	content := `
+<div class="container">
+	<h1>Authorize access</h1>
+	<h3><strong>{{ .client }}</strong> is requesting access to your account.</h3>
+	<div id="skoauth-signedout" class="form-group error" style="display:none">
+		You are not signed in. Please sign in to this application in another tab, then reload this page to continue.
+	</div>
+	<div id="skoauth-actions" class="form-submit" style="display:none">
+		<button id="skoauth-allow" class="submit-button">Authorize</button>
+		<a id="skoauth-deny" class="secondary" style="margin-left:1rem">Cancel</a>
+	</div>
+</div>
+<script>
+(function () {
+	var raw = localStorage.getItem('skauth');
+	var token = null;
+	try { token = raw ? JSON.parse(raw) : null; } catch (e) { token = raw; }
+
+	var actions = document.getElementById('skoauth-actions');
+	var signedOut = document.getElementById('skoauth-signedout');
+
+	if (!token) { signedOut.style.display = 'block'; return; }
+	actions.style.display = 'block';
+
+	document.getElementById('skoauth-deny').setAttribute('href', "{{ .deny }}");
+
+	document.getElementById('skoauth-allow').addEventListener('click', function () {
+		fetch(window.location.pathname + window.location.search, {
+			method: 'POST',
+			headers: { 'Authorization': 'Bearer ' + token }
+		})
+			.then(function (r) { return r.json(); })
+			.then(function (d) {
+				if (d && d.redirect) { window.location.href = d.redirect; }
+				else { signedOut.textContent = 'Authorization failed. Please try again.'; signedOut.style.display = 'block'; }
+			})
+			.catch(function () { signedOut.textContent = 'Authorization failed. Please try again.'; signedOut.style.display = 'block'; });
+	});
+})();
+</script>`
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Content-Type":    "text/html",
+			"Referrer-Policy": "no-referrer",
+			"Cache-Control":   "no-store",
+		}),
+		Data: html.MustRender(html.RenderArgs{
+			PageTitle:   "Stormkit - Authorize",
+			PageContent: content,
+			ContentData: map[string]any{"client": client, "deny": deny},
+		}),
+	}
+}
+
+func oauthJSON(status int, data any) *shttp.Response {
+	return &shttp.Response{
+		Status: status,
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Content-Type":  "application/json",
+			"Cache-Control": "no-store",
+		}),
+		Data: data,
+	}
+}
+
+func oauthErr(code, desc string) map[string]any {
+	out := map[string]any{"error": code}
+
+	if desc != "" {
+		out["error_description"] = desc
+	}
+
+	return out
+}
+
+// appendQuery adds params to a URL, preserving any existing query.
+func appendQuery(rawURL string, params map[string]string) string {
+	u, err := url.Parse(rawURL)
+
+	if err != nil {
+		return rawURL
+	}
+
+	q := u.Query()
+
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+
+	u.RawQuery = q.Encode()
+
+	return u.String()
+}

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -34,7 +34,7 @@ type oauthServer struct {
 // app serving (this also keeps an app's own /.well-known files reachable).
 func serveOAuth(fn func(*oauthServer) *shttp.Response) func(*RequestContext) *shttp.Response {
 	return func(req *RequestContext) *shttp.Response {
-		if req.Host.Config == nil || !req.Host.Config.SKAuth.OAuthEnabled() {
+		if req.Host.Config == nil || !req.Host.Config.SKAuth.OAuthServerEnabled() {
 			return HandlerForward(req)
 		}
 

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -1,0 +1,242 @@
+package hosting_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	hosting "github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+const oauthSecret = "test-secret-padded-to-32-chars!!"
+const oauthRedirect = "https://client.example.com/callback"
+
+type OAuthSuite struct {
+	suite.Suite
+}
+
+func TestOAuthSuite(t *testing.T) {
+	suite.Run(t, new(OAuthSuite))
+}
+
+func (s *OAuthSuite) host(enabled bool) *hosting.Host {
+	return &hosting.Host{
+		Name: "app.example.com",
+		Config: &appconf.Config{
+			SKAuth: &buildconf.SKAuthConf{
+				Secret:         oauthSecret,
+				Status:         true,
+				TTL:            10,
+				AllowedOrigins: []string{"https://client.example.com"},
+				OAuth:          &buildconf.OAuthConf{Enabled: enabled},
+			},
+		},
+	}
+}
+
+func (s *OAuthSuite) req(host *hosting.Host, method, path, query string, header http.Header, body io.Reader) *hosting.RequestContext {
+	if header == nil {
+		header = make(http.Header)
+	}
+
+	var rc io.ReadCloser
+
+	if body != nil {
+		rc = io.NopCloser(body)
+	}
+
+	rq := &hosting.RequestContext{
+		Host: host,
+		RequestContext: shttp.NewRequestContext(&http.Request{
+			Method: method,
+			Header: header,
+			URL:    &url.URL{Host: host.Name, Path: path, RawPath: path, RawQuery: query},
+			Body:   rc,
+		}),
+	}
+
+	rq.OriginalPath = path
+
+	return rq
+}
+
+// bearer signs a SkAuth session token the way the login handlers do.
+func (s *OAuthSuite) bearer(uid string) string {
+	tok, err := user.JWT(jwt.MapClaims{"uid": uid}, oauthSecret)
+	s.Require().NoError(err)
+
+	return "Bearer " + tok
+}
+
+func pkce(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func (s *OAuthSuite) authzQuery(challenge string) string {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "chatgpt")
+	q.Set("redirect_uri", oauthRedirect)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", "xyz")
+
+	return q.Encode()
+}
+
+func (s *OAuthSuite) json(res *shttp.Response) map[string]any {
+	m, ok := res.Data.(map[string]any)
+	s.Require().True(ok, "expected map response data")
+
+	return m
+}
+
+func (s *OAuthSuite) Test_MetadataAS() {
+	res := hosting.HandleOAuthMetadataAS(s.req(s.host(true), http.MethodGet, "/.well-known/oauth-authorization-server", "", nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	d := s.json(res)
+	s.Equal("https://app.example.com", d["issuer"])
+	s.Equal("https://app.example.com/_stormkit/oauth/authorize", d["authorization_endpoint"])
+	s.Equal("https://app.example.com/_stormkit/oauth/token", d["token_endpoint"])
+	s.Equal([]string{"S256"}, d["code_challenge_methods_supported"])
+}
+
+func (s *OAuthSuite) Test_MetadataResource() {
+	res := hosting.HandleOAuthMetadataResource(s.req(s.host(true), http.MethodGet, "/.well-known/oauth-protected-resource", "", nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	d := s.json(res)
+	s.Equal("https://app.example.com", d["resource"])
+	s.Equal([]string{"https://app.example.com"}, d["authorization_servers"])
+}
+
+func (s *OAuthSuite) Test_Authorize_RendersConsent() {
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Contains(res.Headers.Get("Content-Type"), "text/html")
+	s.Contains(string(res.Data.([]byte)), "Authorize access")
+}
+
+func (s *OAuthSuite) Test_Authorize_RejectsBadRedirect() {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("redirect_uri", "https://evil.example.com/cb")
+	q.Set("code_challenge", pkce("v"))
+	q.Set("code_challenge_method", "S256")
+
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Nil(res.Redirect, "must not redirect to an unvalidated redirect_uri")
+}
+
+func (s *OAuthSuite) Test_Grant_RequiresAuth() {
+	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", s.authzQuery(pkce("v")), nil, nil))
+
+	s.Equal(http.StatusUnauthorized, res.Status)
+	s.Equal("access_denied", s.json(res)["error"])
+}
+
+// codeFromGrant runs a full authorize grant and returns the issued code.
+func (s *OAuthSuite) codeFromGrant(uid, challenge string) string {
+	h := make(http.Header)
+	h.Set("Authorization", s.bearer(uid))
+
+	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", s.authzQuery(challenge), h, nil))
+	s.Require().Equal(http.StatusOK, res.Status)
+
+	redirect, ok := s.json(res)["redirect"].(string)
+	s.Require().True(ok)
+
+	u, err := url.Parse(redirect)
+	s.Require().NoError(err)
+	s.Equal("xyz", u.Query().Get("state"))
+
+	code := u.Query().Get("code")
+	s.Require().NotEmpty(code)
+
+	return code
+}
+
+func (s *OAuthSuite) tokenReq(form url.Values) *hosting.RequestContext {
+	h := make(http.Header)
+	h.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/token", "", h, strings.NewReader(form.Encode()))
+}
+
+func (s *OAuthSuite) Test_Token_ExchangeSucceeds() {
+	verifier := "the-code-verifier-value-1234567890"
+	code := s.codeFromGrant("user-uuid-42", pkce(verifier))
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", oauthRedirect)
+	form.Set("code_verifier", verifier)
+
+	res := hosting.HandleOAuthToken(s.tokenReq(form))
+
+	s.Equal(http.StatusOK, res.Status)
+	d := s.json(res)
+	s.Equal("Bearer", d["token_type"])
+	s.Equal(600, d["expires_in"])
+
+	accessToken, ok := d["access_token"].(string)
+	s.Require().True(ok)
+
+	// The access token is in the SkAuth format, so the edge validation accepts
+	// it: it must carry the resource-owner uid and this app's audience.
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: accessToken, Secret: oauthSecret, MaxMins: 10})
+	s.Require().NotNil(claims)
+	s.Equal("user-uuid-42", claims["uid"])
+	s.Equal("https://app.example.com", claims["aud"])
+}
+
+func (s *OAuthSuite) Test_Token_RejectsWrongVerifier() {
+	code := s.codeFromGrant("user-uuid-42", pkce("real-verifier-value-000000000000"))
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", oauthRedirect)
+	form.Set("code_verifier", "wrong-verifier-value-9999999999999")
+
+	res := hosting.HandleOAuthToken(s.tokenReq(form))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_grant", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Token_CodeIsSingleUse() {
+	verifier := "single-use-verifier-1234567890abcd"
+	code := s.codeFromGrant("user-uuid-7", pkce(verifier))
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", oauthRedirect)
+	form.Set("code_verifier", verifier)
+
+	first := hosting.HandleOAuthToken(s.tokenReq(form))
+	s.Require().Equal(http.StatusOK, first.Status)
+
+	second := hosting.HandleOAuthToken(s.tokenReq(form))
+	s.Equal(http.StatusBadRequest, second.Status)
+	s.Equal("invalid_grant", s.json(second)["error"])
+}

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -145,6 +145,32 @@ func (s *OAuthSuite) Test_Authorize_RejectsBadRedirect() {
 	s.Nil(res.Redirect, "must not redirect to an unvalidated redirect_uri")
 }
 
+// Test_Authorize_SetsAntiFramingHeaders guards the consent page against
+// clickjacking: it must forbid being framed.
+func (s *OAuthSuite) Test_Authorize_SetsAntiFramingHeaders() {
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("DENY", res.Headers.Get("X-Frame-Options"))
+	s.Contains(res.Headers.Get("Content-Security-Policy"), "frame-ancestors 'none'")
+}
+
+// Test_Authorize_AcceptsMixedCaseRedirectHost verifies the redirect_uri host is
+// matched case-insensitively against the allow-list.
+func (s *OAuthSuite) Test_Authorize_AcceptsMixedCaseRedirectHost() {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "chatgpt")
+	q.Set("redirect_uri", "https://Client.Example.com/callback")
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Contains(string(res.Data.([]byte)), "Authorize access")
+}
+
 func (s *OAuthSuite) Test_Grant_RequiresAuth() {
 	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", s.authzQuery(pkce("v")), nil, nil))
 
@@ -187,6 +213,7 @@ func (s *OAuthSuite) Test_Token_ExchangeSucceeds() {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
+	form.Set("client_id", "chatgpt")
 	form.Set("redirect_uri", oauthRedirect)
 	form.Set("code_verifier", verifier)
 
@@ -214,8 +241,26 @@ func (s *OAuthSuite) Test_Token_RejectsWrongVerifier() {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
+	form.Set("client_id", "chatgpt")
 	form.Set("redirect_uri", oauthRedirect)
 	form.Set("code_verifier", "wrong-verifier-value-9999999999999")
+
+	res := hosting.HandleOAuthToken(s.tokenReq(form))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_grant", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Token_RejectsWrongClientID() {
+	verifier := "client-bind-verifier-1234567890abc"
+	code := s.codeFromGrant("user-uuid-42", pkce(verifier))
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("client_id", "not-chatgpt")
+	form.Set("redirect_uri", oauthRedirect)
+	form.Set("code_verifier", verifier)
 
 	res := hosting.HandleOAuthToken(s.tokenReq(form))
 
@@ -230,6 +275,7 @@ func (s *OAuthSuite) Test_Token_CodeIsSingleUse() {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
+	form.Set("client_id", "chatgpt")
 	form.Set("redirect_uri", oauthRedirect)
 	form.Set("code_verifier", verifier)
 

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -39,7 +39,7 @@ func (s *OAuthSuite) host(enabled bool) *hosting.Host {
 				Status:         true,
 				TTL:            10,
 				AllowedOrigins: []string{"https://client.example.com"},
-				OAuth:          &buildconf.OAuthConf{Enabled: enabled},
+				OAuthServer:    &buildconf.OAuthServerConf{Enabled: enabled},
 			},
 		},
 	}

--- a/src/ce/hosting/onetime_code.go
+++ b/src/ce/hosting/onetime_code.go
@@ -1,0 +1,65 @@
+package hosting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// errCodeNotFound is returned by oneTimeCode.redeem when the code is absent or
+// already consumed, letting callers distinguish "unknown code" from a Redis
+// error.
+var errCodeNotFound = errors.New("one-time code not found")
+
+// oneTimeCode is a Redis-backed single-use code store. It marshals a JSON
+// payload under a freshly generated, crypto-random code with a TTL, then reads
+// it back once via GetDel (atomic single-use). Both the OAuth authorization
+// codes and the magic-link session codes are built on it; the prefix keeps
+// their keyspaces from colliding.
+type oneTimeCode struct {
+	prefix string
+	ttl    time.Duration
+}
+
+// issue stashes payload under a fresh code and returns the code.
+func (c oneTimeCode) issue(ctx context.Context, payload any) (string, error) {
+	blob, err := json.Marshal(payload)
+
+	if err != nil {
+		return "", err
+	}
+
+	code, err := utils.SecureRandomToken(48)
+
+	if err != nil {
+		return "", err
+	}
+
+	if err := rediscache.Client().Set(ctx, c.prefix+code, blob, c.ttl).Err(); err != nil {
+		return "", err
+	}
+
+	return code, nil
+}
+
+// redeem atomically reads-and-deletes the payload for code into dst. It returns
+// errCodeNotFound when the code is unknown or already used, and any other error
+// verbatim so callers can distinguish a missing code from a store failure.
+func (c oneTimeCode) redeem(ctx context.Context, code string, dst any) error {
+	raw, err := rediscache.Client().GetDel(ctx, c.prefix+code).Result()
+
+	if errors.Is(err, redis.Nil) || raw == "" {
+		return errCodeNotFound
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal([]byte(raw), dst)
+}

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -29,6 +29,20 @@ func registerReservedRoutes(s *shttp.Service) {
 	sk.Handler(http.MethodGet, "/collect", WithHost(handleCollect))
 	sk.Handler(http.MethodPost, "/collect", WithHost(handleCollect))
 
+	// OAuth 2.1 authorization server (opt-in per environment). The .well-known
+	// discovery documents live off the app root, not under /_stormkit. All fall
+	// through to normal app serving when OAuth is disabled for the host.
+	wk := s.NewEndpoint("/.well-known")
+	wk.Handler(http.MethodGet, "/oauth-authorization-server", WithHost(handleOAuthMetadataAS))
+	wk.Handler(http.MethodGet, "/oauth-protected-resource", WithHost(handleOAuthMetadataResource))
+
+	oauth := s.NewEndpoint("/_stormkit/oauth")
+	oauth.Handler(http.MethodGet, "/authorize", WithHost(handleOAuthAuthorize))
+	oauth.Handler(http.MethodPost, "/authorize", WithHost(handleOAuthGrant))
+	oauth.Handler(http.MethodOptions, "/authorize", WithHost(handleOAuthGrant))
+	oauth.Handler(http.MethodPost, "/token", WithHost(handleOAuthToken))
+	oauth.Handler(http.MethodOptions, "/token", WithHost(handleOAuthToken))
+
 	auth := s.NewEndpoint("/_stormkit/auth")
 
 	// Every path is registered for GET, POST and OPTIONS regardless of the

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -39,7 +39,7 @@ func registerReservedRoutes(s *shttp.Service) {
 	oauth := s.NewEndpoint("/_stormkit/oauth")
 	oauth.Handler(http.MethodGet, "/authorize", WithHost(handleOAuthAuthorize))
 	oauth.Handler(http.MethodPost, "/authorize", WithHost(handleOAuthGrant))
-	oauth.Handler(http.MethodOptions, "/authorize", WithHost(handleOAuthGrant))
+	oauth.Handler(http.MethodOptions, "/authorize", WithHost(handleOAuthAuthorize))
 	oauth.Handler(http.MethodPost, "/token", WithHost(handleOAuthToken))
 	oauth.Handler(http.MethodOptions, "/token", WithHost(handleOAuthToken))
 

--- a/src/ui/src/layouts/AppLayout/EnvMenu.spec.tsx
+++ b/src/ui/src/layouts/AppLayout/EnvMenu.spec.tsx
@@ -97,10 +97,24 @@ describe("~/layouts/AppLayout/EnvMenu.tsx", () => {
     ]);
   });
 
-  // Auth requires a database and is self-hosted only — both cloud and the
-  // development edition must hide it.
-  it.each<Edition>(["cloud", "development"])(
-    "hides the Authentication link on the %s edition",
+  // Auth requires a database, which every non-cloud edition has — so only the
+  // cloud edition hides it.
+  it("hides the Authentication link on the cloud edition", () => {
+    wrapper.unmount(); // drop the self-hosted render from beforeEach
+    createWrapper({ edition: "cloud" });
+
+    const links = wrapper
+      .getAllByRole("link")
+      .map(link => link.getAttribute("href"));
+
+    expect(links).not.toContain(
+      `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/auth`,
+    );
+    expect(wrapper.queryByText("Authentication")).toBeNull();
+  });
+
+  it.each<Edition>(["self-hosted", "development"])(
+    "shows the Authentication link on the %s edition",
     edition => {
       wrapper.unmount(); // drop the self-hosted render from beforeEach
       createWrapper({ edition });
@@ -109,10 +123,9 @@ describe("~/layouts/AppLayout/EnvMenu.tsx", () => {
         .getAllByRole("link")
         .map(link => link.getAttribute("href"));
 
-      expect(links).not.toContain(
+      expect(links).toContain(
         `/apps/${defaultApp.id}/environments/${defaultEnvs[0].id}/auth`,
       );
-      expect(wrapper.queryByText("Authentication")).toBeNull();
     },
   );
 });

--- a/src/ui/src/layouts/AppLayout/EnvMenu.tsx
+++ b/src/ui/src/layouts/AppLayout/EnvMenu.tsx
@@ -16,7 +16,7 @@ export default function EnvMenu() {
   const { app, environments } = useContext(AppContext);
   const { details } = useContext(RootContext);
   const { pathname } = useLocation();
-  const isSelfHosted = details?.stormkit?.edition === "self-hosted";
+  const isNotCloud = details?.stormkit?.edition !== "cloud";
   const [isModalOpen, toggleModal] = useState(false);
   const navigate = useNavigate();
 
@@ -29,8 +29,8 @@ export default function EnvMenu() {
   const selectedEnvId = envId || "";
 
   const envMenu = useMemo(
-    () => envMenuItems({ app, env, pathname, isSelfHosted }),
-    [app, env, pathname, isSelfHosted],
+    () => envMenuItems({ app, env, pathname, isNotCloud }),
+    [app, env, pathname, isNotCloud],
   );
 
   if (!selectedEnvId || !env) {

--- a/src/ui/src/layouts/AppLayout/menu_items.tsx
+++ b/src/ui/src/layouts/AppLayout/menu_items.tsx
@@ -47,12 +47,12 @@ export const envMenuItems = ({
   app,
   env,
   pathname,
-  isSelfHosted,
+  isNotCloud,
 }: {
   app: App;
   env: Environment;
   pathname: string;
-  isSelfHosted: boolean;
+  isNotCloud: boolean;
 }): Path[] => {
   if (!env) {
     return [];
@@ -100,9 +100,9 @@ export const envMenuItems = ({
     },
   ];
 
-  // Authentication relies on a database, so it is shown on the self-hosted
-  // edition only.
-  if (isSelfHosted) {
+  // Authentication relies on a database, which is available on every
+  // non-cloud edition (self-hosted and development).
+  if (isNotCloud) {
     items.push({
       text: "Authentication",
       path: `${envPath}/auth`,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -347,7 +347,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           tokenTtl: 0,
           status: true,
           allowedOrigins: [],
-          oauthEnabled: false,
+          oauthServerEnabled: false,
         })
         .reply(200);
 
@@ -370,7 +370,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
             "https://app.example.com",
             "https://dev.example.com",
           ],
-          oauthEnabled: false,
+          oauthServerEnabled: false,
         })
         .reply(200);
 
@@ -401,7 +401,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           tokenTtl: 0,
           status: true,
           allowedOrigins: [],
-          oauthEnabled: true,
+          oauthServerEnabled: true,
         })
         .reply(200);
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -347,6 +347,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           tokenTtl: 0,
           status: true,
           allowedOrigins: [],
+          oauthEnabled: false,
         })
         .reply(200);
 
@@ -369,6 +370,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
             "https://app.example.com",
             "https://dev.example.com",
           ],
+          oauthEnabled: false,
         })
         .reply(200);
 
@@ -388,6 +390,31 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
         expect(wrapper.getByText("Settings saved successfully")).toBeTruthy();
+      });
+    });
+
+    it("should submit the OAuth toggle when enabled", async () => {
+      const scope = nock(apiDomain)
+        .post("/skauth/config", {
+          envId: currentEnv.id,
+          successUrl: "",
+          tokenTtl: 0,
+          status: true,
+          allowedOrigins: [],
+          oauthEnabled: true,
+        })
+        .reply(200);
+
+      fireEvent.click(
+        await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),
+      );
+
+      fireEvent.submit(
+        wrapper.getByRole("button", { name: "Save" }).closest("form")!,
+      );
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
       });
     });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -181,11 +181,11 @@ export default function SkAuth() {
 
   // The OAuth toggle is a controlled Switch (not part of FormData), so it needs
   // its own state, synced from the config once it loads.
-  const [oauthEnabled, setOauthEnabled] = useState(false);
+  const [oauthServerEnabled, setOauthServerEnabled] = useState(false);
 
   useEffect(() => {
-    setOauthEnabled(Boolean(config?.oauthEnabled));
-  }, [config?.oauthEnabled]);
+    setOauthServerEnabled(Boolean(config?.oauthServerEnabled));
+  }, [config?.oauthServerEnabled]);
 
   const hasSchema = !result.loading && !result.error && Boolean(result.schema);
   const title = "Authentication";
@@ -252,7 +252,7 @@ export default function SkAuth() {
             tokenTtl: tokenTtl || 0,
             status: true,
             allowedOrigins,
-            oauthEnabled,
+            oauthServerEnabled,
           })
             .then(() => {
               setSuccess("Settings saved successfully");
@@ -340,13 +340,13 @@ export default function SkAuth() {
 
         <Box sx={{ mb: 4 }}>
           <Switch
-            name="oauthEnabled"
-            checked={oauthEnabled}
-            setChecked={setOauthEnabled}
+            name="oauthServerEnabled"
+            checked={oauthServerEnabled}
+            setChecked={setOauthServerEnabled}
             label="Enable OAuth server (MCP connectors)"
             description="Turns this environment into an OAuth 2.1 authorization server so AI clients like ChatGPT and Claude can connect to it as an MCP server, signing in your app's own users. Add each connector's redirect origin to Allowed origins above."
           />
-          {oauthEnabled &&
+          {oauthServerEnabled &&
             (config?.allowedOrigins || []).length === 0 && (
               <Alert severity="warning" sx={{ mt: 2 }}>
                 OAuth is enabled but no allowed origins are set. A connector's
@@ -354,7 +354,7 @@ export default function SkAuth() {
                 requests will be rejected.
               </Alert>
             )}
-          {oauthEnabled && (
+          {oauthServerEnabled && (
             <Alert severity="info" sx={{ mt: 2 }}>
               <Typography sx={{ mb: 1 }}>
                 Discovery documents, served on this environment's domain:

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -1,8 +1,9 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
+import { Switch } from "~/components/Form";
 import AddIcon from "@mui/icons-material/Add";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -178,6 +179,14 @@ export default function SkAuth() {
     refreshToken,
   });
 
+  // The OAuth toggle is a controlled Switch (not part of FormData), so it needs
+  // its own state, synced from the config once it loads.
+  const [oauthEnabled, setOauthEnabled] = useState(false);
+
+  useEffect(() => {
+    setOauthEnabled(Boolean(config?.oauthEnabled));
+  }, [config?.oauthEnabled]);
+
   const hasSchema = !result.loading && !result.error && Boolean(result.schema);
   const title = "Authentication";
   const subtitle = "Enable authentication providers for this environment";
@@ -243,6 +252,7 @@ export default function SkAuth() {
             tokenTtl: tokenTtl || 0,
             status: true,
             allowedOrigins,
+            oauthEnabled,
           })
             .then(() => {
               setSuccess("Settings saved successfully");
@@ -324,6 +334,37 @@ export default function SkAuth() {
               A provider is enabled but no allowed origins are set. If your
               frontend runs on a separate domain (or a native app), add its
               origin — otherwise sign-in returns users here instead of your app.
+            </Alert>
+          )}
+        </Box>
+
+        <Box sx={{ mb: 4 }}>
+          <Switch
+            name="oauthEnabled"
+            checked={oauthEnabled}
+            setChecked={setOauthEnabled}
+            label="Enable OAuth server (MCP connectors)"
+            description="Turns this environment into an OAuth 2.1 authorization server so AI clients like ChatGPT and Claude can connect to it as an MCP server, signing in your app's own users. Add each connector's redirect origin to Allowed origins above."
+          />
+          {oauthEnabled &&
+            (config?.allowedOrigins || []).length === 0 && (
+              <Alert severity="warning" sx={{ mt: 2 }}>
+                OAuth is enabled but no allowed origins are set. A connector's
+                redirect_uri must live on an allowed origin, or authorization
+                requests will be rejected.
+              </Alert>
+            )}
+          {oauthEnabled && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              <Typography sx={{ mb: 1 }}>
+                Discovery documents, served on this environment's domain:
+              </Typography>
+              <Box component="code" sx={{ display: "block", fontSize: 12 }}>
+                /.well-known/oauth-authorization-server
+              </Box>
+              <Box component="code" sx={{ display: "block", fontSize: 12 }}>
+                /.well-known/oauth-protected-resource
+              </Box>
             </Alert>
           )}
         </Box>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -223,7 +223,7 @@ interface FetchProvidersResult {
   successUrl?: string;
   tokenTtl?: number;
   allowedOrigins?: string[];
-  oauthEnabled?: boolean;
+  oauthServerEnabled?: boolean;
   redirectUrl: string;
   authUrl: string;
   providers: {
@@ -235,7 +235,7 @@ interface AuthConfig {
   sessionTtl?: number; // in minutes
   successUrl?: string;
   allowedOrigins?: string[];
-  oauthEnabled?: boolean;
+  oauthServerEnabled?: boolean;
 }
 
 interface SaveConfigParams {
@@ -244,7 +244,7 @@ interface SaveConfigParams {
   tokenTtl: number;
   status: boolean;
   allowedOrigins: string[];
-  oauthEnabled: boolean;
+  oauthServerEnabled: boolean;
 }
 
 export const saveConfig = ({
@@ -253,7 +253,7 @@ export const saveConfig = ({
   tokenTtl,
   status,
   allowedOrigins,
-  oauthEnabled,
+  oauthServerEnabled,
 }: SaveConfigParams): Promise<void> =>
   api.post("/skauth/config", {
     envId,
@@ -261,7 +261,7 @@ export const saveConfig = ({
     tokenTtl,
     status,
     allowedOrigins,
-    oauthEnabled,
+    oauthServerEnabled,
   });
 
 export const useFetchProviders = ({
@@ -287,7 +287,7 @@ export const useFetchProviders = ({
           successUrl,
           tokenTtl: sessionTtl,
           allowedOrigins,
-          oauthEnabled,
+          oauthServerEnabled,
         }) => {
           const result: AuthProvider[] = [];
 
@@ -312,7 +312,7 @@ export const useFetchProviders = ({
             });
 
           setProviders(result);
-          setConfig({ successUrl, sessionTtl, allowedOrigins, oauthEnabled });
+          setConfig({ successUrl, sessionTtl, allowedOrigins, oauthServerEnabled });
         },
       )
       .catch(() => {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -223,6 +223,7 @@ interface FetchProvidersResult {
   successUrl?: string;
   tokenTtl?: number;
   allowedOrigins?: string[];
+  oauthEnabled?: boolean;
   redirectUrl: string;
   authUrl: string;
   providers: {
@@ -234,6 +235,7 @@ interface AuthConfig {
   sessionTtl?: number; // in minutes
   successUrl?: string;
   allowedOrigins?: string[];
+  oauthEnabled?: boolean;
 }
 
 interface SaveConfigParams {
@@ -242,6 +244,7 @@ interface SaveConfigParams {
   tokenTtl: number;
   status: boolean;
   allowedOrigins: string[];
+  oauthEnabled: boolean;
 }
 
 export const saveConfig = ({
@@ -250,6 +253,7 @@ export const saveConfig = ({
   tokenTtl,
   status,
   allowedOrigins,
+  oauthEnabled,
 }: SaveConfigParams): Promise<void> =>
   api.post("/skauth/config", {
     envId,
@@ -257,6 +261,7 @@ export const saveConfig = ({
     tokenTtl,
     status,
     allowedOrigins,
+    oauthEnabled,
   });
 
 export const useFetchProviders = ({
@@ -282,6 +287,7 @@ export const useFetchProviders = ({
           successUrl,
           tokenTtl: sessionTtl,
           allowedOrigins,
+          oauthEnabled,
         }) => {
           const result: AuthProvider[] = [];
 
@@ -306,7 +312,7 @@ export const useFetchProviders = ({
             });
 
           setProviders(result);
-          setConfig({ successUrl, sessionTtl, allowedOrigins });
+          setConfig({ successUrl, sessionTtl, allowedOrigins, oauthEnabled });
         },
       )
       .catch(() => {


### PR DESCRIPTION
Implements Phase 1 of #314 — turning any SkAuth-enabled environment into an OAuth 2.1 authorization server so ChatGPT/Claude MCP connectors can authenticate an app's own users without manual token copy-paste. Design agreed in [this comment](https://github.com/stormkit-io/stormkit-io/issues/314#issuecomment-4950565980).

## Endpoints (opt-in per environment)

| Path | Purpose |
|---|---|
| `GET /.well-known/oauth-authorization-server` | RFC 8414 AS metadata |
| `GET /.well-known/oauth-protected-resource` | RFC 9728 resource metadata (binds token audience) |
| `GET /_stormkit/oauth/authorize` | consent screen |
| `POST /_stormkit/oauth/authorize` | grant → issues PKCE-bound, single-use code |
| `POST /_stormkit/oauth/token` | `authorization_code` exchange → access token |

## Design decisions (from the issue thread)

- **Resource owner = the app's own SkAuth end user**, not a Stormkit dashboard account.
- **Edge-validated tokens, no JWKS.** Access tokens are signed with the environment's SkAuth secret in the same claim format (`uid`/`eml` + `aud`/`scope`) as session tokens, so the existing edge validation accepts them and injects `X-User-Id` — **zero app-side changes**. The per-env secret also gives audience isolation for free.
- **Consent is client-assisted** because the SkAuth session lives in `localStorage`, not a cookie: a server-rendered `GET /authorize` can't see the user. The page's script reads the token and POSTs it back to `grant`, which mints the code. `html/template` escapes the injected client/redirect values.
- **`redirect_uri` reuses `SKAuthConf.AllowedOrigins`** as the allowlist — no new config field; operators declare trusted connector origins in one place.
- **Toggle nested under `SKAuthConf.OAuth`**, settable via the existing auth-config API (`oauthEnabled`), and surfaced in the read handler.
- **Fall-through when disabled**: all routes delegate to normal app serving, so an app's own `.well-known` files stay reachable.

## Not in this PR (Phase 2+)

- Dynamic Client Registration (RFC 7591) + client registry with rate-limit/TTL guardrails
- Scope-metadata endpoint for human-readable consent labels
- Dashboard UI for the toggle (backend API is wired; frontend can follow)

## Tests

`OAuthSuite` covers both metadata docs, consent rendering, bad-`redirect_uri` rejection (no open redirect), unauthenticated grant, the full grant→token→validate round-trip, PKCE failure, and single-use code enforcement. Full hosting + skauth + buildconf suites pass.