### PR TITLE
feat: edge OAuth WWW-Authenticate challenge

### DIFF
--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -29,6 +29,11 @@ func InjectSnippets(req *RequestContext, res *shttp.Response) *shttp.Response {
 	return injectSnippets(req, res)
 }
 
+// InjectOAuthChallenge exposes injectOAuthChallenge for tests.
+func InjectOAuthChallenge(req *RequestContext, res *shttp.Response) *shttp.Response {
+	return injectOAuthChallenge(req, res)
+}
+
 // HandleAuthVerify exposes the reserved /_stormkit/auth/verify route handler.
 // Reserved endpoints are unexported handlers now that they are routes rather
 // than middleware branches; this seam lets the existing tests drive the handler

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -116,6 +116,7 @@ func (r *RequestServer) finalize(res *shttp.Response) *shttp.Response {
 
 	res = injectHeaders(r.req, res)
 	res = injectSnippets(r.req, res)
+	res = injectOAuthChallenge(r.req, res)
 
 	if r.req.Host.Config.IsEnterprise {
 		contentType := strings.ToLower(res.Headers.Get("Content-Type"))
@@ -809,6 +810,36 @@ func injectHeaders(req *RequestContext, res *shttp.Response) *shttp.Response {
 			}
 		}
 	}
+
+	return res
+}
+
+// injectOAuthChallenge adds the RFC 9728 resource-metadata challenge to 401
+// responses from an OAuth-server-enabled environment. MCP connectors
+// (ChatGPT/Claude) rely on this header to discover the authorization server and
+// begin the OAuth flow — without it an unauthenticated request to a protected
+// app route just looks like a dead endpoint. It is only added when the app did
+// not set its own WWW-Authenticate, so an app that speaks OAuth itself is never
+// overridden. The metadata URL mirrors the issuer used by the .well-known docs.
+func injectOAuthChallenge(req *RequestContext, res *shttp.Response) *shttp.Response {
+	if res == nil || res.Status != http.StatusUnauthorized {
+		return res
+	}
+
+	if req.Host.Config == nil || !req.Host.Config.SKAuth.OAuthServerEnabled() {
+		return res
+	}
+
+	if res.Headers == nil {
+		res.Headers = make(http.Header)
+	}
+
+	if res.Headers.Get("WWW-Authenticate") != "" {
+		return res
+	}
+
+	metadataURL := "https://" + req.Host.Name + "/.well-known/oauth-protected-resource"
+	res.Headers.Set("WWW-Authenticate", `Bearer resource_metadata="`+metadataURL+`"`)
 
 	return res
 }

--- a/src/ce/hosting/handler_forward_oauth_test.go
+++ b/src/ce/hosting/handler_forward_oauth_test.go
@@ -1,0 +1,72 @@
+package hosting_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	hosting "github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+type OAuthChallengeSuite struct {
+	suite.Suite
+}
+
+func TestOAuthChallengeSuite(t *testing.T) {
+	suite.Run(t, new(OAuthChallengeSuite))
+}
+
+func (s *OAuthChallengeSuite) req(oauthEnabled bool) *hosting.RequestContext {
+	return &hosting.RequestContext{
+		Host: &hosting.Host{
+			Name: "app.example.com",
+			Config: &appconf.Config{
+				SKAuth: &buildconf.SKAuthConf{
+					Status:      true,
+					OAuthServer: &buildconf.OAuthServerConf{Enabled: oauthEnabled},
+				},
+			},
+		},
+	}
+}
+
+const expectedChallenge = `Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"`
+
+func (s *OAuthChallengeSuite) Test_AddsChallenge_On401_WhenEnabled() {
+	res := hosting.InjectOAuthChallenge(s.req(true), &shttp.Response{Status: http.StatusUnauthorized})
+
+	s.Equal(expectedChallenge, res.Headers.Get("WWW-Authenticate"))
+}
+
+func (s *OAuthChallengeSuite) Test_NoChallenge_WhenOAuthDisabled() {
+	res := hosting.InjectOAuthChallenge(s.req(false), &shttp.Response{Status: http.StatusUnauthorized})
+
+	s.Empty(res.Headers.Get("WWW-Authenticate"))
+}
+
+func (s *OAuthChallengeSuite) Test_NoChallenge_OnNon401() {
+	res := hosting.InjectOAuthChallenge(s.req(true), &shttp.Response{Status: http.StatusOK})
+
+	s.Empty(res.Headers.Get("WWW-Authenticate"))
+}
+
+// An app that speaks OAuth itself and sets its own challenge must not be
+// overridden by the edge default.
+func (s *OAuthChallengeSuite) Test_DoesNotOverrideExistingChallenge() {
+	res := &shttp.Response{
+		Status:  http.StatusUnauthorized,
+		Headers: shttp.HeadersFromMap(map[string]string{"WWW-Authenticate": "Bearer realm=\"custom\""}),
+	}
+
+	out := hosting.InjectOAuthChallenge(s.req(true), res)
+
+	s.Equal(`Bearer realm="custom"`, out.Headers.Get("WWW-Authenticate"))
+}
+
+func (s *OAuthChallengeSuite) Test_NilResponse_NoPanic() {
+	s.Nil(hosting.InjectOAuthChallenge(s.req(true), nil))
+}


### PR DESCRIPTION
Complements the OAuth 2.1 authorization server (#358/#359). With DCR in place, MCP connectors (ChatGPT/Claude) can self-provision a client, but they still have to *discover* that an app route is an OAuth-protected resource. Per the MCP auth spec (RFC 9728), that discovery hinges on the resource server answering an unauthenticated request with `401` **and** a `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"` header. Apps rarely emit that header themselves, so the connect attempt just looks like a dead endpoint.

This makes the edge emit that challenge automatically for any environment with the OAuth server enabled.

## Behaviour
- On a `401` from an OAuth-enabled environment, `finalize()` adds `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"`.
- Only when the app didn't already set its own `WWW-Authenticate` (an app that speaks OAuth itself is never overridden).
- No-op for non-401 responses and for environments without the OAuth server enabled.

The metadata URL mirrors the issuer already used by the `.well-known` documents, which this same edge serves.

## Tests
New `OAuthChallengeSuite`: challenge added on 401 when enabled; not added when disabled; not added on non-401; existing app challenge preserved; nil-response safety. `go vet` clean; full `hosting` suite passes.
