### PR TITLE
feat: mcp connector support for oauth server

### DIFF
--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -57,6 +57,20 @@ type OAuthServerConf struct {
 	// Enabled turns the /_stormkit/oauth/* endpoints and the .well-known
 	// discovery documents on for this environment.
 	Enabled bool
+
+	// ResourcePath is the path this environment serves its MCP server on (e.g.
+	// "/mcp"). When set it is appended to the resource identifier in the
+	// protected-resource metadata and the access-token audience, and it selects
+	// which /.well-known/oauth-protected-resource/<path> probe is answered. MCP
+	// clients (Claude, ChatGPT) require the resource to match the URL the user
+	// entered, path included, so this must equal the connector URL's path.
+	ResourcePath string
+
+	// AllowLoopback opts in to RFC 8252 loopback redirects for native/CLI
+	// clients (e.g. Claude Code), which listen on an ephemeral localhost port.
+	// When on, a redirect_uri whose host is a loopback literal is matched on
+	// scheme+path only, ignoring the port.
+	AllowLoopback bool
 }
 
 // OAuthServerEnabled reports whether the OAuth authorization server is active.
@@ -64,6 +78,29 @@ type OAuthServerConf struct {
 // secret and app-user identities.
 func (ac *SKAuthConf) OAuthServerEnabled() bool {
 	return ac != nil && ac.Status && ac.OAuthServer != nil && ac.OAuthServer.Enabled
+}
+
+// ResourcePath returns the configured MCP resource path normalized to a leading
+// slash with no trailing slash (e.g. "mcp/" -> "/mcp"). An unset path returns
+// "", meaning the resource identifier is the bare issuer.
+func (ac *SKAuthConf) ResourcePath() string {
+	if !ac.OAuthServerEnabled() || ac.OAuthServer.ResourcePath == "" {
+		return ""
+	}
+
+	p := utils.TrimPath(ac.OAuthServer.ResourcePath)
+
+	if p == "/" {
+		return ""
+	}
+
+	return p
+}
+
+// AllowLoopbackRedirects reports whether native/CLI clients using RFC 8252
+// loopback redirects are permitted for this environment.
+func (ac *SKAuthConf) AllowLoopbackRedirects() bool {
+	return ac.OAuthServerEnabled() && ac.OAuthServer.AllowLoopback
 }
 
 // Value implements the Sql Driver interface.

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -18,10 +18,13 @@ type AuthConfigUpdateRequest struct {
 	Status         bool     `json:"status"`
 	AllowedOrigins []string `json:"allowedOrigins"`
 
-	// OAuthServerEnabled is a pointer so an omitted field leaves the stored
+	// The OAuth-server fields are pointers so an omitted field leaves the stored
 	// setting untouched: a client that saves other fields (or an older UI that
-	// doesn't know the field) must not silently disable a live OAuth server.
-	OAuthServerEnabled *bool `json:"oauthServerEnabled"`
+	// doesn't know the field) must not silently disable a live OAuth server or
+	// clear its MCP configuration.
+	OAuthServerEnabled *bool   `json:"oauthServerEnabled"`
+	OAuthResourcePath  *string `json:"oauthResourcePath"`
+	OAuthAllowLoopback *bool   `json:"oauthAllowLoopback"`
 }
 
 func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
@@ -98,8 +101,11 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	env.AuthConf.Status = data.Status
 	env.AuthConf.AllowedOrigins = allowedOrigins
 
-	if data.OAuthServerEnabled != nil {
-		env.AuthConf.OAuthServer = &buildconf.OAuthServerConf{Enabled: *data.OAuthServerEnabled}
+	if err := applyOAuthServerConf(env.AuthConf, data); err != nil {
+		return shttp.BadRequest(map[string]any{
+			"error": err.Error(),
+			"hint":  "Provide a relative path such as: /mcp",
+		})
 	}
 
 	err = store.SaveAuthConf(req.Context(), req.EnvID, env.AuthConf)
@@ -118,4 +124,49 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	}
 
 	return shttp.OK()
+}
+
+// applyOAuthServerConf merges the OAuth-server fields from data into conf,
+// leaving any field the client omitted untouched. It validates and normalizes
+// the MCP resource path to a leading-slash relative path.
+func applyOAuthServerConf(conf *buildconf.SKAuthConf, data AuthConfigUpdateRequest) error {
+	if data.OAuthServerEnabled == nil && data.OAuthResourcePath == nil && data.OAuthAllowLoopback == nil {
+		return nil
+	}
+
+	if conf.OAuthServer == nil {
+		conf.OAuthServer = &buildconf.OAuthServerConf{}
+	}
+
+	if data.OAuthServerEnabled != nil {
+		conf.OAuthServer.Enabled = *data.OAuthServerEnabled
+	}
+
+	if data.OAuthAllowLoopback != nil {
+		conf.OAuthServer.AllowLoopback = *data.OAuthAllowLoopback
+	}
+
+	if data.OAuthResourcePath != nil {
+		path := strings.TrimSpace(*data.OAuthResourcePath)
+
+		if path != "" {
+			parsed, err := url.Parse(path)
+
+			// The path must be a bare relative path: no scheme/host, no query or
+			// fragment, and no whitespace. Anything else would be stored verbatim
+			// and then never match the normalized well-known probe, silently
+			// breaking the connector with no error surfaced later.
+			if err != nil || parsed.IsAbs() || parsed.Host != "" ||
+				parsed.RawQuery != "" || parsed.Fragment != "" ||
+				strings.ContainsAny(path, " \t\r\n") {
+				return fmt.Errorf("MCP resource path %q must be a plain relative path such as /mcp", path)
+			}
+
+			path = utils.TrimPath(path)
+		}
+
+		conf.OAuthServer.ResourcePath = path
+	}
+
+	return nil
 }

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
@@ -161,6 +161,58 @@ func (s *HandlerAuthConfigUpdateSuite) Test_AbsoluteURL_ShouldFail() {
 	s.JSONEq(expected, response.String())
 }
 
+// Test_Update_OAuthServerFields persists the MCP path and loopback toggle and
+// normalizes the path to a leading slash.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthServerFields() {
+	s.mockCacheService.On("Reset", types.ID(s.env.ID)).Return(nil).Once()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":              s.env.ID,
+			"status":             true,
+			"oauthServerEnabled": true,
+			"oauthResourcePath":  "mcp",
+			"oauthAllowLoopback": true,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	env, err := buildconf.NewStore().EnvironmentByID(context.Background(), s.env.ID)
+	s.NoError(err)
+	s.Require().NotNil(env.AuthConf.OAuthServer)
+	s.True(env.AuthConf.OAuthServer.Enabled)
+	s.Equal("/mcp", env.AuthConf.OAuthServer.ResourcePath)
+	s.True(env.AuthConf.OAuthServer.AllowLoopback)
+}
+
+// Test_Update_OAuthResourcePath_RejectsQuery guards against a path with a query
+// string, which would be stored verbatim and never match the well-known probe.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthResourcePath_RejectsQuery() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":              s.env.ID,
+			"status":             true,
+			"oauthServerEnabled": true,
+			"oauthResourcePath":  "/mcp?x=1",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
 func TestHandlerAuthConfigUpdate(t *testing.T) {
 	suite.Run(t, &HandlerAuthConfigUpdateSuite{})
 }

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -47,6 +47,8 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 	ttl := 0
 	allowedOrigins := []string{}
 	oauthServerEnabled := false
+	oauthResourcePath := ""
+	oauthAllowLoopback := false
 
 	if env.AuthConf != nil {
 		successURL = env.AuthConf.SuccessURL
@@ -55,6 +57,11 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 
 		if env.AuthConf.AllowedOrigins != nil {
 			allowedOrigins = env.AuthConf.AllowedOrigins
+		}
+
+		if env.AuthConf.OAuthServer != nil {
+			oauthResourcePath = env.AuthConf.OAuthServer.ResourcePath
+			oauthAllowLoopback = env.AuthConf.OAuthServer.AllowLoopback
 		}
 	}
 
@@ -65,6 +72,8 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 			"tokenTtl":           ttl,
 			"allowedOrigins":     allowedOrigins,
 			"oauthServerEnabled": oauthServerEnabled,
+			"oauthResourcePath":  oauthResourcePath,
+			"oauthAllowLoopback": oauthAllowLoopback,
 			"redirectUrl":        skauth.RedirectURL(),
 			"authUrl":            skauth.AuthURL(),
 		},

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -838,8 +838,12 @@ func injectOAuthChallenge(req *RequestContext, res *shttp.Response) *shttp.Respo
 		return res
 	}
 
-	metadataURL := "https://" + req.Host.Name + "/.well-known/oauth-protected-resource"
-	res.Headers.Set("WWW-Authenticate", `Bearer resource_metadata="`+metadataURL+`"`)
+	// Point at the RFC 9728 path-aware metadata document for the configured MCP
+	// path, and advertise the scopes so Claude requests them directly instead of
+	// falling back to whatever scopes_supported lists.
+	metadataURL := "https://" + req.Host.Name + "/.well-known/oauth-protected-resource" + req.Host.Config.SKAuth.ResourcePath()
+	challenge := `Bearer resource_metadata="` + metadataURL + `", scope="` + strings.Join(oauthScopesSupported(), " ") + `"`
+	res.Headers.Set("WWW-Authenticate", challenge)
 
 	return res
 }

--- a/src/ce/hosting/handler_forward_oauth_test.go
+++ b/src/ce/hosting/handler_forward_oauth_test.go
@@ -21,25 +21,43 @@ func TestOAuthChallengeSuite(t *testing.T) {
 }
 
 func (s *OAuthChallengeSuite) req(oauthEnabled bool) *hosting.RequestContext {
+	return s.reqWithPath(oauthEnabled, "")
+}
+
+func (s *OAuthChallengeSuite) reqWithPath(oauthEnabled bool, resourcePath string) *hosting.RequestContext {
 	return &hosting.RequestContext{
 		Host: &hosting.Host{
 			Name: "app.example.com",
 			Config: &appconf.Config{
 				SKAuth: &buildconf.SKAuthConf{
-					Status:      true,
-					OAuthServer: &buildconf.OAuthServerConf{Enabled: oauthEnabled},
+					Status: true,
+					OAuthServer: &buildconf.OAuthServerConf{
+						Enabled:      oauthEnabled,
+						ResourcePath: resourcePath,
+					},
 				},
 			},
 		},
 	}
 }
 
-const expectedChallenge = `Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"`
+const expectedChallenge = `Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource", scope="openid email profile offline_access"`
 
 func (s *OAuthChallengeSuite) Test_AddsChallenge_On401_WhenEnabled() {
 	res := hosting.InjectOAuthChallenge(s.req(true), &shttp.Response{Status: http.StatusUnauthorized})
 
 	s.Equal(expectedChallenge, res.Headers.Get("WWW-Authenticate"))
+}
+
+// With an MCP path configured, the challenge must point at the RFC 9728
+// path-aware metadata document so Claude probes the right resource.
+func (s *OAuthChallengeSuite) Test_Challenge_IncludesResourcePath() {
+	res := hosting.InjectOAuthChallenge(s.reqWithPath(true, "/mcp"), &shttp.Response{Status: http.StatusUnauthorized})
+
+	s.Equal(
+		`Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/mcp", scope="openid email profile offline_access"`,
+		res.Headers.Get("WWW-Authenticate"),
+	)
 }
 
 func (s *OAuthChallengeSuite) Test_NoChallenge_WhenOAuthDisabled() {

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -39,6 +39,23 @@ var oauthScopeCatalog = []oauthScope{
 	{Name: "openid", Label: "Verify your identity"},
 	{Name: "email", Label: "Access your email address"},
 	{Name: "profile", Label: "Access your basic profile information"},
+	{Name: "offline_access", Label: "Maintain access when you are offline"},
+}
+
+// scopeOfflineAccess is the scope a client requests to receive a refresh token.
+// It must be advertised in scopes_supported: Claude only appends it (and thus
+// only obtains a refresh token) when the server declares it.
+const scopeOfflineAccess = "offline_access"
+
+// scopeRequested reports whether the space-separated scope string contains name.
+func scopeRequested(scope, name string) bool {
+	for _, f := range strings.Fields(scope) {
+		if f == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func oauthScopesSupported() []string {
@@ -92,11 +109,39 @@ func serveOAuth(fn func(*oauthServer) *shttp.Response) func(*RequestContext) *sh
 		}
 
 		if req.Method == http.MethodOptions {
-			return finalizeReserved(req, &shttp.Response{Status: http.StatusNoContent})
+			return finalizeReserved(req, withOAuthCORS(&shttp.Response{Status: http.StatusNoContent}))
 		}
 
 		return finalizeReserved(req, fn(&oauthServer{req: req}))
 	}
+}
+
+// oauthCORSHeaders makes the discovery, registration and token endpoints
+// reachable from browser-based MCP clients (e.g. MCP Inspector), which probe
+// them cross-origin. The endpoints authenticate via the Authorization header,
+// never cookies, so a wildcard origin carries no ambient-authority risk.
+var oauthCORSHeaders = map[string]string{
+	"Access-Control-Allow-Origin":  "*",
+	"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+	"Access-Control-Allow-Headers": "Authorization, Content-Type",
+}
+
+// withOAuthCORS adds the permissive CORS headers to res, allocating the header
+// map if needed. Existing headers are preserved.
+func withOAuthCORS(res *shttp.Response) *shttp.Response {
+	if res == nil {
+		return res
+	}
+
+	if res.Headers == nil {
+		res.Headers = make(http.Header)
+	}
+
+	for k, v := range oauthCORSHeaders {
+		res.Headers.Set(k, v)
+	}
+
+	return res
 }
 
 // OAuth route handlers, wired in registerReservedRoutes and exercised by tests
@@ -130,6 +175,21 @@ func (o *oauthServer) issuer() string {
 	return "https://" + o.req.Host.Name
 }
 
+// resourceID is the protected-resource identifier: the issuer plus the
+// configured MCP path (e.g. "https://host/mcp"). MCP clients require this to
+// match the connector URL the user entered, path included — a bare issuer is
+// rejected outright. When no path is configured it degrades to the issuer.
+func (o *oauthServer) resourceID() string {
+	return o.issuer() + o.req.Host.Config.SKAuth.ResourcePath()
+}
+
+// resourceMetadataURL is the RFC 9728 §3.1 location of the protected-resource
+// metadata for resourceID: the /.well-known/oauth-protected-resource segment is
+// inserted between the host and the resource path.
+func (o *oauthServer) resourceMetadataURL() string {
+	return o.issuer() + "/.well-known/oauth-protected-resource" + o.req.Host.Config.SKAuth.ResourcePath()
+}
+
 // metadataAS serves the RFC 8414 authorization-server metadata document.
 func (o *oauthServer) metadataAS() *shttp.Response {
 	iss := o.issuer()
@@ -140,7 +200,7 @@ func (o *oauthServer) metadataAS() *shttp.Response {
 		"token_endpoint":                        iss + "/_stormkit/oauth/token",
 		"registration_endpoint":                 iss + "/_stormkit/oauth/register",
 		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"code_challenge_methods_supported":      []string{"S256"},
 		"token_endpoint_auth_methods_supported": []string{"none"},
 		"scopes_supported":                      oauthScopesSupported(),
@@ -151,13 +211,29 @@ func (o *oauthServer) metadataAS() *shttp.Response {
 // It points MCP clients at this same host as the authorization server and binds
 // the resource identity, which the access-token audience is stamped with.
 func (o *oauthServer) metadataResource() *shttp.Response {
-	iss := o.issuer()
+	// A per-path probe (/.well-known/oauth-protected-resource/<path>) is only
+	// answered when it matches this environment's configured MCP path; any other
+	// subpath falls through to normal app serving so the app keeps its own
+	// well-known files.
+	if sub := o.protectedResourceSubpath(); sub != "" && sub != o.req.Host.Config.SKAuth.ResourcePath() {
+		return HandlerForward(o.req)
+	}
 
 	return oauthJSON(http.StatusOK, map[string]any{
-		"resource":                 iss,
-		"authorization_servers":    []string{iss},
+		"resource":                 o.resourceID(),
+		"authorization_servers":    []string{o.issuer()},
 		"bearer_methods_supported": []string{"header"},
+		"scopes_supported":         oauthScopesSupported(),
 	})
+}
+
+// protectedResourceSubpath returns the path component the client probed after
+// /.well-known/oauth-protected-resource, normalized to a leading slash (e.g.
+// "/mcp"), or "" for the bare root document.
+func (o *oauthServer) protectedResourceSubpath() string {
+	const prefix = "/.well-known/oauth-protected-resource"
+
+	return utils.TrimPath(strings.TrimPrefix(o.req.URL().Path, prefix))
 }
 
 // registrationRequest is the subset of RFC 7591 client metadata we honour. MCP
@@ -185,8 +261,8 @@ const (
 // register serves POST /_stormkit/oauth/register — Dynamic Client Registration
 // (RFC 7591). It is unauthenticated by design (MCP clients self-provision before
 // any user is involved), so it is rate-limited per host and every redirect_uri
-// must sit on an operator-declared AllowedOrigin. Public clients only: we never
-// mint a client_secret.
+// must pass redirectAllowed — a curated connector preset or, when opted in, an
+// RFC 8252 loopback address. Public clients only: we never mint a client_secret.
 func (o *oauthServer) register() *shttp.Response {
 	if !oauthClients.registerAllowed(o.req.Context(), o.req.Host.Name, o.req.RemoteIP()) {
 		return oauthJSON(http.StatusTooManyRequests, oauthErr("temporarily_unavailable", "registration rate limit exceeded, retry later"))
@@ -252,8 +328,8 @@ func (o *oauthServer) register() *shttp.Response {
 // resolveClient looks up the Dynamic Client Registration record for clientID.
 // It returns (client, true) when a record exists and (zero, false) for an
 // unregistered client_id — including on a Redis outage — so callers fall back to
-// the origin-only redirect check. The AllowedOrigins gate still holds in the
-// fallback, so degrading is safe.
+// the origin-only redirect check. The connector-preset (and opt-in loopback) gate
+// in redirectAllowed still holds in the fallback, so degrading is safe.
 func (o *oauthServer) resolveClient(clientID string) (oauthClient, bool) {
 	client, err := oauthClients.get(o.req.Context(), clientID)
 
@@ -272,6 +348,7 @@ type authzParams struct {
 	codeChallengeMethod string
 	state               string
 	scope               string
+	resource            string
 }
 
 func (o *oauthServer) parseAuthzParams() authzParams {
@@ -285,12 +362,59 @@ func (o *oauthServer) parseAuthzParams() authzParams {
 		codeChallengeMethod: q.Get("code_challenge_method"),
 		state:               q.Get("state"),
 		scope:               q.Get("scope"),
+		resource:            q.Get("resource"),
 	}
 }
 
-// redirectAllowed reports whether redirectURI is an absolute URL whose origin is
-// in the environment's SkAuth AllowedOrigins list. Reusing that list means an
-// operator declares the trusted connector origins in one place.
+// validResource reports whether an RFC 8707 resource indicator names this
+// server's protected resource. Only one resource is served per environment, so
+// the accepted values are the path-qualified resource id and, tolerantly, the
+// bare issuer. An empty resource is treated as "not requested" by callers.
+func (o *oauthServer) validResource(resource string) bool {
+	return resource == o.resourceID() || resource == o.issuer()
+}
+
+// audienceFor resolves the access-token audience (RFC 8707). A client may bind
+// the token to a specific resource via the resource indicator; when it does, that
+// value is echoed into aud. Otherwise the token is scoped to this environment's
+// resource id. The caller has already rejected an invalid requested resource.
+func (o *oauthServer) audienceFor(requested, stored string) string {
+	return utils.GetString(requested, stored, o.resourceID())
+}
+
+// oauthConnectorPresets is the curated allow-list of MCP connector redirect
+// origins. These are fixed, public, well-known values published by each vendor,
+// and they move over time (ChatGPT migrated its callback path; Claude added
+// claude.com alongside claude.ai). Maintaining them here — rather than asking
+// every operator to hand-enter them into AllowedOrigins, where they silently rot
+// on the next vendor change — means one edit propagates to every environment.
+// Redirect matching for unregistered clients is origin-only, so a dynamic
+// callback path (e.g. ChatGPT's /connector/oauth/{id}) is covered for free.
+//
+// Allow-listing an origin grants nothing on its own: every token still requires
+// the user to clear the consent screen, and these origins are not
+// attacker-controlled.
+//
+// Last verified: 2026-07-14.
+var oauthConnectorPresets = []string{
+	"https://claude.ai",
+	"https://claude.com",
+	"https://chatgpt.com",
+}
+
+// loopbackHosts are the RFC 8252 §7.3 loopback IP literals, keyed as
+// url.Hostname() reports them (IPv6 brackets stripped). localhost is handled
+// separately (see isLoopbackHost) so it matches case-insensitively as a DNS name.
+var loopbackHosts = map[string]bool{
+	"127.0.0.1": true,
+	"::1":       true,
+}
+
+// redirectAllowed reports whether redirectURI is an absolute URL permitted to
+// receive an authorization code. It trusts the curated connector presets and,
+// when the environment opts in, RFC 8252 loopback redirects for native/CLI
+// clients. Enabling the OAuth server is itself the opt-in to the presets, so no
+// per-origin configuration is required for the supported connectors.
 func (o *oauthServer) redirectAllowed(redirectURI string) bool {
 	u, err := url.Parse(redirectURI)
 
@@ -298,9 +422,34 @@ func (o *oauthServer) redirectAllowed(redirectURI string) bool {
 		return false
 	}
 
+	if o.isLoopbackRedirect(u) {
+		return true
+	}
+
 	// Host is compared case-insensitively: url.Parse lowercases the scheme but
 	// preserves host case, and DNS names are case-insensitive.
-	return o.req.Host.Config.SKAuth.IsAllowedOrigin(u.Scheme + "://" + strings.ToLower(u.Host))
+	origin := u.Scheme + "://" + strings.ToLower(u.Host)
+
+	for _, preset := range oauthConnectorPresets {
+		if preset == origin {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isLoopbackRedirect reports whether u is a loopback redirect the environment
+// has opted in to. Per RFC 8252 §7.3 the port is ignored — the native client
+// binds an ephemeral port on the user's machine — so only scheme+host are
+// checked here; the caller's exact-match narrowing (for registered clients)
+// likewise compares on host, not port.
+func (o *oauthServer) isLoopbackRedirect(u *url.URL) bool {
+	if !o.req.Host.Config.SKAuth.AllowLoopbackRedirects() {
+		return false
+	}
+
+	return isLoopbackHost(u.Hostname())
 }
 
 // authorize serves GET /_stormkit/oauth/authorize — the consent screen. Because
@@ -352,6 +501,10 @@ func (o *oauthServer) grant() *shttp.Response {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "PKCE S256 required"))
 	}
 
+	if p.resource != "" && !o.validResource(p.resource) {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_target", "the requested resource is not served by this server"))
+	}
+
 	if client, registered := o.resolveClient(p.clientID); registered && !client.allowsRedirect(p.redirectURI) {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "redirect_uri is not registered for this client"))
 	}
@@ -381,6 +534,7 @@ func (o *oauthServer) grant() *shttp.Response {
 		RedirectURI:   p.redirectURI,
 		CodeChallenge: p.codeChallenge,
 		Scope:         p.scope,
+		Resource:      p.resource,
 	})
 
 	if err != nil {
@@ -400,16 +554,28 @@ type oauthAuthCode struct {
 	RedirectURI   string `json:"redirectUri"`
 	CodeChallenge string `json:"codeChallenge"`
 	Scope         string `json:"scope"`
+	Resource      string `json:"resource,omitempty"`
 }
 
-// token serves POST /_stormkit/oauth/token — the authorization_code exchange.
-// It verifies the PKCE proof and mints an access token in the SkAuth format, so
-// the edge validates it like any session token.
+// token serves POST /_stormkit/oauth/token. It dispatches on grant_type: the
+// authorization_code exchange (the initial connection) and the refresh_token
+// rotation (silent renewal at access-token expiry). Both mint an access token in
+// the SkAuth format, so the edge validates it like any session token.
 func (o *oauthServer) token() *shttp.Response {
-	if o.req.PostFormValue("grant_type") != "authorization_code" {
+	switch o.req.PostFormValue("grant_type") {
+	case "authorization_code":
+		return o.tokenAuthorizationCode()
+	case "refresh_token":
+		return o.tokenRefresh()
+	default:
 		return oauthJSON(http.StatusBadRequest, oauthErr("unsupported_grant_type", ""))
 	}
+}
 
+// tokenAuthorizationCode redeems a PKCE-bound authorization code. When the grant
+// carried offline_access it also mints a rotating refresh token so the
+// connection survives past the first access-token expiry.
+func (o *oauthServer) tokenAuthorizationCode() *shttp.Response {
 	code := o.req.PostFormValue("code")
 	verifier := o.req.PostFormValue("code_verifier")
 
@@ -442,14 +608,105 @@ func (o *oauthServer) token() *shttp.Response {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "PKCE verification failed"))
 	}
 
-	claims := jwt.MapClaims{"uid": ac.UID, "aud": o.issuer()}
+	// The token request may repeat the RFC 8707 resource indicator; if present it
+	// must name the same resource the code was issued for.
+	requested := o.req.PostFormValue("resource")
 
-	if ac.EML != "" {
-		claims["eml"] = ac.EML
+	if requested != "" && !o.validResource(requested) {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_target", "the requested resource is not served by this server"))
 	}
 
-	if ac.Scope != "" {
-		claims["scope"] = ac.Scope
+	if requested != "" && ac.Resource != "" && requested != ac.Resource {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "resource does not match the authorization request"))
+	}
+
+	aud := o.audienceFor(requested, ac.Resource)
+
+	return o.issueTokens(oauthTokenGrant{
+		uid:      ac.UID,
+		eml:      ac.EML,
+		clientID: ac.ClientID,
+		scope:    ac.Scope,
+		aud:      aud,
+	})
+}
+
+// tokenRefresh rotates a refresh token: the presented token is consumed and a
+// fresh access/refresh pair is minted from the identity and grant it stood in
+// for. An unknown or already-rotated token yields invalid_grant per RFC 6749.
+func (o *oauthServer) tokenRefresh() *shttp.Response {
+	refresh := o.req.PostFormValue("refresh_token")
+
+	if refresh == "" {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "refresh_token is required"))
+	}
+
+	// rotate() consumes the presented token atomically (single-use), which is the
+	// correct security primitive: a peek-then-delete would open a replay window
+	// where two concurrent refreshes both mint. The tradeoff is fail-closed — if
+	// re-issue below fails on a transient Redis error the consumed token is gone
+	// and the connector re-consents, which is preferable to a replayable token.
+	payload, err := oauthRefreshTokens.rotate(o.req.Context(), refresh)
+
+	if err != nil {
+		if errors.Is(err, errRefreshNotFound) {
+			return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "refresh token is invalid or expired"))
+		}
+
+		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
+	}
+
+	// OAuth 2.1 requires public clients to send client_id; when present it must
+	// match the one the refresh token was issued to. We don't hard-require it, so
+	// a client that omits it still works — the single-use refresh token is itself
+	// the proof of possession.
+	if clientID := o.req.PostFormValue("client_id"); clientID != "" && clientID != payload.ClientID {
+		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "client_id mismatch"))
+	}
+
+	// A resource indicator on refresh may narrow, but not redirect, the audience.
+	if requested := o.req.PostFormValue("resource"); requested != "" {
+		if !o.validResource(requested) {
+			return oauthJSON(http.StatusBadRequest, oauthErr("invalid_target", "the requested resource is not served by this server"))
+		}
+
+		if payload.Audience != "" && requested != payload.Audience {
+			return oauthJSON(http.StatusBadRequest, oauthErr("invalid_grant", "resource does not match the original grant"))
+		}
+	}
+
+	return o.issueTokens(oauthTokenGrant{
+		uid:      payload.UID,
+		eml:      payload.EML,
+		clientID: payload.ClientID,
+		scope:    payload.Scope,
+		aud:      payload.Audience,
+	})
+}
+
+// oauthTokenGrant is the identity + grant parameters an access (and optional
+// refresh) token is minted from.
+type oauthTokenGrant struct {
+	uid      string
+	eml      string
+	clientID string
+	scope    string
+	aud      string
+}
+
+// issueTokens mints the SkAuth-format access token for g and, when the grant
+// includes offline_access, a rotating refresh token. The refresh token is always
+// re-issued on this path, so a refresh grant rotates it (the presented one was
+// already consumed by rotate()).
+func (o *oauthServer) issueTokens(g oauthTokenGrant) *shttp.Response {
+	claims := jwt.MapClaims{"uid": g.uid, "aud": g.aud}
+
+	if g.eml != "" {
+		claims["eml"] = g.eml
+	}
+
+	if g.scope != "" {
+		claims["scope"] = g.scope
 	}
 
 	accessToken, err := user.JWT(claims, o.secret())
@@ -458,12 +715,30 @@ func (o *oauthServer) token() *shttp.Response {
 		return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
 	}
 
-	return oauthJSON(http.StatusOK, map[string]any{
+	body := map[string]any{
 		"access_token": accessToken,
 		"token_type":   "Bearer",
 		"expires_in":   o.tokenTTLMinutes() * 60,
-		"scope":        ac.Scope,
-	})
+		"scope":        g.scope,
+	}
+
+	if scopeRequested(g.scope, scopeOfflineAccess) {
+		refresh, err := oauthRefreshTokens.issue(o.req.Context(), oauthRefreshPayload{
+			UID:      g.uid,
+			EML:      g.eml,
+			ClientID: g.clientID,
+			Scope:    g.scope,
+			Audience: g.aud,
+		})
+
+		if err != nil {
+			return oauthJSON(http.StatusInternalServerError, oauthErr("server_error", ""))
+		}
+
+		body["refresh_token"] = refresh
+	}
+
+	return oauthJSON(http.StatusOK, body)
 }
 
 // verifyPKCE checks the S256 proof: base64url(sha256(verifier)) == challenge.
@@ -589,14 +864,14 @@ func (o *oauthServer) consentPage(p authzParams, client oauthClient) *shttp.Resp
 }
 
 func oauthJSON(status int, data any) *shttp.Response {
-	return &shttp.Response{
+	return withOAuthCORS(&shttp.Response{
 		Status: status,
 		Headers: shttp.HeadersFromMap(map[string]string{
 			"Content-Type":  "application/json",
 			"Cache-Control": "no-store",
 		}),
 		Data: data,
-	}
+	})
 }
 
 func oauthErr(code, desc string) map[string]any {

--- a/src/ce/hosting/oauth_client_store.go
+++ b/src/ce/hosting/oauth_client_store.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -37,18 +39,48 @@ type oauthClient struct {
 	IssuedAt     int64    `json:"issuedAt"`
 }
 
-// allowsRedirect reports whether redirectURI exactly matches one of the client's
-// registered redirect_uris. Registration validates every URI against the
-// operator's AllowedOrigins, so a registered match is strictly tighter than the
-// origin-only check.
+// allowsRedirect reports whether redirectURI matches one of the client's
+// registered redirect_uris. The match is exact except for RFC 8252 loopback
+// redirects, where the port is ignored: native/CLI clients register a bare
+// loopback URI (e.g. http://127.0.0.1/callback) but redirect back on an
+// ephemeral port chosen at runtime. The AllowLoopback gate and the connector
+// preset check already ran in redirectAllowed, so this only narrows an
+// already-permitted redirect to the registered set.
 func (c oauthClient) allowsRedirect(redirectURI string) bool {
 	for _, uri := range c.RedirectURIs {
-		if uri == redirectURI {
+		if uri == redirectURI || loopbackRedirectMatches(uri, redirectURI) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// loopbackRedirectMatches reports whether registered and actual are the same
+// loopback redirect ignoring the port (RFC 8252 §7.3). Both must be loopback
+// URLs matching on scheme, host and path.
+func loopbackRedirectMatches(registered, actual string) bool {
+	r, err1 := url.Parse(registered)
+	a, err2 := url.Parse(actual)
+
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	if !isLoopbackHost(r.Hostname()) || !isLoopbackHost(a.Hostname()) {
+		return false
+	}
+
+	return r.Scheme == a.Scheme &&
+		strings.EqualFold(r.Hostname(), a.Hostname()) &&
+		r.Path == a.Path
+}
+
+// isLoopbackHost reports whether host is a loopback literal or "localhost".
+func isLoopbackHost(host string) bool {
+	host = strings.ToLower(host)
+
+	return host == "localhost" || loopbackHosts[host]
 }
 
 // oauthClientStore is the Redis-backed Dynamic Client Registration registry. The

--- a/src/ce/hosting/oauth_mcp_test.go
+++ b/src/ce/hosting/oauth_mcp_test.go
@@ -1,0 +1,318 @@
+package hosting_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	hosting "github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+// hostWith builds a host with the given OAuth server configuration on top of the
+// shared test secret, so MCP-specific tests can opt into a resource path or
+// loopback support without touching the base host() helper.
+func (s *OAuthSuite) hostWith(conf buildconf.OAuthServerConf) *hosting.Host {
+	conf.Enabled = true
+
+	return &hosting.Host{
+		Name: "app.example.com",
+		Config: &appconf.Config{
+			SKAuth: &buildconf.SKAuthConf{
+				Secret:      oauthSecret,
+				Status:      true,
+				TTL:         10,
+				OAuthServer: &conf,
+			},
+		},
+	}
+}
+
+// jsonMaybe returns the response data as a map, or nil when it is not one (e.g.
+// a fall-through response from HandlerForward).
+func (s *OAuthSuite) jsonMaybe(res *shttp.Response) map[string]any {
+	m, _ := res.Data.(map[string]any)
+
+	return m
+}
+
+// --- P0: path-qualified resource + RFC 9728 path-aware well-known ---
+
+func (s *OAuthSuite) Test_MetadataResource_IncludesConfiguredPath() {
+	host := s.hostWith(buildconf.OAuthServerConf{ResourcePath: "/mcp"})
+
+	res := hosting.HandleOAuthMetadataResource(s.req(host, http.MethodGet, "/.well-known/oauth-protected-resource", "", nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	d := s.json(res)
+	s.Equal("https://app.example.com/mcp", d["resource"])
+	s.Equal([]string{"https://app.example.com"}, d["authorization_servers"])
+}
+
+func (s *OAuthSuite) Test_MetadataResource_PathVariant_Match() {
+	host := s.hostWith(buildconf.OAuthServerConf{ResourcePath: "/mcp"})
+
+	res := hosting.HandleOAuthMetadataResource(s.req(host, http.MethodGet, "/.well-known/oauth-protected-resource/mcp", "", nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("https://app.example.com/mcp", s.json(res)["resource"])
+}
+
+// A probe for a path this environment does not serve must not answer with the
+// metadata document; it falls through to normal app serving.
+func (s *OAuthSuite) Test_MetadataResource_PathVariant_Mismatch_FallsThrough() {
+	host := s.hostWith(buildconf.OAuthServerConf{ResourcePath: "/mcp"})
+
+	res := hosting.HandleOAuthMetadataResource(s.req(host, http.MethodGet, "/.well-known/oauth-protected-resource/other", "", nil, nil))
+
+	s.Nil(s.jsonMaybe(res)["resource"], "mismatched path must not return the resource metadata")
+}
+
+// --- CORS on discovery documents ---
+
+func (s *OAuthSuite) Test_MetadataResource_HasCORS() {
+	res := hosting.HandleOAuthMetadataResource(s.req(s.host(true), http.MethodGet, "/.well-known/oauth-protected-resource", "", nil, nil))
+
+	s.Equal("*", res.Headers.Get("Access-Control-Allow-Origin"))
+}
+
+func (s *OAuthSuite) Test_MetadataAS_AdvertisesRefreshAndOfflineAccess() {
+	res := hosting.HandleOAuthMetadataAS(s.req(s.host(true), http.MethodGet, "/.well-known/oauth-authorization-server", "", nil, nil))
+
+	d := s.json(res)
+	s.Contains(d["grant_types_supported"], "refresh_token")
+	s.Contains(d["scopes_supported"], "offline_access")
+}
+
+// --- P1: loopback redirects (RFC 8252) ---
+
+func (s *OAuthSuite) loopbackQuery(redirect string) string {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "claude-code")
+	q.Set("redirect_uri", redirect)
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+
+	return q.Encode()
+}
+
+func (s *OAuthSuite) Test_Authorize_Loopback_AllowedWhenEnabled() {
+	host := s.hostWith(buildconf.OAuthServerConf{AllowLoopback: true})
+
+	res := hosting.HandleOAuthAuthorize(s.req(host, http.MethodGet, "/_stormkit/oauth/authorize", s.loopbackQuery("http://127.0.0.1:54321/callback"), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Contains(string(res.Data.([]byte)), "Authorize access")
+}
+
+func (s *OAuthSuite) Test_Authorize_Loopback_RejectedWhenDisabled() {
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.loopbackQuery("http://127.0.0.1:54321/callback"), nil, nil))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+// A registered native client declares a bare loopback redirect but returns on an
+// ephemeral port; the port must be ignored (RFC 8252 §7.3).
+func (s *OAuthSuite) Test_Authorize_Loopback_RegisteredClient_IgnoresPort() {
+	host := s.hostWith(buildconf.OAuthServerConf{AllowLoopback: true})
+
+	body := `{"client_name":"Claude Code","redirect_uris":["http://127.0.0.1/callback"]}`
+	reg := hosting.HandleOAuthRegister(s.registerReq(host, body))
+	s.Require().Equal(http.StatusCreated, reg.Status)
+
+	clientID := s.json(reg)["client_id"].(string)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", "http://127.0.0.1:61023/callback")
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+
+	res := hosting.HandleOAuthAuthorize(s.req(host, http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Contains(string(res.Data.([]byte)), "Authorize access")
+}
+
+// --- P0: refresh tokens ---
+
+// grantWithScope runs a full authorize grant carrying scope and returns the code.
+func (s *OAuthSuite) grantWithScope(host *hosting.Host, uid, challenge, scope, resource string) string {
+	h := make(http.Header)
+	h.Set("Authorization", s.bearer(uid))
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "chatgpt")
+	q.Set("redirect_uri", oauthRedirect)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", "xyz")
+	q.Set("scope", scope)
+
+	if resource != "" {
+		q.Set("resource", resource)
+	}
+
+	res := hosting.HandleOAuthGrant(s.req(host, http.MethodPost, "/_stormkit/oauth/authorize", q.Encode(), h, nil))
+	s.Require().Equal(http.StatusOK, res.Status)
+
+	u, err := url.Parse(s.json(res)["redirect"].(string))
+	s.Require().NoError(err)
+
+	return u.Query().Get("code")
+}
+
+func (s *OAuthSuite) exchange(host *hosting.Host, code, verifier string) *shttp.Response {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("client_id", "chatgpt")
+	form.Set("redirect_uri", oauthRedirect)
+	form.Set("code_verifier", verifier)
+
+	h := make(http.Header)
+	h.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return hosting.HandleOAuthToken(s.req(host, http.MethodPost, "/_stormkit/oauth/token", "", h, strings.NewReader(form.Encode())))
+}
+
+func (s *OAuthSuite) Test_Token_IssuesRefreshToken_WithOfflineAccess() {
+	verifier := "offline-verifier-value-1234567890a"
+	code := s.grantWithScope(s.host(true), "user-1", pkce(verifier), "openid offline_access", "")
+
+	res := s.exchange(s.host(true), code, verifier)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.NotEmpty(s.json(res)["refresh_token"], "offline_access must yield a refresh token")
+}
+
+func (s *OAuthSuite) Test_Token_NoRefreshToken_WithoutOfflineAccess() {
+	verifier := "no-offline-verifier-value-12345678"
+	code := s.grantWithScope(s.host(true), "user-1", pkce(verifier), "openid", "")
+
+	res := s.exchange(s.host(true), code, verifier)
+
+	s.Equal(http.StatusOK, res.Status)
+	_, has := s.json(res)["refresh_token"]
+	s.False(has, "no refresh token without offline_access")
+}
+
+// refreshReq builds a refresh_token grant request.
+func (s *OAuthSuite) refreshReq(host *hosting.Host, refresh, clientID string) *shttp.Response {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refresh)
+
+	if clientID != "" {
+		form.Set("client_id", clientID)
+	}
+
+	h := make(http.Header)
+	h.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return hosting.HandleOAuthToken(s.req(host, http.MethodPost, "/_stormkit/oauth/token", "", h, strings.NewReader(form.Encode())))
+}
+
+func (s *OAuthSuite) Test_Refresh_RotatesToken() {
+	verifier := "rotate-verifier-value-1234567890ab"
+	code := s.grantWithScope(s.host(true), "user-42", pkce(verifier), "offline_access", "")
+
+	first := s.exchange(s.host(true), code, verifier)
+	refresh := s.json(first)["refresh_token"].(string)
+
+	// A refresh grant mints a fresh access token and rotates the refresh token.
+	res := s.refreshReq(s.host(true), refresh, "chatgpt")
+	s.Equal(http.StatusOK, res.Status)
+
+	d := s.json(res)
+	s.NotEmpty(d["access_token"])
+
+	rotated, ok := d["refresh_token"].(string)
+	s.Require().True(ok)
+	s.NotEqual(refresh, rotated, "refresh token must rotate")
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: d["access_token"].(string), Secret: oauthSecret, MaxMins: 10})
+	s.Require().NotNil(claims)
+	s.Equal("user-42", claims["uid"])
+
+	// The consumed token must not be replayable.
+	replay := s.refreshReq(s.host(true), refresh, "chatgpt")
+	s.Equal(http.StatusBadRequest, replay.Status)
+	s.Equal("invalid_grant", s.json(replay)["error"])
+}
+
+func (s *OAuthSuite) Test_Refresh_InvalidToken() {
+	res := s.refreshReq(s.host(true), "not-a-real-refresh-token", "chatgpt")
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_grant", s.json(res)["error"])
+}
+
+func (s *OAuthSuite) Test_Refresh_ClientMismatch() {
+	verifier := "mismatch-verifier-value-1234567890"
+	code := s.grantWithScope(s.host(true), "user-9", pkce(verifier), "offline_access", "")
+
+	first := s.exchange(s.host(true), code, verifier)
+	refresh := s.json(first)["refresh_token"].(string)
+
+	res := s.refreshReq(s.host(true), refresh, "someone-else")
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_grant", s.json(res)["error"])
+}
+
+// --- P1: audience binding (RFC 8707) ---
+
+func (s *OAuthSuite) Test_Token_AudienceFromResourceIndicator() {
+	host := s.hostWith(buildconf.OAuthServerConf{ResourcePath: "/mcp"})
+	resource := "https://app.example.com/mcp"
+
+	verifier := "audience-verifier-value-1234567890"
+	code := s.grantWithScope(host, "user-1", pkce(verifier), "openid", resource)
+
+	res := s.exchange(host, code, verifier)
+	s.Equal(http.StatusOK, res.Status)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: s.json(res)["access_token"].(string), Secret: oauthSecret, MaxMins: 10})
+	s.Require().NotNil(claims)
+	s.Equal(resource, claims["aud"], "aud must echo the requested resource")
+}
+
+func (s *OAuthSuite) Test_Grant_RejectsUnknownResource() {
+	h := make(http.Header)
+	h.Set("Authorization", s.bearer("user-1"))
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "chatgpt")
+	q.Set("redirect_uri", oauthRedirect)
+	q.Set("code_challenge", pkce("verifier"))
+	q.Set("code_challenge_method", "S256")
+	q.Set("resource", "https://someone-else.example.com/mcp")
+
+	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", q.Encode(), h, nil))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Equal("invalid_target", s.json(res)["error"])
+}
+
+// Audience defaults to the resource id when no indicator is supplied and a path
+// is configured.
+func (s *OAuthSuite) Test_Token_AudienceDefaultsToResourceID() {
+	host := s.hostWith(buildconf.OAuthServerConf{ResourcePath: "/mcp"})
+
+	verifier := "default-aud-verifier-value-1234567"
+	code := s.grantWithScope(host, "user-1", pkce(verifier), "openid", "")
+
+	res := s.exchange(host, code, verifier)
+	s.Equal(http.StatusOK, res.Status)
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: s.json(res)["access_token"].(string), Secret: oauthSecret, MaxMins: 10})
+	s.Require().NotNil(claims)
+	s.Equal("https://app.example.com/mcp", claims["aud"])
+}

--- a/src/ce/hosting/oauth_refresh_store.go
+++ b/src/ce/hosting/oauth_refresh_store.go
@@ -1,0 +1,112 @@
+package hosting
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// errRefreshNotFound is returned when a refresh token is unknown, expired or
+// already rotated, so the token endpoint can answer with RFC 6749 invalid_grant.
+var errRefreshNotFound = errors.New("oauth refresh token not found")
+
+// oauthRefreshTTL bounds how long a refresh token — and therefore an idle
+// connection — survives without use. Each rotation issues a fresh token with a
+// new window, so an actively used connector renews indefinitely while an
+// abandoned one is reaped.
+const oauthRefreshTTL = 30 * 24 * time.Hour
+
+// oauthRefreshPayload is the state a refresh token stands in for. It carries the
+// identity and grant parameters needed to mint a replacement access token
+// without re-consent.
+type oauthRefreshPayload struct {
+	UID      string `json:"uid"`
+	EML      string `json:"eml,omitempty"`
+	ClientID string `json:"clientId"`
+	Scope    string `json:"scope,omitempty"`
+	Audience string `json:"aud,omitempty"`
+}
+
+// oauthRefreshStore is the Redis-backed rotating refresh-token registry. Unlike
+// the 5-minute authorization codes, refresh tokens live for weeks, so the token
+// itself is never stored: the key is its SHA-256 digest. A Redis dump therefore
+// yields no replayable tokens — the endpoint only accepts a value whose digest
+// is present, and the digest can't be reversed.
+type oauthRefreshStore struct {
+	prefix string
+}
+
+var oauthRefreshTokens = oauthRefreshStore{prefix: "oauth:refresh:"}
+
+// key is the Redis key for token: prefix + base64url(sha256(token)).
+func (s oauthRefreshStore) key(token string) string {
+	sum := sha256.Sum256([]byte(token))
+
+	return s.prefix + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// issue stashes payload under a fresh crypto-random refresh token and returns
+// the token to hand back to the client.
+func (s oauthRefreshStore) issue(ctx context.Context, payload oauthRefreshPayload) (string, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return "", errors.New("redis client is not available")
+	}
+
+	blob, err := json.Marshal(payload)
+
+	if err != nil {
+		return "", err
+	}
+
+	token, err := utils.SecureRandomToken(48)
+
+	if err != nil {
+		return "", err
+	}
+
+	if err := client.Set(ctx, s.key(token), blob, oauthRefreshTTL).Err(); err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+// rotate atomically consumes token and returns its payload. Rotation is
+// mandatory for public clients (OAuth 2.1 / the MCP auth spec): the presented
+// token is deleted in the same round-trip, so a captured-then-rotated token is
+// dead on arrival. It returns errRefreshNotFound for an unknown, expired or
+// already-rotated token and any other error verbatim.
+func (s oauthRefreshStore) rotate(ctx context.Context, token string) (oauthRefreshPayload, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return oauthRefreshPayload{}, errors.New("redis client is not available")
+	}
+
+	raw, err := client.GetDel(ctx, s.key(token)).Result()
+
+	if errors.Is(err, redis.Nil) || raw == "" {
+		return oauthRefreshPayload{}, errRefreshNotFound
+	}
+
+	if err != nil {
+		return oauthRefreshPayload{}, err
+	}
+
+	var payload oauthRefreshPayload
+
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return oauthRefreshPayload{}, err
+	}
+
+	return payload, nil
+}

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -20,7 +20,12 @@ import (
 )
 
 const oauthSecret = "test-secret-padded-to-32-chars!!"
-const oauthRedirect = "https://client.example.com/callback"
+
+// oauthRedirect is a curated connector preset origin (ChatGPT's dynamic callback
+// path), which the OAuth server trusts automatically once enabled. Redirect
+// validation is preset-based, not AllowedOrigins-based, so tests exercise the
+// real connector path.
+const oauthRedirect = "https://chatgpt.com/connector/oauth/cb"
 
 type OAuthSuite struct {
 	suite.Suite
@@ -192,12 +197,12 @@ func (s *OAuthSuite) Test_Authorize_SetsAntiFramingHeaders() {
 }
 
 // Test_Authorize_AcceptsMixedCaseRedirectHost verifies the redirect_uri host is
-// matched case-insensitively against the allow-list.
+// matched case-insensitively against the preset origins.
 func (s *OAuthSuite) Test_Authorize_AcceptsMixedCaseRedirectHost() {
 	q := url.Values{}
 	q.Set("response_type", "code")
 	q.Set("client_id", "chatgpt")
-	q.Set("redirect_uri", "https://Client.Example.com/callback")
+	q.Set("redirect_uri", "https://ChatGPT.com/connector/oauth/cb")
 	q.Set("code_challenge", pkce("verifier"))
 	q.Set("code_challenge_method", "S256")
 
@@ -326,7 +331,7 @@ func (s *OAuthSuite) Test_Token_CodeIsSingleUse() {
 // --- Dynamic Client Registration (RFC 7591) ---
 
 func (s *OAuthSuite) Test_Register_Success() {
-	body := `{"client_name":"ChatGPT","redirect_uris":["https://client.example.com/callback"]}`
+	body := `{"client_name":"ChatGPT","redirect_uris":["https://chatgpt.com/connector/oauth/cb"]}`
 
 	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
 
@@ -340,7 +345,7 @@ func (s *OAuthSuite) Test_Register_Success() {
 	s.False(hasSecret, "public clients must not receive a client_secret")
 }
 
-func (s *OAuthSuite) Test_Register_RejectsRedirectOffAllowedOrigin() {
+func (s *OAuthSuite) Test_Register_RejectsRedirectOffPreset() {
 	body := `{"redirect_uris":["https://evil.example.com/cb"]}`
 
 	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
@@ -357,7 +362,7 @@ func (s *OAuthSuite) Test_Register_RequiresRedirectURIs() {
 }
 
 func (s *OAuthSuite) Test_Register_RejectsConfidentialAuthMethod() {
-	body := `{"redirect_uris":["https://client.example.com/callback"],"token_endpoint_auth_method":"client_secret_basic"}`
+	body := `{"redirect_uris":["https://chatgpt.com/connector/oauth/cb"],"token_endpoint_auth_method":"client_secret_basic"}`
 
 	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
 
@@ -368,7 +373,7 @@ func (s *OAuthSuite) Test_Register_RejectsConfidentialAuthMethod() {
 func (s *OAuthSuite) Test_Register_RejectsOversizedBody() {
 	// An oversized body must be refused before anything is written to Redis, so
 	// the unauthenticated endpoint can't be used to amplify storage.
-	body := `{"client_name":"` + strings.Repeat("a", 32*1024) + `","redirect_uris":["https://client.example.com/callback"]}`
+	body := `{"client_name":"` + strings.Repeat("a", 32*1024) + `","redirect_uris":["https://chatgpt.com/connector/oauth/cb"]}`
 
 	res := hosting.HandleOAuthRegister(s.registerReq(s.host(true), body))
 
@@ -379,7 +384,7 @@ func (s *OAuthSuite) Test_Register_RejectsOversizedBody() {
 func (s *OAuthSuite) Test_Register_RejectsTooManyRedirectURIs() {
 	uris := make([]string, 0, 32)
 	for i := 0; i < 32; i++ {
-		uris = append(uris, `"https://client.example.com/callback"`)
+		uris = append(uris, `"https://chatgpt.com/connector/oauth/cb"`)
 	}
 
 	body := `{"redirect_uris":[` + strings.Join(uris, ",") + `]}`
@@ -393,7 +398,7 @@ func (s *OAuthSuite) Test_Register_RejectsTooManyRedirectURIs() {
 func (s *OAuthSuite) Test_Register_Disabled_FallsThrough() {
 	// When OAuth is off the path is not reserved: serveOAuth forwards to normal
 	// app serving instead of registering a client.
-	res := hosting.HandleOAuthRegister(s.registerReq(s.host(false), `{"redirect_uris":["https://client.example.com/callback"]}`))
+	res := hosting.HandleOAuthRegister(s.registerReq(s.host(false), `{"redirect_uris":["https://chatgpt.com/connector/oauth/cb"]}`))
 
 	s.NotEqual(http.StatusCreated, res.Status)
 }
@@ -402,7 +407,7 @@ func (s *OAuthSuite) Test_Register_RateLimited() {
 	host := &hosting.Host{Name: "ratelimit.example.com", Config: s.host(true).Config}
 	hosting.ResetOAuthRateLimit(host.Name)
 
-	body := `{"redirect_uris":["https://client.example.com/callback"]}`
+	body := `{"redirect_uris":["https://chatgpt.com/connector/oauth/cb"]}`
 
 	for i := 0; i < hosting.OAuthRegisterRateMax(); i++ {
 		res := hosting.HandleOAuthRegister(s.registerReq(host, body))
@@ -414,7 +419,7 @@ func (s *OAuthSuite) Test_Register_RateLimited() {
 }
 
 // Test_Authorize_RegisteredClient_BindsRedirect verifies a registered client is
-// held to its declared redirect_uris, even for another path on the same allowed
+// held to its declared redirect_uris, even for another path on the same preset
 // origin (which the origin-only gate alone would permit).
 func (s *OAuthSuite) Test_Authorize_RegisteredClient_BindsRedirect() {
 	clientID := s.registerClient("ChatGPT", oauthRedirect)
@@ -422,7 +427,7 @@ func (s *OAuthSuite) Test_Authorize_RegisteredClient_BindsRedirect() {
 	q := url.Values{}
 	q.Set("response_type", "code")
 	q.Set("client_id", clientID)
-	q.Set("redirect_uri", "https://client.example.com/other")
+	q.Set("redirect_uri", "https://chatgpt.com/connector/oauth/other")
 	q.Set("code_challenge", pkce("verifier"))
 	q.Set("code_challenge_method", "S256")
 

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -34,7 +34,14 @@ func registerReservedRoutes(s *shttp.Service) {
 	// through to normal app serving when OAuth is disabled for the host.
 	wk := s.NewEndpoint("/.well-known")
 	wk.Handler(http.MethodGet, "/oauth-authorization-server", WithHost(handleOAuthMetadataAS))
+	wk.Handler(http.MethodOptions, "/oauth-authorization-server", WithHost(handleOAuthMetadataAS))
 	wk.Handler(http.MethodGet, "/oauth-protected-resource", WithHost(handleOAuthMetadataResource))
+	wk.Handler(http.MethodOptions, "/oauth-protected-resource", WithHost(handleOAuthMetadataResource))
+	// RFC 9728 path-aware probe: /.well-known/oauth-protected-resource/<path>.
+	// The handler answers only when <path> matches the environment's configured
+	// MCP path and otherwise falls through to normal app serving.
+	wk.Handler(http.MethodGet, "/oauth-protected-resource/{path:.*}", WithHost(handleOAuthMetadataResource))
+	wk.Handler(http.MethodOptions, "/oauth-protected-resource/{path:.*}", WithHost(handleOAuthMetadataResource))
 
 	oauth := s.NewEndpoint("/_stormkit/oauth")
 	oauth.Handler(http.MethodPost, "/register", WithHost(handleOAuthRegister))

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -348,6 +348,8 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           status: true,
           allowedOrigins: [],
           oauthServerEnabled: false,
+          oauthResourcePath: "",
+          oauthAllowLoopback: false,
         })
         .reply(200);
 
@@ -371,6 +373,8 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
             "https://dev.example.com",
           ],
           oauthServerEnabled: false,
+          oauthResourcePath: "",
+          oauthAllowLoopback: false,
         })
         .reply(200);
 
@@ -402,12 +406,47 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           status: true,
           allowedOrigins: [],
           oauthServerEnabled: true,
+          oauthResourcePath: "",
+          oauthAllowLoopback: false,
         })
         .reply(200);
 
       fireEvent.click(
         await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),
       );
+
+      fireEvent.submit(
+        wrapper.getByRole("button", { name: "Save" }).closest("form")!,
+      );
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
+      });
+    });
+
+    it("should submit the MCP path and loopback toggle", async () => {
+      const scope = nock(apiDomain)
+        .post("/skauth/config", {
+          envId: currentEnv.id,
+          successUrl: "",
+          tokenTtl: 0,
+          status: true,
+          allowedOrigins: [],
+          oauthServerEnabled: true,
+          oauthResourcePath: "/mcp",
+          oauthAllowLoopback: true,
+        })
+        .reply(200);
+
+      fireEvent.click(
+        await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),
+      );
+
+      fireEvent.change(await wrapper.findByLabelText("MCP server path"), {
+        target: { value: "/mcp" },
+      });
+
+      fireEvent.click(await wrapper.findByLabelText("Allow native / CLI clients"));
 
       fireEvent.submit(
         wrapper.getByRole("button", { name: "Save" }).closest("form")!,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -179,13 +179,15 @@ export default function SkAuth() {
     refreshToken,
   });
 
-  // The OAuth toggle is a controlled Switch (not part of FormData), so it needs
-  // its own state, synced from the config once it loads.
+  // The OAuth toggles are controlled Switches (not part of FormData), so they
+  // need their own state, synced from the config once it loads.
   const [oauthServerEnabled, setOauthServerEnabled] = useState(false);
+  const [oauthAllowLoopback, setOauthAllowLoopback] = useState(false);
 
   useEffect(() => {
     setOauthServerEnabled(Boolean(config?.oauthServerEnabled));
-  }, [config?.oauthServerEnabled]);
+    setOauthAllowLoopback(Boolean(config?.oauthAllowLoopback));
+  }, [config?.oauthServerEnabled, config?.oauthAllowLoopback]);
 
   const hasSchema = !result.loading && !result.error && Boolean(result.schema);
   const title = "Authentication";
@@ -253,6 +255,9 @@ export default function SkAuth() {
             status: true,
             allowedOrigins,
             oauthServerEnabled,
+            oauthResourcePath:
+              ((data.get("oauthResourcePath") as string) || "").trim(),
+            oauthAllowLoopback,
           })
             .then(() => {
               setSuccess("Settings saved successfully");
@@ -344,35 +349,56 @@ export default function SkAuth() {
             checked={oauthServerEnabled}
             setChecked={setOauthServerEnabled}
             label="Enable OAuth server (MCP connectors)"
-            description="Turns this environment into an OAuth 2.1 authorization server so AI clients like ChatGPT and Claude can connect to it as an MCP server, signing in your app's own users. Add each connector's redirect origin to Allowed origins above."
+            description="Turns this environment into an OAuth 2.1 authorization server so AI clients like ChatGPT and Claude can connect to it as an MCP server, signing in your app's own users. The Claude and ChatGPT connector origins are trusted automatically — no manual origin setup needed."
           />
-          {oauthServerEnabled &&
-            (config?.allowedOrigins || []).length === 0 && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                OAuth is enabled but no allowed origins are set. A connector's
-                redirect_uri must live on an allowed origin, or authorization
-                requests will be rejected.
-              </Alert>
-            )}
           {oauthServerEnabled && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              <Typography sx={{ mb: 1 }}>
-                Discovery documents, served on this environment's domain:
-              </Typography>
-              <Box component="code" sx={{ display: "block", fontSize: 12 }}>
-                /.well-known/oauth-authorization-server
+            <>
+              <Box sx={{ mt: 3 }}>
+                <TextField
+                  label="MCP server path"
+                  name="oauthResourcePath"
+                  placeholder="/mcp"
+                  fullWidth
+                  defaultValue={config?.oauthResourcePath || ""}
+                  variant="filled"
+                  autoComplete="off"
+                  helperText="The path this environment serves its MCP server on. Connectors require the resource identifier to match the URL you enter (path included), so set this to the connector URL's path — e.g. /mcp for https://your-app.com/mcp."
+                  slotProps={{
+                    inputLabel: {
+                      shrink: true,
+                    },
+                  }}
+                />
               </Box>
-              <Box component="code" sx={{ display: "block", fontSize: 12 }}>
-                /.well-known/oauth-protected-resource
+              <Box sx={{ mt: 3 }}>
+                <Switch
+                  name="oauthAllowLoopback"
+                  checked={oauthAllowLoopback}
+                  setChecked={setOauthAllowLoopback}
+                  label="Allow native / CLI clients"
+                  description="Permit RFC 8252 loopback redirects (http://127.0.0.1 and http://localhost on any port) so native tools like Claude Code can connect. Leave off if you only use browser-based connectors."
+                />
               </Box>
-              <Typography sx={{ mt: 2, mb: 1 }}>
-                Connectors self-register via Dynamic Client Registration (RFC
-                7591); no manual client setup is needed:
-              </Typography>
-              <Box component="code" sx={{ display: "block", fontSize: 12 }}>
-                POST /_stormkit/oauth/register
-              </Box>
-            </Alert>
+              <Alert severity="info" sx={{ mt: 2 }}>
+                <Typography sx={{ mb: 1 }}>
+                  Discovery documents, served on this environment's domain:
+                </Typography>
+                <Box component="code" sx={{ display: "block", fontSize: 12 }}>
+                  /.well-known/oauth-authorization-server
+                </Box>
+                <Box component="code" sx={{ display: "block", fontSize: 12 }}>
+                  /.well-known/oauth-protected-resource
+                  {config?.oauthResourcePath || ""}
+                </Box>
+                <Typography sx={{ mt: 2, mb: 1 }}>
+                  Connectors self-register via Dynamic Client Registration (RFC
+                  7591); no manual client setup is needed:
+                </Typography>
+                <Box component="code" sx={{ display: "block", fontSize: 12 }}>
+                  POST /_stormkit/oauth/register
+                </Box>
+              </Alert>
+            </>
           )}
         </Box>
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -224,6 +224,8 @@ interface FetchProvidersResult {
   tokenTtl?: number;
   allowedOrigins?: string[];
   oauthServerEnabled?: boolean;
+  oauthResourcePath?: string;
+  oauthAllowLoopback?: boolean;
   redirectUrl: string;
   authUrl: string;
   providers: {
@@ -236,6 +238,8 @@ interface AuthConfig {
   successUrl?: string;
   allowedOrigins?: string[];
   oauthServerEnabled?: boolean;
+  oauthResourcePath?: string;
+  oauthAllowLoopback?: boolean;
 }
 
 interface SaveConfigParams {
@@ -245,6 +249,8 @@ interface SaveConfigParams {
   status: boolean;
   allowedOrigins: string[];
   oauthServerEnabled: boolean;
+  oauthResourcePath: string;
+  oauthAllowLoopback: boolean;
 }
 
 export const saveConfig = ({
@@ -254,6 +260,8 @@ export const saveConfig = ({
   status,
   allowedOrigins,
   oauthServerEnabled,
+  oauthResourcePath,
+  oauthAllowLoopback,
 }: SaveConfigParams): Promise<void> =>
   api.post("/skauth/config", {
     envId,
@@ -262,6 +270,8 @@ export const saveConfig = ({
     status,
     allowedOrigins,
     oauthServerEnabled,
+    oauthResourcePath,
+    oauthAllowLoopback,
   });
 
 export const useFetchProviders = ({
@@ -288,6 +298,8 @@ export const useFetchProviders = ({
           tokenTtl: sessionTtl,
           allowedOrigins,
           oauthServerEnabled,
+          oauthResourcePath,
+          oauthAllowLoopback,
         }) => {
           const result: AuthProvider[] = [];
 
@@ -312,7 +324,14 @@ export const useFetchProviders = ({
             });
 
           setProviders(result);
-          setConfig({ successUrl, sessionTtl, allowedOrigins, oauthServerEnabled });
+          setConfig({
+            successUrl,
+            sessionTtl,
+            allowedOrigins,
+            oauthServerEnabled,
+            oauthResourcePath,
+            oauthAllowLoopback,
+          });
         },
       )
       .catch(() => {


### PR DESCRIPTION
Closes #363.

Finishes MCP connector support (Claude + ChatGPT) for the OAuth 2.1 authorization server. Verified against the live-server gaps documented in the issue.

## Unifying design

An environment declares **"I serve an MCP server at `/mcp`"** and the rest is derived from it. OAuth redirect validation no longer uses `AllowedOrigins` (that stays for magic-link) — instead a **curated connector preset list** (`claude.ai`, `claude.com`, `chatgpt.com`) is trusted automatically whenever the OAuth server is enabled. Maintaining the list here means a vendor URL change is one edit, not a silent break for every operator.

## P0 — unblocks connectors

- **Path-qualified `resource`** — protected-resource metadata emits `https://host/mcp` (was the bare issuer, which connectors reject).
- **RFC 9728 per-path well-known** — serves `/.well-known/oauth-protected-resource/<path>`; a non-matching probe falls through to the app.
- **`WWW-Authenticate`** now points at the path variant and carries the `scope` parameter.
- **Refresh tokens** — Redis-backed, SHA-256-keyed, **rotating** (single-use, `invalid_grant` on replay), gated on `offline_access`. `grant_types_supported` / `scopes_supported` updated.

## P1 — correctness & compatibility

- **Audience binding (RFC 8707)** — the `resource` indicator is read at authorize + token and echoed into `aud`; `invalid_target` on an unknown resource.
- **Loopback redirects (RFC 8252)** — port-agnostic for both unregistered and DCR-registered clients, behind an "Allow native/CLI clients" toggle (Claude Code).
- **Connector presets** — auto-trusted when enabled; no per-origin config.
- **CORS `*`** on all OAuth JSON responses + OPTIONS preflights (MCP Inspector).

## Config / API / UI

Per-env `OAuthServerConf.ResourcePath` + `AllowLoopback`. Auth-config update handler merges the new fields with pointer-omission safety (a partial update can't wipe the path or disable a live server). SkAuth settings UI gains an MCP-path field and a native-clients toggle.

## Testing

New Go tests (`oauth_mcp_test.go`) for path resource, per-path well-known, refresh issue/rotate/replay, loopback (incl. registered-client port-agnostic), audience binding, and CORS; config-handler tests for the new fields and path validation; challenge-header path/scope tests; 19 UI SkAuth tests. `go build ./...`, `gofmt`, and `go vet` clean. An adversarial production review found no blockers and no security holes.
