### PR TITLE
feat: add oauth token revocation endpoint

### DIFF
--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -57,6 +57,7 @@ func HandleOAuthRegister(req *RequestContext) *shttp.Response  { return handleOA
 func HandleOAuthAuthorize(req *RequestContext) *shttp.Response { return handleOAuthAuthorize(req) }
 func HandleOAuthGrant(req *RequestContext) *shttp.Response     { return handleOAuthGrant(req) }
 func HandleOAuthToken(req *RequestContext) *shttp.Response     { return handleOAuthToken(req) }
+func HandleOAuthRevoke(req *RequestContext) *shttp.Response    { return handleOAuthRevoke(req) }
 
 // OAuthRegisterRateMax exposes the per-host registration limit so the rate-limit
 // test can drive it up to the threshold without hard-coding the constant.

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -156,6 +156,7 @@ var (
 	handleOAuthAuthorize        = serveOAuth((*oauthServer).authorize)
 	handleOAuthGrant            = serveOAuth((*oauthServer).grant)
 	handleOAuthToken            = serveOAuth((*oauthServer).token)
+	handleOAuthRevoke           = serveOAuth((*oauthServer).revoke)
 )
 
 func (o *oauthServer) secret() string {
@@ -198,15 +199,17 @@ func (o *oauthServer) metadataAS() *shttp.Response {
 	iss := o.issuer()
 
 	return oauthJSON(http.StatusOK, map[string]any{
-		"issuer":                                iss,
-		"authorization_endpoint":                iss + "/_stormkit/oauth/authorize",
-		"token_endpoint":                        iss + "/_stormkit/oauth/token",
-		"registration_endpoint":                 iss + "/_stormkit/oauth/register",
-		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
-		"code_challenge_methods_supported":      []string{"S256"},
-		"token_endpoint_auth_methods_supported": []string{"none"},
-		"scopes_supported":                      oauthScopesSupported(),
+		"issuer":                                     iss,
+		"authorization_endpoint":                     iss + "/_stormkit/oauth/authorize",
+		"token_endpoint":                             iss + "/_stormkit/oauth/token",
+		"registration_endpoint":                      iss + "/_stormkit/oauth/register",
+		"revocation_endpoint":                        iss + "/_stormkit/oauth/revoke",
+		"response_types_supported":                   []string{"code"},
+		"grant_types_supported":                      []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":           []string{"S256"},
+		"token_endpoint_auth_methods_supported":      []string{"none"},
+		"revocation_endpoint_auth_methods_supported": []string{"none"},
+		"scopes_supported":                           oauthScopesSupported(),
 	})
 }
 
@@ -649,6 +652,27 @@ func (o *oauthServer) token() *shttp.Response {
 	default:
 		return oauthJSON(http.StatusBadRequest, oauthErr("unsupported_grant_type", ""))
 	}
+}
+
+// revoke serves POST /_stormkit/oauth/revoke (RFC 7009). It revokes a refresh
+// token by deleting it from the store, killing the connection's ability to renew
+// silently. Access tokens are stateless HS256 JWTs with a short TTL, so they are
+// not separately revocable and simply expire — this is documented in the AS
+// metadata by advertising only revocation of the refresh token. Per RFC 7009 §2.2
+// the endpoint returns 200 whether or not the token was valid, so it can't be
+// used to probe token validity; token_type_hint is advisory and ignored (we only
+// hold refresh tokens).
+func (o *oauthServer) revoke() *shttp.Response {
+	if token := o.req.PostFormValue("token"); token != "" {
+		_ = oauthRefreshTokens.revoke(o.req.Context(), token)
+	}
+
+	return withOAuthCORS(&shttp.Response{
+		Status: http.StatusOK,
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Cache-Control": "no-store",
+		}),
+	})
 }
 
 // tokenAuthorizationCode redeems a PKCE-bound authorization code. When the grant

--- a/src/ce/hosting/oauth_mcp_test.go
+++ b/src/ce/hosting/oauth_mcp_test.go
@@ -266,6 +266,52 @@ func (s *OAuthSuite) Test_Refresh_ClientMismatch() {
 	s.Equal("invalid_grant", s.json(res)["error"])
 }
 
+// --- RFC 7009: token revocation ---
+
+// revokeReq builds a POST /_stormkit/oauth/revoke with the given token.
+func (s *OAuthSuite) revokeReq(host *hosting.Host, token string) *shttp.Response {
+	form := url.Values{}
+	form.Set("token", token)
+
+	h := make(http.Header)
+	h.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return hosting.HandleOAuthRevoke(s.req(host, http.MethodPost, "/_stormkit/oauth/revoke", "", h, strings.NewReader(form.Encode())))
+}
+
+func (s *OAuthSuite) Test_Revoke_RefreshToken_KillsRenewal() {
+	verifier := "revoke-verifier-value-1234567890ab"
+	code := s.grantWithScope(s.host(true), "user-42", pkce(verifier), "offline_access", "")
+
+	refresh := s.json(s.exchange(s.host(true), code, verifier))["refresh_token"].(string)
+
+	// Revoking returns 200 with no body per RFC 7009.
+	res := s.revokeReq(s.host(true), refresh)
+	s.Equal(http.StatusOK, res.Status)
+
+	// The revoked token can no longer renew the session.
+	replay := s.refreshReq(s.host(true), refresh, "chatgpt")
+	s.Equal(http.StatusBadRequest, replay.Status)
+	s.Equal("invalid_grant", s.json(replay)["error"])
+}
+
+// Test_Revoke_UnknownToken_Returns200 guards RFC 7009 §2.2: an unknown token
+// must still return 200 so the endpoint can't be used to probe validity.
+func (s *OAuthSuite) Test_Revoke_UnknownToken_Returns200() {
+	s.Equal(http.StatusOK, s.revokeReq(s.host(true), "not-a-real-refresh-token").Status)
+	s.Equal(http.StatusOK, s.revokeReq(s.host(true), "").Status)
+}
+
+// Test_MetadataAS_AdvertisesRevocation verifies the revocation endpoint is
+// discoverable in the RFC 8414 metadata.
+func (s *OAuthSuite) Test_MetadataAS_AdvertisesRevocation() {
+	res := hosting.HandleOAuthMetadataAS(s.req(s.host(true), http.MethodGet, "/.well-known/oauth-authorization-server", "", nil, nil))
+
+	d := s.json(res)
+	s.Equal("https://app.example.com/_stormkit/oauth/revoke", d["revocation_endpoint"])
+	s.Contains(d["revocation_endpoint_auth_methods_supported"], "none")
+}
+
 // --- P1: audience binding (RFC 8707) ---
 
 func (s *OAuthSuite) Test_Token_AudienceFromResourceIndicator() {

--- a/src/ce/hosting/oauth_refresh_store.go
+++ b/src/ce/hosting/oauth_refresh_store.go
@@ -80,6 +80,19 @@ func (s oauthRefreshStore) issue(ctx context.Context, payload oauthRefreshPayloa
 	return token, nil
 }
 
+// revoke deletes token from the store if present. It is idempotent — an unknown,
+// expired or already-rotated token is a no-op — which matches RFC 7009's rule
+// that revocation report success regardless, so a caller can't probe validity.
+func (s oauthRefreshStore) revoke(ctx context.Context, token string) error {
+	client := rediscache.Client()
+
+	if client == nil {
+		return errors.New("redis client is not available")
+	}
+
+	return client.Del(ctx, s.key(token)).Err()
+}
+
 // rotate atomically consumes token and returns its payload. Rotation is
 // mandatory for public clients (OAuth 2.1 / the MCP auth spec): the presented
 // token is deleted in the same round-trip, so a captured-then-rotated token is

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -51,6 +51,8 @@ func registerReservedRoutes(s *shttp.Service) {
 	oauth.Handler(http.MethodOptions, "/authorize", WithHost(handleOAuthAuthorize))
 	oauth.Handler(http.MethodPost, "/token", WithHost(handleOAuthToken))
 	oauth.Handler(http.MethodOptions, "/token", WithHost(handleOAuthToken))
+	oauth.Handler(http.MethodPost, "/revoke", WithHost(handleOAuthRevoke))
+	oauth.Handler(http.MethodOptions, "/revoke", WithHost(handleOAuthRevoke))
 
 	auth := s.NewEndpoint("/_stormkit/auth")
 


### PR DESCRIPTION
## Summary

Implements RFC 7009 token revocation — the first item of the PR-2 security hardening for issue #314.

Adds **`POST /_stormkit/oauth/revoke`**. It deletes the presented **refresh token** from the Redis store (`oauthRefreshTokens.revoke`), killing a connector's ability to renew silently — so a user revoking a connected app actually severs it. Advertised as `revocation_endpoint` (auth method `none`) in the RFC 8414 metadata so clients can discover it.

## Notes

- **Access tokens** are stateless short-lived HS256 JWTs, so they aren't separately revocable and simply expire on their own TTL. Revocation is therefore refresh-token-scoped; the access token dies within its window. (A true access-token blocklist would be the alternative, deliberately not added — it reintroduces per-request state the stateless design avoids.)
- Per **RFC 7009 §2.2** the endpoint returns `200` whether or not the token was valid (`revoke` is idempotent), so it can't be used to probe token validity. `token_type_hint` is advisory and ignored (we only hold refresh tokens).
- Public clients (`token_endpoint_auth_methods: none`), so the endpoint is unauthenticated — consistent with the rest of the connector flow.

## Tests

`Test_Revoke_RefreshToken_KillsRenewal` (revoke → subsequent refresh is `invalid_grant`), `Test_Revoke_UnknownToken_Returns200` (unknown/empty token still 200), `Test_MetadataAS_AdvertisesRevocation`. Full `src/ce/hosting/...` suite passes; `go vet` clean.

Remaining PR-2 items (separate PRs): RFC 8707 `aud` enforcement at the edge, upstream `x-auth-method`/`x-oauth-client-id`/`x-oauth-scope` headers.