### PR TITLE
fix: verify x oauth state with env secret

### DIFF
--- a/src/ce/api/app/skauth/client_x.go
+++ b/src/ce/api/app/skauth/client_x.go
@@ -22,9 +22,14 @@ var TwitterAuthBase = "https://x.com/i/oauth2/authorize"
 // Step 6: Obtain client ID and client secret
 type XClient struct {
 	oauth2Config *oauth2.Config
+	// stateSecret verifies the state JWT on the token exchange. It must match
+	// the secret AuthCodeURL signed the state with (the environment's auth
+	// secret); an empty value falls back to the global app secret in ParseJWT.
+	// A mismatch drops the encrypted PKCE verifier, breaking the X exchange.
+	stateSecret string
 }
 
-func NewXClient(clientID, secretKey, redirectURL string) Client {
+func NewXClient(clientID, secretKey, redirectURL, stateSecret string) Client {
 	config := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: secretKey,
@@ -43,6 +48,7 @@ func NewXClient(clientID, secretKey, redirectURL string) Client {
 
 	return &XClient{
 		oauth2Config: config,
+		stateSecret:  stateSecret,
 	}
 }
 
@@ -112,9 +118,13 @@ func (x *XClient) UserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo,
 func (x *XClient) Exchange(ctx context.Context, req *shttp.RequestContext) (*oauth2.Token, error) {
 	code := req.FormValue("code")
 
-	// Parse JWT claims from state parameter to extract encrypted PKCE verifier
+	// Parse JWT claims from state parameter to extract encrypted PKCE verifier.
+	// The state is signed with the environment's auth secret in AuthCodeURL, so
+	// it must be verified with the same secret here — otherwise the claims are
+	// dropped and the PKCE verifier is lost.
 	claims := user.ParseJWT(&user.ParseJWTArgs{
 		Bearer: req.FormValue("state"),
+		Secret: x.stateSecret,
 	})
 
 	// Extract and decrypt the PKCE verifier if present

--- a/src/ce/api/app/skauth/client_x_test.go
+++ b/src/ce/api/app/skauth/client_x_test.go
@@ -2,6 +2,7 @@ package skauth_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -33,7 +34,7 @@ func (s *ClientXSuite) BeforeTest(suiteName, _ string) {
 	s.originalTwitterAPIBase = skauth.TwitterAPIBase
 	s.conn = databasetest.InitTx(suiteName)
 	s.server = nil
-	s.client = skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback")
+	s.client = skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback", "")
 	admin.MustConfig().SetURL("localhost")
 }
 
@@ -80,7 +81,7 @@ func (s *ClientXSuite) Test_UserInfo_Success() {
 	}
 
 	// Use new client to ensure we're testing with a mock server
-	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback")
+	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback", "")
 	userInfo, err := client.UserInfo(context.Background(), token)
 
 	s.NoError(err)
@@ -109,7 +110,7 @@ func (s *ClientXSuite) Test_UserInfo_NoUsername_NoProfileURL() {
 
 	token := &oauth2.Token{AccessToken: "test-access-token", TokenType: "Bearer"}
 
-	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback")
+	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback", "")
 	userInfo, err := client.UserInfo(context.Background(), token)
 
 	s.NoError(err)
@@ -131,7 +132,7 @@ func (s *ClientXSuite) Test_UserInfo_InvalidJSON() {
 	}
 
 	// Use new client to ensure we're testing with a mock server
-	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback")
+	client := skauth.NewXClient("test-client-id", "test-client-secret", "https://app.example.com/_stormkit/auth/callback", "")
 	userInfo, err := client.UserInfo(context.Background(), token)
 
 	s.Error(err)
@@ -246,6 +247,90 @@ func (s *ClientXSuite) Test_Exchange_InvalidState() {
 	// This should fail because state JWT is invalid
 	_, err = s.client.Exchange(ctx, req)
 	s.Error(err)
+}
+
+// Test_Exchange_SendsCodeVerifier_WhenStateSecretMatches guards the regression
+// that broke X login: AuthCodeURL signs the state with the environment auth
+// secret, so Exchange must verify it with the same secret to recover the
+// encrypted PKCE verifier. When it matches, the token request carries
+// code_verifier and X accepts the exchange.
+func (s *ClientXSuite) Test_Exchange_SendsCodeVerifier_WhenStateSecretMatches() {
+	const secret = "env-auth-secret"
+
+	var captured url.Values
+
+	s.mockServer(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"tok","token_type":"bearer"}`))
+	})
+
+	// Construct after the token URL is overridden so the exchange hits the mock.
+	client := skauth.NewXClient("id", "secret", "https://app.example.com/cb", secret)
+
+	verifier, err := utils.SecureRandomToken(64)
+	s.NoError(err)
+
+	state, err := user.JWT(jwt.MapClaims{
+		"pkce": utils.EncryptToString(verifier),
+		"eid":  1,
+		"prv":  "x",
+	}, secret)
+	s.NoError(err)
+
+	req := s.exchangeRequest("auth-code", state)
+	token, err := client.Exchange(context.Background(), req)
+
+	s.NoError(err)
+	s.Equal("tok", token.AccessToken)
+	s.Equal(verifier, captured.Get("code_verifier"), "PKCE verifier must be sent when the state secret matches")
+}
+
+// Test_Exchange_DropsVerifier_WhenStateSecretMismatches documents the failure
+// mode: if the state was signed with a different secret than the client
+// verifies with, the claims (and thus the PKCE verifier) are dropped and the
+// exchange falls back to a non-PKCE request — which X rejects with
+// "Missing required parameter [code_verifier]".
+func (s *ClientXSuite) Test_Exchange_DropsVerifier_WhenStateSecretMismatches() {
+	var captured url.Values
+
+	s.mockServer(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"tok","token_type":"bearer"}`))
+	})
+
+	client := skauth.NewXClient("id", "secret", "https://app.example.com/cb", "the-right-secret")
+
+	state, err := user.JWT(jwt.MapClaims{
+		"pkce": utils.EncryptToString("some-verifier"),
+		"eid":  1,
+		"prv":  "x",
+	}, "a-different-secret")
+	s.NoError(err)
+
+	req := s.exchangeRequest("auth-code", state)
+	_, err = client.Exchange(context.Background(), req)
+
+	s.NoError(err)
+	s.Empty(captured.Get("code_verifier"), "verifier is dropped when the state secret does not match")
+}
+
+func (s *ClientXSuite) exchangeRequest(code, state string) *shttp.RequestContext {
+	form := url.Values{}
+	form.Set("code", code)
+	form.Set("state", state)
+
+	httpReq, err := http.NewRequest("POST", "http://example.com/callback", strings.NewReader(form.Encode()))
+	s.NoError(err)
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Form = form
+
+	return shttp.NewRequestContext(httpReq)
 }
 
 func TestClientXSuite(t *testing.T) {

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -138,20 +138,29 @@ func (p *Provider) Supported() bool {
 	}
 }
 
+// ClientParams configures the provider client returned by Provider.Client.
+type ClientParams struct {
+	// RedirectURL is the absolute OAuth2 callback the provider redirects back
+	// to; it must match between the authorization request and the token
+	// exchange, and is ignored by non-OAuth providers.
+	RedirectURL string
+	// Secret is the environment's auth secret used to sign and verify the OAuth
+	// state JWT. X needs it on the token exchange to recover the encrypted PKCE
+	// verifier carried in the state; other providers ignore it.
+	Secret string
+}
+
 // Client returns the provider client (OAuth or non-OAuth) for the provider.
-// redirectURL is the absolute OAuth2 callback the provider redirects back to;
-// it must match between the authorization request and the token exchange, and
-// is ignored by non-OAuth providers.
-func (p *Provider) Client(redirectURL string) Client {
+func (p *Provider) Client(params ClientParams) Client {
 	if DefaultClient != nil {
 		return DefaultClient
 	}
 
 	switch p.Name {
 	case ProviderGoogle:
-		return NewGoogleClient(p.Data.ClientID, p.Data.ClientSecret, redirectURL)
+		return NewGoogleClient(p.Data.ClientID, p.Data.ClientSecret, params.RedirectURL)
 	case ProviderX:
-		return NewXClient(p.Data.ClientID, p.Data.ClientSecret, redirectURL)
+		return NewXClient(p.Data.ClientID, p.Data.ClientSecret, params.RedirectURL, params.Secret)
 	case ProviderEmail:
 		return NewEmailClient()
 	case ProviderMagicLink:

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -61,7 +61,10 @@ func (m *skAuthMiddleware) handleOAuthInitiate(providerName string) (*shttp.Resp
 		return resp, nil
 	}
 
-	authURL, err := prv.Client(m.callbackURL()).AuthCodeURL(skauth.AuthCodeURLParams{
+	authURL, err := prv.Client(skauth.ClientParams{
+		RedirectURL: m.callbackURL(),
+		Secret:      env.AuthConf.Secret,
+	}).AuthCodeURL(skauth.AuthCodeURLParams{
 		EnvID:        envID,
 		ProviderName: providerName,
 		Referrer:     redirect,
@@ -146,7 +149,10 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 		return m.loginErrorRedirect(referOrigin, "This sign-in method is not available."), nil
 	}
 
-	client := prv.Client(m.callbackURL())
+	client := prv.Client(skauth.ClientParams{
+		RedirectURL: m.callbackURL(),
+		Secret:      env.AuthConf.Secret,
+	})
 
 	if client == nil {
 		return m.loginErrorRedirect(referOrigin, "This sign-in method is not available."), nil


### PR DESCRIPTION
## Problem

X (Twitter) login fails at the callback with:

> oauth callback: failed to exchange authorization code: oauth2: "invalid_request" "Missing required parameter [code_verifier]."

### Root cause

PR #376 (`fix: auth security hardening`) started signing the OAuth **state JWT with the environment's auth secret**:

```go
state, err := user.JWT(claims, params.Secret) // was user.JWT(claims)
```

But the X client's `Exchange` still parsed that state with **no secret**, so `ParseJWT` fell back to the global app secret, signature verification failed, and the claims came back `nil`. The encrypted `pkce` verifier lives in those claims, so it was silently dropped — X's exchange took the non-PKCE fallback path and X rejected it for the missing `code_verifier`.

**Only X is affected.** Google's `Exchange` ignores the state and uses `code` directly (no PKCE); email/magic-link `Exchange` are no-ops. The central callback already parses state with the env secret — only X's second, secret-less re-parse was broken.

## Fix

Thread the environment secret into the X client so `Exchange` verifies the state with the same key `AuthCodeURL` signed it with.

- `client_x.go` — `XClient` gains a `stateSecret`; `Exchange` passes it to `ParseJWT`.
- `sk_auth_model.go` — `Provider.Client` now takes a `ClientParams{RedirectURL, Secret}` struct.
- `skauth_oauth.go` — the initiate and callback handlers pass `env.AuthConf.Secret`.

## Tests

Two new regression tests capture the token-endpoint POST body and assert:
- `code_verifier` is **present** when the state secret matches, and
- it is **dropped** when the secret mismatches (the exact broken behavior).

`go build ./src/...`, the X client suite, and the hosting OAuth suite all pass.