### PR TITLE
feat: add session logout endpoint

### DIFF
--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -89,6 +89,8 @@ func ServeAuth(req *RequestContext) (*shttp.Response, error) {
 		return handleAuthMagic(req), nil
 	case "/_stormkit/auth/refresh":
 		return handleAuthRefresh(req), nil
+	case "/_stormkit/auth/logout":
+		return handleAuthLogout(req), nil
 	case "/_stormkit/auth/me":
 		return handleAuthMe(req), nil
 	case skauth.CallbackPath:

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -58,6 +58,32 @@ func (m *skAuthMiddleware) sessionCookieFor(token string) http.Cookie {
 	return cookie
 }
 
+// expiredSessionCookie is the deletion counterpart of sessionCookieFor: the same
+// Name/Path/Domain (which the browser matches on) with MaxAge<0, so a Set-Cookie
+// carrying it clears the session cookie.
+func (m *skAuthMiddleware) expiredSessionCookie() http.Cookie {
+	return http.Cookie{
+		Name:     buildconf.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Domain:   m.req.Host.Config.SKAuth.CookieDomain,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	}
+}
+
+// handleLogout clears the session cookie. The session is an HttpOnly cookie the
+// app's JS cannot clear, so sign-out must expire it server side. Registered
+// POST-only (see registerReservedRoutes), so a cross-site GET can't force it.
+func (m *skAuthMiddleware) handleLogout() (*shttp.Response, error) {
+	return &shttp.Response{
+		Status:  http.StatusOK,
+		Cookies: []http.Cookie{m.expiredSessionCookie()},
+	}, nil
+}
+
 // deliverSession sets the session cookie and 302s to redirectURL. Used by the
 // browser login landings (email verify, magic link, OAuth-provider callback);
 // the cookie is first-party to this auth host, so it is also readable by the

--- a/src/ce/hosting/middleware.skauth_cookie_test.go
+++ b/src/ce/hosting/middleware.skauth_cookie_test.go
@@ -158,3 +158,26 @@ func (s *SkAuthCookieSuite) Test_Refresh_CookieMode_CookieDelivery() {
 	s.Require().Len(res.Cookies, 1)
 	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
+
+// Test_Logout_ExpiresCookie verifies POST /_stormkit/auth/logout clears the
+// session cookie — the only way to end a session, since the HttpOnly cookie is
+// invisible to the app's JS.
+func (s *SkAuthCookieSuite) Test_Logout_ExpiresCookie() {
+	req := s.request(s.host(), nil)
+	req.RequestContext.Method = http.MethodPost
+	req.RequestContext.Request.URL = &url.URL{Host: "www.example.com", Path: "/_stormkit/auth/logout", RawPath: "/_stormkit/auth/logout"}
+	req.OriginalPath = "/_stormkit/auth/logout"
+
+	res, err := hosting.ServeAuth(req)
+
+	s.NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusOK, res.Status)
+
+	s.Require().Len(res.Cookies, 1)
+	c := res.Cookies[0]
+	s.Equal(buildconf.SessionCookieName, c.Name)
+	s.Empty(c.Value)
+	s.Equal(".example.com", c.Domain)
+	s.Less(c.MaxAge, 0, "a deletion cookie must have MaxAge<0")
+}

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -67,6 +67,7 @@ func registerReservedRoutes(s *shttp.Service) {
 
 	reg("/register", handleAuthRegisterLogin, http.MethodPost, http.MethodOptions)
 	reg("/login", handleAuthRegisterLogin, http.MethodPost, http.MethodOptions)
+	reg("/logout", handleAuthLogout, http.MethodPost, http.MethodOptions)
 	reg("/refresh", handleAuthRefresh, http.MethodPost, http.MethodOptions)
 	reg("/me", handleAuthMe, http.MethodGet, http.MethodOptions)
 	// Magic link: GET follows the emailed verification link, POST requests one.
@@ -109,6 +110,7 @@ func serveReservedAuth(fn func(*skAuthMiddleware) (*shttp.Response, error)) func
 var (
 	handleAuthVerify        = serveReservedAuth((*skAuthMiddleware).handleVerify)
 	handleAuthRefresh       = serveReservedAuth((*skAuthMiddleware).handleRefresh)
+	handleAuthLogout        = serveReservedAuth((*skAuthMiddleware).handleLogout)
 	handleAuthMe            = serveReservedAuth((*skAuthMiddleware).handleMe)
 	handleAuthMagic         = serveReservedAuth((*skAuthMiddleware).handleMagic)
 	handleAuthOAuthCallback = serveReservedAuth((*skAuthMiddleware).handleOAuthCallback)


### PR DESCRIPTION
## Summary

Re-created on top of #371 + #373 (the original #370 branch predated both and no longer applied cleanly).

The session is now an HttpOnly cookie that the app's JS cannot clear, so there was no way to sign a user out. Adds **`POST /_stormkit/auth/logout`**, which expires the session cookie (`Set-Cookie` with `MaxAge<0`, matching the cookie's Name/Path/Domain). Registered POST-only, so a cross-site GET can't force a logout.

```js
await fetch('/_stormkit/auth/logout', { method: 'POST', credentials: 'include' });
```

## Tests

`Test_Logout_ExpiresCookie` (200 + deletion cookie with MaxAge<0). Full `src/ce/hosting/...` suite passes; `go vet` clean.

Closes the last gap in the cookie-session arc (#366, #368, #371, #373).