### PR TITLE
feat: cookie-only sessions, bearer for native clients

### DIFF
--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -41,19 +41,10 @@ type SKAuthConf struct {
 	// that origin after clicking the email link.
 	AllowedOrigins []string
 
-	// SessionStorage selects where the browser keeps the SkAuth session token
-	// after login: "localStorage" (default) or "cookie". localStorage attaches
-	// the token to XHR as a bearer; cookie mode issues a Secure, HttpOnly,
-	// SameSite=Lax session cookie that rides both SPA XHR and the top-level
-	// navigation the OAuth /authorize endpoint depends on. The two are mutually
-	// exclusive — one credential, no drift. Cookie mode is a prerequisite for
-	// the OAuth server (a localStorage session is invisible to /authorize).
-	SessionStorage string
-
 	// CookieDomain optionally scopes the session cookie to a parent domain
 	// (e.g. ".example.com") so it is shared across subdomains — needed when the
 	// login origin and the OAuth authorization-server origin are different
-	// subdomains. Empty means a host-only cookie. Only used in cookie mode.
+	// subdomains. Empty means a host-only cookie.
 	CookieDomain string
 
 	// LoginURL is the app-owned login page the OAuth /authorize endpoint
@@ -72,17 +63,8 @@ type SKAuthConf struct {
 	OAuthServer *OAuthServerConf
 }
 
-// SessionCookieName is the name of the SkAuth session cookie set in cookie mode.
+// SessionCookieName is the name of the SkAuth session cookie.
 const SessionCookieName = "skauth_session"
-
-// SessionStorageCookie is the SessionStorage value that enables cookie mode.
-const SessionStorageCookie = "cookie"
-
-// SessionInCookie reports whether the SkAuth session is stored in a cookie
-// rather than localStorage. The OAuth authorization server requires this.
-func (ac *SKAuthConf) SessionInCookie() bool {
-	return ac != nil && ac.SessionStorage == SessionStorageCookie
-}
 
 // OAuthServerConf configures the OAuth 2.1 authorization server layered on
 // SkAuth. Distinct from the OAuth *provider* logins (Google, X), where the app

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update.go
@@ -26,7 +26,6 @@ type AuthConfigUpdateRequest struct {
 	OAuthServerEnabled *bool   `json:"oauthServerEnabled"`
 	OAuthResourcePath  *string `json:"oauthResourcePath"`
 	OAuthAllowLoopback *bool   `json:"oauthAllowLoopback"`
-	SessionStorage     *string `json:"sessionStorage"`
 	CookieDomain       *string `json:"cookieDomain"`
 	LoginURL           *string `json:"loginUrl"`
 }
@@ -105,10 +104,10 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	env.AuthConf.Status = data.Status
 	env.AuthConf.AllowedOrigins = allowedOrigins
 
-	if err := applySessionStorageConf(env.AuthConf, data); err != nil {
+	if err := applySessionConf(env.AuthConf, data); err != nil {
 		return shttp.BadRequest(map[string]any{
 			"error": err.Error(),
-			"hint":  "Session storage must be either \"localStorage\" or \"cookie\".",
+			"hint":  "Cookie domain must be a bare host such as .example.com; login URL a relative path or absolute URL.",
 		})
 	}
 
@@ -116,17 +115,6 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 		return shttp.BadRequest(map[string]any{
 			"error": err.Error(),
 			"hint":  "Provide a relative path such as: /mcp",
-		})
-	}
-
-	// The OAuth authorization server can only identify the user on the
-	// top-level /authorize navigation from a cookie session; a localStorage
-	// session dead-ends silently at the consent screen. Refuse the combination
-	// rather than let the connect flow break with no error surfaced.
-	if env.AuthConf.OAuthServerEnabled() && !env.AuthConf.SessionInCookie() {
-		return shttp.BadRequest(map[string]any{
-			"error": "The OAuth server requires cookie session storage. Set session storage to \"cookie\" before enabling it.",
-			"hint":  "Auth settings → Session storage → Cookie.",
 		})
 	}
 
@@ -148,20 +136,10 @@ func handlerAuthConfigUpdate(req *app.RequestContext) *shttp.Response {
 	return shttp.OK()
 }
 
-// applySessionStorageConf merges the session-storage fields from data into
-// conf, leaving any omitted field untouched. It validates the storage mode and
-// the login URL the OAuth /authorize endpoint delegates to.
-func applySessionStorageConf(conf *buildconf.SKAuthConf, data AuthConfigUpdateRequest) error {
-	if data.SessionStorage != nil {
-		mode := strings.TrimSpace(*data.SessionStorage)
-
-		if mode != "" && mode != "localStorage" && mode != buildconf.SessionStorageCookie {
-			return fmt.Errorf("session storage %q must be either \"localStorage\" or \"cookie\"", mode)
-		}
-
-		conf.SessionStorage = mode
-	}
-
+// applySessionConf merges the session cookie fields from data into conf,
+// leaving any omitted field untouched. It validates the cookie domain and the
+// login URL the OAuth /authorize endpoint delegates to.
+func applySessionConf(conf *buildconf.SKAuthConf, data AuthConfigUpdateRequest) error {
 	if data.CookieDomain != nil {
 		domain := strings.TrimSpace(*data.CookieDomain)
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
@@ -176,7 +176,6 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthServerFields() {
 			"oauthServerEnabled": true,
 			"oauthResourcePath":  "mcp",
 			"oauthAllowLoopback": true,
-			"sessionStorage":     "cookie",
 		},
 		map[string]string{
 			"Authorization": usertest.Authorization(s.usr.ID),
@@ -214,48 +213,6 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthResourcePath_RejectsQuer
 	s.Equal(http.StatusBadRequest, response.Code)
 }
 
-// Test_Update_OAuthServer_RequiresCookieMode refuses to enable the OAuth server
-// while session storage is localStorage — the combination dead-ends silently at
-// the consent screen, so it must be rejected at save time.
-func (s *HandlerAuthConfigUpdateSuite) Test_Update_OAuthServer_RequiresCookieMode() {
-	response := shttptest.RequestWithHeaders(
-		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
-		shttp.MethodPost,
-		"/skauth/config",
-		map[string]any{
-			"envId":              s.env.ID,
-			"status":             true,
-			"oauthServerEnabled": true,
-			"sessionStorage":     "localStorage",
-		},
-		map[string]string{
-			"Authorization": usertest.Authorization(s.usr.ID),
-		},
-	)
-
-	s.Equal(http.StatusBadRequest, response.Code)
-	s.Contains(response.String(), "cookie session storage")
-}
-
-// Test_Update_RejectsInvalidSessionStorage guards the session-storage enum.
-func (s *HandlerAuthConfigUpdateSuite) Test_Update_RejectsInvalidSessionStorage() {
-	response := shttptest.RequestWithHeaders(
-		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
-		shttp.MethodPost,
-		"/skauth/config",
-		map[string]any{
-			"envId":          s.env.ID,
-			"status":         true,
-			"sessionStorage": "sqlite",
-		},
-		map[string]string{
-			"Authorization": usertest.Authorization(s.usr.ID),
-		},
-	)
-
-	s.Equal(http.StatusBadRequest, response.Code)
-}
-
 // Test_Update_RejectsProtocolRelativeLoginURL rejects a scheme-relative login URL
 // (leading "//"): it points at another host, not a path on the AS origin, so it
 // must not slip past validation and become a broken same-host redirect.
@@ -265,10 +222,9 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_RejectsProtocolRelativeLoginU
 		shttp.MethodPost,
 		"/skauth/config",
 		map[string]any{
-			"envId":          s.env.ID,
-			"status":         true,
-			"sessionStorage": "cookie",
-			"loginUrl":       "//evil.example.com",
+			"envId":    s.env.ID,
+			"status":   true,
+			"loginUrl": "//evil.example.com",
 		},
 		map[string]string{
 			"Authorization": usertest.Authorization(s.usr.ID),

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -49,7 +49,6 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 	oauthServerEnabled := false
 	oauthResourcePath := ""
 	oauthAllowLoopback := false
-	sessionStorage := ""
 	cookieDomain := ""
 	loginURL := ""
 
@@ -57,7 +56,6 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 		successURL = env.AuthConf.SuccessURL
 		ttl = env.AuthConf.TTL
 		oauthServerEnabled = env.AuthConf.OAuthServerEnabled()
-		sessionStorage = env.AuthConf.SessionStorage
 		cookieDomain = env.AuthConf.CookieDomain
 		loginURL = env.AuthConf.LoginURL
 
@@ -80,7 +78,6 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 			"oauthServerEnabled": oauthServerEnabled,
 			"oauthResourcePath":  oauthResourcePath,
 			"oauthAllowLoopback": oauthAllowLoopback,
-			"sessionStorage":     sessionStorage,
 			"cookieDomain":       cookieDomain,
 			"loginUrl":           loginURL,
 			"redirectUrl":        skauth.RedirectURL(),

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -1,11 +1,10 @@
 package hosting
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
+	"strings"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -20,21 +19,15 @@ type skAuthMiddleware struct {
 }
 
 // sessionBearer returns the SkAuth session token for the request, consulting
-// both credentials: the Authorization bearer (localStorage mode and API
-// clients) and the session cookie (cookie mode, where a top-level navigation or
-// a credentials:'include' XHR carries no Authorization header).
+// both credentials: the session cookie (browsers — a top-level navigation or a
+// credentials:'include' XHR carries no Authorization header) and the
+// Authorization bearer (native/mobile and MCP clients, which send no cookie).
 //
-// In cookie mode the cookie is preferred so a stale Authorization bearer — e.g.
-// a token left in localStorage from before the switch to cookie mode, which the
-// old SPA still attaches to every XHR — can't mask the live cookie session. API
-// and MCP clients send no cookie, so the Authorization bearer remains the
-// fallback. In localStorage mode there is no session cookie, so only the bearer
-// applies.
+// The cookie is preferred so a stale Authorization bearer — e.g. a token an old
+// SPA still attaches to every XHR — can't mask the live cookie session.
 func sessionBearer(req *RequestContext) string {
-	if req.Host.Config.SKAuth.SessionInCookie() {
-		if cookie, err := req.Cookie(buildconf.SessionCookieName); err == nil && cookie != nil && cookie.Value != "" {
-			return cookie.Value
-		}
+	if cookie, err := req.Cookie(buildconf.SessionCookieName); err == nil && cookie != nil && cookie.Value != "" {
+		return cookie.Value
 	}
 
 	return user.ParseBearer(req.Header.Get("Authorization"))
@@ -65,31 +58,21 @@ func (m *skAuthMiddleware) sessionCookieFor(token string) http.Cookie {
 	return cookie
 }
 
-// deliverSession hands the freshly minted session token to the browser and
-// sends it on to redirectURL. In cookie mode it sets the shared session cookie
-// and 302s; in localStorage mode it renders the landing page whose script
-// stashes the token before redirecting. Callers compute redirectURL as either a
-// relative path or an absolute URL on the destination origin.
+// deliverSession sets the session cookie and 302s to redirectURL. Used by the
+// browser login landings (email verify, magic link, OAuth-provider callback);
+// the cookie is first-party to this auth host, so it is also readable by the
+// OAuth /authorize navigation. redirectURL is a relative path or an absolute URL
+// on the destination origin.
 func (m *skAuthMiddleware) deliverSession(token, redirectURL string) *shttp.Response {
-	if m.req.Host.Config.SKAuth.SessionInCookie() {
-		return &shttp.Response{
-			Status:   http.StatusFound,
-			Redirect: &redirectURL,
-			Cookies:  []http.Cookie{m.sessionCookieFor(token)},
-			Headers: shttp.HeadersFromMap(map[string]string{
-				"Cache-Control":   "no-store",
-				"Referrer-Policy": "no-referrer",
-			}),
-		}
+	return &shttp.Response{
+		Status:   http.StatusFound,
+		Redirect: &redirectURL,
+		Cookies:  []http.Cookie{m.sessionCookieFor(token)},
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Cache-Control":   "no-store",
+			"Referrer-Policy": "no-referrer",
+		}),
 	}
-
-	head := fmt.Sprintf(
-		`<script>localStorage.setItem('skauth', JSON.stringify(%q));window.location.href=%q;</script>`,
-		token,
-		redirectURL,
-	)
-
-	return m.renderVerifyPage(http.StatusOK, head, "")
 }
 
 func (m *skAuthMiddleware) handleRegisterLogin(path string) (*shttp.Response, error) {
@@ -192,43 +175,15 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
 	token, _ := data["token"].(string)
 
-	// Cross-origin: the POST came from a whitelisted frontend. In cookie mode the
-	// session rides a first-party cookie set on this auth host (see
-	// crossOriginCookieResponse); otherwise fall back to the localStorage bounce.
+	// Cross-origin: the POST came from a whitelisted frontend. The session cookie
+	// is first-party to this auth host (also the OAuth AS), so it is set here and
+	// the browser is sent straight to the destination origin — no dependency on
+	// the frontend host carrying its own auth config.
 	if redirect, _ := data["redirect"].(string); redirect != "" {
-		if res := m.crossOriginCookieResponse(redirect, token); res != nil {
-			return res, nil
-		}
-
-		landing, err := stashSessionToken(m.req.Context(), redirect, successURL, token)
-
-		if err != nil {
-			return m.renderVerifyPage(http.StatusInternalServerError, "", "magic link verification failed"), nil
-		}
-
-		head := fmt.Sprintf(`<script>window.location.href=%q;</script>`, landing)
-
-		return m.renderVerifyPage(http.StatusOK, head, ""), nil
+		return m.deliverSession(token, redirect+successURL), nil
 	}
 
 	return m.deliverSession(token, successURL+"?verified=true"), nil
-}
-
-// crossOriginCookieResponse returns the cookie-mode delivery for a login that
-// lands on a different origin (magic-link, OAuth-provider): the session cookie
-// is set first-party on this auth host — which is also the OAuth authorization
-// server — and the browser is sent straight to origin+successURL. This removes
-// the localStorage bounce and, crucially in a decoupled setup, stops the landing
-// from depending on the frontend host carrying its own cookie-mode config. It
-// returns nil when the environment is not in cookie mode, so the caller keeps
-// its existing localStorage delivery. origin is scheme+host (no trailing slash);
-// SuccessURL is validated at config time to start with "/".
-func (m *skAuthMiddleware) crossOriginCookieResponse(origin, token string) *shttp.Response {
-	if !m.req.Host.Config.SKAuth.SessionInCookie() {
-		return nil
-	}
-
-	return m.deliverSession(token, origin+m.req.Host.Config.SKAuth.SuccessURL)
 }
 
 // finalizeSessionResponse adapts a successful JSON auth response (login,
@@ -241,7 +196,7 @@ func (m *skAuthMiddleware) crossOriginCookieResponse(origin, token string) *shtt
 // In cookie mode a decoupled frontend must send the auth XHR with credentials,
 // and the app's CORS config must allow them, for the browser to store the cookie.
 func (m *skAuthMiddleware) finalizeSessionResponse(res *shttp.Response, token string) *shttp.Response {
-	if res == nil || res.Status >= http.StatusBadRequest || !m.req.Host.Config.SKAuth.SessionInCookie() {
+	if res == nil || res.Status >= http.StatusBadRequest || !m.wantsCookieDelivery() {
 		return res
 	}
 
@@ -267,6 +222,39 @@ func (m *skAuthMiddleware) finalizeSessionResponse(res *shttp.Response, token st
 	return res
 }
 
+// sessionDeliveryHeader lets a native/mobile client opt into bearer delivery on
+// a cookie-mode environment: it has no cookie jar, so it asks for the token in
+// the response body and sends it back as an Authorization bearer. Browsers omit
+// the header and get the cookie.
+const (
+	sessionDeliveryHeader = "X-Session-Delivery"
+	sessionDeliveryBearer = "bearer"
+)
+
+// wantsCookieDelivery reports whether the session should be delivered as a
+// cookie (the browser default) rather than a bearer token in the response body.
+// Bearer delivery — token in the body, no cookie, and no cookie-CSRF Origin gate
+// — applies when either:
+//
+//   - the client opts in via the X-Session-Delivery header (native/mobile at
+//     login, where there is no session credential yet to infer from); or
+//   - the request authenticated with an Authorization bearer and carries no
+//     session cookie (a native client rotating its token at /refresh) — so it
+//     "just works" without the header. A browser always presents the cookie, so
+//     the cookie wins even if a stale Authorization header rides along.
+func (m *skAuthMiddleware) wantsCookieDelivery() bool {
+	if strings.EqualFold(m.req.Header.Get(sessionDeliveryHeader), sessionDeliveryBearer) {
+		return false
+	}
+
+	if cookie, err := m.req.Cookie(buildconf.SessionCookieName); (err != nil || cookie.Value == "") &&
+		user.ParseBearer(m.req.Header.Get("Authorization")) != "" {
+		return false
+	}
+
+	return true
+}
+
 // cookieOriginAllowed reports whether the request that is about to receive a
 // session cookie originates from a trusted browser context. Same-host requests
 // and configured AllowedOrigins pass; a missing or foreign Origin is rejected.
@@ -286,35 +274,6 @@ func (m *skAuthMiddleware) cookieOriginAllowed() bool {
 	return m.req.Host.Config.SKAuth.IsAllowedOrigin(origin)
 }
 
-// sessionCode is the payload stored in Redis under the one-time login code. The
-// auth host mints the session token and computes the post-login redirect, then
-// stashes both so the landing page can inject the token and redirect — without
-// the landing host needing its own auth config.
-type sessionCode struct {
-	Token    string `json:"token"`
-	Redirect string `json:"redirect"`
-}
-
-// magicLinkCodeStore holds the one-time login codes for the magic-link landing.
-// The empty prefix keeps the bare-code keyspace the landing URL embeds; OAuth
-// codes live under their own prefix so the two never collide.
-var magicLinkCodeStore = oneTimeCode{prefix: "", ttl: 2 * time.Minute}
-
-// stashSessionToken stores the session token and its post-login redirect under a
-// fresh one-time code and returns the landing URL on the destination origin. The
-// browser is sent there; codeLanding reads the payload back and injects the token
-// into localStorage on that origin. origin is scheme+host (no trailing slash);
-// successURL is validated at config time to start with '/'.
-func stashSessionToken(ctx context.Context, origin, successURL, token string) (string, error) {
-	code, err := magicLinkCodeStore.issue(ctx, sessionCode{Token: token, Redirect: origin + successURL})
-
-	if err != nil {
-		return "", err
-	}
-
-	return origin + "/_stormkit/auth?code=" + code, nil
-}
-
 // loginErrorRedirect bounces a failed sign-in back to the app's redirect page
 // (origin + SuccessURL) with a user-friendly message in the login_error query
 // param, instead of rendering a Stormkit error page. The underlying cause should
@@ -330,54 +289,6 @@ func (m *skAuthMiddleware) loginErrorRedirect(origin, message string) *shttp.Res
 		Status:   http.StatusFound,
 		Redirect: &target,
 	}
-}
-
-// codeLanding serves the one-time-code login landing. It is host-config
-// independent: the token and redirect were stashed in Redis by the auth host, so
-// it works even on a frontend deployment that has no auth config of its own.
-// Returns nil when the code is absent or unknown, so the request falls through to
-// normal serving (the SPA) instead of rendering an error.
-func (m *skAuthMiddleware) codeLanding() *shttp.Response {
-	code := m.req.Query().Get("code")
-
-	if code == "" {
-		return nil
-	}
-
-	var sc sessionCode
-
-	if err := magicLinkCodeStore.redeem(m.req.Context(), code, &sc); err != nil {
-		return nil
-	}
-
-	// This landing runs on the destination origin, so a cookie set here (with
-	// the configured Domain) is visible to the app and its authorization
-	// server — exactly the cross-subdomain boundary the bounce exists to cross.
-	return m.deliverSession(sc.Token, sc.Redirect)
-}
-
-// handleCallback renders the terminal states of the one-time-code landing on an
-// auth-enabled host. The success path (a valid code) is handled earlier by
-// codeLanding, so by the time we get here the code is missing or unknown.
-func (m *skAuthMiddleware) handleCallback() (*shttp.Response, error) {
-	status := http.StatusOK
-	content := "invalid session"
-
-	if m.req.Query().Get("code") == "" {
-		status = http.StatusBadRequest
-		content = "code is missing"
-	}
-
-	return &shttp.Response{
-		Status: status,
-		Headers: shttp.HeadersFromMap(map[string]string{
-			"Content-Type": "text/html",
-		}),
-		Data: html.MustRender(html.RenderArgs{
-			PageTitle:   "Stormkit - Auth",
-			PageContent: content,
-		}),
-	}, nil
 }
 
 func (m *skAuthMiddleware) renderVerifyPage(status int, head, content string) *shttp.Response {
@@ -396,46 +307,18 @@ func (m *skAuthMiddleware) renderVerifyPage(status int, head, content string) *s
 	}
 }
 
-// WithSKAuth carries the cross-cutting auth concerns that must run for every app
-// request: the config-independent one-time-code login landing and the
-// verified-bearer -> identity header injection. The discrete /_stormkit/auth/*
-// endpoints (register, login, verify, magic, refresh, me, callback, provider)
-// are served by dedicated routes — see registerReservedRoutes.
+// WithSKAuth injects the verified-bearer identity headers (X-User-Id /
+// X-User-Email) for every app request. The discrete /_stormkit/auth/* endpoints
+// (register, login, verify, magic, refresh, logout, me, callback, provider) are
+// served by dedicated routes — see registerReservedRoutes.
 func WithSKAuth(req *RequestContext) (*shttp.Response, error) {
-	path := req.URL().Path
-
-	// The one-time-code login landing works on any Stormkit host: the token and
-	// its redirect live in Redis (stashed by the auth host), so the destination
-	// frontend doesn't need its own auth config. This must run before the
-	// SKAuth-nil gate below. The exact-match compare keeps normal traffic free —
-	// the query is parsed only on /_stormkit/auth, and Redis is touched only when
-	// a code is actually present. codeLanding returns nil for an absent/unknown
-	// code so we fall through to normal serving (the SPA). Skip OPTIONS so a CORS
-	// preflight can't consume the one-time code (real landings are GET
-	// navigations and are never preflighted).
-	if path == "/_stormkit/auth" && req.Method != http.MethodOptions && req.Query().Get("code") != "" {
-		if resp := (&skAuthMiddleware{req: req}).codeLanding(); resp != nil {
-			return resp, nil
-		}
-	}
-
 	if req.Host.Config.SKAuth == nil {
 		return nil, nil
 	}
 
 	injectUserHeaders(req)
 
-	// Only the bare landing remains here; its terminal states (missing/unknown
-	// code) render the auth page. Everything under /_stormkit/auth/ is routed.
-	if path != "/_stormkit/auth" {
-		return nil, nil
-	}
-
-	if req.Method == http.MethodOptions {
-		return &shttp.Response{Status: http.StatusNoContent}, nil
-	}
-
-	return (&skAuthMiddleware{req: req}).handleCallback()
+	return nil, nil
 }
 
 // injectUserHeaders strips any client-supplied identity headers and, when a

--- a/src/ce/hosting/middleware.skauth_cookie_test.go
+++ b/src/ce/hosting/middleware.skauth_cookie_test.go
@@ -1,18 +1,15 @@
 package hosting_test
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
-	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stretchr/testify/suite"
 )
@@ -29,22 +26,16 @@ func TestSkAuthCookieSuite(t *testing.T) {
 	suite.Run(t, new(SkAuthCookieSuite))
 }
 
-func (s *SkAuthCookieSuite) host(cookieMode bool) *hosting.Host {
-	conf := &buildconf.SKAuthConf{
-		Secret:     cookieSecret,
-		SuccessURL: "/",
-		Status:     true,
-		TTL:        10,
-	}
-
-	if cookieMode {
-		conf.SessionStorage = buildconf.SessionStorageCookie
-		conf.CookieDomain = ".example.com"
-	}
-
+func (s *SkAuthCookieSuite) host() *hosting.Host {
 	return &hosting.Host{
-		Name:   "www.example.com",
-		Config: &appconf.Config{SKAuth: conf},
+		Name: "www.example.com",
+		Config: &appconf.Config{SKAuth: &buildconf.SKAuthConf{
+			Secret:       cookieSecret,
+			SuccessURL:   "/",
+			Status:       true,
+			TTL:          10,
+			CookieDomain: ".example.com",
+		}},
 	}
 }
 
@@ -81,7 +72,7 @@ func (s *SkAuthCookieSuite) Test_Edge_InjectsUserFromCookie() {
 	h := make(http.Header)
 	h.Set("Cookie", buildconf.SessionCookieName+"="+s.token("user-42"))
 
-	req := s.request(s.host(true), h)
+	req := s.request(s.host(), h)
 	res, err := hosting.WithSKAuth(req)
 
 	s.NoError(err)
@@ -95,7 +86,7 @@ func (s *SkAuthCookieSuite) Test_Edge_InjectsUserFromAuthorization() {
 	h := make(http.Header)
 	h.Set("Authorization", "Bearer "+s.token("user-7"))
 
-	req := s.request(s.host(false), h)
+	req := s.request(s.host(), h)
 	_, err := hosting.WithSKAuth(req)
 
 	s.NoError(err)
@@ -108,68 +99,62 @@ func (s *SkAuthCookieSuite) Test_Edge_NoCredential_NoIdentity() {
 	h := make(http.Header)
 	h.Set("X-User-Id", "spoofed")
 
-	req := s.request(s.host(true), h)
+	req := s.request(s.host(), h)
 	_, err := hosting.WithSKAuth(req)
 
 	s.NoError(err)
 	s.Empty(req.Header.Get("X-User-Id"))
 }
 
-// Test_Login_CookieMode_SetsCookie verifies the one-time-code landing issues a
-// shared, hardened session cookie and 302s — instead of a localStorage script —
-// when the environment is in cookie mode.
-func (s *SkAuthCookieSuite) Test_Login_CookieMode_SetsCookie() {
-	ctx := context.Background()
-	code := "cookie-mode-code-1"
-	token := s.token("user-99")
+// refreshRequest builds a POST /_stormkit/auth/refresh with the given headers.
+func (s *SkAuthCookieSuite) refreshRequest(host *hosting.Host, header http.Header) *hosting.RequestContext {
+	req := s.request(host, header)
+	req.RequestContext.Method = http.MethodPost
+	req.RequestContext.Request.URL = &url.URL{Host: host.Name, Path: "/_stormkit/auth/refresh", RawPath: "/_stormkit/auth/refresh"}
+	req.OriginalPath = "/_stormkit/auth/refresh"
 
-	rds := rediscache.Client()
-	rds.Set(ctx, code, `{"token":"`+token+`","redirect":"https://app.example.com/dashboard"}`, time.Minute*2)
-	defer rds.Del(ctx, code)
-
-	req := s.request(s.host(true), nil)
-	req.RequestContext.Method = http.MethodGet
-	req.RequestContext.Request.URL = &url.URL{Host: "www.example.com", Path: "/_stormkit/auth", RawQuery: "code=" + code}
-	req.OriginalPath = "/_stormkit/auth"
-
-	res, err := hosting.WithSKAuth(req)
-
-	s.NoError(err)
-	s.Require().NotNil(res)
-	s.Equal(http.StatusFound, res.Status)
-	s.Require().NotNil(res.Redirect)
-	s.Equal("https://app.example.com/dashboard", *res.Redirect)
-
-	s.Require().Len(res.Cookies, 1)
-	c := res.Cookies[0]
-	s.Equal(buildconf.SessionCookieName, c.Name)
-	s.Equal(token, c.Value)
-	s.Equal(".example.com", c.Domain)
-	s.True(c.Secure)
-	s.True(c.HttpOnly)
-	s.Equal(http.SameSiteLaxMode, c.SameSite)
+	return req
 }
 
-// Test_Login_LocalStorageMode_UsesScript keeps the default behavior: no cookie,
-// a localStorage-injecting landing page.
-func (s *SkAuthCookieSuite) Test_Login_LocalStorageMode_UsesScript() {
-	ctx := context.Background()
-	code := "ls-mode-code-1"
-	token := "ls.session.jwt"
+// Test_Refresh_CookieMode_BearerDelivery verifies a native/mobile client can
+// rotate its session on a cookie-mode env: authenticating with an Authorization
+// bearer and opting into bearer delivery yields a new token in the body and no
+// cookie.
+func (s *SkAuthCookieSuite) Test_Refresh_CookieMode_BearerDelivery() {
+	h := make(http.Header)
+	h.Set("Authorization", "Bearer "+s.token("user-mobile"))
+	h.Set("X-Session-Delivery", "bearer")
 
-	rds := rediscache.Client()
-	rds.Set(ctx, code, `{"token":"`+token+`","redirect":"https://app.example.com/dashboard"}`, time.Minute*2)
-	defer rds.Del(ctx, code)
-
-	req := s.request(s.host(false), nil)
-	req.RequestContext.Request.URL = &url.URL{Host: "www.example.com", Path: "/_stormkit/auth", RawQuery: "code=" + code}
-	req.OriginalPath = "/_stormkit/auth"
-
-	res, err := hosting.WithSKAuth(req)
+	res, err := hosting.ServeAuth(s.refreshRequest(s.host(), h))
 
 	s.NoError(err)
 	s.Require().NotNil(res)
 	s.Equal(http.StatusOK, res.Status)
-	s.Empty(res.Cookies)
-	s.Contains(string(res.Data.([]byte)), "localStorage.setItem('skauth'")
+
+	data, ok := res.Data.(map[string]any)
+	s.Require().True(ok)
+	s.NotEmpty(data["token"], "bearer delivery must return a rotated token")
+	s.Empty(res.Cookies, "bearer delivery must not set a cookie")
+}
+
+// Test_Refresh_CookieMode_CookieDelivery verifies the browser path: a
+// cookie-authenticated refresh rotates the cookie and returns no token.
+func (s *SkAuthCookieSuite) Test_Refresh_CookieMode_CookieDelivery() {
+	h := make(http.Header)
+	h.Set("Cookie", buildconf.SessionCookieName+"="+s.token("user-browser"))
+	h.Set("Origin", "https://www.example.com")
+
+	res, err := hosting.ServeAuth(s.refreshRequest(s.host(), h))
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+
+	data, ok := res.Data.(map[string]any)
+	s.Require().True(ok)
+	_, hasToken := data["token"]
+	s.False(hasToken, "cookie delivery must not return the token in the body")
+
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -242,8 +242,9 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_Success() {
 	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 
 	s.NoError(err)
-	s.Equal(http.StatusOK, res.Status)
-	s.Contains(string(res.Data.([]byte)), "localStorage.setItem('skauth'")
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
 // Test_Verify_UIDClaimIsUUID confirms the session JWT carries the user's
@@ -261,21 +262,10 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_UIDClaimIsUUID() {
 
 	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 	s.Require().NoError(err)
-	s.Require().Equal(http.StatusOK, res.Status)
+	s.Require().Equal(http.StatusFound, res.Status)
+	s.Require().Len(res.Cookies, 1)
 
-	body := string(res.Data.([]byte))
-	const marker = `JSON.stringify("`
-	idx := strings.Index(body, marker)
-	s.Require().GreaterOrEqual(idx, 0, "session token missing from response body")
-
-	start := idx + len(marker)
-	end := start
-
-	for end < len(body) && body[end] != '"' {
-		end++
-	}
-
-	sessionToken := body[start:end]
+	sessionToken := res.Cookies[0].Value
 	claims := user.ParseJWT(&user.ParseJWTArgs{
 		Bearer:  sessionToken,
 		Secret:  env.AuthConf.Secret,
@@ -304,7 +294,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_TokenConsumedOnce() {
 
 	first, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.NoError(err)
-	s.Equal(http.StatusOK, first.Status)
+	s.Equal(http.StatusFound, first.Status)
 
 	// Reusing a consumed token bounces back to the app with a login_error.
 	second, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
@@ -332,7 +322,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_Error_CrossOrigin_RedirectsToInit
 
 	first, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
 	s.Require().NoError(err)
-	s.Require().Equal(http.StatusOK, first.Status)
+	s.Require().Equal(http.StatusFound, first.Status)
 
 	// Replaying the consumed token: the error redirect must target the initiating
 	// origin, not the verify host.
@@ -390,15 +380,13 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_CrossOrigin_RedirectsToInitiator(
 	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 
 	s.NoError(err)
-	s.Equal(http.StatusOK, res.Status)
-
-	body := string(res.Data.([]byte))
-	// Cross-origin path bounces to the initiator's one-time-code landing, which
-	// injects the token into localStorage there — no fragment, and this response
-	// must not touch localStorage on the wrong host.
-	s.Contains(body, "https://app.example.com/_stormkit/auth?code=")
-	s.NotContains(body, "#skauth=")
-	s.NotContains(body, "localStorage")
+	// Cross-origin: the session cookie is set first-party on this auth host and
+	// the browser is 302'd straight to the initiating origin's success URL.
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Equal("https://app.example.com/dashboard", *res.Redirect)
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
 func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() {
@@ -423,11 +411,13 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() 
 	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
 
 	s.NoError(err)
-	s.Equal(http.StatusOK, res.Status)
-
-	body := string(res.Data.([]byte))
-	s.Contains(body, "localStorage.setItem('skauth'")
-	s.NotContains(body, "https://app.example.com/dashboard#skauth=")
+	// Stale redirect is dropped, so the session is delivered same-origin: cookie
+	// set here and 302 to the local success URL, never the untrusted origin.
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Equal("/dashboard?verified=true", *res.Redirect)
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
 func truncateMagicLinkAuthTables() {

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -68,10 +68,8 @@ func (s *WithSKAuthOAuthSuite) setupCallbackEnvWith(providerStatus bool, auth *b
 	}))
 
 	// In production the request host config is loaded from the same env, so
-	// mirror the session-storage settings onto it (hostFor otherwise stubs a
-	// bare localStorage config).
+	// mirror the cookie domain onto it (hostFor otherwise stubs a bare config).
 	host := s.hostFor(env.ID)
-	host.Config.SKAuth.SessionStorage = auth.SessionStorage
 	host.Config.SKAuth.CookieDomain = auth.CookieDomain
 
 	return host
@@ -106,19 +104,20 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
 	s.Require().NotNil(res)
 	s.Equal(http.StatusFound, res.Status)
 	s.Require().NotNil(res.Redirect)
-	s.Contains(*res.Redirect, "https://app.example.com/_stormkit/auth?code=")
+	s.Equal("https://app.example.com/dashboard", *res.Redirect)
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
-// Test_Callback_CookieMode_SetsCookieAndSkipsLanding verifies that in cookie mode
-// the OAuth-provider callback sets a first-party session cookie on this auth host
-// and redirects straight to the initiating origin — no localStorage bounce, and
-// no dependency on that origin carrying its own auth config (the decoupled case).
-func (s *WithSKAuthOAuthSuite) Test_Callback_CookieMode_SetsCookieAndSkipsLanding() {
+// Test_Callback_SetsCookieWithDomain verifies the OAuth-provider callback sets a
+// first-party session cookie on this auth host (also the OAuth AS), scoped to the
+// configured cookie domain, and redirects straight to the initiating origin — no
+// dependency on that origin carrying its own auth config (the decoupled case).
+func (s *WithSKAuthOAuthSuite) Test_Callback_SetsCookieWithDomain() {
 	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
-		Secret:         "test-secret-padded-to-32-chars!!",
-		Status:         true,
-		SessionStorage: buildconf.SessionStorageCookie,
-		CookieDomain:   ".example.com",
+		Secret:       "test-secret-padded-to-32-chars!!",
+		Status:       true,
+		CookieDomain: ".example.com",
 	})
 
 	token := &oauth2.Token{}

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -2,7 +2,6 @@ package hosting_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,7 +16,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
-	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -135,98 +133,6 @@ func (s *WithSKAuthSuite) Test_NonAuthPath() {
 
 	s.NoError(err)
 	s.Nil(res)
-}
-
-// Test_MissingCode checks that the middleware returns 400 when the code query
-// parameter is absent.
-// Note: the "code is missing" message is overwritten by the Redis lookup path
-// ("invalid session") because both branches share the same content variable and
-// an empty-key Redis lookup always returns an empty string.
-func (s *WithSKAuthSuite) Test_MissingCode() {
-	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth")
-	res, err := hosting.WithSKAuth(req)
-
-	s.NoError(err)
-	s.NotNil(res)
-	s.Equal(http.StatusBadRequest, res.Status)
-	s.Equal("text/html", res.Headers.Get("Content-Type"))
-	s.Contains(string(res.Data.([]byte)), "code is missing")
-}
-
-// Test_InvalidCode checks that the middleware returns 200 with an "invalid session"
-// message when the submitted code is not found in Redis.
-func (s *WithSKAuthSuite) Test_InvalidCode() {
-	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth?code=unknown-code")
-	res, err := hosting.WithSKAuth(req)
-
-	s.NoError(err)
-	s.NotNil(res)
-	s.Equal(http.StatusOK, res.Status)
-	s.Equal("text/html", res.Headers.Get("Content-Type"))
-	s.Contains(string(res.Data.([]byte)), "invalid session")
-}
-
-// Test_ValidCode checks that the middleware returns 200 and injects a script that
-// stores the session token in localStorage and redirects to the stashed target
-// when a valid code is presented.
-func (s *WithSKAuthSuite) Test_ValidCode() {
-	ctx := context.Background()
-	code := "test-valid-code-123"
-	sessionToken := "test.session.jwt"
-
-	rds := rediscache.Client()
-	rds.Set(ctx, code, `{"token":"`+sessionToken+`","redirect":"https://app.example.com/dashboard"}`, time.Minute*2)
-	defer rds.Del(ctx, code)
-
-	req := s.newRequest(s.hostWithSKAuth(), "/_stormkit/auth?code="+code)
-	res, err := hosting.WithSKAuth(req)
-
-	s.NoError(err)
-	s.NotNil(res)
-	s.Equal(http.StatusOK, res.Status)
-	s.Equal("text/html", res.Headers.Get("Content-Type"))
-
-	body := string(res.Data.([]byte))
-	s.Contains(body, `localStorage.setItem('skauth'`)
-	s.Contains(body, sessionToken)
-	s.Contains(body, "https://app.example.com/dashboard")
-}
-
-// Test_CodeLanding_FrontendWithoutSKAuth verifies the one-time-code landing works
-// on a Stormkit host with NO auth config of its own — the cross-origin case where
-// the frontend is a separate deployment. The token + redirect were stashed in
-// Redis by the auth host, so injection must still happen here, and the code is
-// consumed one-time.
-func (s *WithSKAuthSuite) Test_CodeLanding_FrontendWithoutSKAuth() {
-	ctx := context.Background()
-	code := "frontend-code-456"
-	sessionToken := "front.session.jwt"
-
-	rds := rediscache.Client()
-	rds.Set(ctx, code, `{"token":"`+sessionToken+`","redirect":"https://www.triplan.to/"}`, time.Minute*2)
-	defer rds.Del(ctx, code)
-
-	host := &hosting.Host{
-		Name:   "www.triplan.to",
-		Config: &appconf.Config{}, // no SKAuth configured on the frontend host
-	}
-
-	res, err := hosting.WithSKAuth(s.newRequest(host, "/_stormkit/auth?code="+code))
-
-	s.NoError(err)
-	s.Require().NotNil(res)
-	s.Equal(http.StatusOK, res.Status)
-
-	body := string(res.Data.([]byte))
-	s.Contains(body, `localStorage.setItem('skauth'`)
-	s.Contains(body, sessionToken)
-	s.Contains(body, "https://www.triplan.to/")
-
-	// One-time use: the code is consumed, so a replay falls through to normal
-	// serving (nil response).
-	res2, err := hosting.WithSKAuth(s.newRequest(host, "/_stormkit/auth?code="+code))
-	s.NoError(err)
-	s.Nil(res2)
 }
 
 // Test_RegisterPath_SKAuthDisabled checks that /_stormkit/auth/register is a no-op when SKAuth is not configured.

--- a/src/ce/hosting/oauth_mcp_test.go
+++ b/src/ce/hosting/oauth_mcp_test.go
@@ -22,11 +22,10 @@ func (s *OAuthSuite) hostWith(conf buildconf.OAuthServerConf) *hosting.Host {
 		Name: "app.example.com",
 		Config: &appconf.Config{
 			SKAuth: &buildconf.SKAuthConf{
-				Secret:         oauthSecret,
-				Status:         true,
-				TTL:            10,
-				SessionStorage: buildconf.SessionStorageCookie,
-				OAuthServer:    &conf,
+				Secret:      oauthSecret,
+				Status:      true,
+				TTL:         10,
+				OAuthServer: &conf,
 			},
 		},
 	}

--- a/src/ce/hosting/oauth_test.go
+++ b/src/ce/hosting/oauth_test.go
@@ -51,13 +51,6 @@ func (s *OAuthSuite) host(enabled bool) *hosting.Host {
 		OAuthServer:    &buildconf.OAuthServerConf{Enabled: enabled},
 	}
 
-	// The OAuth server requires cookie session storage (enforced at config save),
-	// so an OAuth-enabled host is always in cookie mode — that is how /authorize
-	// and grant() read the session off the top-level navigation.
-	if enabled {
-		conf.SessionStorage = buildconf.SessionStorageCookie
-	}
-
 	return &hosting.Host{
 		Name:   "app.example.com",
 		Config: &appconf.Config{SKAuth: conf},

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -116,14 +116,14 @@ var (
 	})
 
 	// handleAuthProvider serves /_stormkit/auth/{provider}. A known provider
-	// starts the OAuth flow; anything else falls to the one-time-code landing's
-	// terminal state, matching the old middleware fall-through.
+	// starts the OAuth flow; anything else is not a reserved endpoint, so it
+	// falls through to normal app serving.
 	handleAuthProvider = serveReservedAuth(func(m *skAuthMiddleware) (*shttp.Response, error) {
 		if provider, ok := isOAuthProviderPath(m.req.URL().Path); ok {
 			return m.handleOAuthInitiate(provider)
 		}
 
-		return m.handleCallback()
+		return HandlerForward(m.req), nil
 	})
 )
 

--- a/src/ce/hosting/skauth_email_test.go
+++ b/src/ce/hosting/skauth_email_test.go
@@ -60,7 +60,6 @@ func (s *WithSKAuthEmailSuite) hostFor(envID types.ID) *hosting.Host {
 
 func (s *WithSKAuthEmailSuite) hostForCookie(envID types.ID) *hosting.Host {
 	host := s.hostFor(envID)
-	host.Config.SKAuth.SessionStorage = buildconf.SessionStorageCookie
 	host.Config.SKAuth.CookieDomain = ".example.com"
 
 	return host
@@ -184,20 +183,30 @@ func (s *WithSKAuthEmailSuite) setupEnv(withMailer bool) (*factory.MockEnv, erro
 	return env, err
 }
 
+// register and login default to bearer delivery (X-Session-Delivery: bearer), so
+// the response carries the token in the body and skips the cookie-CSRF Origin
+// gate — the simplest shape for tests that just need a session or a user. The
+// browser cookie path is exercised by registerOrigin / loginOrigin.
 func (s *WithSKAuthEmailSuite) register(host *hosting.Host, email, password string) *shttp.Response {
-	res, err := hosting.ServeAuth(s.postRequest(host, "/_stormkit/auth/register", map[string]any{
+	req := s.postRequest(host, "/_stormkit/auth/register", map[string]any{
 		"email":    email,
 		"password": password,
-	}))
+	})
+	req.Header.Set("X-Session-Delivery", "bearer")
+
+	res, err := hosting.ServeAuth(req)
 	s.Require().NoError(err)
 	return res
 }
 
 func (s *WithSKAuthEmailSuite) login(host *hosting.Host, email, password string) *shttp.Response {
-	res, err := hosting.ServeAuth(s.postRequest(host, "/_stormkit/auth/login", map[string]any{
+	req := s.postRequest(host, "/_stormkit/auth/login", map[string]any{
 		"email":    email,
 		"password": password,
-	}))
+	})
+	req.Header.Set("X-Session-Delivery", "bearer")
+
+	res, err := hosting.ServeAuth(req)
 	s.Require().NoError(err)
 	return res
 }
@@ -206,6 +215,21 @@ func (s *WithSKAuthEmailSuite) login(host *hosting.Host, email, password string)
 // auth host — the value the cookie-mode CSRF guard accepts.
 func (s *WithSKAuthEmailSuite) sameHostOrigin(host *hosting.Host) string {
 	return "https://" + host.Name
+}
+
+// loginBearer logs in as a native/mobile client: it opts into bearer delivery
+// via the X-Session-Delivery header and sends no Origin (native clients aren't
+// subject to CORS), so it must receive the token in the body and no cookie.
+func (s *WithSKAuthEmailSuite) loginBearer(host *hosting.Host, email, password string) *shttp.Response {
+	req := s.postRequest(host, "/_stormkit/auth/login", map[string]any{
+		"email":    email,
+		"password": password,
+	})
+	req.Header.Set("X-Session-Delivery", "bearer")
+
+	res, err := hosting.ServeAuth(req)
+	s.Require().NoError(err)
+	return res
 }
 
 func (s *WithSKAuthEmailSuite) loginOrigin(host *hosting.Host, origin, email, password string) *shttp.Response {
@@ -257,11 +281,14 @@ func (s *WithSKAuthEmailSuite) Test_Register_BodyEnvIdIgnored() {
 	s.Require().NoError(err)
 
 	// Post with a different envId in the body — should still succeed using the host's env.
-	res, err := hosting.ServeAuth(s.postRequest(s.hostFor(env.ID), "/_stormkit/auth/register", map[string]any{
+	req := s.postRequest(s.hostFor(env.ID), "/_stormkit/auth/register", map[string]any{
 		"envId":    "9999999",
 		"email":    "crossenv@example.com",
 		"password": "supersecret123",
-	}))
+	})
+	req.Header.Set("X-Session-Delivery", "bearer")
+
+	res, err := hosting.ServeAuth(req)
 	s.Require().NoError(err)
 	s.Equal(http.StatusCreated, res.Status)
 }
@@ -410,6 +437,27 @@ func (s *WithSKAuthEmailSuite) Test_Login_CookieMode_SetsCookieNoToken() {
 	s.Equal(http.SameSiteLaxMode, res.Cookies[0].SameSite)
 }
 
+// Test_Login_CookieMode_BearerDelivery verifies that a native/mobile client on a
+// cookie-mode env can opt into bearer delivery: with X-Session-Delivery: bearer
+// (and no Origin, as native clients send) it gets the token in the body and no
+// cookie, and is not blocked by the cookie-CSRF Origin guard.
+func (s *WithSKAuthEmailSuite) Test_Login_CookieMode_BearerDelivery() {
+	env, err := s.setupEnv(false)
+	s.Require().NoError(err)
+
+	host := s.hostForCookie(env.ID)
+
+	s.Require().Equal(http.StatusCreated, s.registerOrigin(host, s.sameHostOrigin(host), "mobile@example.com", "supersecret123").Status)
+
+	res := s.loginBearer(host, "mobile@example.com", "supersecret123")
+
+	s.Equal(http.StatusOK, res.Status)
+
+	data := s.jsonData(res)
+	s.NotEmpty(data["token"], "bearer delivery must return the token in the body")
+	s.Empty(res.Cookies, "bearer delivery must not set a cookie")
+}
+
 // Test_Register_CookieMode_SetsCookieNoToken verifies the same single-credential
 // behavior on the auto-login register path (no mailer / verification).
 func (s *WithSKAuthEmailSuite) Test_Register_CookieMode_SetsCookieNoToken() {
@@ -460,7 +508,12 @@ func (s *WithSKAuthEmailSuite) Test_Login_CookieMode_MissingOrigin_Rejected() {
 
 	s.Require().Equal(http.StatusCreated, s.registerOrigin(host, s.sameHostOrigin(host), "victim2@example.com", "supersecret123").Status)
 
-	res := s.login(host, "victim2@example.com", "supersecret123")
+	// A browser cookie login with no Origin and no bearer opt-in: must be refused.
+	res, err := hosting.ServeAuth(s.postRequest(host, "/_stormkit/auth/login", map[string]any{
+		"email":    "victim2@example.com",
+		"password": "supersecret123",
+	}))
+	s.Require().NoError(err)
 
 	s.Equal(http.StatusForbidden, res.Status)
 	s.Empty(res.Cookies, "no session cookie may be set when Origin is absent")
@@ -590,10 +643,10 @@ func (s *WithSKAuthEmailSuite) Test_Verify_Success() {
 
 	res := hosting.HandleAuthVerify(s.getRequest(host, fmt.Sprintf("/_stormkit/auth/verify?token=%s&envId=%d", capturedToken, env.ID)))
 
-	s.Equal(http.StatusOK, res.Status)
-
-	body := string(res.Data.([]byte))
-	s.Contains(body, "localStorage.setItem('skauth'")
+	// Verification sets the session cookie and 302s to the success URL.
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().Len(res.Cookies, 1)
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
 func (s *WithSKAuthEmailSuite) Test_Verify_InvalidToken() {

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -237,27 +237,10 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
 
-	// Cookie mode: set a first-party cookie on this auth host (also the OAuth AS)
-	// and send the user straight to the initiating origin — no localStorage
-	// bounce, and no dependency on that origin carrying its own auth config.
-	if res := m.crossOriginCookieResponse(referOrigin, sessionToken); res != nil {
-		return res, nil
-	}
-
-	// localStorage mode: stash the token under a one-time code and send the
-	// browser to the landing page on the initiating origin, which injects it into
-	// localStorage there (codeLanding). Keeps the token out of the URL.
-	target, err := stashSessionToken(req.Context(), referOrigin, successURL, sessionToken)
-
-	if err != nil {
-		slog.Errorf("oauth callback: failed to save session code: %s", err.Error())
-		return m.loginErrorRedirect(referOrigin, "We couldn't complete sign-in. Please try again."), nil
-	}
-
-	return &shttp.Response{
-		Status:   http.StatusFound,
-		Redirect: &target,
-	}, nil
+	// Set a first-party cookie on this auth host (also the OAuth AS) and send the
+	// user straight to the initiating origin — no dependency on that origin
+	// carrying its own auth config.
+	return m.deliverSession(sessionToken, referOrigin+successURL), nil
 }
 
 // resolveRedirect determines and validates the post-login redirect origin.

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.spec.tsx
@@ -333,7 +333,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
       await waitFor(() => {
         expect(
           wrapper.getByText(
-            "Relative URL to redirect to after successful authentication. At this URL, browser code can read the skauth item from localStorage.",
+            "Relative URL to redirect to after successful authentication. The session is set as a cookie; your app can confirm it by calling /_stormkit/auth/me with credentials.",
           ),
         ).toBeTruthy();
       });
@@ -350,7 +350,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: false,
           oauthResourcePath: "",
           oauthAllowLoopback: false,
-          sessionStorage: "localStorage",
           cookieDomain: "",
           loginUrl: "",
         })
@@ -380,7 +379,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: false,
           oauthResourcePath: "",
           oauthAllowLoopback: false,
-          sessionStorage: "localStorage",
           cookieDomain: "",
           loginUrl: "",
         })
@@ -416,15 +414,10 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: true,
           oauthResourcePath: "",
           oauthAllowLoopback: false,
-          sessionStorage: "cookie",
           cookieDomain: "",
           loginUrl: "",
         })
         .reply(200);
-
-      fireEvent.click(
-        await wrapper.findByLabelText("Store session in a cookie"),
-      );
 
       fireEvent.click(
         await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),
@@ -450,15 +443,10 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx", () => {
           oauthServerEnabled: true,
           oauthResourcePath: "/mcp",
           oauthAllowLoopback: true,
-          sessionStorage: "cookie",
           cookieDomain: "",
           loginUrl: "",
         })
         .reply(200);
-
-      fireEvent.click(
-        await wrapper.findByLabelText("Store session in a cookie"),
-      );
 
       fireEvent.click(
         await wrapper.findByLabelText("Enable OAuth server (MCP connectors)"),

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -179,27 +179,15 @@ export default function SkAuth() {
     refreshToken,
   });
 
-  // The OAuth and session-storage toggles are controlled Switches (not part of
-  // FormData), so they need their own state, synced from the config once it
-  // loads.
+  // The OAuth toggles are controlled Switches (not part of FormData), so they
+  // need their own state, synced from the config once it loads.
   const [oauthServerEnabled, setOauthServerEnabled] = useState(false);
   const [oauthAllowLoopback, setOauthAllowLoopback] = useState(false);
-  const [sessionCookieMode, setSessionCookieMode] = useState(false);
 
   useEffect(() => {
     setOauthServerEnabled(Boolean(config?.oauthServerEnabled));
     setOauthAllowLoopback(Boolean(config?.oauthAllowLoopback));
-    setSessionCookieMode(config?.sessionStorage === "cookie");
-  }, [
-    config?.oauthServerEnabled,
-    config?.oauthAllowLoopback,
-    config?.sessionStorage,
-  ]);
-
-  // The OAuth server can only read the session on the top-level /authorize
-  // navigation from a cookie; a localStorage session dead-ends at consent. The
-  // backend refuses this combination, so mirror the guard in the UI.
-  const oauthNeedsCookie = oauthServerEnabled && !sessionCookieMode;
+  }, [config?.oauthServerEnabled, config?.oauthAllowLoopback]);
 
   const hasSchema = !result.loading && !result.error && Boolean(result.schema);
   const title = "Authentication";
@@ -260,14 +248,6 @@ export default function SkAuth() {
             return;
           }
 
-          if (oauthNeedsCookie) {
-            setSaveError(
-              "The OAuth server requires cookie session storage. Enable it below before saving.",
-            );
-            setSaving(false);
-            return;
-          }
-
           saveConfig({
             envId: env.id!,
             successUrl: (data.get("successUrl") as string) || "",
@@ -279,7 +259,6 @@ export default function SkAuth() {
               (data.get("oauthResourcePath") as string) || ""
             ).trim(),
             oauthAllowLoopback,
-            sessionStorage: sessionCookieMode ? "cookie" : "localStorage",
             cookieDomain: ((data.get("cookieDomain") as string) || "").trim(),
             loginUrl: ((data.get("loginUrl") as string) || "").trim(),
           })
@@ -305,7 +284,7 @@ export default function SkAuth() {
             defaultValue={config?.successUrl || ""}
             variant="filled"
             autoComplete="off"
-            helperText="Relative URL to redirect to after successful authentication. At this URL, browser code can read the skauth item from localStorage."
+            helperText="Relative URL to redirect to after successful authentication. The session is set as a cookie; your app can confirm it by calling /_stormkit/auth/me with credentials."
             slotProps={{
               inputLabel: {
                 shrink: true,
@@ -372,43 +351,31 @@ export default function SkAuth() {
         </Box>
 
         <Box sx={{ mb: 4 }}>
-          <Switch
-            name="sessionCookieMode"
-            checked={sessionCookieMode}
-            setChecked={setSessionCookieMode}
-            label="Store session in a cookie"
-            description="Where the browser keeps the session after login. Off stores a bearer token in localStorage (attached to XHR). On issues a Secure, HttpOnly, SameSite=Lax cookie that rides both XHR and top-level navigations. Cookie mode is required by the OAuth server, and is a strict superset of localStorage — pick it if your app spans subdomains or connects MCP clients."
+          <TextField
+            label="Cookie domain"
+            name="cookieDomain"
+            placeholder=".example.com"
+            fullWidth
+            defaultValue={config?.cookieDomain || ""}
+            variant="filled"
+            autoComplete="off"
+            helperText="Optional. The session is a Secure, HttpOnly, SameSite=Lax cookie. Scope it to a parent domain so it is shared across subdomains (e.g. .example.com covers www. and api.). Leave empty for a single-host setup."
+            slotProps={{ inputLabel: { shrink: true } }}
           />
-          {sessionCookieMode && (
-            <>
-              <Box sx={{ mt: 3 }}>
-                <TextField
-                  label="Cookie domain"
-                  name="cookieDomain"
-                  placeholder=".example.com"
-                  fullWidth
-                  defaultValue={config?.cookieDomain || ""}
-                  variant="filled"
-                  autoComplete="off"
-                  helperText="Optional. Scope the session cookie to a parent domain so it is shared across subdomains (e.g. .example.com covers www. and api.). Leave empty for a single-host setup."
-                  slotProps={{ inputLabel: { shrink: true } }}
-                />
-              </Box>
-              <Box sx={{ mt: 3 }}>
-                <TextField
-                  label="Login URL"
-                  name="loginUrl"
-                  placeholder="/login"
-                  fullWidth
-                  defaultValue={config?.loginUrl || ""}
-                  variant="filled"
-                  autoComplete="off"
-                  helperText="The app's own login page. When an MCP client starts an OAuth flow and the user has no session, /authorize redirects here with a return_to query parameter; your login page must send the user back to that URL after signing in. A relative path or an absolute URL."
-                  slotProps={{ inputLabel: { shrink: true } }}
-                />
-              </Box>
-            </>
-          )}
+        </Box>
+
+        <Box sx={{ mb: 4 }}>
+          <TextField
+            label="Login URL"
+            name="loginUrl"
+            placeholder="/login"
+            fullWidth
+            defaultValue={config?.loginUrl || ""}
+            variant="filled"
+            autoComplete="off"
+            helperText="The app's own login page, used by the OAuth server. When an MCP client starts a connect flow and the user has no session, /authorize redirects here with a return_to query parameter; your login page must send the user back to that URL after signing in. A relative path or an absolute URL."
+            slotProps={{ inputLabel: { shrink: true } }}
+          />
         </Box>
 
         <Box sx={{ mb: 4 }}>
@@ -419,13 +386,6 @@ export default function SkAuth() {
             label="Enable OAuth server (MCP connectors)"
             description="Turns this environment into an OAuth 2.1 authorization server so AI clients like ChatGPT and Claude can connect to it as an MCP server, signing in your app's own users. The Claude and ChatGPT connector origins are trusted automatically — no manual origin setup needed."
           />
-          {oauthNeedsCookie && (
-            <Alert severity="warning" sx={{ mt: 2 }}>
-              The OAuth server needs the session in a cookie to identify the
-              user on the consent screen. Enable "Store session in a cookie"
-              above, otherwise the connect flow dead-ends at consent.
-            </Alert>
-          )}
           {oauthServerEnabled && (
             <>
               <Box sx={{ mt: 3 }}>
@@ -482,7 +442,7 @@ export default function SkAuth() {
             type="submit"
             variant="contained"
             color="secondary"
-            disabled={result.loading || loading || saving || oauthNeedsCookie}
+            disabled={result.loading || loading || saving}
           >
             Save
           </Button>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/actions.tsx
@@ -226,7 +226,6 @@ interface FetchProvidersResult {
   oauthServerEnabled?: boolean;
   oauthResourcePath?: string;
   oauthAllowLoopback?: boolean;
-  sessionStorage?: string;
   cookieDomain?: string;
   loginUrl?: string;
   redirectUrl: string;
@@ -243,7 +242,6 @@ interface AuthConfig {
   oauthServerEnabled?: boolean;
   oauthResourcePath?: string;
   oauthAllowLoopback?: boolean;
-  sessionStorage?: string;
   cookieDomain?: string;
   loginUrl?: string;
 }
@@ -257,7 +255,6 @@ interface SaveConfigParams {
   oauthServerEnabled: boolean;
   oauthResourcePath: string;
   oauthAllowLoopback: boolean;
-  sessionStorage: string;
   cookieDomain: string;
   loginUrl: string;
 }
@@ -271,7 +268,6 @@ export const saveConfig = ({
   oauthServerEnabled,
   oauthResourcePath,
   oauthAllowLoopback,
-  sessionStorage,
   cookieDomain,
   loginUrl,
 }: SaveConfigParams): Promise<void> =>
@@ -284,7 +280,6 @@ export const saveConfig = ({
     oauthServerEnabled,
     oauthResourcePath,
     oauthAllowLoopback,
-    sessionStorage,
     cookieDomain,
     loginUrl,
   });
@@ -315,7 +310,6 @@ export const useFetchProviders = ({
           oauthServerEnabled,
           oauthResourcePath,
           oauthAllowLoopback,
-          sessionStorage,
           cookieDomain,
           loginUrl,
         }) => {
@@ -349,7 +343,6 @@ export const useFetchProviders = ({
             oauthServerEnabled,
             oauthResourcePath,
             oauthAllowLoopback,
-            sessionStorage,
             cookieDomain,
             loginUrl,
           });


### PR DESCRIPTION
## Summary

Collapses SkAuth session delivery to a single mechanism, closing out the cookie-session arc (#366, #368, #370).

Cookie is now the **only** browser session. localStorage mode — its toggle, the `localStorage.setItem('skauth')` injection, and the one-time-code landing machinery (`codeLanding`, `stashSessionToken`, the `/_stormkit/auth?code=` bounce) — is removed. Native/mobile clients that can't use cookies opt into **bearer delivery** with an `X-Session-Delivery: bearer` header and receive the token in the body instead.

## Why

With bearer-via-header, cookie mode became a strict superset (browser + mobile + OAuth), so the localStorage/cookie toggle no longer earned its keep. One mechanism = no localStorage-vs-cookie drift, HttpOnly by default, and OAuth `/authorize` always works.

## Behavior

- **Browsers:** always a `Secure; HttpOnly; SameSite=Lax` session cookie. login/register/verify/magic-link/OAuth-provider callbacks set it first-party on the auth host and 302 to the destination.
- **Native/mobile:** send `X-Session-Delivery: bearer` at login → token in body, no cookie, no CSRF Origin gate. At `/refresh`, a client that authenticated with an `Authorization` bearer and no cookie gets a bearer back automatically (no header needed).
- **OAuth server:** the cookie-mode guardrail is gone — cookie is always on. `CookieDomain` and `LoginURL` move out from behind the removed toggle in the dashboard.

## Breaking change

Environments previously on localStorage session mode switch to cookie sessions on deploy. Apps reading `localStorage.skauth` must move to `credentials:'include'` + `/_stormkit/auth/me`; native apps must send `X-Session-Delivery: bearer` to receive a token. Accepted given the small auth user base.

## Tests

Full `src/ce/hosting/...`, skauth and buildconf suites pass; `go vet` clean; UI spec 19/19; `tsc` clean. Net −355 lines.