### PR TITLE
feat: cookie session mode for oauth authorize

### DIFF
--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -41,6 +41,28 @@ type SKAuthConf struct {
 	// that origin after clicking the email link.
 	AllowedOrigins []string
 
+	// SessionStorage selects where the browser keeps the SkAuth session token
+	// after login: "localStorage" (default) or "cookie". localStorage attaches
+	// the token to XHR as a bearer; cookie mode issues a Secure, HttpOnly,
+	// SameSite=Lax session cookie that rides both SPA XHR and the top-level
+	// navigation the OAuth /authorize endpoint depends on. The two are mutually
+	// exclusive — one credential, no drift. Cookie mode is a prerequisite for
+	// the OAuth server (a localStorage session is invisible to /authorize).
+	SessionStorage string
+
+	// CookieDomain optionally scopes the session cookie to a parent domain
+	// (e.g. ".example.com") so it is shared across subdomains — needed when the
+	// login origin and the OAuth authorization-server origin are different
+	// subdomains. Empty means a host-only cookie. Only used in cookie mode.
+	CookieDomain string
+
+	// LoginURL is the app-owned login page the OAuth /authorize endpoint
+	// redirects an unauthenticated user to. The app authenticates with its own
+	// UI, establishes the shared session cookie, and bounces the user back to
+	// the return_to URL /authorize appends. A relative path (leading "/") on
+	// the authorization-server origin, or an absolute URL on the login origin.
+	LoginURL string
+
 	// OAuthServer, when enabled, turns this environment into an OAuth 2.1
 	// authorization server for MCP connectors (see /_stormkit/oauth and the
 	// .well-known discovery documents). Note this is the opposite role from the
@@ -48,6 +70,18 @@ type SKAuthConf struct {
 	// external clients connect to. It builds on the SkAuth identity;
 	// redirect_uri targets are validated against AllowedOrigins.
 	OAuthServer *OAuthServerConf
+}
+
+// SessionCookieName is the name of the SkAuth session cookie set in cookie mode.
+const SessionCookieName = "skauth_session"
+
+// SessionStorageCookie is the SessionStorage value that enables cookie mode.
+const SessionStorageCookie = "cookie"
+
+// SessionInCookie reports whether the SkAuth session is stored in a cookie
+// rather than localStorage. The OAuth authorization server requires this.
+func (ac *SKAuthConf) SessionInCookie() bool {
+	return ac != nil && ac.SessionStorage == SessionStorageCookie
 }
 
 // OAuthServerConf configures the OAuth 2.1 authorization server layered on

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -18,13 +18,17 @@ type AuthConfigUpdateRequest struct {
 	Status         bool     `json:"status"`
 	AllowedOrigins []string `json:"allowedOrigins"`
 
-	// The OAuth-server fields are pointers so an omitted field leaves the stored
-	// setting untouched: a client that saves other fields (or an older UI that
-	// doesn't know the field) must not silently disable a live OAuth server or
-	// clear its MCP configuration.
+	// The OAuth-server and session-storage fields are pointers so an omitted
+	// field leaves the stored setting untouched: a client that saves other
+	// fields (or an older UI that doesn't know the field) must not silently
+	// disable a live OAuth server, clear its MCP configuration, or flip the
+	// session-storage mode out from under it.
 	OAuthServerEnabled *bool   `json:"oauthServerEnabled"`
 	OAuthResourcePath  *string `json:"oauthResourcePath"`
 	OAuthAllowLoopback *bool   `json:"oauthAllowLoopback"`
+	SessionStorage     *string `json:"sessionStorage"`
+	CookieDomain       *string `json:"cookieDomain"`
+	LoginURL           *string `json:"loginUrl"`
 }
 
 func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
@@ -101,10 +105,28 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	env.AuthConf.Status = data.Status
 	env.AuthConf.AllowedOrigins = allowedOrigins
 
+	if err := applySessionStorageConf(env.AuthConf, data); err != nil {
+		return shttp.BadRequest(map[string]any{
+			"error": err.Error(),
+			"hint":  "Session storage must be either \"localStorage\" or \"cookie\".",
+		})
+	}
+
 	if err := applyOAuthServerConf(env.AuthConf, data); err != nil {
 		return shttp.BadRequest(map[string]any{
 			"error": err.Error(),
 			"hint":  "Provide a relative path such as: /mcp",
+		})
+	}
+
+	// The OAuth authorization server can only identify the user on the
+	// top-level /authorize navigation from a cookie session; a localStorage
+	// session dead-ends silently at the consent screen. Refuse the combination
+	// rather than let the connect flow break with no error surfaced.
+	if env.AuthConf.OAuthServerEnabled() && !env.AuthConf.SessionInCookie() {
+		return shttp.BadRequest(map[string]any{
+			"error": "The OAuth server requires cookie session storage. Set session storage to \"cookie\" before enabling it.",
+			"hint":  "Auth settings → Session storage → Cookie.",
 		})
 	}
 
@@ -124,6 +146,64 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	}
 
 	return shttp.OK()
+}
+
+// applySessionStorageConf merges the session-storage fields from data into
+// conf, leaving any omitted field untouched. It validates the storage mode and
+// the login URL the OAuth /authorize endpoint delegates to.
+func applySessionStorageConf(conf *buildconf.SKAuthConf, data AuthConfigUpdateRequest) error {
+	if data.SessionStorage != nil {
+		mode := strings.TrimSpace(*data.SessionStorage)
+
+		if mode != "" && mode != "localStorage" && mode != buildconf.SessionStorageCookie {
+			return fmt.Errorf("session storage %q must be either \"localStorage\" or \"cookie\"", mode)
+		}
+
+		conf.SessionStorage = mode
+	}
+
+	if data.CookieDomain != nil {
+		domain := strings.TrimSpace(*data.CookieDomain)
+
+		// A cookie Domain attribute is a bare host (optionally dot-prefixed for
+		// subdomain sharing): no scheme, port, path, or whitespace.
+		if domain != "" && (strings.ContainsAny(domain, " \t\r\n/:") || strings.Contains(domain, "..")) {
+			return fmt.Errorf("cookie domain %q must be a bare host such as .example.com", domain)
+		}
+
+		conf.CookieDomain = domain
+	}
+
+	if data.LoginURL != nil {
+		loginURL := strings.TrimSpace(*data.LoginURL)
+
+		if loginURL != "" {
+			parsed, err := url.Parse(loginURL)
+
+			// The login URL is either a relative path on the AS origin (leading
+			// "/") or an absolute http(s) URL on the app's login origin. Anything
+			// else can't be redirected to safely.
+			if err != nil {
+				return fmt.Errorf("login URL %q is not a valid URL", loginURL)
+			}
+
+			if parsed.IsAbs() {
+				if parsed.Scheme != "http" && parsed.Scheme != "https" {
+					return fmt.Errorf("login URL %q must be an http(s) URL or a relative path", loginURL)
+				}
+			} else if !strings.HasPrefix(loginURL, "/") || strings.HasPrefix(loginURL, "//") {
+				// A leading "//" is a scheme-relative reference to another host, not
+				// a path on the AS origin. Reject it here rather than let it silently
+				// become a broken same-host path when delegateToLogin prefixes the
+				// issuer.
+				return fmt.Errorf("login URL %q must be an absolute URL or a leading-slash path", loginURL)
+			}
+		}
+
+		conf.LoginURL = loginURL
+	}
+
+	return nil
 }
 
 // applyOAuthServerConf merges the OAuth-server fields from data into conf,

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
@@ -176,6 +176,7 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthServerFields() {
 			"oauthServerEnabled": true,
 			"oauthResourcePath":  "mcp",
 			"oauthAllowLoopback": true,
+			"sessionStorage":     "cookie",
 		},
 		map[string]string{
 			"Authorization": usertest.Authorization(s.usr.ID),
@@ -204,6 +205,70 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthResourcePath_RejectsQuer
 			"status":             true,
 			"oauthServerEnabled": true,
 			"oauthResourcePath":  "/mcp?x=1",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_Update_OAuthServer_RequiresCookieMode refuses to enable the OAuth server
+// while session storage is localStorage — the combination dead-ends silently at
+// the consent screen, so it must be rejected at save time.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthServer_RequiresCookieMode() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":              s.env.ID,
+			"status":             true,
+			"oauthServerEnabled": true,
+			"sessionStorage":     "localStorage",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "cookie session storage")
+}
+
+// Test_Update_RejectsInvalidSessionStorage guards the session-storage enum.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_RejectsInvalidSessionStorage() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"sessionStorage": "sqlite",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_Update_RejectsProtocolRelativeLoginURL rejects a scheme-relative login URL
+// (leading "//"): it points at another host, not a path on the AS origin, so it
+// must not slip past validation and become a broken same-host redirect.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_RejectsProtocolRelativeLoginURL() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"sessionStorage": "cookie",
+			"loginUrl":       "//evil.example.com",
 		},
 		map[string]string{
 			"Authorization": usertest.Authorization(s.usr.ID),

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -49,11 +49,17 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 	oauthServerEnabled := false
 	oauthResourcePath := ""
 	oauthAllowLoopback := false
+	sessionStorage := ""
+	cookieDomain := ""
+	loginURL := ""
 
 	if env.AuthConf != nil {
 		successURL = env.AuthConf.SuccessURL
 		ttl = env.AuthConf.TTL
 		oauthServerEnabled = env.AuthConf.OAuthServerEnabled()
+		sessionStorage = env.AuthConf.SessionStorage
+		cookieDomain = env.AuthConf.CookieDomain
+		loginURL = env.AuthConf.LoginURL
 
 		if env.AuthConf.AllowedOrigins != nil {
 			allowedOrigins = env.AuthConf.AllowedOrigins
@@ -74,6 +80,9 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 			"oauthServerEnabled": oauthServerEnabled,
 			"oauthResourcePath":  oauthResourcePath,
 			"oauthAllowLoopback": oauthAllowLoopback,
+			"sessionStorage":     sessionStorage,
+			"cookieDomain":       cookieDomain,
+			"loginUrl":           loginURL,
 			"redirectUrl":        skauth.RedirectURL(),
 			"authUrl":            skauth.AuthURL(),
 		},

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -19,6 +19,79 @@ type skAuthMiddleware struct {
 	req *RequestContext
 }
 
+// sessionBearer returns the SkAuth session token for the request, consulting
+// both credentials: the Authorization bearer (localStorage mode and API
+// clients) and the session cookie (cookie mode, where a top-level navigation or
+// a credentials:'include' XHR carries no Authorization header).
+//
+// In cookie mode the cookie is preferred so a stale Authorization bearer — e.g.
+// a token left in localStorage from before the switch to cookie mode, which the
+// old SPA still attaches to every XHR — can't mask the live cookie session. API
+// and MCP clients send no cookie, so the Authorization bearer remains the
+// fallback. In localStorage mode there is no session cookie, so only the bearer
+// applies.
+func sessionBearer(req *RequestContext) string {
+	if req.Host.Config.SKAuth.SessionInCookie() {
+		if cookie, err := req.Cookie(buildconf.SessionCookieName); err == nil && cookie != nil && cookie.Value != "" {
+			return cookie.Value
+		}
+	}
+
+	return user.ParseBearer(req.Header.Get("Authorization"))
+}
+
+// sessionCookieFor builds the SkAuth session cookie carrying token. It is
+// Secure + HttpOnly (the edge reads it server-side; the SPA uses /me), and
+// SameSite=Lax so it still rides the top-level navigation into the OAuth
+// /authorize endpoint while resisting CSRF. A configured CookieDomain shares it
+// across subdomains (login origin vs. authorization-server origin).
+func (m *skAuthMiddleware) sessionCookieFor(token string) http.Cookie {
+	conf := m.req.Host.Config.SKAuth
+
+	cookie := http.Cookie{
+		Name:     buildconf.SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		Domain:   conf.CookieDomain,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	if conf.TTL > 0 {
+		cookie.MaxAge = conf.TTL * 60
+	}
+
+	return cookie
+}
+
+// deliverSession hands the freshly minted session token to the browser and
+// sends it on to redirectURL. In cookie mode it sets the shared session cookie
+// and 302s; in localStorage mode it renders the landing page whose script
+// stashes the token before redirecting. Callers compute redirectURL as either a
+// relative path or an absolute URL on the destination origin.
+func (m *skAuthMiddleware) deliverSession(token, redirectURL string) *shttp.Response {
+	if m.req.Host.Config.SKAuth.SessionInCookie() {
+		return &shttp.Response{
+			Status:   http.StatusFound,
+			Redirect: &redirectURL,
+			Cookies:  []http.Cookie{m.sessionCookieFor(token)},
+			Headers: shttp.HeadersFromMap(map[string]string{
+				"Cache-Control":   "no-store",
+				"Referrer-Policy": "no-referrer",
+			}),
+		}
+	}
+
+	head := fmt.Sprintf(
+		`<script>localStorage.setItem('skauth', JSON.stringify(%q));window.location.href=%q;</script>`,
+		token,
+		redirectURL,
+	)
+
+	return m.renderVerifyPage(http.StatusOK, head, "")
+}
+
 func (m *skAuthMiddleware) handleRegisterLogin(path string) (*shttp.Response, error) {
 	if m.req.Method != http.MethodPost {
 		return &shttp.Response{
@@ -62,13 +135,9 @@ func (m *skAuthMiddleware) handleVerify() (*shttp.Response, error) {
 		return m.renderVerifyPage(http.StatusInternalServerError, "", "verification failed"), nil
 	}
 
-	head := fmt.Sprintf(
-		`<script>localStorage.setItem('skauth', JSON.stringify('%s'));window.location.href="%s?verified=true";</script>`,
-		data["token"],
-		m.req.Host.Config.SKAuth.SuccessURL,
-	)
+	token, _ := data["token"].(string)
 
-	return m.renderVerifyPage(http.StatusOK, head, ""), nil
+	return m.deliverSession(token, m.req.Host.Config.SKAuth.SuccessURL+"?verified=true"), nil
 }
 
 func (m *skAuthMiddleware) handleMagicLinkRequest() (*shttp.Response, error) {
@@ -141,13 +210,7 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 		return m.renderVerifyPage(http.StatusOK, head, ""), nil
 	}
 
-	head := fmt.Sprintf(
-		`<script>localStorage.setItem('skauth', JSON.stringify(%q));window.location.href=%q;</script>`,
-		token,
-		successURL+"?verified=true",
-	)
-
-	return m.renderVerifyPage(http.StatusOK, head, ""), nil
+	return m.deliverSession(token, successURL+"?verified=true"), nil
 }
 
 // sessionCode is the payload stored in Redis under the one-time login code. The
@@ -214,13 +277,10 @@ func (m *skAuthMiddleware) codeLanding() *shttp.Response {
 		return nil
 	}
 
-	head := fmt.Sprintf(
-		`<script>localStorage.setItem('skauth', JSON.stringify('%s'));window.location.href=%q;</script>`,
-		sc.Token,
-		sc.Redirect,
-	)
-
-	return m.renderVerifyPage(http.StatusOK, head, "")
+	// This landing runs on the destination origin, so a cookie set here (with
+	// the configured Domain) is visible to the app and its authorization
+	// server — exactly the cross-subdomain boundary the bounce exists to cross.
+	return m.deliverSession(sc.Token, sc.Redirect)
 }
 
 // handleCallback renders the terminal states of the one-time-code landing on an
@@ -313,7 +373,7 @@ func injectUserHeaders(req *RequestContext) {
 	req.Header.Del("X-User-Id")
 	req.Header.Del("X-User-Email")
 
-	bearer := user.ParseBearer(req.Header.Get("Authorization"))
+	bearer := sessionBearer(req)
 
 	if bearer == "" {
 		return
@@ -365,7 +425,7 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 		}, nil
 	}
 
-	bearer := user.ParseBearer(m.req.Header.Get("Authorization"))
+	bearer := sessionBearer(m.req)
 
 	if bearer == "" {
 		return &shttp.Response{
@@ -407,10 +467,19 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 		}, nil
 	}
 
-	return &shttp.Response{
+	res := &shttp.Response{
 		Status: http.StatusOK,
 		Data:   map[string]any{"token": token},
-	}, nil
+	}
+
+	// In cookie mode the SPA can't read the token to persist it, so the rotated
+	// session must ride back as a refreshed cookie on the credentials:'include'
+	// XHR. The token stays in the body too for localStorage clients.
+	if m.req.Host.Config.SKAuth.SessionInCookie() {
+		res.Cookies = []http.Cookie{m.sessionCookieFor(token)}
+	}
+
+	return res, nil
 }
 
 // handleMe returns the full profile for the user identified by the bearer token

--- a/src/ce/hosting/middleware.skauth_cookie_test.go
+++ b/src/ce/hosting/middleware.skauth_cookie_test.go
@@ -1,0 +1,175 @@
+package hosting_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stretchr/testify/suite"
+)
+
+const cookieSecret = "test-secret-padded-to-32-chars!!"
+
+// SkAuthCookieSuite covers cookie-mode session storage: the edge reading the
+// session from a cookie, and the login handlers issuing one.
+type SkAuthCookieSuite struct {
+	suite.Suite
+}
+
+func TestSkAuthCookieSuite(t *testing.T) {
+	suite.Run(t, new(SkAuthCookieSuite))
+}
+
+func (s *SkAuthCookieSuite) host(cookieMode bool) *hosting.Host {
+	conf := &buildconf.SKAuthConf{
+		Secret:     cookieSecret,
+		SuccessURL: "/",
+		Status:     true,
+		TTL:        10,
+	}
+
+	if cookieMode {
+		conf.SessionStorage = buildconf.SessionStorageCookie
+		conf.CookieDomain = ".example.com"
+	}
+
+	return &hosting.Host{
+		Name:   "www.example.com",
+		Config: &appconf.Config{SKAuth: conf},
+	}
+}
+
+func (s *SkAuthCookieSuite) token(uid string) string {
+	tok, err := user.JWT(jwt.MapClaims{"uid": uid}, cookieSecret)
+	s.Require().NoError(err)
+
+	return tok
+}
+
+func (s *SkAuthCookieSuite) request(host *hosting.Host, header http.Header) *hosting.RequestContext {
+	if header == nil {
+		header = make(http.Header)
+	}
+
+	rq := &hosting.RequestContext{
+		Host: host,
+		RequestContext: shttp.NewRequestContext(&http.Request{
+			Method: http.MethodGet,
+			Header: header,
+			URL:    &url.URL{Host: host.Name, Path: "/dashboard", RawPath: "/dashboard"},
+		}),
+	}
+
+	rq.OriginalPath = "/dashboard"
+
+	return rq
+}
+
+// Test_Edge_InjectsUserFromCookie verifies the edge resolves the session from
+// the cookie (no Authorization header) and injects the identity headers — the
+// core of what makes cookie mode work on top-level navigations.
+func (s *SkAuthCookieSuite) Test_Edge_InjectsUserFromCookie() {
+	h := make(http.Header)
+	h.Set("Cookie", buildconf.SessionCookieName+"="+s.token("user-42"))
+
+	req := s.request(s.host(true), h)
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res, "a normal path falls through after injecting headers")
+	s.Equal("user-42", req.Header.Get("X-User-Id"))
+}
+
+// Test_Edge_InjectsUserFromAuthorization guards the localStorage/API path: the
+// Authorization bearer must still resolve identity after adding cookie support.
+func (s *SkAuthCookieSuite) Test_Edge_InjectsUserFromAuthorization() {
+	h := make(http.Header)
+	h.Set("Authorization", "Bearer "+s.token("user-7"))
+
+	req := s.request(s.host(false), h)
+	_, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Equal("user-7", req.Header.Get("X-User-Id"))
+}
+
+// Test_Edge_NoCredential_NoIdentity verifies no session yields no identity
+// header (and any client-supplied one is stripped).
+func (s *SkAuthCookieSuite) Test_Edge_NoCredential_NoIdentity() {
+	h := make(http.Header)
+	h.Set("X-User-Id", "spoofed")
+
+	req := s.request(s.host(true), h)
+	_, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Empty(req.Header.Get("X-User-Id"))
+}
+
+// Test_Login_CookieMode_SetsCookie verifies the one-time-code landing issues a
+// shared, hardened session cookie and 302s — instead of a localStorage script —
+// when the environment is in cookie mode.
+func (s *SkAuthCookieSuite) Test_Login_CookieMode_SetsCookie() {
+	ctx := context.Background()
+	code := "cookie-mode-code-1"
+	token := s.token("user-99")
+
+	rds := rediscache.Client()
+	rds.Set(ctx, code, `{"token":"`+token+`","redirect":"https://app.example.com/dashboard"}`, time.Minute*2)
+	defer rds.Del(ctx, code)
+
+	req := s.request(s.host(true), nil)
+	req.RequestContext.Method = http.MethodGet
+	req.RequestContext.Request.URL = &url.URL{Host: "www.example.com", Path: "/_stormkit/auth", RawQuery: "code=" + code}
+	req.OriginalPath = "/_stormkit/auth"
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Equal("https://app.example.com/dashboard", *res.Redirect)
+
+	s.Require().Len(res.Cookies, 1)
+	c := res.Cookies[0]
+	s.Equal(buildconf.SessionCookieName, c.Name)
+	s.Equal(token, c.Value)
+	s.Equal(".example.com", c.Domain)
+	s.True(c.Secure)
+	s.True(c.HttpOnly)
+	s.Equal(http.SameSiteLaxMode, c.SameSite)
+}
+
+// Test_Login_LocalStorageMode_UsesScript keeps the default behavior: no cookie,
+// a localStorage-injecting landing page.
+func (s *SkAuthCookieSuite) Test_Login_LocalStorageMode_UsesScript() {
+	ctx := context.Background()
+	code := "ls-mode-code-1"
+	token := "ls.session.jwt"
+
+	rds := rediscache.Client()
+	rds.Set(ctx, code, `{"token":"`+token+`","redirect":"https://app.example.com/dashboard"}`, time.Minute*2)
+	defer rds.Del(ctx, code)
+
+	req := s.request(s.host(false), nil)
+	req.RequestContext.Request.URL = &url.URL{Host: "www.example.com", Path: "/_stormkit/auth", RawQuery: "code=" + code}
+	req.OriginalPath = "/_stormkit/auth"
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+	s.Empty(res.Cookies)
+	s.Contains(string(res.Data.([]byte)), "localStorage.setItem('skauth'")
+}

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -118,8 +118,11 @@ func serveOAuth(fn func(*oauthServer) *shttp.Response) func(*RequestContext) *sh
 
 // oauthCORSHeaders makes the discovery, registration and token endpoints
 // reachable from browser-based MCP clients (e.g. MCP Inspector), which probe
-// them cross-origin. The endpoints authenticate via the Authorization header,
-// never cookies, so a wildcard origin carries no ambient-authority risk.
+// them cross-origin. Those endpoints authenticate via the Authorization header;
+// authorize()/grant() instead authenticate via the session cookie, so grant()
+// enforces a same-origin Origin check. The wildcard therefore only ever exposes
+// the unauthenticated discovery/registration/token responses cross-origin —
+// never a cookie-authenticated action.
 var oauthCORSHeaders = map[string]string{
 	"Access-Control-Allow-Origin":  "*",
 	"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
@@ -452,9 +455,10 @@ func (o *oauthServer) isLoopbackRedirect(u *url.URL) bool {
 	return isLoopbackHost(u.Hostname())
 }
 
-// authorize serves GET /_stormkit/oauth/authorize — the consent screen. Because
-// the SkAuth session lives in localStorage (no server-readable cookie), the page
-// is client-assisted: its script reads the token and POSTs back to grant().
+// authorize serves GET /_stormkit/oauth/authorize — the consent screen. The
+// SkAuth session rides this top-level navigation as a cookie; authorize() reads
+// it server-side and renders consent only when a valid session is present,
+// delegating to the app's login page otherwise.
 func (o *oauthServer) authorize() *shttp.Response {
 	p := o.parseAuthzParams()
 
@@ -480,14 +484,101 @@ func (o *oauthServer) authorize() *shttp.Response {
 		return o.redirectError(p, "invalid_request", "a PKCE code_challenge using S256 is required")
 	}
 
+	// The consent screen must know who is granting access. In cookie mode the
+	// session rides this top-level navigation; if it is absent we delegate to
+	// the app's own login page, which authenticates the user and bounces back
+	// here once the shared session cookie is set. Only then do we render consent.
+	if _, _, ok := o.sessionIdentity(); !ok {
+		return o.delegateToLogin(p)
+	}
+
 	return o.consentPage(p, client)
 }
 
+// oauthLoginRetryParam marks a return-from-login navigation. If /authorize is
+// reached with it set and there is still no session, the delegation loop is
+// broken with an actionable error instead of bouncing to login again.
+const oauthLoginRetryParam = "sk_auth_retried"
+
+// sessionIdentity resolves the SkAuth session on the current request (cookie or
+// Authorization bearer) into a user id and email. ok is false when there is no
+// valid session — the caller then delegates to login.
+func (o *oauthServer) sessionIdentity() (uid, eml string, ok bool) {
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer:  sessionBearer(o.req),
+		Secret:  o.secret(),
+		MaxMins: o.req.Host.Config.SKAuth.TTL,
+	})
+
+	if claims == nil {
+		return "", "", false
+	}
+
+	uid, _ = claims["uid"].(string)
+
+	if uid == "" {
+		return "", "", false
+	}
+
+	eml, _ = claims["eml"].(string)
+
+	return uid, eml, true
+}
+
+// delegateToLogin redirects an unauthenticated /authorize navigation to the
+// app's configured login page with a return_to pointing back at this exact
+// authorize request (with the retry marker). When no login URL is configured,
+// or we have already bounced once, it surfaces an actionable error rather than
+// dead-ending or looping.
+func (o *oauthServer) delegateToLogin(p authzParams) *shttp.Response {
+	loginURL := strings.TrimSpace(o.req.Host.Config.SKAuth.LoginURL)
+
+	if loginURL == "" || o.req.Query().Get(oauthLoginRetryParam) == "1" {
+		return o.errorPage("You are not signed in. Sign in to the application and try connecting again.")
+	}
+
+	returnTo := appendQuery(o.authorizeURL(), map[string]string{oauthLoginRetryParam: "1"})
+
+	if strings.HasPrefix(loginURL, "/") {
+		loginURL = o.issuer() + loginURL
+	}
+
+	target := appendQuery(loginURL, map[string]string{"return_to": returnTo})
+
+	return &shttp.Response{
+		Status:   http.StatusFound,
+		Redirect: &target,
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Cache-Control": "no-store",
+		}),
+	}
+}
+
+// authorizeURL reconstructs the absolute URL of the current /authorize request
+// so the app can bounce the user back to it after login.
+func (o *oauthServer) authorizeURL() string {
+	u := *o.req.URL()
+	u.Scheme = "https"
+	u.Host = o.req.Host.Name
+
+	return u.String()
+}
+
 // grant serves POST /_stormkit/oauth/authorize. The consent page calls it with
-// the user's SkAuth bearer; it validates identity + params and mints a one-time
-// authorization code bound to the PKCE challenge.
+// the session cookie (credentials:'include'); it validates identity + params and
+// mints a one-time authorization code bound to the PKCE challenge.
 func (o *oauthServer) grant() *shttp.Response {
 	p := o.parseAuthzParams()
+
+	// grant() authenticates from the session cookie, so it must never be drivable
+	// cross-site. SameSite=Lax already withholds the cookie on a cross-site POST;
+	// this Origin check enforces the same-origin invariant server-side so the
+	// guarantee survives any future loosening of the cookie's SameSite policy. The
+	// same-origin consent page sends a matching Origin; native/CLI clients use
+	// /token, not grant(), and send no Origin here.
+	if origin := o.req.Header.Get("Origin"); origin != "" && origin != o.issuer() {
+		return oauthJSON(http.StatusForbidden, oauthErr("access_denied", "cross-origin request rejected"))
+	}
 
 	if !o.redirectAllowed(p.redirectURI) {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "invalid redirect_uri"))
@@ -509,23 +600,11 @@ func (o *oauthServer) grant() *shttp.Response {
 		return oauthJSON(http.StatusBadRequest, oauthErr("invalid_request", "redirect_uri is not registered for this client"))
 	}
 
-	claims := user.ParseJWT(&user.ParseJWTArgs{
-		Bearer:  user.ParseBearer(o.req.Header.Get("Authorization")),
-		Secret:  o.secret(),
-		MaxMins: o.req.Host.Config.SKAuth.TTL,
-	})
+	uid, eml, ok := o.sessionIdentity()
 
-	if claims == nil {
+	if !ok {
 		return oauthJSON(http.StatusUnauthorized, oauthErr("access_denied", "authentication required"))
 	}
-
-	uid, _ := claims["uid"].(string)
-
-	if uid == "" {
-		return oauthJSON(http.StatusUnauthorized, oauthErr("access_denied", "invalid session"))
-	}
-
-	eml, _ := claims["eml"].(string)
 
 	code, err := oauthCodeStore.issue(o.req.Context(), oauthAuthCode{
 		UID:           uid,
@@ -781,11 +860,12 @@ func (o *oauthServer) errorPage(msg string) *shttp.Response {
 	}
 }
 
-// consentPage renders the client-assisted consent screen. The script pulls the
-// SkAuth token from localStorage and POSTs it back to grant(); when signed out
-// it prompts the user to sign in first. html/template escapes the injected
-// values in both HTML and JS contexts. A registered client is shown by its
-// declared client_name; the requested scopes are listed with human-readable
+// consentPage renders the consent screen. authorize() has already established a
+// session, so the Authorize button simply POSTs back to grant() with the
+// session cookie riding the same-origin request (credentials:'include'); grant
+// mints the code and returns the redirect target. html/template escapes the
+// injected values in both HTML and JS contexts. A registered client is shown by
+// its declared client_name; the requested scopes are listed with human-readable
 // labels so the user sees exactly what is being granted.
 func (o *oauthServer) consentPage(p authzParams, client oauthClient) *shttp.Response {
 	name := client.ClientName
@@ -809,39 +889,31 @@ func (o *oauthServer) consentPage(p authzParams, client oauthClient) *shttp.Resp
 		{{ range .scopes }}<li>{{ . }}</li>{{ end }}
 	</ul>
 	{{ end }}
-	<div id="skoauth-signedout" class="form-group error" style="display:none">
-		You are not signed in. Please sign in to this application in another tab, then reload this page to continue.
-	</div>
-	<div id="skoauth-actions" class="form-submit" style="display:none">
+	<div id="skoauth-error" class="form-group error" style="display:none"></div>
+	<div id="skoauth-actions" class="form-submit">
 		<button id="skoauth-allow" class="submit-button">Authorize</button>
 		<a id="skoauth-deny" class="secondary" style="margin-left:1rem">Cancel</a>
 	</div>
 </div>
 <script>
 (function () {
-	var raw = localStorage.getItem('skauth');
-	var token = null;
-	try { token = raw ? JSON.parse(raw) : null; } catch (e) { token = raw; }
+	var err = document.getElementById('skoauth-error');
 
-	var actions = document.getElementById('skoauth-actions');
-	var signedOut = document.getElementById('skoauth-signedout');
-
-	if (!token) { signedOut.style.display = 'block'; return; }
-	actions.style.display = 'block';
+	function fail() { err.textContent = 'Authorization failed. Please try again.'; err.style.display = 'block'; }
 
 	document.getElementById('skoauth-deny').setAttribute('href', "{{ .deny }}");
 
 	document.getElementById('skoauth-allow').addEventListener('click', function () {
 		fetch(window.location.pathname + window.location.search, {
 			method: 'POST',
-			headers: { 'Authorization': 'Bearer ' + token }
+			credentials: 'include'
 		})
 			.then(function (r) { return r.json(); })
 			.then(function (d) {
 				if (d && d.redirect) { window.location.href = d.redirect; }
-				else { signedOut.textContent = 'Authorization failed. Please try again.'; signedOut.style.display = 'block'; }
+				else { fail(); }
 			})
-			.catch(function () { signedOut.textContent = 'Authorization failed. Please try again.'; signedOut.style.display = 'block'; });
+			.catch(fail);
 	});
 })();
 </script>`

--- a/src/ce/hosting/oauth_mcp_test.go
+++ b/src/ce/hosting/oauth_mcp_test.go
@@ -22,10 +22,11 @@ func (s *OAuthSuite) hostWith(conf buildconf.OAuthServerConf) *hosting.Host {
 		Name: "app.example.com",
 		Config: &appconf.Config{
 			SKAuth: &buildconf.SKAuthConf{
-				Secret:      oauthSecret,
-				Status:      true,
-				TTL:         10,
-				OAuthServer: &conf,
+				Secret:         oauthSecret,
+				Status:         true,
+				TTL:            10,
+				SessionStorage: buildconf.SessionStorageCookie,
+				OAuthServer:    &conf,
 			},
 		},
 	}
@@ -103,7 +104,7 @@ func (s *OAuthSuite) loopbackQuery(redirect string) string {
 func (s *OAuthSuite) Test_Authorize_Loopback_AllowedWhenEnabled() {
 	host := s.hostWith(buildconf.OAuthServerConf{AllowLoopback: true})
 
-	res := hosting.HandleOAuthAuthorize(s.req(host, http.MethodGet, "/_stormkit/oauth/authorize", s.loopbackQuery("http://127.0.0.1:54321/callback"), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(host, http.MethodGet, "/_stormkit/oauth/authorize", s.loopbackQuery("http://127.0.0.1:54321/callback"), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Contains(string(res.Data.([]byte)), "Authorize access")
@@ -133,7 +134,7 @@ func (s *OAuthSuite) Test_Authorize_Loopback_RegisteredClient_IgnoresPort() {
 	q.Set("code_challenge", pkce("verifier"))
 	q.Set("code_challenge_method", "S256")
 
-	res := hosting.HandleOAuthAuthorize(s.req(host, http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(host, http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Contains(string(res.Data.([]byte)), "Authorize access")

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -43,17 +43,24 @@ func (s *OAuthSuite) SetupTest() {
 }
 
 func (s *OAuthSuite) host(enabled bool) *hosting.Host {
+	conf := &buildconf.SKAuthConf{
+		Secret:         oauthSecret,
+		Status:         true,
+		TTL:            10,
+		AllowedOrigins: []string{"https://client.example.com"},
+		OAuthServer:    &buildconf.OAuthServerConf{Enabled: enabled},
+	}
+
+	// The OAuth server requires cookie session storage (enforced at config save),
+	// so an OAuth-enabled host is always in cookie mode — that is how /authorize
+	// and grant() read the session off the top-level navigation.
+	if enabled {
+		conf.SessionStorage = buildconf.SessionStorageCookie
+	}
+
 	return &hosting.Host{
-		Name: "app.example.com",
-		Config: &appconf.Config{
-			SKAuth: &buildconf.SKAuthConf{
-				Secret:         oauthSecret,
-				Status:         true,
-				TTL:            10,
-				AllowedOrigins: []string{"https://client.example.com"},
-				OAuthServer:    &buildconf.OAuthServerConf{Enabled: enabled},
-			},
-		},
+		Name:   "app.example.com",
+		Config: &appconf.Config{SKAuth: conf},
 	}
 }
 
@@ -89,6 +96,19 @@ func (s *OAuthSuite) bearer(uid string) string {
 	s.Require().NoError(err)
 
 	return "Bearer " + tok
+}
+
+// session returns request headers carrying a valid SkAuth session cookie, as a
+// cookie-mode browser navigation to /authorize would. The consent screen now
+// requires a readable session; without it /authorize delegates to login.
+func (s *OAuthSuite) session(uid string) http.Header {
+	tok, err := user.JWT(jwt.MapClaims{"uid": uid}, oauthSecret)
+	s.Require().NoError(err)
+
+	h := make(http.Header)
+	h.Set("Cookie", buildconf.SessionCookieName+"="+tok)
+
+	return h
 }
 
 func pkce(verifier string) string {
@@ -166,7 +186,7 @@ func (s *OAuthSuite) Test_MetadataResource() {
 }
 
 func (s *OAuthSuite) Test_Authorize_RendersConsent() {
-	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Contains(res.Headers.Get("Content-Type"), "text/html")
@@ -189,7 +209,7 @@ func (s *OAuthSuite) Test_Authorize_RejectsBadRedirect() {
 // Test_Authorize_SetsAntiFramingHeaders guards the consent page against
 // clickjacking: it must forbid being framed.
 func (s *OAuthSuite) Test_Authorize_SetsAntiFramingHeaders() {
-	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Equal("DENY", res.Headers.Get("X-Frame-Options"))
@@ -206,7 +226,7 @@ func (s *OAuthSuite) Test_Authorize_AcceptsMixedCaseRedirectHost() {
 	q.Set("code_challenge", pkce("verifier"))
 	q.Set("code_challenge_method", "S256")
 
-	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Contains(string(res.Data.([]byte)), "Authorize access")
@@ -217,6 +237,99 @@ func (s *OAuthSuite) Test_Grant_RequiresAuth() {
 
 	s.Equal(http.StatusUnauthorized, res.Status)
 	s.Equal("access_denied", s.json(res)["error"])
+}
+
+// hostLogin returns an OAuth-enabled host with a configured delegation login URL.
+func (s *OAuthSuite) hostLogin(loginURL string) *hosting.Host {
+	host := s.host(true)
+	host.Config.SKAuth.LoginURL = loginURL
+
+	return host
+}
+
+// Test_Authorize_NoSession_DelegatesToLogin verifies that, without a readable
+// session, /authorize redirects to the app's login URL with a return_to that
+// points back at this exact request (carrying the loop-guard marker).
+func (s *OAuthSuite) Test_Authorize_NoSession_DelegatesToLogin() {
+	res := hosting.HandleOAuthAuthorize(s.req(s.hostLogin("/login"), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), nil, nil))
+
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+
+	u, err := url.Parse(*res.Redirect)
+	s.Require().NoError(err)
+	s.Equal("https://app.example.com/login", u.Scheme+"://"+u.Host+u.Path)
+
+	returnTo := u.Query().Get("return_to")
+	s.Require().NotEmpty(returnTo)
+
+	ret, err := url.Parse(returnTo)
+	s.Require().NoError(err)
+	s.Equal("/_stormkit/oauth/authorize", ret.Path)
+	s.Equal("1", ret.Query().Get("sk_auth_retried"))
+	s.Equal("chatgpt", ret.Query().Get("client_id"))
+}
+
+// Test_Authorize_NoSession_NoLoginURL_Errors surfaces an actionable error rather
+// than dead-ending when no session exists and no login URL is configured.
+func (s *OAuthSuite) Test_Authorize_NoSession_NoLoginURL_Errors() {
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), nil, nil))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Contains(string(res.Data.([]byte)), "not signed in")
+}
+
+// Test_Authorize_NoSession_RetryStops breaks the delegation loop: a return from
+// login that still has no session must error, not bounce to login again.
+func (s *OAuthSuite) Test_Authorize_NoSession_RetryStops() {
+	q := s.authzQuery(pkce("verifier")) + "&sk_auth_retried=1"
+
+	res := hosting.HandleOAuthAuthorize(s.req(s.hostLogin("/login"), http.MethodGet, "/_stormkit/oauth/authorize", q, nil, nil))
+
+	s.Equal(http.StatusBadRequest, res.Status)
+	s.Nil(res.Redirect)
+	s.Contains(string(res.Data.([]byte)), "not signed in")
+}
+
+// Test_Grant_FromCookie mints an authorization code when the session rides a
+// cookie rather than the Authorization header (the cookie-mode consent POST).
+func (s *OAuthSuite) Test_Grant_FromCookie() {
+	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), s.session("user-cookie"), nil))
+
+	s.Require().Equal(http.StatusOK, res.Status)
+
+	redirect, ok := s.json(res)["redirect"].(string)
+	s.Require().True(ok)
+
+	u, err := url.Parse(redirect)
+	s.Require().NoError(err)
+	s.NotEmpty(u.Query().Get("code"))
+}
+
+// Test_Grant_RejectsCrossOriginPost guards the cookie-authenticated grant against
+// a cross-site POST: even with a valid session cookie, a mismatched Origin is
+// refused so the code mint can't be driven from another site if the cookie's
+// SameSite policy is ever loosened.
+func (s *OAuthSuite) Test_Grant_RejectsCrossOriginPost() {
+	h := s.session("user-cookie")
+	h.Set("Origin", "https://evil.example.com")
+
+	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), h, nil))
+
+	s.Equal(http.StatusForbidden, res.Status)
+	s.Equal("access_denied", s.json(res)["error"])
+}
+
+// Test_Grant_AcceptsSameOriginPost confirms the Origin check lets the real
+// same-origin consent POST through.
+func (s *OAuthSuite) Test_Grant_AcceptsSameOriginPost() {
+	h := s.session("user-cookie")
+	h.Set("Origin", "https://app.example.com")
+
+	res := hosting.HandleOAuthGrant(s.req(s.host(true), http.MethodPost, "/_stormkit/oauth/authorize", s.authzQuery(pkce("verifier")), h, nil))
+
+	s.Require().Equal(http.StatusOK, res.Status)
+	s.NotEmpty(s.json(res)["redirect"])
 }
 
 // codeFromGrant runs a full authorize grant and returns the issued code.
@@ -449,7 +562,7 @@ func (s *OAuthSuite) Test_Authorize_RegisteredClient_ShowsName() {
 	q.Set("code_challenge", pkce("verifier"))
 	q.Set("code_challenge_method", "S256")
 
-	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Contains(string(res.Data.([]byte)), "Claude")
@@ -466,7 +579,7 @@ func (s *OAuthSuite) Test_Authorize_ShowsScopeLabels() {
 	q.Set("code_challenge_method", "S256")
 	q.Set("scope", "email profile")
 
-	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), nil, nil))
+	res := hosting.HandleOAuthAuthorize(s.req(s.host(true), http.MethodGet, "/_stormkit/oauth/authorize", q.Encode(), s.session("user-1"), nil))
 
 	s.Equal(http.StatusOK, res.Status)
 	html := string(res.Data.([]byte))

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -350,10 +350,15 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: false,
           oauthResourcePath: "",
           oauthAllowLoopback: false,
+          sessionStorage: "localStorage",
+          cookieDomain: "",
+          loginUrl: "",
         })
         .reply(200);
 
-      fireEvent.submit(wrapper.getByRole("button", { name: "Save" }).closest("form")!);
+      fireEvent.submit(
+        wrapper.getByRole("button", { name: "Save" }).closest("form")!,
+      );
 
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
@@ -375,6 +380,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: false,
           oauthResourcePath: "",
           oauthAllowLoopback: false,
+          sessionStorage: "localStorage",
+          cookieDomain: "",
+          loginUrl: "",
         })
         .reply(200);
 
@@ -408,8 +416,15 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: true,
           oauthResourcePath: "",
           oauthAllowLoopback: false,
+          sessionStorage: "cookie",
+          cookieDomain: "",
+          loginUrl: "",
         })
         .reply(200);
+
+      fireEvent.click(
+        await wrapper.findByLabelText("Store session in a cookie"),
+      );
 
       fireEvent.click(
         await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),
@@ -435,8 +450,15 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: true,
           oauthResourcePath: "/mcp",
           oauthAllowLoopback: true,
+          sessionStorage: "cookie",
+          cookieDomain: "",
+          loginUrl: "",
         })
         .reply(200);
+
+      fireEvent.click(
+        await wrapper.findByLabelText("Store session in a cookie"),
+      );
 
       fireEvent.click(
         await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),
@@ -446,7 +468,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
         target: { value: "/mcp" },
       });
 
-      fireEvent.click(await wrapper.findByLabelText("Allow native / CLI clients"));
+      fireEvent.click(
+        await wrapper.findByLabelText("Allow native / CLI clients"),
+      );
 
       fireEvent.submit(
         wrapper.getByRole("button", { name: "Save" }).closest("form")!,
@@ -460,7 +484,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
     it("should display error when save fails", async () => {
       nock(apiDomain).post("/skauth/config").reply(500);
 
-      fireEvent.submit(wrapper.getByRole("button", { name: "Save" }).closest("form")!);
+      fireEvent.submit(
+        wrapper.getByRole("button", { name: "Save" }).closest("form")!,
+      );
 
       await waitFor(() => {
         expect(wrapper.getByText("Failed to save settings")).toBeTruthy();

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -179,15 +179,27 @@ export default function SkAuth() {
     refreshToken,
   });
 
-  // The OAuth toggles are controlled Switches (not part of FormData), so they
-  // need their own state, synced from the config once it loads.
+  // The OAuth and session-storage toggles are controlled Switches (not part of
+  // FormData), so they need their own state, synced from the config once it
+  // loads.
   const [oauthServerEnabled, setOauthServerEnabled] = useState(false);
   const [oauthAllowLoopback, setOauthAllowLoopback] = useState(false);
+  const [sessionCookieMode, setSessionCookieMode] = useState(false);
 
   useEffect(() => {
     setOauthServerEnabled(Boolean(config?.oauthServerEnabled));
     setOauthAllowLoopback(Boolean(config?.oauthAllowLoopback));
-  }, [config?.oauthServerEnabled, config?.oauthAllowLoopback]);
+    setSessionCookieMode(config?.sessionStorage === "cookie");
+  }, [
+    config?.oauthServerEnabled,
+    config?.oauthAllowLoopback,
+    config?.sessionStorage,
+  ]);
+
+  // The OAuth server can only read the session on the top-level /authorize
+  // navigation from a cookie; a localStorage session dead-ends at consent. The
+  // backend refuses this combination, so mirror the guard in the UI.
+  const oauthNeedsCookie = oauthServerEnabled && !sessionCookieMode;
 
   const hasSchema = !result.loading && !result.error && Boolean(result.schema);
   const title = "Authentication";
@@ -248,6 +260,14 @@ export default function SkAuth() {
             return;
           }
 
+          if (oauthNeedsCookie) {
+            setSaveError(
+              "The OAuth server requires cookie session storage. Enable it below before saving.",
+            );
+            setSaving(false);
+            return;
+          }
+
           saveConfig({
             envId: env.id!,
             successUrl: (data.get("successUrl") as string) || "",
@@ -255,9 +275,13 @@ export default function SkAuth() {
             status: true,
             allowedOrigins,
             oauthServerEnabled,
-            oauthResourcePath:
-              ((data.get("oauthResourcePath") as string) || "").trim(),
+            oauthResourcePath: (
+              (data.get("oauthResourcePath") as string) || ""
+            ).trim(),
             oauthAllowLoopback,
+            sessionStorage: sessionCookieMode ? "cookie" : "localStorage",
+            cookieDomain: ((data.get("cookieDomain") as string) || "").trim(),
+            loginUrl: ((data.get("loginUrl") as string) || "").trim(),
           })
             .then(() => {
               setSuccess("Settings saved successfully");
@@ -335,11 +359,55 @@ export default function SkAuth() {
             }}
           />
           {showOriginsHint && (
-            <Alert severity="warning" sx={{ mt: 2 }} onClose={dismissOriginsHint}>
+            <Alert
+              severity="warning"
+              sx={{ mt: 2 }}
+              onClose={dismissOriginsHint}
+            >
               A provider is enabled but no allowed origins are set. If your
               frontend runs on a separate domain (or a native app), add its
               origin — otherwise sign-in returns users here instead of your app.
             </Alert>
+          )}
+        </Box>
+
+        <Box sx={{ mb: 4 }}>
+          <Switch
+            name="sessionCookieMode"
+            checked={sessionCookieMode}
+            setChecked={setSessionCookieMode}
+            label="Store session in a cookie"
+            description="Where the browser keeps the session after login. Off stores a bearer token in localStorage (attached to XHR). On issues a Secure, HttpOnly, SameSite=Lax cookie that rides both XHR and top-level navigations. Cookie mode is required by the OAuth server, and is a strict superset of localStorage — pick it if your app spans subdomains or connects MCP clients."
+          />
+          {sessionCookieMode && (
+            <>
+              <Box sx={{ mt: 3 }}>
+                <TextField
+                  label="Cookie domain"
+                  name="cookieDomain"
+                  placeholder=".example.com"
+                  fullWidth
+                  defaultValue={config?.cookieDomain || ""}
+                  variant="filled"
+                  autoComplete="off"
+                  helperText="Optional. Scope the session cookie to a parent domain so it is shared across subdomains (e.g. .example.com covers www. and api.). Leave empty for a single-host setup."
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+              </Box>
+              <Box sx={{ mt: 3 }}>
+                <TextField
+                  label="Login URL"
+                  name="loginUrl"
+                  placeholder="/login"
+                  fullWidth
+                  defaultValue={config?.loginUrl || ""}
+                  variant="filled"
+                  autoComplete="off"
+                  helperText="The app's own login page. When an MCP client starts an OAuth flow and the user has no session, /authorize redirects here with a return_to query parameter; your login page must send the user back to that URL after signing in. A relative path or an absolute URL."
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+              </Box>
+            </>
           )}
         </Box>
 
@@ -351,6 +419,13 @@ export default function SkAuth() {
             label="Enable OAuth server (MCP connectors)"
             description="Turns this environment into an OAuth 2.1 authorization server so AI clients like ChatGPT and Claude can connect to it as an MCP server, signing in your app's own users. The Claude and ChatGPT connector origins are trusted automatically — no manual origin setup needed."
           />
+          {oauthNeedsCookie && (
+            <Alert severity="warning" sx={{ mt: 2 }}>
+              The OAuth server needs the session in a cookie to identify the
+              user on the consent screen. Enable "Store session in a cookie"
+              above, otherwise the connect flow dead-ends at consent.
+            </Alert>
+          )}
           {oauthServerEnabled && (
             <>
               <Box sx={{ mt: 3 }}>
@@ -407,7 +482,7 @@ export default function SkAuth() {
             type="submit"
             variant="contained"
             color="secondary"
-            disabled={result.loading || loading || saving}
+            disabled={result.loading || loading || saving || oauthNeedsCookie}
           >
             Save
           </Button>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -226,6 +226,9 @@ interface FetchProvidersResult {
   oauthServerEnabled?: boolean;
   oauthResourcePath?: string;
   oauthAllowLoopback?: boolean;
+  sessionStorage?: string;
+  cookieDomain?: string;
+  loginUrl?: string;
   redirectUrl: string;
   authUrl: string;
   providers: {
@@ -240,6 +243,9 @@ interface AuthConfig {
   oauthServerEnabled?: boolean;
   oauthResourcePath?: string;
   oauthAllowLoopback?: boolean;
+  sessionStorage?: string;
+  cookieDomain?: string;
+  loginUrl?: string;
 }
 
 interface SaveConfigParams {
@@ -251,6 +257,9 @@ interface SaveConfigParams {
   oauthServerEnabled: boolean;
   oauthResourcePath: string;
   oauthAllowLoopback: boolean;
+  sessionStorage: string;
+  cookieDomain: string;
+  loginUrl: string;
 }
 
 export const saveConfig = ({
@@ -262,6 +271,9 @@ export const saveConfig = ({
   oauthServerEnabled,
   oauthResourcePath,
   oauthAllowLoopback,
+  sessionStorage,
+  cookieDomain,
+  loginUrl,
 }: SaveConfigParams): Promise<void> =>
   api.post("/skauth/config", {
     envId,
@@ -272,6 +284,9 @@ export const saveConfig = ({
     oauthServerEnabled,
     oauthResourcePath,
     oauthAllowLoopback,
+    sessionStorage,
+    cookieDomain,
+    loginUrl,
   });
 
 export const useFetchProviders = ({
@@ -300,6 +315,9 @@ export const useFetchProviders = ({
           oauthServerEnabled,
           oauthResourcePath,
           oauthAllowLoopback,
+          sessionStorage,
+          cookieDomain,
+          loginUrl,
         }) => {
           const result: AuthProvider[] = [];
 
@@ -331,6 +349,9 @@ export const useFetchProviders = ({
             oauthServerEnabled,
             oauthResourcePath,
             oauthAllowLoopback,
+            sessionStorage,
+            cookieDomain,
+            loginUrl,
           });
         },
       )


### PR DESCRIPTION
## Summary

Fixes the P0 from issue #314 that blocked the MCP connect flow at the consent screen.

The OAuth consent page read the SkAuth session from `localStorage` via client JS, but `/authorize` is a **top-level browser navigation on the authorization-server origin** — it could not read a `localStorage` session set on the app origin, so it dead-ended at *"You are not signed in"* for every app on the default localStorage-bearer auth (100% of the time).

## What changed

- **Session storage mode** (`SKAuthConf.SessionStorage`: `localStorage` | `cookie`). Cookie mode issues a `Secure; HttpOnly; SameSite=Lax` session cookie with a configurable `Domain` (cross-subdomain sharing between the login origin and the AS origin). It rides both SPA XHR and the top-level `/authorize` navigation. The two modes are mutually exclusive — one credential, no drift.
- **Edge** reads the session from the cookie *or* the `Authorization` header (`sessionBearer`), so `X-User-Id`/`X-User-Email` injection is unchanged downstream.
- **`/authorize` delegation**: with no readable session it 302s to the app's configured `LoginURL` with a loop-guarded `return_to`; the app authenticates with its own UI, sets the shared cookie, and bounces back. Stormkit does not own per-app login UX.
- **Guardrail**: the dashboard refuses to enable the OAuth server unless session storage is cookie mode, so the connect flow can no longer silently dead-end at consent.
- **UI**: "Store session in a cookie" toggle + Cookie domain + Login URL fields; enabling OAuth in localStorage mode disables Save and warns.

## Contract notes for apps adopting cookie mode

- The app's login page must honor the `return_to` query param and redirect back to it after login.
- The session cookie is `HttpOnly` — SPA JS can no longer read the token; apps must use `credentials:'include'` + `/me`. This is a clean break from localStorage, but only when an app opts into cookie mode.

## Tests

New `middleware.skauth_cookie_test.go` (edge cookie read, hardened-cookie emission), delegation + loop-guard + grant-from-cookie in `oauth_test.go`, config guardrail tests. Existing consent-render tests updated to supply a session cookie (consent now requires one). Full `src/ce/hosting/...` and skauth packages pass, `go vet` clean, UI spec 19/19, `tsc` clean.

Part of #314. Follow-up (PR 2): RFC 8707 `aud` enforcement, RFC 7009 `/revoke`, upstream `x-auth-method`/`x-oauth-client-id`/`x-oauth-scope` headers.