### PR TITLE
feat: add oauth dynamic client registration (phase 2)

### DIFF
--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -1,11 +1,14 @@
 package hosting
 
 import (
+	"context"
+
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/analytics"
 	"github.com/stormkit-io/stormkit-io/src/lib/pool"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
 
@@ -45,9 +48,27 @@ func HandleOAuthMetadataAS(req *RequestContext) *shttp.Response { return handleO
 func HandleOAuthMetadataResource(req *RequestContext) *shttp.Response {
 	return handleOAuthMetadataResource(req)
 }
+func HandleOAuthRegister(req *RequestContext) *shttp.Response  { return handleOAuthRegister(req) }
 func HandleOAuthAuthorize(req *RequestContext) *shttp.Response { return handleOAuthAuthorize(req) }
 func HandleOAuthGrant(req *RequestContext) *shttp.Response     { return handleOAuthGrant(req) }
 func HandleOAuthToken(req *RequestContext) *shttp.Response     { return handleOAuthToken(req) }
+
+// OAuthRegisterRateMax exposes the per-host registration limit so the rate-limit
+// test can drive it up to the threshold without hard-coding the constant.
+func OAuthRegisterRateMax() int { return registerRateMax }
+
+// ResetOAuthRateLimit clears the registration counters for a host (across every
+// caller-IP window) so tests start from a clean slate regardless of prior runs
+// against the shared Redis.
+func ResetOAuthRateLimit(host string) {
+	c := rediscache.Client()
+
+	keys, _ := c.Keys(context.Background(), "oauth:reg:rate:"+host+":*")
+
+	if len(keys) > 0 {
+		c.Del(context.Background(), keys...)
+	}
+}
 
 // ServeAuth dispatches a /_stormkit/auth/* request to its route handler, the
 // same way registerReservedRoutes wires them into mux. It mirrors the WithSKAuth

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -22,6 +22,58 @@ import (
 // codes used by the magic-link landing.
 var oauthCodeStore = oneTimeCode{prefix: "oauth:code:", ttl: 5 * time.Minute}
 
+// oauthScope pairs a scope token with the human-readable label shown on the
+// consent screen. The catalog is advertised via scopes_supported so clients can
+// discover what they may request.
+type oauthScope struct {
+	Name  string
+	Label string
+}
+
+// oauthScopeCatalog is the fixed set of scopes this authorization server
+// understands. Because the access token only carries identity (uid/eml) and the
+// edge injects X-User-Id, scopes are informational — they give the consent
+// screen meaningful labels rather than enforcing per-scope access. Unknown
+// requested scopes still render, using their raw token as the label.
+var oauthScopeCatalog = []oauthScope{
+	{Name: "openid", Label: "Verify your identity"},
+	{Name: "email", Label: "Access your email address"},
+	{Name: "profile", Label: "Access your basic profile information"},
+}
+
+func oauthScopesSupported() []string {
+	names := make([]string, len(oauthScopeCatalog))
+
+	for i, s := range oauthScopeCatalog {
+		names[i] = s.Name
+	}
+
+	return names
+}
+
+// scopeLabels maps a space-separated scope request to the display labels shown
+// on consent. A requested scope missing from the catalog falls back to its raw
+// token, so the user always sees exactly what was asked for.
+func scopeLabels(scope string) []string {
+	fields := strings.Fields(scope)
+	labels := make([]string, 0, len(fields))
+
+	for _, f := range fields {
+		label := f
+
+		for _, s := range oauthScopeCatalog {
+			if s.Name == f {
+				label = s.Label
+				break
+			}
+		}
+
+		labels = append(labels, label)
+	}
+
+	return labels
+}
+
 // oauthServer implements the OAuth 2.1 authorization server layered on SkAuth.
 // The end user (an app's own SkAuth user) is the resource owner; access tokens
 // are signed with the environment's SkAuth secret, so the existing edge
@@ -52,6 +104,7 @@ func serveOAuth(fn func(*oauthServer) *shttp.Response) func(*RequestContext) *sh
 var (
 	handleOAuthMetadataAS       = serveOAuth((*oauthServer).metadataAS)
 	handleOAuthMetadataResource = serveOAuth((*oauthServer).metadataResource)
+	handleOAuthRegister         = serveOAuth((*oauthServer).register)
 	handleOAuthAuthorize        = serveOAuth((*oauthServer).authorize)
 	handleOAuthGrant            = serveOAuth((*oauthServer).grant)
 	handleOAuthToken            = serveOAuth((*oauthServer).token)
@@ -85,10 +138,12 @@ func (o *oauthServer) metadataAS() *shttp.Response {
 		"issuer":                                iss,
 		"authorization_endpoint":                iss + "/_stormkit/oauth/authorize",
 		"token_endpoint":                        iss + "/_stormkit/oauth/token",
+		"registration_endpoint":                 iss + "/_stormkit/oauth/register",
 		"response_types_supported":              []string{"code"},
 		"grant_types_supported":                 []string{"authorization_code"},
 		"code_challenge_methods_supported":      []string{"S256"},
 		"token_endpoint_auth_methods_supported": []string{"none"},
+		"scopes_supported":                      oauthScopesSupported(),
 	})
 }
 
@@ -103,6 +158,110 @@ func (o *oauthServer) metadataResource() *shttp.Response {
 		"authorization_servers":    []string{iss},
 		"bearer_methods_supported": []string{"header"},
 	})
+}
+
+// registrationRequest is the subset of RFC 7591 client metadata we honour. MCP
+// connectors are public PKCE clients, so we only need their redirect_uris and a
+// display name; everything else is validated for compatibility but not stored.
+type registrationRequest struct {
+	RedirectURIs            []string `json:"redirect_uris"`
+	ClientName              string   `json:"client_name"`
+	Scope                   string   `json:"scope"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+// Bounds on the unauthenticated registration request. They cap how much an
+// anonymous caller can push into Redis under the sliding 30-day TTL: the body
+// cap fences off the raw read, and the field caps bound what actually gets
+// persisted so a single record can't be inflated with a giant name or thousands
+// of redirect_uris.
+const (
+	maxRegisterBodyBytes = 16 * 1024
+	maxRedirectURIs      = 10
+	maxClientNameLen     = 256
+	maxScopeLen          = 512
+)
+
+// register serves POST /_stormkit/oauth/register — Dynamic Client Registration
+// (RFC 7591). It is unauthenticated by design (MCP clients self-provision before
+// any user is involved), so it is rate-limited per host and every redirect_uri
+// must sit on an operator-declared AllowedOrigin. Public clients only: we never
+// mint a client_secret.
+func (o *oauthServer) register() *shttp.Response {
+	if !oauthClients.registerAllowed(o.req.Context(), o.req.Host.Name, o.req.RemoteIP()) {
+		return oauthJSON(http.StatusTooManyRequests, oauthErr("temporarily_unavailable", "registration rate limit exceeded, retry later"))
+	}
+
+	if o.req.Request != nil && o.req.Request.Body != nil {
+		o.req.Request.Body = http.MaxBytesReader(nil, o.req.Request.Body, maxRegisterBodyBytes)
+	}
+
+	var body registrationRequest
+
+	if err := o.req.Post(&body); err != nil {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_client_metadata", "request body must be valid JSON within the size limit"))
+	}
+
+	if len(body.RedirectURIs) == 0 {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_redirect_uri", "at least one redirect_uri is required"))
+	}
+
+	if len(body.RedirectURIs) > maxRedirectURIs {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_redirect_uri", "too many redirect_uris"))
+	}
+
+	if len(body.ClientName) > maxClientNameLen || len(body.Scope) > maxScopeLen {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_client_metadata", "client_name or scope is too long"))
+	}
+
+	for _, uri := range body.RedirectURIs {
+		if !o.redirectAllowed(uri) {
+			return oauthJSON(http.StatusBadRequest, oauthErr("invalid_redirect_uri", "every redirect_uri must be on an allowed origin"))
+		}
+	}
+
+	// We only issue public (PKCE) clients, so a request for a confidential auth
+	// method is refused rather than silently downgraded to none.
+	if body.TokenEndpointAuthMethod != "" && body.TokenEndpointAuthMethod != "none" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_client_metadata", "only token_endpoint_auth_method=none (public client) is supported"))
+	}
+
+	client, err := oauthClients.register(o.req.Context(), oauthClient{
+		ClientName:   body.ClientName,
+		RedirectURIs: body.RedirectURIs,
+		Scope:        body.Scope,
+		IssuedAt:     time.Now().Unix(),
+	})
+
+	if err != nil {
+		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
+	}
+
+	return oauthJSON(http.StatusCreated, map[string]any{
+		"client_id":                  client.ClientID,
+		"client_id_issued_at":        client.IssuedAt,
+		"redirect_uris":              client.RedirectURIs,
+		"client_name":                client.ClientName,
+		"scope":                      client.Scope,
+		"grant_types":                []string{"authorization_code"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	})
+}
+
+// resolveClient looks up the Dynamic Client Registration record for clientID.
+// It returns (client, true) when a record exists and (zero, false) for an
+// unregistered client_id — including on a Redis outage — so callers fall back to
+// the origin-only redirect check. The AllowedOrigins gate still holds in the
+// fallback, so degrading is safe.
+func (o *oauthServer) resolveClient(clientID string) (oauthClient, bool) {
+	client, err := oauthClients.get(o.req.Context(), clientID)
+
+	if err != nil {
+		return oauthClient{}, false
+	}
+
+	return client, true
 }
 
 type authzParams struct {
@@ -156,6 +315,14 @@ func (o *oauthServer) authorize() *shttp.Response {
 		return o.errorPage("The redirect_uri is not allowed for this application.")
 	}
 
+	// A registered client narrows the check to exactly the redirect_uris it
+	// registered; an unregistered client_id falls back to the origin-only gate.
+	client, registered := o.resolveClient(p.clientID)
+
+	if registered && !client.allowsRedirect(p.redirectURI) {
+		return o.errorPage("The redirect_uri is not registered for this client.")
+	}
+
 	if p.responseType != "code" {
 		return o.redirectError(p, "unsupported_response_type", "only response_type=code is supported")
 	}
@@ -164,7 +331,7 @@ func (o *oauthServer) authorize() *shttp.Response {
 		return o.redirectError(p, "invalid_request", "a PKCE code_challenge using S256 is required")
 	}
 
-	return o.consentPage(p)
+	return o.consentPage(p, client)
 }
 
 // grant serves POST /_stormkit/oauth/authorize. The consent page calls it with
@@ -183,6 +350,10 @@ func (o *oauthServer) grant() *shttp.Response {
 
 	if p.codeChallenge == "" || p.codeChallengeMethod != "S256" {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "PKCE S256 required"))
+	}
+
+	if client, registered := o.resolveClient(p.clientID); registered && !client.allowsRedirect(p.redirectURI) {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "redirect_uri is not registered for this client"))
 	}
 
 	claims := user.ParseJWT(&user.ParseJWTArgs{
@@ -338,12 +509,18 @@ func (o *oauthServer) errorPage(msg string) *shttp.Response {
 // consentPage renders the client-assisted consent screen. The script pulls the
 // SkAuth token from localStorage and POSTs it back to grant(); when signed out
 // it prompts the user to sign in first. html/template escapes the injected
-// values in both HTML and JS contexts.
-func (o *oauthServer) consentPage(p authzParams) *shttp.Response {
-	client := p.clientID
+// values in both HTML and JS contexts. A registered client is shown by its
+// declared client_name; the requested scopes are listed with human-readable
+// labels so the user sees exactly what is being granted.
+func (o *oauthServer) consentPage(p authzParams, client oauthClient) *shttp.Response {
+	name := client.ClientName
 
-	if client == "" {
-		client = "An application"
+	if name == "" {
+		name = p.clientID
+	}
+
+	if name == "" {
+		name = "An application"
 	}
 
 	deny := appendQuery(p.redirectURI, map[string]string{"error": "access_denied", "state": p.state})
@@ -352,6 +529,11 @@ func (o *oauthServer) consentPage(p authzParams) *shttp.Response {
 <div class="container">
 	<h1>Authorize access</h1>
 	<h3><strong>{{ .client }}</strong> is requesting access to your account.</h3>
+	{{ if .scopes }}
+	<ul class="skoauth-scopes">
+		{{ range .scopes }}<li>{{ . }}</li>{{ end }}
+	</ul>
+	{{ end }}
 	<div id="skoauth-signedout" class="form-group error" style="display:none">
 		You are not signed in. Please sign in to this application in another tab, then reload this page to continue.
 	</div>
@@ -401,7 +583,7 @@ func (o *oauthServer) consentPage(p authzParams) *shttp.Response {
 		Data: html.MustRender(html.RenderArgs{
 			PageTitle:   "Stormkit - Authorize",
 			PageContent: content,
-			ContentData: map[string]any{"client": client, "deny": deny},
+			ContentData: map[string]any{"client": name, "deny": deny, "scopes": scopeLabels(p.scope)},
 		}),
 	}
 }

--- a/src/ce/hosting/oauth_client_store.go
+++ b/src/ce/hosting/oauth_client_store.go
@@ -1,0 +1,154 @@
+package hosting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// errClientNotFound is returned by oauthClientStore.get when the client_id is
+// unknown or has expired, letting callers fall back to the origin-only check.
+var errClientNotFound = errors.New("oauth client not found")
+
+// oauthClientTTL is how long a registered client survives. It slides on each
+// successful lookup, so an actively used connector never expires while abandoned
+// registrations from the unauthenticated endpoint are reaped.
+const oauthClientTTL = 30 * 24 * time.Hour
+
+// registration rate-limit: a fixed window per host and caller IP blunts abuse
+// of the unauthenticated Dynamic Client Registration endpoint.
+const (
+	registerRateMax    = 20
+	registerRateWindow = time.Hour
+)
+
+// oauthClient is the persisted Dynamic Client Registration record (RFC 7591).
+// Only the fields the authorization flow actually consumes are stored.
+type oauthClient struct {
+	ClientID     string   `json:"clientId"`
+	ClientName   string   `json:"clientName,omitempty"`
+	RedirectURIs []string `json:"redirectUris"`
+	Scope        string   `json:"scope,omitempty"`
+	IssuedAt     int64    `json:"issuedAt"`
+}
+
+// allowsRedirect reports whether redirectURI exactly matches one of the client's
+// registered redirect_uris. Registration validates every URI against the
+// operator's AllowedOrigins, so a registered match is strictly tighter than the
+// origin-only check.
+func (c oauthClient) allowsRedirect(redirectURI string) bool {
+	for _, uri := range c.RedirectURIs {
+		if uri == redirectURI {
+			return true
+		}
+	}
+
+	return false
+}
+
+// oauthClientStore is the Redis-backed Dynamic Client Registration registry. The
+// "oauth:client:" prefix namespaces it away from the authorization codes.
+type oauthClientStore struct {
+	prefix string
+}
+
+var oauthClients = oauthClientStore{prefix: "oauth:client:"}
+
+// register stashes a freshly-provisioned client under a generated client_id and
+// returns the stored record (with ClientID populated).
+func (s oauthClientStore) register(ctx context.Context, c oauthClient) (oauthClient, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return oauthClient{}, errors.New("redis client is not available")
+	}
+
+	id, err := utils.SecureRandomToken(24)
+
+	if err != nil {
+		return oauthClient{}, err
+	}
+
+	c.ClientID = id
+
+	blob, err := json.Marshal(c)
+
+	if err != nil {
+		return oauthClient{}, err
+	}
+
+	if err := client.Set(ctx, s.prefix+id, blob, oauthClientTTL).Err(); err != nil {
+		return oauthClient{}, err
+	}
+
+	return c, nil
+}
+
+// get reads a registered client and slides its TTL. It returns errClientNotFound
+// for an unknown or expired client so callers can distinguish that from a store
+// failure and fall back to the origin-only redirect check.
+func (s oauthClientStore) get(ctx context.Context, clientID string) (oauthClient, error) {
+	if clientID == "" {
+		return oauthClient{}, errClientNotFound
+	}
+
+	client := rediscache.Client()
+
+	if client == nil {
+		return oauthClient{}, errClientNotFound
+	}
+
+	raw, err := client.GetEx(ctx, s.prefix+clientID, oauthClientTTL).Result()
+
+	if errors.Is(err, redis.Nil) || raw == "" {
+		return oauthClient{}, errClientNotFound
+	}
+
+	if err != nil {
+		return oauthClient{}, err
+	}
+
+	var c oauthClient
+
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		return oauthClient{}, err
+	}
+
+	return c, nil
+}
+
+// registerAllowed enforces the fixed-window registration rate limit, keyed per
+// host and caller IP so a single abusive caller can't burn the whole app's
+// quota and lock legitimate connectors out of self-registration. It fails open
+// on a Redis error: the register handler's own Set will surface a real outage
+// as a server_error, so we don't want to double-reject on a transient blip.
+func (s oauthClientStore) registerAllowed(ctx context.Context, host, ip string) bool {
+	client := rediscache.Client()
+
+	if client == nil {
+		return true
+	}
+
+	key := "oauth:reg:rate:" + host + ":" + ip
+
+	n, err := client.Incr(ctx, key).Result()
+
+	if err != nil {
+		return true
+	}
+
+	// Incr creates the key without a TTL, so arm one whenever the key has none.
+	// Checking every call self-heals a counter left un-expiring by a failed
+	// Expire or a crash between Incr and Expire; otherwise the key would live
+	// forever and block this host+IP permanently once past the cap.
+	if ttl, err := client.TTL(ctx, key).Result(); err == nil && ttl < 0 {
+		client.Expire(ctx, key, registerRateWindow)
+	}
+
+	return n <= registerRateMax
+}

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -30,6 +30,13 @@ func TestOAuthSuite(t *testing.T) {
 	suite.Run(t, new(OAuthSuite))
 }
 
+// SetupTest clears the shared host's registration rate-limit counter so a
+// registration test never trips the limit because of a prior test or re-run
+// against the same Redis.
+func (s *OAuthSuite) SetupTest() {
+	hosting.ResetOAuthRateLimit("app.example.com")
+}
+
 func (s *OAuthSuite) host(enabled bool) *hosting.Host {
 	return &hosting.Host{
 		Name: "app.example.com",
@@ -104,6 +111,33 @@ func (s *OAuthSuite) json(res *shttp.Response) map[string]any {
 	return m
 }
 
+// registerReq builds a POST /_stormkit/oauth/register with a JSON body.
+func (s *OAuthSuite) registerReq(host *hosting.Host, bodyJSON string) *hosting.RequestContext {
+	h := make(http.Header)
+	h.Set("Content-Type", "application/json")
+
+	return s.req(host, http.MethodPost, "/_stormkit/oauth/register", "", h, strings.NewReader(bodyJSON))
+}
+
+// registerClient registers a client and returns the issued client_id.
+func (s *OAuthSuite) registerClient(name string, redirectURIs ...string) string {
+	uris := make([]string, len(redirectURIs))
+	for i, u := range redirectURIs {
+		uris[i] = `"` + u + `"`
+	}
+
+	body := `{"client_name":"` + name + `","redirect_uris":[` + strings.Join(uris, ",") + `]}`
+
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
+	s.Require().Equal(http.StatusCreated, res.Status)
+
+	id, ok := s.json(res)["client_id"].(string)
+	s.Require().True(ok)
+	s.Require().NotEmpty(id)
+
+	return id
+}
+
 func (s *OAuthSuite) Test_MetadataAS() {
 	res := hosting.HandleOAuthMetadataAS(s.req(s.host(true), http.MethodGet, "/.well-known/oauth-authorization-server", "", nil, nil))
 
@@ -112,7 +146,9 @@ func (s *OAuthSuite) Test_MetadataAS() {
 	s.Equal("https://app.example.com", d["issuer"])
 	s.Equal("https://app.example.com/_stormkit/oauth/authorize", d["authorization_endpoint"])
 	s.Equal("https://app.example.com/_stormkit/oauth/token", d["token_endpoint"])
+	s.Equal("https://app.example.com/_stormkit/oauth/register", d["registration_endpoint"])
 	s.Equal([]string{"S256"}, d["code_challenge_methods_supported"])
+	s.Contains(d["scopes_supported"], "email")
 }
 
 func (s *OAuthSuite) Test_MetadataResource() {
@@ -285,4 +321,150 @@ func (s *OAuthSuite) Test_Token_CodeIsSingleUse() {
 	second := hosting.HandleOAuthToken(s.tokenReq(form))
 	s.Equal(http.StatusBadRequest, second.Status)
 	s.Equal("invalid_grant", s.json(second)["error"])
+}
+
+// --- Dynamic Client Registration (RFC 7591) ---
+
+func (s *OAuthSuite) Test_Register_Success() {
+	body := `{"client_name":"ChatGPT","redirect_uris":["https://client.example.com/callback"]}`
+
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
+
+	s.Equal(http.StatusCreated, res.Status)
+	d := s.json(res)
+	s.NotEmpty(d["client_id"])
+	s.Equal("none", d["token_endpoint_auth_method"])
+	s.Equal("ChatGPT", d["client_name"])
+	// Public PKCE client: no secret must ever be issued.
+	_, hasSecret := d["client_secret"]
+	s.False(hasSecret, "public clients must not receive a client_secret")
+}
+
+func (s *OAuthSuite) Test_Register_RejectsRedirectOffAllowedOrigin() {
+	body := `{"redirect_uris":["https://evil.example.com/cb"]}`
+
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_redirect_uri", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Register_RequiresRedirectURIs() {
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), `{"client_name":"NoRedirect"}`))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_redirect_uri", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Register_RejectsConfidentialAuthMethod() {
+	body := `{"redirect_uris":["https://client.example.com/callback"],"token_endpoint_auth_method":"client_secret_basic"}`
+
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_client_metadata", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Register_RejectsOversizedBody() {
+	// An oversized body must be refused before anything is written to Redis, so
+	// the unauthenticated endpoint can't be used to amplify storage.
+	body := `{"client_name":"` + strings.Repeat("a", 32*1024) + `","redirect_uris":["https://client.example.com/callback"]}`
+
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_client_metadata", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Register_RejectsTooManyRedirectURIs() {
+	uris := make([]string, 0, 32)
+	for i := 0; i < 32; i++ {
+		uris = append(uris, `"https://client.example.com/callback"`)
+	}
+
+	body := `{"redirect_uris":[` + strings.Join(uris, ",") + `]}`
+
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_redirect_uri", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Register_Disabled_FallsThrough() {
+	// When OAuth is off the path is not reserved: serveOAuth forwards to normal
+	// app serving instead of registering a client.
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(false), `{"redirect_uris":["https://client.example.com/callback"]}`))
+
+	s.NotEqual(http.StatusCreated, res.Status)
+}
+
+func (s *OAuthSuite) Test_Register_RateLimited() {
+	host := &hosting.Host{Name: "ratelimit.example.com", Config: s.host(true).Config}
+	hosting.ResetOAuthRateLimit(host.Name)
+
+	body := `{"redirect_uris":["https://client.example.com/callback"]}`
+
+	for i := 0; i < hosting.OAuthRegisterRateMax(); i++ {
+		res := hosting.HandleOAuthRegister(s.registerReq(host, body))
+		s.Require().Equal(http.StatusCreated, res.Status, "registration %d should succeed", i)
+	}
+
+	res := hosting.HandleOAuthRegister(s.registerReq(host, body))
+	s.Equal(http.StatusTooManyRequests, res.Status)
+}
+
+// Test_Authorize_RegisteredClient_BindsRedirect verifies a registered client is
+// held to its declared redirect_uris, even for another path on the same allowed
+// origin (which the origin-only gate alone would permit).
+func (s *OAuthSuite) Test_Authorize_RegisteredClient_BindsRedirect() {
+	clientID := s.registerClient("ChatGPT", oauthRedirect)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", "https://client.example.com/other")
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Contains(string(res.Data.([]byte)), "not registered")
+}
+
+// Test_Authorize_RegisteredClient_ShowsName renders the client's declared
+// client_name on the consent screen rather than the opaque client_id.
+func (s *OAuthSuite) Test_Authorize_RegisteredClient_ShowsName() {
+	clientID := s.registerClient("Claude", oauthRedirect)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", oauthRedirect)
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Contains(string(res.Data.([]byte)), "Claude")
+}
+
+// Test_Authorize_ShowsScopeLabels renders human-readable labels for known
+// scopes on the consent screen.
+func (s *OAuthSuite) Test_Authorize_ShowsScopeLabels() {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "chatgpt")
+	q.Set("redirect_uri", oauthRedirect)
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+	q.Set("scope", "email profile")
+
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	html := string(res.Data.([]byte))
+	s.Contains(html, "Access your email address")
+	s.Contains(html, "Access your basic profile information")
 }

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -37,6 +37,8 @@ func registerReservedRoutes(s *shttp.Service) {
 	wk.Handler(http.MethodGet, "/oauth-protected-resource", WithHost(handleOAuthMetadataResource))
 
 	oauth := s.NewEndpoint("/_stormkit/oauth")
+	oauth.Handler(http.MethodPost, "/register", WithHost(handleOAuthRegister))
+	oauth.Handler(http.MethodOptions, "/register", WithHost(handleOAuthRegister))
 	oauth.Handler(http.MethodGet, "/authorize", WithHost(handleOAuthAuthorize))
 	oauth.Handler(http.MethodPost, "/authorize", WithHost(handleOAuthGrant))
 	oauth.Handler(http.MethodOptions, "/authorize", WithHost(handleOAuthAuthorize))

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -365,6 +365,13 @@ export default function SkAuth() {
               <Box component="code" sx={{ display: "block", fontSize: 12 }}>
                 /.well-known/oauth-protected-resource
               </Box>
+              <Typography sx={{ mt: 2, mb: 1 }}>
+                Connectors self-register via Dynamic Client Registration (RFC
+                7591); no manual client setup is needed:
+              </Typography>
+              <Box component="code" sx={{ display: "block", fontSize: 12 }}>
+                POST /_stormkit/oauth/register
+              </Box>
             </Alert>
           )}
         </Box>


### PR DESCRIPTION
Supersedes #358 (that PR was auto-closed by a force-push from a shallow clone; this recreates it from a clean commit with correct history).

Phase 2 of the OAuth 2.1 authorization server: Dynamic Client Registration (RFC 7591) so ChatGPT/Claude MCP connectors can self-provision a `client_id`. See #358 for the full description.

## Review fixes folded in
- **Rate limit keyed per host + caller IP** (was per app-host, so one caller could burn a customer's whole quota).
- **Nil-Redis guards** in the client store's `get()`/`register()` so a cold Redis outage degrades to origin-only / returns `server_error` instead of panicking.
- **Self-healing rate-limit TTL** so a lost `Expire` can't lock a host out permanently.
- **Request size caps** (16KB body via `MaxBytesReader`, plus `redirect_uris` count and `client_name`/`scope` length) on the unauthenticated endpoint.

Tests added for the oversized-body and too-many-redirect-uris cases; `go vet` clean and the full `hosting` suite passes.
