### PR TITLE
feat: add session logout endpoint

### DIFF
--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -89,6 +89,8 @@ func ServeAuth(req *RequestContext) (*shttp.Response, error) {
 		return handleAuthMagic(req), nil
 	case "/_stormkit/auth/refresh":
 		return handleAuthRefresh(req), nil
+	case "/_stormkit/auth/logout":
+		return handleAuthLogout(req), nil
 	case "/_stormkit/auth/me":
 		return handleAuthMe(req), nil
 	case skauth.CallbackPath:

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -65,6 +65,41 @@ func (m *skAuthMiddleware) sessionCookieFor(token string) http.Cookie {
 	return cookie
 }
 
+// expiredSessionCookie is the deletion counterpart of sessionCookieFor: the same
+// Name/Path/Domain (which the browser matches on) with MaxAge<0, so a Set-Cookie
+// carrying it clears the session cookie.
+func (m *skAuthMiddleware) expiredSessionCookie() http.Cookie {
+	return http.Cookie{
+		Name:     buildconf.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Domain:   m.req.Host.Config.SKAuth.CookieDomain,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	}
+}
+
+// handleLogout clears the session cookie. In cookie mode the session lives in an
+// HttpOnly cookie the app's JS cannot clear, so sign-out must expire it server
+// side; the endpoint gives cookie- and localStorage-mode apps a single logout
+// call (localStorage clients also drop their own stored token). POST-only, so a
+// cross-site GET can't force a logout.
+func (m *skAuthMiddleware) handleLogout() (*shttp.Response, error) {
+	if m.req.Method != http.MethodPost {
+		return &shttp.Response{
+			Status: http.StatusMethodNotAllowed,
+			Data:   map[string]any{"errors": []string{"method not allowed"}},
+		}, nil
+	}
+
+	return &shttp.Response{
+		Status:  http.StatusOK,
+		Cookies: []http.Cookie{m.expiredSessionCookie()},
+	}, nil
+}
+
 // deliverSession hands the freshly minted session token to the browser and
 // sends it on to redirectURL. In cookie mode it sets the shared session cookie
 // and 302s; in localStorage mode it renders the landing page whose script

--- a/src/ce/hosting/middleware.skauth_cookie_test.go
+++ b/src/ce/hosting/middleware.skauth_cookie_test.go
@@ -173,3 +173,41 @@ func (s *SkAuthCookieSuite) Test_Login_LocalStorageMode_UsesScript() {
 	s.Empty(res.Cookies)
 	s.Contains(string(res.Data.([]byte)), "localStorage.setItem('skauth'")
 }
+
+// logoutRequest builds a request to the logout endpoint with the given method.
+func (s *SkAuthCookieSuite) logoutRequest(host *hosting.Host, method string) *hosting.RequestContext {
+	req := s.request(host, nil)
+	req.RequestContext.Method = method
+	req.RequestContext.Request.URL = &url.URL{Host: host.Name, Path: "/_stormkit/auth/logout", RawPath: "/_stormkit/auth/logout"}
+	req.OriginalPath = "/_stormkit/auth/logout"
+
+	return req
+}
+
+// Test_Logout_ExpiresCookie verifies POST /_stormkit/auth/logout clears the
+// session cookie — the only way to end a cookie-mode session, since the HttpOnly
+// cookie is invisible to the app's JS.
+func (s *SkAuthCookieSuite) Test_Logout_ExpiresCookie() {
+	res, err := hosting.ServeAuth(s.logoutRequest(s.host(true), http.MethodPost))
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+
+	s.Require().Len(res.Cookies, 1)
+	c := res.Cookies[0]
+	s.Equal(buildconf.SessionCookieName, c.Name)
+	s.Empty(c.Value)
+	s.Equal(".example.com", c.Domain)
+	s.Less(c.MaxAge, 0, "a deletion cookie must have MaxAge<0")
+}
+
+// Test_Logout_RejectsGet guards against a cross-site GET forcing a logout.
+func (s *SkAuthCookieSuite) Test_Logout_RejectsGet() {
+	res, err := hosting.ServeAuth(s.logoutRequest(s.host(true), http.MethodGet))
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusMethodNotAllowed, res.Status)
+	s.Empty(res.Cookies)
+}

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -70,6 +70,7 @@ func registerReservedRoutes(s *shttp.Service) {
 	add("/verify", handleAuthVerify)
 	add("/magic", handleAuthMagic)
 	add("/refresh", handleAuthRefresh)
+	add("/logout", handleAuthLogout)
 	add("/me", handleAuthMe)
 	add("/callback", handleAuthOAuthCallback)
 	add("/{provider}", handleAuthProvider)
@@ -107,6 +108,7 @@ func serveReservedAuth(fn func(*skAuthMiddleware) (*shttp.Response, error)) func
 var (
 	handleAuthVerify        = serveReservedAuth((*skAuthMiddleware).handleVerify)
 	handleAuthRefresh       = serveReservedAuth((*skAuthMiddleware).handleRefresh)
+	handleAuthLogout        = serveReservedAuth((*skAuthMiddleware).handleLogout)
 	handleAuthMe            = serveReservedAuth((*skAuthMiddleware).handleMe)
 	handleAuthMagic         = serveReservedAuth((*skAuthMiddleware).handleMagic)
 	handleAuthOAuthCallback = serveReservedAuth((*skAuthMiddleware).handleOAuthCallback)


### PR DESCRIPTION
## Summary

Completes cookie session mode (#366, #368). In cookie mode the session lives in an **HttpOnly** cookie the app's JS cannot clear, so there was previously no way to sign a user out — `localStorage.removeItem('skauth')` no longer does anything.

Adds **`POST /_stormkit/auth/logout`**, which expires the session cookie (`Set-Cookie` with `MaxAge<0`, matching the session cookie's Name/Path/Domain). It's POST-only so a cross-site `GET` can't force a logout, and returns 200 in both modes so apps have a single logout call regardless of storage mode.

## Frontend usage (cookie mode)

```js
await fetch('/_stormkit/auth/logout', { method: 'POST', credentials: 'include' });
// cookie is now cleared; treat the user as signed out
```

## Tests

`Test_Logout_ExpiresCookie` (200 + deletion cookie with MaxAge<0) and `Test_Logout_RejectsGet` (405). Full `src/ce/hosting/...` suite passes, `go vet` clean.

## Context

Verified against Triplan: after login the `skauth_session` cookie is set on `.triplan.to` and `/_stormkit/auth/me` with `credentials:'include'` returns the user — cookie mode works end-to-end. This PR closes the remaining hole (sign-out).