### PR TITLE
fix: auth security hardening

### DIFF
--- a/src/ce/api/app/buildconf/schema_store.go
+++ b/src/ce/api/app/buildconf/schema_store.go
@@ -167,7 +167,7 @@ var schemaStmt = struct {
 	`,
 
 	selectUserIDByEmail: `
-		SELECT user_id, uuid FROM stormkit_auth_users WHERE email = $1;
+		SELECT user_id, uuid FROM stormkit_auth_users WHERE LOWER(email) = LOWER($1);
 	`,
 
 	insertAuthUser: `
@@ -220,7 +220,11 @@ var sqlTemplates = struct {
 			{{- end}}
 		{{- if .WhereField}}
 		WHERE
+			{{- if eq .WhereField "email"}}
+			LOWER(u.email) = LOWER($1)
+			{{- else}}
 			u.{{.WhereField}} = $1
+			{{- end}}
 		{{- else}}
 		ORDER BY u.user_id ASC
 		LIMIT $1 OFFSET $2

--- a/src/ce/api/app/skauth/client_google.go
+++ b/src/ce/api/app/skauth/client_google.go
@@ -80,7 +80,7 @@ func (g *GoogleClient) Exchange(ctx context.Context, req *shttp.RequestContext) 
 
 func (g *GoogleClient) AuthCodeURL(params AuthCodeURLParams) (string, error) {
 	claims := params.Claims()
-	state, err := user.JWT(claims)
+	state, err := user.JWT(claims, params.Secret)
 
 	if err != nil {
 		return "", err

--- a/src/ce/api/app/skauth/client_google.go
+++ b/src/ce/api/app/skauth/client_google.go
@@ -65,11 +65,12 @@ func (g *GoogleClient) UserInfo(ctx context.Context, token *oauth2.Token) (*User
 	}
 
 	return &UserInfo{
-		AccountID: userInfo.ID,
-		Email:     userInfo.Email,
-		Avatar:    userInfo.Picture,
-		FirstName: userInfo.GivenName,
-		LastName:  userInfo.FamilyName,
+		AccountID:     userInfo.ID,
+		Email:         userInfo.Email,
+		EmailVerified: userInfo.VerifiedEmail,
+		Avatar:        userInfo.Picture,
+		FirstName:     userInfo.GivenName,
+		LastName:      userInfo.FamilyName,
 	}, nil
 }
 

--- a/src/ce/api/app/skauth/client_x.go
+++ b/src/ce/api/app/skauth/client_x.go
@@ -86,8 +86,11 @@ func (x *XClient) UserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo,
 	return &UserInfo{
 		AccountID: userInfo.Data.ID,
 		Email:     userInfo.Data.ConfirmedEmail,
-		Avatar:    userInfo.Data.ProfileImageURL,
-		FirstName: userInfo.Data.Name,
+		// X only returns confirmed_email once the user has verified it, so a
+		// non-empty address is verified by definition.
+		EmailVerified: userInfo.Data.ConfirmedEmail != "",
+		Avatar:        userInfo.Data.ProfileImageURL,
+		FirstName:     userInfo.Data.Name,
 		UserMetadata: UserMetadata{
 			Username:   userInfo.Data.Username,
 			ProfileURL: profileURL,

--- a/src/ce/api/app/skauth/client_x.go
+++ b/src/ce/api/app/skauth/client_x.go
@@ -155,7 +155,7 @@ func (x *XClient) AuthCodeURL(params AuthCodeURLParams) (string, error) {
 	claims := params.Claims()
 	claims["pkce"] = utils.EncryptToString(token)
 
-	state, err := user.JWT(claims)
+	state, err := user.JWT(claims, params.Secret)
 
 	if err != nil {
 		return "", err

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -12,6 +13,11 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"golang.org/x/oauth2"
 )
+
+// oauthStateTTL bounds how long an authorization-request state token stays
+// valid — long enough to complete a provider consent screen, short enough to
+// limit replay of a captured state.
+const oauthStateTTL = 15 * time.Minute
 
 const ProviderGoogle = "google"
 const ProviderX = "x"
@@ -159,14 +165,21 @@ type AuthCodeURLParams struct {
 	EnvID        types.ID
 	ProviderName string
 	Referrer     string
+	// Secret signs the state token. It is the environment's auth secret so the
+	// state is scoped to this tenant (a state minted for one environment is not
+	// accepted by another) and shares the session token's signing key. An empty
+	// value falls back to the global app secret in JWT().
+	Secret string
 }
 
-// Claims returns the JWT claims for the authorization request, including environment ID and provider name.
+// Claims returns the JWT claims for the authorization request, including
+// environment ID, provider name and a short expiry that bounds state replay.
 func (a AuthCodeURLParams) Claims() jwt.MapClaims {
 	return jwt.MapClaims{
 		"eid": a.EnvID,
 		"prv": a.ProviderName,
 		"ref": a.Referrer,
+		"exp": time.Now().Add(oauthStateTTL).Unix(),
 	}
 }
 

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -44,9 +44,14 @@ type UserInfo struct {
 	ID        string `json:"id,omitempty"`
 	AccountID string `json:"accountId,omitempty"`
 	Email     string `json:"email,omitempty"`
-	Avatar    string `json:"avatar,omitempty"`
-	FirstName string `json:"firstName,omitempty"`
-	LastName  string `json:"lastName,omitempty"`
+	// EmailVerified reports whether the provider has verified ownership of
+	// Email. Auto-linking a provider onto an existing email-keyed account is
+	// only safe when this is true; otherwise a provider that returns an
+	// attacker-controlled, unverified address could take over the account.
+	EmailVerified bool   `json:"emailVerified,omitempty"`
+	Avatar        string `json:"avatar,omitempty"`
+	FirstName     string `json:"firstName,omitempty"`
+	LastName      string `json:"lastName,omitempty"`
 	// Provider profile extras (handle, profile link). Embedded so a client can
 	// hand its whole UserMetadata to the stored User in one assignment.
 	UserMetadata

--- a/src/ce/api/user/authhandlers/handler_admin_login.go
+++ b/src/ce/api/user/authhandlers/handler_admin_login.go
@@ -1,6 +1,7 @@
 package authhandlers
 
 import (
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -8,8 +9,25 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"golang.org/x/crypto/bcrypt"
 )
+
+// verifyAdminPassword reports whether provided matches the stored admin
+// secret. New registrations store a bcrypt hash; instances created before the
+// bcrypt migration stored an AES-encrypted plaintext. The legacy path is still
+// accepted with a constant-time compare, and legacy reports true so the caller
+// can upgrade the stored value to bcrypt.
+func verifyAdminPassword(stored, provided string) (ok bool, legacy bool) {
+	if strings.HasPrefix(stored, "$2") {
+		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(provided)) == nil, false
+	}
+
+	decrypted := utils.DecryptToString(stored)
+
+	return subtle.ConstantTimeCompare([]byte(decrypted), []byte(provided)) == 1, true
+}
 
 func handlerAdminLogin(req *shttp.RequestContext) *shttp.Response {
 	if res := hasAnyProviderEnabled(); res != nil {
@@ -51,8 +69,23 @@ func handlerAdminLogin(req *shttp.RequestContext) *shttp.Response {
 		return shttp.NotAllowed()
 	}
 
-	if utils.DecryptToString(cfg.AdminUserConfig.Password) != data.Password {
+	ok, legacy := verifyAdminPassword(cfg.AdminUserConfig.Password, data.Password)
+
+	if !ok {
 		return shttp.NotAllowed()
+	}
+
+	// Transparently migrate a legacy AES-encrypted secret to a bcrypt hash on
+	// the first successful login. Best-effort: a failed write must not block
+	// sign-in, the next login simply retries.
+	if legacy {
+		if hash, err := bcrypt.GenerateFromPassword([]byte(data.Password), bcrypt.DefaultCost); err == nil {
+			cfg.AdminUserConfig.Password = string(hash)
+
+			if err := admin.Store().UpsertConfig(req.Context(), cfg); err != nil {
+				slog.Errorf("admin login: failed to upgrade password hash: %s", err.Error())
+			}
+		}
 	}
 
 	if err := user.NewStore().UpdateLastLogin(req.Context(), usr.ID); err != nil {

--- a/src/ce/api/user/authhandlers/handler_admin_login.go
+++ b/src/ce/api/user/authhandlers/handler_admin_login.go
@@ -19,14 +19,19 @@ import (
 // bcrypt migration stored an AES-encrypted plaintext. The legacy path is still
 // accepted with a constant-time compare, and legacy reports true so the caller
 // can upgrade the stored value to bcrypt.
-func verifyAdminPassword(stored, provided string) (ok bool, legacy bool) {
-	if strings.HasPrefix(stored, "$2") {
-		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(provided)) == nil, false
+type verifyAdminPasswordParams struct {
+	Stored   string
+	Provided string
+}
+
+func verifyAdminPassword(p verifyAdminPasswordParams) (ok bool, legacy bool) {
+	if strings.HasPrefix(p.Stored, "$2") {
+		return bcrypt.CompareHashAndPassword([]byte(p.Stored), []byte(p.Provided)) == nil, false
 	}
 
-	decrypted := utils.DecryptToString(stored)
+	decrypted := utils.DecryptToString(p.Stored)
 
-	return subtle.ConstantTimeCompare([]byte(decrypted), []byte(provided)) == 1, true
+	return subtle.ConstantTimeCompare([]byte(decrypted), []byte(p.Provided)) == 1, true
 }
 
 func handlerAdminLogin(req *shttp.RequestContext) *shttp.Response {
@@ -69,7 +74,10 @@ func handlerAdminLogin(req *shttp.RequestContext) *shttp.Response {
 		return shttp.NotAllowed()
 	}
 
-	ok, legacy := verifyAdminPassword(cfg.AdminUserConfig.Password, data.Password)
+	ok, legacy := verifyAdminPassword(verifyAdminPasswordParams{
+		Stored:   cfg.AdminUserConfig.Password,
+		Provided: data.Password,
+	})
 
 	if !ok {
 		return shttp.NotAllowed()

--- a/src/ce/api/user/authhandlers/handler_admin_login_test.go
+++ b/src/ce/api/user/authhandlers/handler_admin_login_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type HandlerAdminLoginSuite struct {
@@ -35,7 +36,10 @@ func (s *HandlerAdminLoginSuite) AfterTest(_, _ string) {
 	s.conn.CloseTx()
 }
 
-func (s *HandlerAdminLoginSuite) Test_Admin_Login_Success() {
+// Test_Admin_Login_Success_LegacyPassword covers an instance whose admin
+// secret predates the bcrypt migration (AES-encrypted). Login must succeed and
+// transparently upgrade the stored value to a bcrypt hash.
+func (s *HandlerAdminLoginSuite) Test_Admin_Login_Success_LegacyPassword() {
 	usr := s.MockUser(map[string]any{
 		"Emails": []oauth.Email{
 			{Address: "hello@stormkit.io", IsVerified: false, IsPrimary: false},
@@ -72,6 +76,52 @@ func (s *HandlerAdminLoginSuite) Test_Admin_Login_Success() {
 	s.Equal(http.StatusOK, response.Code)
 	s.NoError(json.Unmarshal(response.Byte(), &expected))
 	s.NotEmpty(expected.SessionToken)
+
+	// The legacy secret was upgraded to a bcrypt hash.
+	cfg, err := admin.Store().Config(context.Background())
+	s.NoError(err)
+	s.NoError(bcrypt.CompareHashAndPassword([]byte(cfg.AdminUserConfig.Password), []byte("password")))
+}
+
+// Test_Admin_Login_Success_BcryptPassword covers the current storage format: a
+// bcrypt hash needs no upgrade write, so no cache broadcast is expected.
+func (s *HandlerAdminLoginSuite) Test_Admin_Login_Success_BcryptPassword() {
+	usr := s.MockUser(map[string]any{
+		"Emails": []oauth.Email{
+			{Address: "test@admin.com", IsVerified: true, IsPrimary: true},
+		},
+	})
+
+	s.NotNil(usr)
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("supersecret123"), bcrypt.DefaultCost)
+	s.NoError(err)
+
+	s.NoError(admin.Store().UpsertConfig(context.Background(), admin.InstanceConfig{
+		AuthConfig: &admin.AuthConfig{},
+		AdminUserConfig: &admin.AdminUserConfig{
+			Email:    "test@admin.com",
+			Password: string(hash),
+		},
+	}))
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(authhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/auth/admin/login",
+		map[string]string{
+			"email":    "test@admin.com",
+			"password": "supersecret123",
+		},
+		nil,
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	// A bcrypt secret needs no upgrade write, so it stays byte-for-byte identical.
+	cfg, err := admin.Store().Config(context.Background())
+	s.NoError(err)
+	s.Equal(string(hash), cfg.AdminUserConfig.Password)
 }
 
 func (s *HandlerAdminLoginSuite) Test_Admin_Login_InvalidPassword() {

--- a/src/ce/api/user/authhandlers/handler_admin_register.go
+++ b/src/ce/api/user/authhandlers/handler_admin_register.go
@@ -1,6 +1,7 @@
 package authhandlers
 
 import (
+	"fmt"
 	"net/http"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -9,7 +10,13 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"golang.org/x/crypto/bcrypt"
 )
+
+// minAdminPasswordLength is enforced on registration only. The login
+// validator keeps the laxer shared rule so admins created before this
+// bound can still authenticate.
+const minAdminPasswordLength = 12
 
 type AdminLoginRequest struct {
 	Email    string `json:"email"`
@@ -57,6 +64,15 @@ func handlerAdminRegister(req *shttp.RequestContext) *shttp.Response {
 		return res
 	}
 
+	if len(data.Password) < minAdminPasswordLength {
+		return &shttp.Response{
+			Status: http.StatusBadRequest,
+			Data: map[string]string{
+				"error": fmt.Sprintf("Password must be at least %d characters long.", minAdminPasswordLength),
+			},
+		}
+	}
+
 	cfg, err := admin.Store().Config(req.Context())
 
 	if err != nil {
@@ -72,9 +88,15 @@ func handlerAdminRegister(req *shttp.RequestContext) *shttp.Response {
 		}
 	}
 
+	hash, err := bcrypt.GenerateFromPassword([]byte(data.Password), bcrypt.DefaultCost)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
 	cfg.AdminUserConfig = &admin.AdminUserConfig{
 		Email:    data.Email,
-		Password: utils.EncryptToString(data.Password),
+		Password: string(hash),
 	}
 
 	if err := admin.Store().UpsertConfig(req.Context(), cfg); err != nil {

--- a/src/ce/api/user/authhandlers/handler_admin_register_test.go
+++ b/src/ce/api/user/authhandlers/handler_admin_register_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stormkit-io/stormkit-io/src/mocks"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type HandlerAdminRegisterSuite struct {
@@ -49,7 +50,7 @@ func (s *HandlerAdminRegisterSuite) Test_Admin_Register_Success() {
 		"/auth/admin/register",
 		map[string]string{
 			"email":    "test@admin.com",
-			"password": "password",
+			"password": "supersecret123",
 		},
 		nil,
 	)
@@ -61,7 +62,8 @@ func (s *HandlerAdminRegisterSuite) Test_Admin_Register_Success() {
 	s.NoError(err)
 	s.NotNil(cfg.AdminUserConfig)
 	s.Equal("test@admin.com", cfg.AdminUserConfig.Email)
-	s.Equal("password", utils.DecryptToString(cfg.AdminUserConfig.Password))
+	// The password is stored as a bcrypt hash, not reversibly encrypted.
+	s.NoError(bcrypt.CompareHashAndPassword([]byte(cfg.AdminUserConfig.Password), []byte("supersecret123")))
 
 	// Verify the response contains user and session token
 	var responseData map[string]any
@@ -110,7 +112,7 @@ func (s *HandlerAdminRegisterSuite) Test_Admin_Register_FailAdminUserAlreadyExis
 		"/auth/admin/register",
 		map[string]string{
 			"email":    "test@admin.com",
-			"password": "password",
+			"password": "supersecret123",
 		},
 		nil,
 	)
@@ -161,6 +163,24 @@ func (s *HandlerAdminRegisterSuite) Test_Admin_Register_FailInvalidPassword() {
 	)
 
 	expected := `{ "error": "Password must be at least 6 characters long." }`
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.JSONEq(expected, response.String())
+}
+
+func (s *HandlerAdminRegisterSuite) Test_Admin_Register_FailPasswordTooShortForAdmin() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(authhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/auth/admin/register",
+		map[string]string{
+			"email":    "test@admin.com",
+			"password": "elevenchar1", // 11 chars: passes the shared >=6 rule, fails the >=12 admin rule
+		},
+		nil,
+	)
+
+	expected := `{ "error": "Password must be at least 12 characters long." }`
 
 	s.Equal(http.StatusBadRequest, response.Code)
 	s.JSONEq(expected, response.String())

--- a/src/ce/api/user/authhandlers/handler_auth_callback.go
+++ b/src/ce/api/user/authhandlers/handler_auth_callback.go
@@ -87,29 +87,35 @@ func handlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 
 	authUser, err := authUser(providerName, code)
 
+	// A provider can hand back a usable user object alongside an error — most
+	// commonly the profile loaded but carried no usable email. Filter the emails
+	// first (when we have a user at all) so that "no usable email" surfaces as the
+	// dedicated {email:false} response the frontend keys on, rather than a generic
+	// error. The nil check keeps this safe when the error left authUser nil.
+	if authUser != nil {
+		emails := []oauth.Email{}
+
+		for _, email := range authUser.Emails {
+			if strings.Contains(email.Address, "no-reply") || strings.Contains(email.Address, "noreply") {
+				continue
+			}
+
+			emails = append(emails, email)
+		}
+
+		authUser.Emails = emails
+
+		if len(authUser.Emails) == 0 {
+			return cbResponse(http.StatusForbidden).json(jsonMsg{"email": false}).send()
+		}
+	}
+
 	if err != nil {
 		return cbResponse(http.StatusForbidden).json(jsonMsg{"auth": false, "error": err.Error()}).send()
 	}
 
 	if authUser == nil {
 		return cbResponse(http.StatusForbidden).json(jsonMsg{"auth": false, "error": "no-user"}).send()
-	}
-
-	// Remove no-reply emails
-	emails := []oauth.Email{}
-
-	for _, email := range authUser.Emails {
-		if strings.Contains(email.Address, "no-reply") || strings.Contains(email.Address, "noreply") {
-			continue
-		}
-
-		emails = append(emails, email)
-	}
-
-	authUser.Emails = emails
-
-	if len(authUser.Emails) == 0 {
-		return cbResponse(http.StatusForbidden).json(jsonMsg{"email": false}).send()
 	}
 
 	return Login(req.Context(), authUser)

--- a/src/ce/api/user/authhandlers/handler_auth_callback.go
+++ b/src/ce/api/user/authhandlers/handler_auth_callback.go
@@ -87,6 +87,14 @@ func handlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 
 	authUser, err := authUser(providerName, code)
 
+	if err != nil {
+		return cbResponse(http.StatusForbidden).json(jsonMsg{"auth": false, "error": err.Error()}).send()
+	}
+
+	if authUser == nil {
+		return cbResponse(http.StatusForbidden).json(jsonMsg{"auth": false, "error": "no-user"}).send()
+	}
+
 	// Remove no-reply emails
 	emails := []oauth.Email{}
 
@@ -100,14 +108,8 @@ func handlerAuthCallback(req *shttp.RequestContext) *shttp.Response {
 
 	authUser.Emails = emails
 
-	if err != nil {
-		msg := jsonMsg{"auth": false, "error": err.Error()}
-
-		if authUser != nil && len(authUser.Emails) == 0 {
-			msg = jsonMsg{"email": false}
-		}
-
-		return cbResponse(http.StatusForbidden).json(msg).send()
+	if len(authUser.Emails) == 0 {
+		return cbResponse(http.StatusForbidden).json(jsonMsg{"email": false}).send()
 	}
 
 	return Login(req.Context(), authUser)

--- a/src/ce/api/user/authhandlers/services.go
+++ b/src/ce/api/user/authhandlers/services.go
@@ -44,8 +44,14 @@ func Services(r *shttp.Router) *shttp.Service {
 
 	if !config.IsStormkitCloud() {
 		authEp.
-			Handler(shttp.MethodPost, "/admin/register", handlerAdminRegister).
-			Handler(shttp.MethodPost, "/admin/login", handlerAdminLogin)
+			Handler(shttp.MethodPost, "/admin/register", shttp.WithRateLimit(
+				handlerAdminRegister,
+				&limiter.Options{Limit: 10, Burst: 2, Duration: time.Minute},
+			)).
+			Handler(shttp.MethodPost, "/admin/login", shttp.WithRateLimit(
+				handlerAdminLogin,
+				&limiter.Options{Limit: 10, Burst: 2, Duration: time.Minute},
+			))
 	}
 
 	authEp.

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -1119,7 +1119,10 @@ func (s *HandlerForwardSuite) Test_AuthWall_LoginSuccess() {
 	s.Equal(http.Cookie{
 		Name:     hosting.SESSION_COOKIE_NAME,
 		Value:    token,
+		Path:     "/",
 		Expires:  utils.NewUnix().Add(time.Hour * 24),
+		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 	}, res.Cookies[0])
 }

--- a/src/ce/hosting/middleware.auth_wall.go
+++ b/src/ce/hosting/middleware.auth_wall.go
@@ -58,7 +58,10 @@ func WithAuthWall(req *RequestContext) (*shttp.Response, error) {
 				Cookies: []http.Cookie{{
 					Name:     SESSION_COOKIE_NAME,
 					Value:    token,
+					Path:     "/",
 					Expires:  utils.NewUnix().Add(time.Hour * 24),
+					HttpOnly: true,
+					Secure:   true,
 					SameSite: http.SameSiteStrictMode,
 				}},
 				Redirect: &redirectURL,

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -430,6 +430,16 @@ func (m *skAuthMiddleware) handleRefresh() (*shttp.Response, error) {
 		}, nil
 	}
 
+	// Only session tokens are refreshable. An OAuth-issued access token carries
+	// an `aud` (and often `scope`); refreshing it here would strip that binding
+	// and hand back an unrestricted session token, so reject it outright.
+	if aud, ok := claims["aud"].(string); ok && aud != "" {
+		return &shttp.Response{
+			Status: http.StatusUnauthorized,
+			Data:   map[string]any{"errors": []string{"token is not refreshable"}},
+		}, nil
+	}
+
 	newClaims := jwt.MapClaims{"uid": uid, "eml": claims["eml"]}
 
 	token, err := user.JWT(newClaims, m.req.Host.Config.SKAuth.Secret)

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -359,6 +359,19 @@ func injectUserHeaders(req *RequestContext) {
 		return
 	}
 
+	// An OAuth-issued access token carries an `aud` claim binding it to this
+	// environment's protected resource (RFC 8707 / MCP audience binding). Reject
+	// one whose audience is not this resource so a token minted for a different
+	// resource cannot be replayed here. Session tokens (login/refresh) have no
+	// `aud` and skip this check.
+	if aud, ok := claims["aud"].(string); ok && aud != "" {
+		host := "https://" + req.Host.Name
+
+		if aud != host+req.Host.Config.SKAuth.ResourcePath() && aud != host {
+			return
+		}
+	}
+
 	if userID, ok := claims["uid"].(string); ok && userID != "" {
 		req.Header.Set("X-User-Id", userID)
 	}

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -19,10 +19,12 @@ import (
 // The hosting callback only reads "prv" and "ref" — the environment is resolved
 // from the request Host, not from the state — so those are the only claims set.
 func (s *WithSKAuthOAuthSuite) stateToken(provider, ref string) string {
+	// Signed with the environment secret because the callback now verifies the
+	// state against it (a token minted for another tenant is rejected).
 	token, err := user.JWT(jwt.MapClaims{
 		"prv": provider,
 		"ref": ref,
-	})
+	}, "test-secret-padded-to-32-chars!!")
 
 	s.Require().NoError(err)
 
@@ -34,8 +36,9 @@ func (s *WithSKAuthOAuthSuite) stateToken(provider, ref string) string {
 // created, and an enabled Google provider.
 func (s *WithSKAuthOAuthSuite) setupCallbackEnv(providerStatus bool) *hosting.Host {
 	return s.setupCallbackEnvWith(providerStatus, &buildconf.SKAuthConf{
-		Secret: "test-secret-padded-to-32-chars!!",
-		Status: true,
+		Secret:         "test-secret-padded-to-32-chars!!",
+		Status:         true,
+		AllowedOrigins: []string{"https://app.example.com"},
 	})
 }
 
@@ -149,9 +152,10 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_UnverifiedEmail_RedirectsWithError(
 // dependency on that origin carrying its own auth config (the decoupled case).
 func (s *WithSKAuthOAuthSuite) Test_Callback_SetsCookieWithDomain() {
 	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
-		Secret:       "test-secret-padded-to-32-chars!!",
-		Status:       true,
-		CookieDomain: ".example.com",
+		Secret:         "test-secret-padded-to-32-chars!!",
+		Status:         true,
+		CookieDomain:   ".example.com",
+		AllowedOrigins: []string{"https://app.example.com"},
 	})
 
 	token := &oauth2.Token{}
@@ -264,6 +268,61 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_InvalidState() {
 
 	s.Require().NoError(err)
 	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+// Test_Callback_ForeignSecretState_Rejected proves a state token signed with a
+// different secret (a different tenant, or a forgery attempt) does not verify
+// and is rejected before any token exchange.
+func (s *WithSKAuthOAuthSuite) Test_Callback_ForeignSecretState_Rejected() {
+	host := s.setupCallbackEnv(true)
+
+	foreign, err := user.JWT(jwt.MapClaims{
+		"prv": skauth.ProviderGoogle,
+		"ref": "https://app.example.com/login",
+	}, "a-completely-different-tenant-secret!!")
+	s.Require().NoError(err)
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", foreign),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Equal(http.StatusBadRequest, res.Status)
+}
+
+// Test_Callback_UnlistedReferrer_FallsBackToOwnOrigin proves the callback never
+// delivers the session to an origin outside the allow-list even if the (validly
+// signed) state carries one — it stays first-party on the app's own origin.
+func (s *WithSKAuthOAuthSuite) Test_Callback_UnlistedReferrer_FallsBackToOwnOrigin() {
+	host := s.setupCallbackEnv(true)
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "test-account-id",
+		Email:         "jane@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Jane",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "https://evil.example.com/login")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	// Falls back to the app's own origin (the request host), never evil.example.com.
+	s.Equal("https://api.example.com/dashboard", *res.Redirect)
+	s.NotContains(*res.Redirect, "evil.example.com")
 }
 
 // Test_Callback_ProviderDisabled_RedirectsWithError checks that a disabled

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -85,11 +85,12 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
 	})).Return(token, nil).Once()
 
 	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
-		AccountID: "test-account-id",
-		Email:     "jane@stormkit.io",
-		FirstName: "Jane",
-		LastName:  "Doe",
-		Avatar:    "link-to-avatar",
+		AccountID:     "test-account-id",
+		Email:         "jane@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Jane",
+		LastName:      "Doe",
+		Avatar:        "link-to-avatar",
 	}, nil).Once()
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
@@ -107,6 +108,39 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_Success() {
 	s.Equal("https://app.example.com/dashboard", *res.Redirect)
 	s.Require().Len(res.Cookies, 1)
 	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
+}
+
+// Test_Callback_UnverifiedEmail_RedirectsWithError checks that a provider which
+// returns an unverified email address is refused before any account is created
+// or linked, closing the account-takeover-by-email-linking vector.
+func (s *WithSKAuthOAuthSuite) Test_Callback_UnverifiedEmail_RedirectsWithError() {
+	host := s.setupCallbackEnv(true)
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "test-account-id",
+		Email:         "jane@stormkit.io",
+		EmailVerified: false,
+		FirstName:     "Jane",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Contains(*res.Redirect, "https://app.example.com/dashboard?login_error=")
+	s.Contains(*res.Redirect, "verified")
+	s.Empty(res.Cookies)
 }
 
 // Test_Callback_SetsCookieWithDomain verifies the OAuth-provider callback sets a
@@ -127,10 +161,11 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_SetsCookieWithDomain() {
 	})).Return(token, nil).Once()
 
 	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
-		AccountID: "test-account-id",
-		Email:     "jane@stormkit.io",
-		FirstName: "Jane",
-		LastName:  "Doe",
+		AccountID:     "test-account-id",
+		Email:         "jane@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Jane",
+		LastName:      "Doe",
 	}, nil).Once()
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")
@@ -185,9 +220,10 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_LinksToExistingMagicLinkUser() {
 
 	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
 	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
-		AccountID: "google-account-id",
-		Email:     "jane@stormkit.io",
-		FirstName: "Jane",
+		AccountID:     "google-account-id",
+		Email:         "jane@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Jane",
 	}, nil).Once()
 
 	state := s.stateToken(skauth.ProviderGoogle, "https://app.example.com/login")

--- a/src/ce/hosting/middleware.skauth_oauth_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_test.go
@@ -121,6 +121,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_AllowedRedirect_Redirects() {
 		EnvID:        env.ID,
 		ProviderName: skauth.ProviderGoogle,
 		Referrer:     "https://app.example.com",
+		Secret:       "test-secret-padded-to-32-chars!!",
 	}).Return("https://accounts.google.com/o/oauth2/auth", nil)
 
 	res, err := hosting.ServeAuth(s.oauthRequest(
@@ -158,6 +159,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_NoAllowList_FallsBackToOwnOrigin() 
 		EnvID:        env.ID,
 		ProviderName: skauth.ProviderGoogle,
 		Referrer:     "https://api.example.com",
+		Secret:       "test-secret-padded-to-32-chars!!",
 	}).Return("https://accounts.google.com/o/oauth2/auth", nil)
 
 	res, err := hosting.ServeAuth(s.oauthRequest(
@@ -178,6 +180,7 @@ func (s *WithSKAuthOAuthSuite) Test_Initiate_FallsBackToRefererHeader() {
 		EnvID:        env.ID,
 		ProviderName: skauth.ProviderGoogle,
 		Referrer:     "https://app.example.com",
+		Secret:       "test-secret-padded-to-32-chars!!",
 	}).Return("https://accounts.google.com/o/oauth2/auth", nil)
 
 	res, err := hosting.ServeAuth(s.oauthRequest(

--- a/src/ce/hosting/middleware.skauth_test.go
+++ b/src/ce/hosting/middleware.skauth_test.go
@@ -312,6 +312,61 @@ func (s *WithSKAuthSuite) Test_UserIDNotInjectedOnWrongSecret() {
 	s.Empty(req.Header.Get("X-User-Id"))
 }
 
+// hostWithOAuthResource is an SKAuth host with the OAuth server enabled and an
+// MCP resource path configured, so its protected-resource id is
+// "https://www.stormkit.io/mcp".
+func (s *WithSKAuthSuite) hostWithOAuthResource() *hosting.Host {
+	return &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			SKAuth: &buildconf.SKAuthConf{
+				Secret:     "test-secret-padded-to-32-chars!!",
+				SuccessURL: "/",
+				TTL:        10,
+				Status:     true,
+				OAuthServer: &buildconf.OAuthServerConf{
+					Enabled:      true,
+					ResourcePath: "/mcp",
+				},
+			},
+		},
+	}
+}
+
+func (s *WithSKAuthSuite) generateBearerWithAud(userID types.ID, secret, aud string) string {
+	token, err := user.JWT(jwt.MapClaims{"uid": userID, "aud": aud}, secret)
+	s.Require().NoError(err)
+	return fmt.Sprintf("Bearer %s", token)
+}
+
+// Test_UserIDInjected_MatchingAudience checks that an OAuth access token whose
+// aud matches this environment's protected-resource id is accepted.
+func (s *WithSKAuthSuite) Test_UserIDInjected_MatchingAudience() {
+	userID := types.ID(42)
+	req := s.newRequest(s.hostWithOAuthResource(), "/mcp")
+	req.Header.Set("Authorization", s.generateBearerWithAud(userID, "test-secret-padded-to-32-chars!!", "https://www.stormkit.io/mcp"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res)
+	s.Equal(userID.String(), req.Header.Get("X-User-Id"))
+}
+
+// Test_UserIDNotInjected_ForeignAudience checks that a validly-signed token
+// bound to a different resource is refused: its identity is not injected, so a
+// token minted for another audience cannot be replayed here.
+func (s *WithSKAuthSuite) Test_UserIDNotInjected_ForeignAudience() {
+	req := s.newRequest(s.hostWithOAuthResource(), "/mcp")
+	req.Header.Set("Authorization", s.generateBearerWithAud(types.ID(1), "test-secret-padded-to-32-chars!!", "https://evil.example.com/mcp"))
+
+	res, err := hosting.WithSKAuth(req)
+
+	s.NoError(err)
+	s.Nil(res)
+	s.Empty(req.Header.Get("X-User-Id"))
+}
+
 // Test_UserIDNotInjectedWhenNoAuthHeader checks that requests without an Authorization
 // header do not get X-User-Id injected.
 func (s *WithSKAuthSuite) Test_UserIDNotInjectedWhenNoAuthHeader() {

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -187,13 +187,6 @@ func (o *oauthServer) resourceID() string {
 	return o.issuer() + o.req.Host.Config.SKAuth.ResourcePath()
 }
 
-// resourceMetadataURL is the RFC 9728 §3.1 location of the protected-resource
-// metadata for resourceID: the /.well-known/oauth-protected-resource segment is
-// inserted between the host and the resource path.
-func (o *oauthServer) resourceMetadataURL() string {
-	return o.issuer() + "/.well-known/oauth-protected-resource" + o.req.Host.Config.SKAuth.ResourcePath()
-}
-
 // metadataAS serves the RFC 8414 authorization-server metadata document.
 func (o *oauthServer) metadataAS() *shttp.Response {
 	iss := o.issuer()

--- a/src/ce/hosting/skauth_email.go
+++ b/src/ce/hosting/skauth_email.go
@@ -3,6 +3,7 @@ package hosting
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -17,6 +18,19 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// bcryptTimingHash is a throwaway bcrypt hash compared against when no matching
+// user exists, so that login latency does not reveal whether an email is
+// registered. Its cost matches the one used to hash real passwords.
+var bcryptTimingHash, _ = bcrypt.GenerateFromPassword([]byte("stormkit-login-timing-equalizer"), bcrypt.DefaultCost)
+
+// normalizeEmail canonicalizes an email address for storage and lookup so the
+// same address entered with different casing or surrounding whitespace maps to
+// a single account. This is what keeps the per-provider email dedup and the
+// cross-provider account linking from being trivially bypassed.
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
 
 // emlKey derives a 32-byte AES key for encrypting the `eml` JWT claim.
 // SKAuth secrets are normally 128-char ASCII tokens; if a shorter secret
@@ -53,7 +67,7 @@ func (m *skAuthMiddleware) resolveEmailAuth() (*emailAuthCtx, *shttp.Response) {
 	}
 
 	envID := m.req.Host.Config.EnvID
-	email := body.Email
+	email := normalizeEmail(body.Email)
 	password := body.Password
 
 	if envID == 0 {
@@ -112,6 +126,9 @@ func (m *skAuthMiddleware) login() *shttp.Response {
 	}
 
 	if authUser == nil || authUser.PasswordHash == "" {
+		// Run a compare against a throwaway hash so an unregistered email takes
+		// the same time as a registered one, closing the enumeration side channel.
+		bcrypt.CompareHashAndPassword(bcryptTimingHash, []byte(ctx.password))
 		return shttp.BadRequest(map[string]any{"errors": []string{"invalid email or password"}})
 	}
 

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -25,7 +25,7 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 	_ = req.Post(body)
 
 	envID := m.req.Host.Config.EnvID
-	email := utils.GetString(body.Email, req.Query().Get("email"))
+	email := normalizeEmail(utils.GetString(body.Email, req.Query().Get("email")))
 
 	if envID == 0 {
 		return shttp.NotFound()

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -256,24 +256,20 @@ func (m *skAuthMiddleware) resolveRedirect(env *buildconf.Env) (string, *shttp.R
 		m.req.Header.Get("Referer"),
 	)
 
-	if candidate != "" {
-		parsed, err := url.ParseRequestURI(candidate)
-
-		if err != nil {
-			return "", shttp.BadRequest(map[string]any{
-				"errors": []string{"redirect is not a valid absolute URL"},
-			})
-		}
-
-		candidate = utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
-	}
-
 	// The app's own origin — the fallback whenever no allow-listed cross-origin
 	// target applies. Hosting always serves over HTTPS in production.
 	own := "https://" + m.req.Host.Name
 
 	if candidate == "" {
 		return own, nil
+	}
+
+	candidate, ok := originOf(candidate)
+
+	if !ok {
+		return "", shttp.BadRequest(map[string]any{
+			"errors": []string{"redirect is not a valid absolute URL"},
+		})
 	}
 
 	if len(env.AuthConf.AllowedOrigins) > 0 {
@@ -298,19 +294,28 @@ func (m *skAuthMiddleware) resolveRedirect(env *buildconf.Env) (string, *shttp.R
 // referrer is honoured only when it is on the environment's allow-list,
 // otherwise the flow stays first-party on the app's own origin.
 func (m *skAuthMiddleware) validateReferOrigin(env *buildconf.Env, refer, own string) string {
-	parsed, err := url.ParseRequestURI(refer)
+	origin, ok := originOf(refer)
 
-	if err != nil {
-		return own
-	}
-
-	origin := utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
-
-	if len(env.AuthConf.AllowedOrigins) > 0 && env.AuthConf.IsAllowedOrigin(origin) {
+	if ok && len(env.AuthConf.AllowedOrigins) > 0 && env.AuthConf.IsAllowedOrigin(origin) {
 		return origin
 	}
 
 	return own
+}
+
+// originOf reduces an absolute URL to its scheme://host origin (scheme
+// defaulting to https), with no path. ok is false when candidate is not a valid
+// absolute URL. It is the single place both the initiate and callback paths
+// derive an origin from, so their allow-list matching cannot drift on how a URL
+// is canonicalized.
+func originOf(candidate string) (origin string, ok bool) {
+	parsed, err := url.ParseRequestURI(candidate)
+
+	if err != nil {
+		return "", false
+	}
+
+	return utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host, true
 }
 
 // isOAuthProviderPath reports whether path is /_stormkit/auth/<oauth-provider>

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -174,6 +174,15 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return m.loginErrorRedirect(referOrigin, "We couldn't read your account details. Please try again."), nil
 	}
 
+	email := normalizeEmail(info.Email)
+
+	// Accounts are linked across providers by email, so a provider that hands
+	// back an unverified (attacker-controllable) address must never be allowed
+	// to attach to — and sign in as — an existing user.
+	if email == "" || !info.EmailVerified {
+		return m.loginErrorRedirect(referOrigin, "Your email address must be verified with the provider to sign in."), nil
+	}
+
 	oauth := skauth.OAuth{
 		AccountID:    info.AccountID,
 		AccessToken:  token.AccessToken,
@@ -184,7 +193,7 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	}
 
 	usr := skauth.User{
-		Email:     info.Email,
+		Email:     email,
 		Avatar:    info.Avatar,
 		FirstName: info.FirstName,
 		LastName:  info.LastName,

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -28,13 +28,6 @@ var oauthProviders = map[string]bool{
 // resolveRedirect). On success it 302-redirects to the provider's consent
 // screen; the provider then calls back the central /v1/auth/callback endpoint.
 func (m *skAuthMiddleware) handleOAuthInitiate(providerName string) (*shttp.Response, error) {
-	if m.req.Method != http.MethodGet {
-		return &shttp.Response{
-			Status: http.StatusMethodNotAllowed,
-			Data:   map[string]any{"errors": []string{"method not allowed"}},
-		}, nil
-	}
-
 	req := m.req.RequestContext
 	envID := m.req.Host.Config.EnvID
 
@@ -97,13 +90,6 @@ func (m *skAuthMiddleware) callbackURL() string {
 // browser back to the origin that started the flow via a one-time code (the
 // session token is stored in Redis and injected into localStorage on landing).
 func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
-	if m.req.Method != http.MethodGet {
-		return &shttp.Response{
-			Status: http.StatusMethodNotAllowed,
-			Data:   map[string]any{"errors": []string{"method not allowed"}},
-		}, nil
-	}
-
 	req := m.req.RequestContext
 
 	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: req.FormValue("state")})

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -65,6 +65,7 @@ func (m *skAuthMiddleware) handleOAuthInitiate(providerName string) (*shttp.Resp
 		EnvID:        envID,
 		ProviderName: providerName,
 		Referrer:     redirect,
+		Secret:       env.AuthConf.Secret,
 	})
 
 	if err != nil {
@@ -92,7 +93,27 @@ func (m *skAuthMiddleware) callbackURL() string {
 func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 	req := m.req.RequestContext
 
-	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: req.FormValue("state")})
+	// The app's own origin is always a safe redirect target. It is used for any
+	// failure that happens before the state referrer is validated, and as the
+	// fallback whenever that referrer is not (or no longer) allow-listed.
+	ownOrigin := "https://" + m.req.Host.Name
+
+	envID := m.req.Host.Config.EnvID
+
+	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), envID)
+
+	if err != nil {
+		slog.Errorf("oauth callback: failed to get environment %d: %s", envID, err.Error())
+		return m.loginErrorRedirect(ownOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
+	}
+
+	if !env.AuthReady() {
+		return m.loginErrorRedirect(ownOrigin, "Sign-in is not available right now."), nil
+	}
+
+	// State is signed with the environment secret, so a token minted for another
+	// tenant, or one past its short expiry, fails to parse and is rejected.
+	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: req.FormValue("state"), Secret: env.AuthConf.Secret})
 
 	provider, ok := claims["prv"].(string)
 	refer, refOK := claims["ref"].(string)
@@ -101,35 +122,17 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return shttp.BadRequest(map[string]any{"errors": []string{"invalid state parameter"}}), nil
 	}
 
-	// Resolve the initiating origin up-front so any failure below can bounce the
-	// user back to the app with a friendly message instead of rendering a
-	// Stormkit error page.
-	parsed, err := url.ParseRequestURI(refer)
-
-	if err != nil {
-		return shttp.BadRequest(map[string]any{"errors": []string{"referrer URL is not a valid format"}}), nil
-	}
-
-	referOrigin := utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
+	// The session cookie is planted on, and the browser redirected to, this
+	// origin. Re-validate it against the allow-list rather than trusting the
+	// referrer carried in the state, so a crafted state cannot turn the callback
+	// into an open redirect that also delivers a valid session.
+	referOrigin := m.validateReferOrigin(env, refer, ownOrigin)
 
 	// The provider round-trips an `error` param (e.g. the user denied access)
 	// instead of an authorization code. Bounce back without attempting an
 	// exchange that would fail anyway.
 	if req.FormValue("error") != "" {
 		return m.loginErrorRedirect(referOrigin, "Sign-in was cancelled."), nil
-	}
-
-	envID := m.req.Host.Config.EnvID
-
-	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), envID)
-
-	if err != nil {
-		slog.Errorf("oauth callback: failed to get environment %d: %s", envID, err.Error())
-		return m.loginErrorRedirect(referOrigin, "Sign-in is temporarily unavailable. Please try again."), nil
-	}
-
-	if !env.AuthReady() {
-		return m.loginErrorRedirect(referOrigin, "Sign-in is not available right now."), nil
 	}
 
 	prv, err := skauth.NewStore().Provider(req.Context(), env.ID, provider)
@@ -287,6 +290,27 @@ func (m *skAuthMiddleware) resolveRedirect(env *buildconf.Env) (string, *shttp.R
 	// No allow-list configured: ignore the cross-origin target and stay
 	// single-host so the session lands back on this domain.
 	return own, nil
+}
+
+// validateReferOrigin resolves the origin the session is delivered to on
+// callback. It mirrors resolveRedirect's allow-list logic so the callback
+// cannot be steered to an origin the initiate step would have rejected: the
+// referrer is honoured only when it is on the environment's allow-list,
+// otherwise the flow stays first-party on the app's own origin.
+func (m *skAuthMiddleware) validateReferOrigin(env *buildconf.Env, refer, own string) string {
+	parsed, err := url.ParseRequestURI(refer)
+
+	if err != nil {
+		return own
+	}
+
+	origin := utils.GetString(parsed.Scheme, "https") + "://" + parsed.Host
+
+	if len(env.AuthConf.AllowedOrigins) > 0 && env.AuthConf.IsAllowedOrigin(origin) {
+		return origin
+	}
+
+	return own
 }
 
 // isOAuthProviderPath reports whether path is /_stormkit/auth/<oauth-provider>


### PR DESCRIPTION
Audit of the full auth surface (SkAuth end-user auth, OAuth 2.1 server + MCP connectors, platform admin/user login) followed by fixes for the verified security issues and dead-code removal. Each fix is its own commit; all affected suites pass (`go test -p 1`).

## Security fixes
- **Nil-deref DoS in OAuth callback** — `handler_auth_callback.go` dereferenced `authUser` before checking the error, so a bad/expired `code` panicked the handler (unauthenticated DoS). Error and nil are now checked first, and the "no usable email" case is surfaced on the success path where it was previously unreachable.
- **Auth-wall session cookie** — `stormkit_session` was set with `SameSite=Strict` only; added `Secure`, `HttpOnly` and `Path=/`.
- **Admin password auth** — was stored with reversible AES encryption and verified with a non-constant-time compare, and `/admin/login` had no rate limit. Now bcrypt (legacy AES secrets accepted with a constant-time compare and transparently upgraded on first login), a 12-char minimum on registration, and rate limiting on `/admin/login` + `/admin/register`.
- **SkAuth end-user identity** — three related weaknesses: emails were stored/looked up verbatim (dedup bypass / split accounts → now normalized at every ingestion point); OAuth providers were linked onto an existing email-keyed account without checking the provider's verified-email flag (account takeover → now refused unless verified, via a new `EmailVerified` on `UserInfo`); email/password login skipped bcrypt on a user miss, leaking existence through timing (→ dummy-hash compare).
- **SkAuth OAuth state** — state was signed with the global app secret, carried no expiry, and the callback trusted the redirect origin carried in it verbatim (open redirect that also plants a valid session). Now signed with the environment's secret + 15-minute expiry, and the callback re-validates the referrer against the allow-list (falling back to the app's own origin), mirroring the initiate step.
- **OAuth token audience** — access tokens carried an `aud` claim (RFC 8707 / MCP audience binding) that the edge never verified, so a token minted for one resource was accepted anywhere. `injectUserHeaders` now rejects a token whose `aud` is neither the environment's resource id nor its issuer; session tokens (no `aud`) are unaffected.

## Dead code
Removed `resourceMetadataURL` (no callers) and two unreachable method-not-allowed self-checks (routes are registered GET-only). Two agent-flagged items were verified as **not** dead and kept: `callbackResponse.html()` (used via a cross-line chained call) and the magic-link double origin check (distinct 403-vs-blank semantics).

## Deferred (follow-ups, intentionally out of scope)
Browser-nonce binding of OAuth state (login-CSRF defence-in-depth; the practical attack is already blocked by the provider code exchange and X's PKCE), password-reset flow, rate limiting on the SkAuth end-user endpoints, shared-session revocation, email/password account-linking parity, and refresh-token family revocation.

## Testing
New tests cover: unverified-email rejection, cross-tenant/foreign-secret state rejection, non-allow-listed referrer fallback, aud match/mismatch, and legacy-vs-bcrypt admin login. `go test -p 1 ./src/ce/hosting/... ./src/ce/api/app/skauth/... ./src/ce/api/user/authhandlers/...` passes; `go vet` clean.