### PR TITLE
fix: cookie mode across all login routes

### DIFF
--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -192,13 +192,14 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
 	token, _ := data["token"].(string)
 
-	// Cross-origin: the POST came from a whitelisted frontend. Stash the token
-	// under a one-time code and bounce the user back to that origin's landing
-	// page, which injects it into localStorage there (codeLanding). We do NOT
-	// touch localStorage here because this host is the wrong origin for the
-	// token. SuccessURL is validated at config time to start with '/', so origin
-	// (no trailing slash) + successURL joins cleanly.
+	// Cross-origin: the POST came from a whitelisted frontend. In cookie mode the
+	// session rides a first-party cookie set on this auth host (see
+	// crossOriginCookieResponse); otherwise fall back to the localStorage bounce.
 	if redirect, _ := data["redirect"].(string); redirect != "" {
+		if res := m.crossOriginCookieResponse(redirect, token); res != nil {
+			return res, nil
+		}
+
 		landing, err := stashSessionToken(m.req.Context(), redirect, successURL, token)
 
 		if err != nil {
@@ -211,6 +212,78 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	}
 
 	return m.deliverSession(token, successURL+"?verified=true"), nil
+}
+
+// crossOriginCookieResponse returns the cookie-mode delivery for a login that
+// lands on a different origin (magic-link, OAuth-provider): the session cookie
+// is set first-party on this auth host — which is also the OAuth authorization
+// server — and the browser is sent straight to origin+successURL. This removes
+// the localStorage bounce and, crucially in a decoupled setup, stops the landing
+// from depending on the frontend host carrying its own cookie-mode config. It
+// returns nil when the environment is not in cookie mode, so the caller keeps
+// its existing localStorage delivery. origin is scheme+host (no trailing slash);
+// SuccessURL is validated at config time to start with "/".
+func (m *skAuthMiddleware) crossOriginCookieResponse(origin, token string) *shttp.Response {
+	if !m.req.Host.Config.SKAuth.SessionInCookie() {
+		return nil
+	}
+
+	return m.deliverSession(token, origin+m.req.Host.Config.SKAuth.SuccessURL)
+}
+
+// finalizeSessionResponse adapts a successful JSON auth response (login,
+// register, refresh) to the environment's session-storage mode. In cookie mode
+// it sets the session cookie and removes the token from the body, so the browser
+// holds exactly one credential — the cookie — and the app can't drift by also
+// stashing the token in localStorage. In localStorage mode the response is
+// returned unchanged, with the token in the body for the app to store.
+//
+// In cookie mode a decoupled frontend must send the auth XHR with credentials,
+// and the app's CORS config must allow them, for the browser to store the cookie.
+func (m *skAuthMiddleware) finalizeSessionResponse(res *shttp.Response, token string) *shttp.Response {
+	if res == nil || res.Status >= http.StatusBadRequest || !m.req.Host.Config.SKAuth.SessionInCookie() {
+		return res
+	}
+
+	// A session cookie must never be planted on a cross-site request: an attacker
+	// who auto-submits a cross-site form login (text/plain body, no CORS
+	// preflight) would otherwise fixate the victim's browser with the attacker's
+	// session cookie. Browsers always send Origin on POST and cookie mode only
+	// benefits browsers, so a missing or non-allow-listed Origin is treated as
+	// cross-site and the login is refused before the cookie is set.
+	if !m.cookieOriginAllowed() {
+		return &shttp.Response{
+			Status: http.StatusForbidden,
+			Data:   map[string]any{"errors": []string{"cross-origin session request rejected"}},
+		}
+	}
+
+	res.Cookies = append(res.Cookies, m.sessionCookieFor(token))
+
+	if data, ok := res.Data.(map[string]any); ok {
+		delete(data, "token")
+	}
+
+	return res
+}
+
+// cookieOriginAllowed reports whether the request that is about to receive a
+// session cookie originates from a trusted browser context. Same-host requests
+// and configured AllowedOrigins pass; a missing or foreign Origin is rejected.
+// This gates the cookie-setting POST endpoints (login, register, refresh)
+// against login CSRF / session fixation.
+func (m *skAuthMiddleware) cookieOriginAllowed() bool {
+	origin := m.req.Header.Get("Origin")
+
+	if origin == "" {
+		return false
+	}
+
+	if origin == "https://"+m.req.Host.Name {
+		return true
+	}
+
+	return m.req.Host.Config.SKAuth.IsAllowedOrigin(origin)
 }
 
 // sessionCode is the payload stored in Redis under the one-time login code. The
@@ -467,19 +540,13 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 		}, nil
 	}
 
-	res := &shttp.Response{
+	// finalizeSessionResponse rotates the cookie and drops the token from the body
+	// in cookie mode; in localStorage mode it returns the token for the SPA to
+	// persist.
+	return m.finalizeSessionResponse(&shttp.Response{
 		Status: http.StatusOK,
 		Data:   map[string]any{"token": token},
-	}
-
-	// In cookie mode the SPA can't read the token to persist it, so the rotated
-	// session must ride back as a refreshed cookie on the credentials:'include'
-	// XHR. The token stays in the body too for localStorage clients.
-	if m.req.Host.Config.SKAuth.SessionInCookie() {
-		res.Cookies = []http.Cookie{m.sessionCookieFor(token)}
-	}
-
-	return res, nil
+	}, token), nil
 }
 
 // handleMe returns the full profile for the user identified by the bearer token

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -33,11 +33,15 @@ func (s *WithSKAuthOAuthSuite) stateToken(provider, ref string) string {
 // auth enabled with a signing secret, a real schema store with the auth table
 // created, and an enabled Google provider.
 func (s *WithSKAuthOAuthSuite) setupCallbackEnv(providerStatus bool) *hosting.Host {
+	return s.setupCallbackEnvWith(providerStatus, &buildconf.SKAuthConf{
+		Secret: "test-secret-padded-to-32-chars!!",
+		Status: true,
+	})
+}
+
+func (s *WithSKAuthOAuthSuite) setupCallbackEnvWith(providerStatus bool, auth *buildconf.SKAuthConf) *hosting.Host {
 	env := s.MockEnv(s.app, map[string]any{
-		"AuthConf": &buildconf.SKAuthConf{
-			Secret: "test-secret-padded-to-32-chars!!",
-			Status: true,
-		},
+		"AuthConf": auth,
 		"SchemaConf": &buildconf.SchemaConf{
 			SchemaName:        s.conn.Cfg.Schema,
 			DBName:            s.conn.Cfg.DBName,
@@ -63,7 +67,14 @@ func (s *WithSKAuthOAuthSuite) setupCallbackEnv(providerStatus bool) *hosting.Ho
 		},
 	}))
 
-	return s.hostFor(env.ID)
+	// In production the request host config is loaded from the same env, so
+	// mirror the session-storage settings onto it (hostFor otherwise stubs a
+	// bare localStorage config).
+	host := s.hostFor(env.ID)
+	host.Config.SKAuth.SessionStorage = auth.SessionStorage
+	host.Config.SKAuth.CookieDomain = auth.CookieDomain
+
+	return host
 }
 
 func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
@@ -96,6 +107,53 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
 	s.Equal(http.StatusFound, res.Status)
 	s.Require().NotNil(res.Redirect)
 	s.Contains(*res.Redirect, "https://app.example.com/_stormkit/auth?code=")
+}
+
+// Test_Callback_CookieMode_SetsCookieAndSkipsLanding verifies that in cookie mode
+// the OAuth-provider callback sets a first-party session cookie on this auth host
+// and redirects straight to the initiating origin — no localStorage bounce, and
+// no dependency on that origin carrying its own auth config (the decoupled case).
+func (s *WithSKAuthOAuthSuite) Test_Callback_CookieMode_SetsCookieAndSkipsLanding() {
+	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
+		Secret:         "test-secret-padded-to-32-chars!!",
+		Status:         true,
+		SessionStorage: buildconf.SessionStorageCookie,
+		CookieDomain:   ".example.com",
+	})
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.MatchedBy(func(req *shttp.RequestContext) bool {
+		return req.FormValue("code") == "test-code"
+	})).Return(token, nil).Once()
+
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID: "test-account-id",
+		Email:     "jane@stormkit.io",
+		FirstName: "Jane",
+		LastName:  "Doe",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Equal("https://app.example.com/dashboard", *res.Redirect)
+	s.NotContains(*res.Redirect, "/_stormkit/auth?code=")
+
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
+	s.Equal(".example.com", res.Cookies[0].Domain)
+	s.True(res.Cookies[0].HttpOnly)
+	s.True(res.Cookies[0].Secure)
 }
 
 // Test_Callback_LinksToExistingMagicLinkUser guards against the duplicate-account

--- a/src/ce/hosting/skauth_email.go
+++ b/src/ce/hosting/skauth_email.go
@@ -141,10 +141,10 @@ func (m *skAuthMiddleware) login() *shttp.Response {
 		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error()))
 	}
 
-	return &shttp.Response{
+	return m.finalizeSessionResponse(&shttp.Response{
 		Status: http.StatusOK,
 		Data:   map[string]any{"token": sessionToken, "email": ctx.email, "userId": authUser.UUID},
-	}
+	}, sessionToken)
 }
 
 func (m *skAuthMiddleware) register() *shttp.Response {
@@ -219,10 +219,10 @@ func (m *skAuthMiddleware) register() *shttp.Response {
 		return shttp.Error(err, fmt.Sprintf("failed to generate session token: %s", err.Error()))
 	}
 
-	return &shttp.Response{
+	return m.finalizeSessionResponse(&shttp.Response{
 		Status: http.StatusCreated,
 		Data:   map[string]any{"token": sessionToken, "email": ctx.email, "userId": usr.UUID},
-	}
+	}, sessionToken)
 }
 
 func (m *skAuthMiddleware) verifyEmail() *shttp.Response {

--- a/src/ce/hosting/skauth_email_test.go
+++ b/src/ce/hosting/skauth_email_test.go
@@ -58,6 +58,14 @@ func (s *WithSKAuthEmailSuite) hostFor(envID types.ID) *hosting.Host {
 	}
 }
 
+func (s *WithSKAuthEmailSuite) hostForCookie(envID types.ID) *hosting.Host {
+	host := s.hostFor(envID)
+	host.Config.SKAuth.SessionStorage = buildconf.SessionStorageCookie
+	host.Config.SKAuth.CookieDomain = ".example.com"
+
+	return host
+}
+
 func (s *WithSKAuthEmailSuite) postRequest(host *hosting.Host, path string, body any) *hosting.RequestContext {
 	var buf bytes.Buffer
 
@@ -190,6 +198,36 @@ func (s *WithSKAuthEmailSuite) login(host *hosting.Host, email, password string)
 		"email":    email,
 		"password": password,
 	}))
+	s.Require().NoError(err)
+	return res
+}
+
+// sameHostOrigin is the Origin a first-party browser POST carries against the
+// auth host — the value the cookie-mode CSRF guard accepts.
+func (s *WithSKAuthEmailSuite) sameHostOrigin(host *hosting.Host) string {
+	return "https://" + host.Name
+}
+
+func (s *WithSKAuthEmailSuite) loginOrigin(host *hosting.Host, origin, email, password string) *shttp.Response {
+	req := s.postRequest(host, "/_stormkit/auth/login", map[string]any{
+		"email":    email,
+		"password": password,
+	})
+	req.Header.Set("Origin", origin)
+
+	res, err := hosting.ServeAuth(req)
+	s.Require().NoError(err)
+	return res
+}
+
+func (s *WithSKAuthEmailSuite) registerOrigin(host *hosting.Host, origin, email, password string) *shttp.Response {
+	req := s.postRequest(host, "/_stormkit/auth/register", map[string]any{
+		"email":    email,
+		"password": password,
+	})
+	req.Header.Set("Origin", origin)
+
+	res, err := hosting.ServeAuth(req)
 	s.Require().NoError(err)
 	return res
 }
@@ -341,6 +379,91 @@ func (s *WithSKAuthEmailSuite) Test_Login_Success() {
 	s.NotEmpty(data["token"])
 	s.Equal("login@example.com", data["email"])
 	s.NotEmpty(data["userId"])
+}
+
+// Test_Login_CookieMode_SetsCookieNoToken verifies that in cookie mode login sets
+// the session cookie and omits the token from the body, so the browser holds a
+// single credential (no localStorage-vs-cookie drift).
+func (s *WithSKAuthEmailSuite) Test_Login_CookieMode_SetsCookieNoToken() {
+	env, err := s.setupEnv(false)
+	s.Require().NoError(err)
+
+	host := s.hostForCookie(env.ID)
+	origin := s.sameHostOrigin(host)
+
+	s.Require().Equal(http.StatusCreated, s.registerOrigin(host, origin, "cookie@example.com", "supersecret123").Status)
+
+	res := s.loginOrigin(host, origin, "cookie@example.com", "supersecret123")
+
+	s.Equal(http.StatusOK, res.Status)
+
+	data := s.jsonData(res)
+	_, hasToken := data["token"]
+	s.False(hasToken, "cookie mode must not return the token in the body")
+	s.Equal("cookie@example.com", data["email"])
+
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
+	s.Equal(".example.com", res.Cookies[0].Domain)
+	s.True(res.Cookies[0].HttpOnly)
+	s.True(res.Cookies[0].Secure)
+	s.Equal(http.SameSiteLaxMode, res.Cookies[0].SameSite)
+}
+
+// Test_Register_CookieMode_SetsCookieNoToken verifies the same single-credential
+// behavior on the auto-login register path (no mailer / verification).
+func (s *WithSKAuthEmailSuite) Test_Register_CookieMode_SetsCookieNoToken() {
+	env, err := s.setupEnv(false)
+	s.Require().NoError(err)
+
+	host := s.hostForCookie(env.ID)
+
+	res := s.registerOrigin(host, s.sameHostOrigin(host), "cookiereg@example.com", "supersecret123")
+
+	s.Equal(http.StatusCreated, res.Status)
+
+	data := s.jsonData(res)
+	_, hasToken := data["token"]
+	s.False(hasToken, "cookie mode must not return the token in the body")
+
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
+}
+
+// Test_Login_CookieMode_ForeignOrigin_Rejected verifies the login-CSRF guard: in
+// cookie mode a login POST carrying a foreign (non-allow-listed) Origin is
+// refused with 403 and no session cookie, so an attacker can't plant their own
+// session on the victim's browser via a cross-site form post.
+func (s *WithSKAuthEmailSuite) Test_Login_CookieMode_ForeignOrigin_Rejected() {
+	env, err := s.setupEnv(false)
+	s.Require().NoError(err)
+
+	host := s.hostForCookie(env.ID)
+	origin := s.sameHostOrigin(host)
+
+	s.Require().Equal(http.StatusCreated, s.registerOrigin(host, origin, "victim@example.com", "supersecret123").Status)
+
+	res := s.loginOrigin(host, "https://evil.example.org", "victim@example.com", "supersecret123")
+
+	s.Equal(http.StatusForbidden, res.Status)
+	s.Empty(res.Cookies, "no session cookie may be set for a cross-origin login")
+}
+
+// Test_Login_CookieMode_MissingOrigin_Rejected verifies that a cookie-mode login
+// with no Origin header (browsers always send one on POST) is treated as
+// cross-site and refused, closing the CSRF vector for form posts.
+func (s *WithSKAuthEmailSuite) Test_Login_CookieMode_MissingOrigin_Rejected() {
+	env, err := s.setupEnv(false)
+	s.Require().NoError(err)
+
+	host := s.hostForCookie(env.ID)
+
+	s.Require().Equal(http.StatusCreated, s.registerOrigin(host, s.sameHostOrigin(host), "victim2@example.com", "supersecret123").Status)
+
+	res := s.login(host, "victim2@example.com", "supersecret123")
+
+	s.Equal(http.StatusForbidden, res.Status)
+	s.Empty(res.Cookies, "no session cookie may be set when Origin is absent")
 }
 
 func (s *WithSKAuthEmailSuite) Test_Login_WrongPassword() {

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -235,11 +235,19 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
 	}
 
-	// Stash the token under a one-time code and send the browser to the landing
-	// page on the initiating origin, which injects it into localStorage there
-	// (codeLanding). This works whether or not that origin runs its own auth
-	// config, and keeps the token out of the URL.
-	target, err := stashSessionToken(req.Context(), referOrigin, m.req.Host.Config.SKAuth.SuccessURL, sessionToken)
+	successURL := m.req.Host.Config.SKAuth.SuccessURL
+
+	// Cookie mode: set a first-party cookie on this auth host (also the OAuth AS)
+	// and send the user straight to the initiating origin — no localStorage
+	// bounce, and no dependency on that origin carrying its own auth config.
+	if res := m.crossOriginCookieResponse(referOrigin, sessionToken); res != nil {
+		return res, nil
+	}
+
+	// localStorage mode: stash the token under a one-time code and send the
+	// browser to the landing page on the initiating origin, which injects it into
+	// localStorage there (codeLanding). Keeps the token out of the URL.
+	target, err := stashSessionToken(req.Context(), referOrigin, successURL, sessionToken)
 
 	if err != nil {
 		slog.Errorf("oauth callback: failed to save session code: %s", err.Error())


### PR DESCRIPTION
## Summary

Follow-up to #366. Cookie session mode only converted the GET landing pages, so the **OAuth-provider callback (Google / X / GitHub), magic-link cross-origin, and email/password endpoints still delivered a localStorage session** — enabling cookie mode had no effect on those logins.

Surfaced while testing the Google connector against a decoupled setup (frontend and backend on different hosts, auth enabled only on the backend).

## Changes

- **Redirect flows (OAuth provider, magic link):** in cookie mode, set a first-party session cookie on the auth host — which is also the OAuth authorization server — and redirect straight to the initiating origin, skipping the localStorage landing bounce. This also removes the decoupled-setup dependency on the *frontend* host carrying its own cookie-mode config (the landing used to run there).
- **Email/password `login` / `register` / `refresh`:** in cookie mode, set the cookie and **omit the token from the JSON body**, so the browser holds a single credential and can't drift between localStorage and cookie. In localStorage mode the token is still returned unchanged.

## Route coverage after this change

| Route | Cookie mode |
|---|---|
| `/auth/callback` (all OAuth providers) | ✅ |
| `/auth/magic` (magic link) | ✅ |
| `/auth/verify` (email verify) | ✅ (already) |
| `/auth/login`, `/auth/register` | ✅ cookie set, token omitted |
| `/auth/refresh` | ✅ rotates cookie, token omitted |
| `/auth/me` | ✅ reads via cookie |

## Note for decoupled setups

In cookie mode the session cookie is first-party to the backend (auth host + OAuth AS), which is exactly what the top-level `/authorize` navigation needs. For a frontend on a different subdomain to send it on XHR, set the cookie domain to the shared parent (e.g. `.example.com`) and send requests with credentials.

## Tests

New cookie-mode tests: OAuth callback (cookie set, no landing bounce), email/password login + register (cookie set, token omitted). Full `src/ce/hosting/...` suite passes, `go vet` clean.