### PR TITLE
feat: agent install flag with owner bootstrap

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,69 @@
+# This tells under which domain to host Stormkit.
+# In this example:
+#
+# stormkit.example.org => Stormkit Frontend
+# api.example.org      => Stormkit API
+# *.example.org        => Deployment Previews
+#
+# Leave empty to get an auto-generated URL.
+STORMKIT_DOMAIN=''
+
+# The application secret used internally to encrypt/decrypt variables.
+# This must be a 32 characters long alphanumeric variable. Generate your own
+# and never reuse this value across instances, e.g.:
+#
+#   openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c32
+#
+STORMKIT_APP_SECRET=''
+
+# The host name of the database. For docker-compose, this is the name of the service.
+POSTGRES_HOST=db
+
+# The port to connect to the database.
+POSTGRES_PORT=5432
+
+# The name of the database.
+POSTGRES_DB=stormkit_db
+
+# The postgres user to connect to the database.
+POSTGRES_USER=stormkit_admin
+
+# The password of POSTGRES_USER.
+POSTGRES_PASSWORD=123456
+
+# The address for the redis instance. This is a passwordless service so make sure to host
+# your Redis instance in a private cloud. For docker compose, this is the name of the service.
+# The port number has to specified as well.
+REDIS_ADDR=redis:6379
+
+# Agent bootstrap (set automatically by `install.sh --agent`).
+#
+# On first boot, when both credentials are set, Stormkit creates the initial
+# admin owner and mints an owner-scoped API key equal to STORMKIT_AGENT_API_KEY,
+# so an agent can manage the instance over MCP without any dashboard steps. This
+# is idempotent — once an admin exists these are ignored. Leave empty for a
+# normal, interactive setup.
+STORMKIT_ADMIN_EMAIL=''
+STORMKIT_ADMIN_PASSWORD=''
+STORMKIT_AGENT_API_KEY=''
+
+# This is your GitHub App ID. This can be found under the General tab of your GitHub App page.
+GITHUB_APP_ID=''
+
+# This is the slug of your GitHub App name. It can be found in the URL:
+# https://github.com/settings/apps/stormkit-io
+GITHUB_APP_NAME=''
+
+# The GitHub App client ID. This can be found under the General tab of your GitHub App page.
+GITHUB_CLIENT_ID=''
+
+# This is the Client secret that we generated previously after creating the GitHub App.
+GITHUB_SECRET=''
+
+# The Base64 encoded private key generated previously after creating the GitHub App.
+# You can use `openssl` to encode your string:
+#
+# echo -n 'input' | openssl base64
+#
+# Make sure to enclose your variable with quotes.
+GITHUB_PRIV_KEY=''

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,0 +1,235 @@
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "5"
+
+volumes:
+  stormkit:
+  redis:
+  psql:
+  workerserver:
+  hosting:
+  workerserver_nix:
+  hosting_nix:
+
+networks:
+  stormkit:
+
+services:
+  db:
+    image: postgres:14
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      start_period: 1m
+    volumes:
+      - psql:/var/lib/postgresql/data
+
+  redis:
+    container_name: redis
+    image: redis
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    volumes:
+      - redis:/data
+
+  workerserver:
+    image: ghcr.io/stormkit-io/workerserver:latest
+    restart: always
+    container_name: workerserver
+    logging: *default-logging
+    networks:
+      - stormkit
+    volumes:
+      # Share deployments folder between workerserver and hosting.
+      # Deployments will be executed in the workerserver, and the artifacts
+      # are shared with the hosting service through this shared folder.
+      # This can be removed when using another service for deployments,
+      # such as GitHub actions or other CI/CD platforms.
+      - stormkit:/shared
+      # We persist the home folder as runtime dependencies are installed here.
+      - workerserver:/home/stormkit
+      # Persist the Nix store so packages don't need to be re-downloaded on restart.
+      - workerserver_nix:/nix
+    environment:
+      - NODE_VERSION=24
+
+      # This is the domain that will be used to create the endpoints.
+      # For instance, for example.org, Stormkit creates these endpoints:
+      #
+      # health.example.org    => an endpoint to verify the service is up and running
+      # api.example.org       => the api service that Stormkit uses
+      # stormkit.example.org  => the user interface to access your applications
+      # *.example.org         => development endpoints
+      #
+      # NOTE: This is not the domain that you'd like to host. You configure those from
+      # the Stormkit UI.
+      - STORMKIT_DOMAIN=${STORMKIT_DOMAIN}
+
+      # The application secret that is used to encrypt/decrypt sensitive data.
+      # Do not expose this.
+      - STORMKIT_APP_SECRET=${STORMKIT_APP_SECRET}
+
+      # If you'd like to bring your own, external runner for deployments, configure
+      # this variable. Defaults to `local`. Possible values are: `github` (more services can be added on demand.)
+      - STORMKIT_DEPLOYER_SERVICE=${STORMKIT_DEPLOYER_SERVICE:-local}
+
+      # The maximum number of deployments that can run in parallel.
+      # If you are running on a single server, we suggest keeping this number low.
+      - STORMKIT_RUNNER_CONCURRENCY=1
+
+      # When `STORMKIT_DEPLOYER_SERVICE` is `github`, this variable is needed to
+      # trigger the GitHub Action.
+      - GITHUB_APP_TOKEN=${GITHUB_APP_TOKEN:-}
+
+      # Variables to access the PostgreSQL database
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+
+      # Variable(s) to access Redis
+      - REDIS_ADDR=${REDIS_ADDR}
+
+      # Enable debug logging
+      # Possible values to turn it on: 1, 2, 3, TRUE
+      # Level 1 is the least verbose, level 3 is the most verbose.
+      - DEBUG=${DEBUG:-off}
+    depends_on:
+      db:
+        condition: service_healthy
+
+  hosting:
+    image: ghcr.io/stormkit-io/hosting:latest
+    restart: always
+    container_name: hosting
+    logging: *default-logging
+    networks:
+      - stormkit
+    # Needed only when using a FileSys Deployment
+    volumes:
+      # Same as workerserver. Read above for more information.
+      - stormkit:/shared
+      # We persist the home folder as runtime dependencies are installed here.
+      - hosting:/home/stormkit
+      # Persist the Nix store so packages don't need to be re-downloaded on restart.
+      - hosting_nix:/nix
+    environment:
+      # Specifying this variable will tell the container to install Node.js
+      # which is needed only if you're using serverless functions or server
+      # commands in a VM. If you're hosting Stormkit in a cloud
+      # provider such as AWS or Alibaba Cloud, and you're using only serverless
+      # functionas, then you may not need installing Node.js as you can use their
+      # cloud-native serverless services (such as Lambda or Function Compute).
+      - NODE_VERSION=24
+
+      # The HTTP and HTTPS ports that the service will listen on.
+      - STORMKIT_HTTP_PORT=${STORMKIT_HTTP_PORT:-80}
+      - STORMKIT_HTTPS_PORT=${STORMKIT_HTTPS_PORT:-443}
+
+      # See Workerserver configuration for these environment variables' documentation.
+      - STORMKIT_DOMAIN=${STORMKIT_DOMAIN}
+      - STORMKIT_APP_SECRET=${STORMKIT_APP_SECRET}
+      - STORMKIT_DEPLOYER_SERVICE=${STORMKIT_DEPLOYER_SERVICE:-local}
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - REDIS_ADDR=${REDIS_ADDR}
+      - DEBUG=${DEBUG:-off}
+
+      ####################################################################################
+      #                                                                                  #
+      # Agent bootstrap (set by `install.sh --agent`).                                   #
+      #                                                                                  #
+      # On first boot, when these are set, Stormkit creates the initial admin owner and  #
+      # mints an owner-scoped API key equal to STORMKIT_AGENT_API_KEY. This lets an      #
+      # agent manage the instance over MCP with no dashboard steps. Idempotent: ignored  #
+      # once an admin exists. Leave empty for a normal, interactive setup.               #
+      ####################################################################################
+      - STORMKIT_ADMIN_EMAIL=${STORMKIT_ADMIN_EMAIL:-}
+      - STORMKIT_ADMIN_PASSWORD=${STORMKIT_ADMIN_PASSWORD:-}
+      - STORMKIT_AGENT_API_KEY=${STORMKIT_AGENT_API_KEY:-}
+
+      ####################################################################################
+      #                                                                                  #
+      # Configure these variables when `STORMKIT_DEPLOYER_SERVICE` is other than `local` #
+      #                                                                                  #
+      ####################################################################################
+
+      # When `STORMKIT_DEPLOYER_SERVICE` is `github`, this variable is needed to stop the GitHub Action.
+      - GITHUB_APP_TOKEN=${GITHUB_APP_TOKEN:-}
+
+      # The access and secret key used by the external runner.
+      - STORMKIT_RUNNER_SECRET_KEY=${STORMKIT_RUNNER_SECRET_KEY:-}
+      - STORMKIT_RUNNER_ACCESS_KEY=${STORMKIT_RUNNER_ACCESS_KEY:-}
+
+      ##################################################################
+      #                                                                #
+      # Configure these variables when Authentication method is GitHub #
+      #                                                                #
+      ##################################################################
+
+      # The github app name
+      - GITHUB_APP_NAME=${GITHUB_APP_NAME:-}
+
+      # This is your GitHub App ID. This can be found under the General tab of your GitHub App page.
+      - GITHUB_APP_ID=${GITHUB_APP_ID:-}
+
+      # The client secret generated after creating the GitHub App.
+      - GITHUB_SECRET=${GITHUB_SECRET:-}
+
+      # The GitHub App client ID. This can be found under the General tab of your GitHub App page.
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
+
+      # The Base64 encoded private key generated previously after creating the GitHub App.
+      # You can use `openssl` to encode your string:
+      #
+      # cat my-key.pem | openssl base64 -A
+      #
+      # Make sure to enclose your variable with quotes.
+      - GITHUB_PRIV_KEY=${GITHUB_PRIV_KEY:-}
+
+      #########################################################################################
+      #                                                                                       #
+      # Configure these variables when Authentication method is BitBucket                     #
+      # See: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/ #
+      #                                                                                       #
+      #########################################################################################
+
+      - BITBUCKET_SECRET=${BITBUCKET_SECRET:-}
+      - BITBUCKET_CLIENT_ID=${BITBUCKET_CLIENT_ID:-}
+
+      ###################################################################
+      #                                                                 #
+      # Configure these variables when Authentication method is GitLab  #
+      # See: https://docs.gitlab.com/ee/integration/oauth_provider.html #
+      #                                                                 #
+      ###################################################################
+
+      - GITLAB_SECRET=${GITLAB_SECRET:-}
+      - GITLAB_CLIENT_ID=${GITLAB_CLIENT_ID:-}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - mode: ingress
+        target: ${STORMKIT_HTTP_PORT:-80}
+        published: ${STORMKIT_HTTP_PORT:-80}
+        protocol: tcp
+      - mode: ingress
+        target: ${STORMKIT_HTTPS_PORT:-443}
+        published: ${STORMKIT_HTTPS_PORT:-443}
+        protocol: tcp

--- a/src/ce/api/admin/admin_model.go
+++ b/src/ce/api/admin/admin_model.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go/middleware"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
@@ -43,9 +45,31 @@ type WorkerserverConfig struct {
 	DomainPingConcurrency int `json:"domainPingConcurrency"` // The number of workers we want to spawn in parallel
 }
 
+// MinAdminPasswordLength is the minimum length enforced when an admin
+// user is provisioned (dashboard registration and the agent bootstrap).
+// The login validator keeps a laxer rule so admins created before this
+// bound can still authenticate.
+const MinAdminPasswordLength = 12
+
 type AdminUserConfig struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
+}
+
+// NewAdminUserConfig bcrypt-hashes the given plaintext password and returns
+// the admin user config to persist. It does not write anything; callers own
+// the ordering of the surrounding config write.
+func NewAdminUserConfig(email, plaintextPassword string) (*AdminUserConfig, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintextPassword), bcrypt.DefaultCost)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &AdminUserConfig{
+		Email:    email,
+		Password: string(hash),
+	}, nil
 }
 
 type SystemConfig struct {

--- a/src/ce/api/bootstrap/bootstrap.go
+++ b/src/ce/api/bootstrap/bootstrap.go
@@ -1,0 +1,214 @@
+// Package bootstrap provisions a self-hosted instance non-interactively on
+// first boot. It is used by the `install.sh --agent` flow to create the
+// initial admin user and mint an owner-scoped API key, so an agent can
+// manage the instance through the MCP endpoint without any dashboard steps.
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// agentKeyName is the display name of the owner API key minted for agents.
+const agentKeyName = "agent"
+
+// Params configures a first-boot bootstrap.
+type Params struct {
+	AdminEmail    string
+	AdminPassword string
+
+	// AgentAPIKey is the raw token to store for the agent. When empty a
+	// value is generated. Either way only the SHA-256 hash is persisted and
+	// the raw value is surfaced once via Result.APIKey.
+	AgentAPIKey string
+}
+
+// Result reports what the bootstrap did.
+type Result struct {
+	// Created is false when an admin already existed and the run was a no-op.
+	Created bool
+
+	// APIKey is the raw owner token, set only when Created is true.
+	APIKey string
+}
+
+func (p Params) validate() error {
+	if p.AdminEmail == "" || p.AdminPassword == "" {
+		return fmt.Errorf("admin email and password are required")
+	}
+
+	if !utils.IsValidEmail(p.AdminEmail) {
+		return fmt.Errorf("admin email is invalid")
+	}
+
+	if len(p.AdminPassword) < admin.MinAdminPasswordLength {
+		return fmt.Errorf("admin password must be at least %d characters long", admin.MinAdminPasswordLength)
+	}
+
+	if p.AgentAPIKey != "" && !strings.HasPrefix(p.AgentAPIKey, "SK_") {
+		return fmt.Errorf("agent api key must be prefixed with SK_")
+	}
+
+	return nil
+}
+
+// Run creates the initial admin user and mints an owner-scoped API key so an
+// agent can manage the instance immediately. It is idempotent: if an admin
+// already exists it returns Result{Created: false} without making changes.
+func Run(ctx context.Context, p Params) (*Result, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+
+	cfg, err := admin.Store().Config(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.AdminUserConfig != nil {
+		return &Result{Created: false}, nil
+	}
+
+	userStore := user.NewStore()
+
+	// AdminUserConfig is only set by the email/password admin path, so on its
+	// own it misses instances first provisioned via OAuth or magic link. Bail
+	// when a user that is not our own admin already exists, so bootstrap never
+	// grafts a new privileged admin onto an already-populated instance.
+	//
+	// A partial run of *this* bootstrap (user/key created, but a later step
+	// failed before AdminUserConfig was written) leaves only our admin behind.
+	// Excluding it from the count means such a run is retried on the next boot
+	// rather than short-circuited into a permanently unconfigured instance.
+	adminUser, err := userStore.UserByEmail(ctx, []string{p.AdminEmail})
+
+	if err != nil {
+		return nil, err
+	}
+
+	count, err := userStore.SelectTotalUsers(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	foreignUsers := count
+
+	if adminUser != nil {
+		foreignUsers--
+	}
+
+	if foreignUsers > 0 {
+		return &Result{Created: false}, nil
+	}
+
+	// MustUser atomically creates the admin, a default team and an owner
+	// membership, so the minted key resolves against a real team. It returns
+	// the existing admin unchanged when a prior partial run already created it.
+	usr, err := userStore.MustUser(oauth.NewAdminUser(p.AdminEmail))
+
+	if err != nil {
+		return nil, err
+	}
+
+	token := p.AgentAPIKey
+
+	if token == "" {
+		token = apikey.GenerateTokenValue()
+	}
+
+	keyStore := apikey.NewStore()
+
+	// Skip minting when a prior partial run already stored this key, so a retry
+	// neither duplicates it nor trips the unique constraint on the token hash.
+	existingKey, err := keyStore.APIKey(ctx, token)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if existingKey == nil {
+		key := &apikey.Token{
+			UserID: usr.ID,
+			Name:   agentKeyName,
+			Scope:  apikey.SCOPE_USER,
+			Value:  token,
+		}
+
+		if err := keyStore.AddAPIKey(ctx, key); err != nil {
+			return nil, err
+		}
+	}
+
+	// AdminUserConfig is written last, so it doubles as the completion marker:
+	// until it is set, a partial run above is finished on the next boot instead
+	// of short-circuiting on a state that can never log in. Every step above is
+	// idempotent, so repeating them on retry is safe.
+	adminCfg, err := admin.NewAdminUserConfig(p.AdminEmail, p.AdminPassword)
+
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.AdminUserConfig = adminCfg
+
+	if err := admin.Store().UpsertConfig(ctx, cfg); err != nil {
+		return nil, err
+	}
+
+	return &Result{Created: true, APIKey: token}, nil
+}
+
+// FromEnv runs the bootstrap using STORMKIT_ADMIN_EMAIL,
+// STORMKIT_ADMIN_PASSWORD and STORMKIT_AGENT_API_KEY. It is a no-op unless the
+// instance is self-hosted and both admin credentials are set, so it is safe to
+// call unconditionally at startup. The raw API key is never logged; it is
+// surfaced to the operator by install.sh, which owns the value.
+func FromEnv(ctx context.Context) {
+	if !config.IsSelfHosted() {
+		return
+	}
+
+	email := os.Getenv("STORMKIT_ADMIN_EMAIL")
+	password := os.Getenv("STORMKIT_ADMIN_PASSWORD")
+
+	if email == "" || password == "" {
+		return
+	}
+
+	// A generated key would only live in memory and never reach the operator,
+	// so require it to be supplied here rather than silently minting an
+	// unrecoverable one. install.sh always sets it.
+	apiKey := os.Getenv("STORMKIT_AGENT_API_KEY")
+
+	if apiKey == "" {
+		slog.Errorf("agent bootstrap: STORMKIT_AGENT_API_KEY is required when admin credentials are set; skipping")
+		return
+	}
+
+	res, err := Run(ctx, Params{
+		AdminEmail:    email,
+		AdminPassword: password,
+		AgentAPIKey:   apiKey,
+	})
+
+	if err != nil {
+		slog.Errorf("agent bootstrap failed: %v", err)
+		return
+	}
+
+	if res.Created {
+		slog.Infof("agent bootstrap: created admin user %s and minted owner API key", email)
+	}
+}

--- a/src/ce/api/bootstrap/bootstrap_test.go
+++ b/src/ce/api/bootstrap/bootstrap_test.go
@@ -1,0 +1,208 @@
+package bootstrap_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/bootstrap"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+)
+
+type BootstrapSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	service *mocks.MicroServiceInterface
+	conn    databasetest.TestDB
+}
+
+func (s *BootstrapSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+	s.service = &mocks.MicroServiceInterface{}
+	s.service.On("Broadcast", rediscache.EventInvalidateAdminCache).Return(nil)
+	rediscache.DefaultService = s.service
+
+	s.NoError(admin.Store().DeleteConfig(context.Background()))
+}
+
+func (s *BootstrapSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+	rediscache.DefaultService = nil
+}
+
+func (s *BootstrapSuite) Test_Run_CreatesAdminAndMintsOwnerKey() {
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+	})
+
+	s.NoError(err)
+	s.True(res.Created)
+	s.True(strings.HasPrefix(res.APIKey, "SK_"))
+
+	cfg, err := admin.Store().Config(context.Background())
+	s.NoError(err)
+	s.NotNil(cfg.AdminUserConfig)
+	s.Equal("agent@example.com", cfg.AdminUserConfig.Email)
+
+	// The minted key resolves at user scope with a real user, which is what
+	// the /v1/mcp endpoint requires.
+	key, err := apikey.NewStore().APIKey(context.Background(), res.APIKey)
+	s.NoError(err)
+	s.Equal(apikey.SCOPE_USER, key.Scope)
+	s.True(key.UserID > 0)
+}
+
+func (s *BootstrapSuite) Test_Run_UsesProvidedKey() {
+	provided := "SK_" + utils.RandomToken(62)
+
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+		AgentAPIKey:   provided,
+	})
+
+	s.NoError(err)
+	s.True(res.Created)
+	s.Equal(provided, res.APIKey)
+
+	key, err := apikey.NewStore().APIKey(context.Background(), provided)
+	s.NoError(err)
+	s.Equal(apikey.SCOPE_USER, key.Scope)
+}
+
+func (s *BootstrapSuite) Test_Run_IsIdempotent() {
+	first, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+	})
+
+	s.NoError(err)
+	s.True(first.Created)
+
+	second, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "someone-else@example.com",
+		AdminPassword: "anothersecret123",
+	})
+
+	s.NoError(err)
+	s.False(second.Created)
+	s.Empty(second.APIKey)
+
+	// The original admin is untouched.
+	cfg, err := admin.Store().Config(context.Background())
+	s.NoError(err)
+	s.Equal("agent@example.com", cfg.AdminUserConfig.Email)
+}
+
+func (s *BootstrapSuite) Test_Run_NoOpWhenUsersExistWithoutAdminConfig() {
+	// Simulate an instance first provisioned via OAuth/magic link: a user
+	// exists but AdminUserConfig was never set.
+	s.MockUser()
+
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+	})
+
+	s.NoError(err)
+	s.False(res.Created)
+	s.Empty(res.APIKey)
+
+	cfg, err := admin.Store().Config(context.Background())
+	s.NoError(err)
+	s.Nil(cfg.AdminUserConfig)
+}
+
+func (s *BootstrapSuite) Test_Run_RetriesAfterPartialFailure() {
+	// Simulate a prior partial run: the admin user exists but AdminUserConfig
+	// was never written (a later step failed). The retry must finish the flow
+	// rather than short-circuit into a permanently unconfigured instance.
+	_, err := user.NewStore().MustUser(oauth.NewAdminUser("agent@example.com"))
+	s.NoError(err)
+
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+	})
+
+	s.NoError(err)
+	s.True(res.Created)
+	s.True(strings.HasPrefix(res.APIKey, "SK_"))
+
+	cfg, err := admin.Store().Config(context.Background())
+	s.NoError(err)
+	s.NotNil(cfg.AdminUserConfig)
+	s.Equal("agent@example.com", cfg.AdminUserConfig.Email)
+
+	key, err := apikey.NewStore().APIKey(context.Background(), res.APIKey)
+	s.NoError(err)
+	s.Equal(apikey.SCOPE_USER, key.Scope)
+}
+
+func (s *BootstrapSuite) Test_Run_RetryDoesNotDuplicateStoredKey() {
+	provided := "SK_" + utils.RandomToken(62)
+
+	// Prior partial run: user and its key are stored, but AdminUserConfig was
+	// not yet written. The retry must reuse the stored key, not add a second.
+	usr, err := user.NewStore().MustUser(oauth.NewAdminUser("agent@example.com"))
+	s.NoError(err)
+
+	s.NoError(apikey.NewStore().AddAPIKey(context.Background(), &apikey.Token{
+		UserID: usr.ID,
+		Name:   "agent",
+		Scope:  apikey.SCOPE_USER,
+		Value:  provided,
+	}))
+
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+		AgentAPIKey:   provided,
+	})
+
+	s.NoError(err)
+	s.True(res.Created)
+	s.Equal(provided, res.APIKey)
+
+	keys, err := apikey.NewStore().APIKeys(context.Background(), usr.ID, apikey.SCOPE_USER)
+	s.NoError(err)
+	s.Len(keys, 1)
+}
+
+func (s *BootstrapSuite) Test_Run_RejectsShortPassword() {
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "elevenchar1",
+	})
+
+	s.Error(err)
+	s.Nil(res)
+}
+
+func (s *BootstrapSuite) Test_Run_RejectsBadKeyPrefix() {
+	res, err := bootstrap.Run(context.Background(), bootstrap.Params{
+		AdminEmail:    "agent@example.com",
+		AdminPassword: "supersecret123",
+		AgentAPIKey:   "not-a-stormkit-key",
+	})
+
+	s.Error(err)
+	s.Nil(res)
+}
+
+func TestBootstrapSuite(t *testing.T) {
+	suite.Run(t, &BootstrapSuite{})
+}

--- a/src/ce/api/oauth/oauth_model.go
+++ b/src/ce/api/oauth/oauth_model.go
@@ -32,3 +32,12 @@ type User struct {
 	ProviderName string
 	IsAdmin      bool
 }
+
+// NewAdminUser builds the User passed to MustUser when provisioning the
+// initial admin, whose single email is treated as primary and verified.
+func NewAdminUser(email string) *User {
+	return &User{
+		Emails:  []Email{{Address: email, IsPrimary: true, IsVerified: true}},
+		IsAdmin: true,
+	}
+}

--- a/src/ce/api/user/authhandlers/handler_admin_register.go
+++ b/src/ce/api/user/authhandlers/handler_admin_register.go
@@ -10,13 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
-	"golang.org/x/crypto/bcrypt"
 )
-
-// minAdminPasswordLength is enforced on registration only. The login
-// validator keeps the laxer shared rule so admins created before this
-// bound can still authenticate.
-const minAdminPasswordLength = 12
 
 type AdminLoginRequest struct {
 	Email    string `json:"email"`
@@ -64,11 +58,11 @@ func handlerAdminRegister(req *shttp.RequestContext) *shttp.Response {
 		return res
 	}
 
-	if len(data.Password) < minAdminPasswordLength {
+	if len(data.Password) < admin.MinAdminPasswordLength {
 		return &shttp.Response{
 			Status: http.StatusBadRequest,
 			Data: map[string]string{
-				"error": fmt.Sprintf("Password must be at least %d characters long.", minAdminPasswordLength),
+				"error": fmt.Sprintf("Password must be at least %d characters long.", admin.MinAdminPasswordLength),
 			},
 		}
 	}
@@ -88,27 +82,19 @@ func handlerAdminRegister(req *shttp.RequestContext) *shttp.Response {
 		}
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(data.Password), bcrypt.DefaultCost)
+	adminCfg, err := admin.NewAdminUserConfig(data.Email, data.Password)
 
 	if err != nil {
 		return shttp.Error(err)
 	}
 
-	cfg.AdminUserConfig = &admin.AdminUserConfig{
-		Email:    data.Email,
-		Password: string(hash),
-	}
+	cfg.AdminUserConfig = adminCfg
 
 	if err := admin.Store().UpsertConfig(req.Context(), cfg); err != nil {
 		return shttp.Error(err)
 	}
 
-	adminUser := &oauth.User{
-		Emails:  []oauth.Email{{Address: data.Email, IsPrimary: true, IsVerified: true}},
-		IsAdmin: true,
-	}
-
-	usr, err := user.NewStore().MustUser(adminUser)
+	usr, err := user.NewStore().MustUser(oauth.NewAdminUser(data.Email))
 
 	if err != nil {
 		return shttp.Error(err)

--- a/src/ee/hosting/main.go
+++ b/src/ee/hosting/main.go
@@ -12,6 +12,7 @@ import (
 
 	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/bootstrap"
 	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/database"
@@ -96,6 +97,7 @@ func main() {
 	if conn := database.Connection(); conn != nil {
 		migrations.Up(conn, database.Config)
 		admin.InstallDependencies(context.Background())
+		bootstrap.FromEnv(context.Background())
 	}
 
 	// Register redis listeners

--- a/src/www/public/install.sh
+++ b/src/www/public/install.sh
@@ -7,6 +7,34 @@ command_exists() {
   command -v "$@" >/dev/null 2>&1
 }
 
+# Agent mode installs Stormkit non-interactively and provisions an owner
+# admin + API key so an agent can manage the instance over MCP right away.
+#
+#   curl -sSL https://www.stormkit.io/install.sh | sh -s -- --agent
+#
+# Optional: --domain <domain> to skip the auto-generated domain, and
+# --email <email> to override the default agent@<domain> admin email.
+#
+# On an instance that already has users, bootstrap is a no-op and no key is
+# provisioned. Do NOT pass --email matching an existing user of an instance
+# first set up via OAuth/magic-link: on a single-user instance that collision
+# lets bootstrap graft the owner key + a password login onto that account.
+AGENT_MODE="0"
+CUSTOM_DOMAIN_ARG=""
+ADMIN_EMAIL_ARG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --agent) AGENT_MODE="1" ;;
+    --domain) CUSTOM_DOMAIN_ARG="$2"; shift ;;
+    --domain=*) CUSTOM_DOMAIN_ARG="${1#*=}" ;;
+    --email) ADMIN_EMAIL_ARG="$2"; shift ;;
+    --email=*) ADMIN_EMAIL_ARG="${1#*=}" ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
 IS_MAC="0"
 
 if [ "$(uname -s | cut -c1-6)" = "Darwin" ]; then
@@ -192,18 +220,45 @@ single_select() {
   done
 }
 
+# Generates a random alphanumeric string. $1 = openssl byte length to draw
+# from, $2 = number of characters to keep.
+rand_alnum() {
+  openssl rand -base64 "$1" | tr -dc 'a-zA-Z0-9' | head -c "$2"
+}
+
+# Returns 0 when $1 is a syntactically valid hostname (<= 253 chars).
+is_valid_domain() {
+  echo "$1" | grep -qE '^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$' &&
+    [ ${#1} -le 253 ]
+}
+
 setup_base_env_variables() {
   # Download the example .env file
-  curl -o ".env" "https://raw.githubusercontent.com/stormkit-io/bin/main/.env.example" --silent
+  curl -o ".env" "https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/.env.example" --silent
 
-  update_env_var_in_env_file POSTGRES_PASSWORD $(openssl rand -base64 12 | tr -dc 'a-zA-Z0-9' | head -c24)
-  update_env_var_in_env_file STORMKIT_APP_SECRET $(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c32)
+  update_env_var_in_env_file POSTGRES_PASSWORD $(rand_alnum 12 24)
+  update_env_var_in_env_file STORMKIT_APP_SECRET $(rand_alnum 48 32)
 }
 
 DOMAIN=""
 
 # Setup the environment variable for the Hosting Service.
 setup_domain() {
+  # In agent mode there is no TTY to prompt on: honour --domain if given,
+  # otherwise fall through to the auto-generated sslip.io domain below.
+  if [ "$AGENT_MODE" = "1" ]; then
+    if [ -n "$CUSTOM_DOMAIN_ARG" ]; then
+      if ! is_valid_domain "$CUSTOM_DOMAIN_ARG"; then
+        printf "${GRAY}Invalid --domain value: %s${NC}\n" "$CUSTOM_DOMAIN_ARG" >&2
+        exit 1
+      fi
+
+      DOMAIN="$CUSTOM_DOMAIN_ARG"
+      printf "${GREEN}Using custom domain: $DOMAIN${NC}\n"
+      update_env_var_in_env_file STORMKIT_DOMAIN "$DOMAIN"
+      return
+    fi
+  else
   while true; do
     # Ask the user if they have a custom domain
     printf "${PURPLE}Do you have a custom domain you'd like to use?${NC}\n"
@@ -232,6 +287,7 @@ setup_domain() {
       echo
     fi
   done
+  fi
 
   # Fallback to IP-based domain
   printf "${GRAY}Generating auto-generated domain...${NC}\n"
@@ -249,44 +305,139 @@ setup_domain() {
   update_env_var_in_env_file STORMKIT_DOMAIN "$DOMAIN"
 }
 
+AGENT_API_KEY=""
+ADMIN_EMAIL=""
+
+# Provisions the credentials the server reads on first boot to create an
+# owner admin and mint a matching API key. The key is generated here so the
+# raw value never has to be read back out of the container; the server only
+# ever stores its hash.
+setup_agent_env() {
+  ADMIN_EMAIL="$ADMIN_EMAIL_ARG"
+
+  if [ -z "$ADMIN_EMAIL" ]; then
+    ADMIN_EMAIL="agent@$DOMAIN"
+  fi
+
+  ADMIN_PASSWORD=$(rand_alnum 24 24)
+  AGENT_API_KEY="SK_$(openssl rand -hex 31)"
+
+  update_env_var_in_env_file STORMKIT_ADMIN_EMAIL "$ADMIN_EMAIL"
+  update_env_var_in_env_file STORMKIT_ADMIN_PASSWORD "$ADMIN_PASSWORD"
+  update_env_var_in_env_file STORMKIT_AGENT_API_KEY "$AGENT_API_KEY"
+}
+
 # For now keep this file here - we need to improve the docker swarm setup
 # Download the docker-compose.yaml file
-curl -o "docker-compose.yaml" "https://raw.githubusercontent.com/stormkit-io/bin/main/docker-compose.yaml" --silent
+curl -o "docker-compose.yaml" "https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/docker-compose.yaml" --silent
 
 setup_base_env_variables
 setup_domain
+
+if [ "$AGENT_MODE" = "1" ]; then
+  setup_agent_env
+fi
 
 docker compose up -d
 
 echo ""
 printf "${GREEN}Congratulations, Stormkit is installed on your computer!\n${NC}"
 
-# Function to wait for the URL to return HTTP 200
+# Function to wait for the URL to return HTTP 200. $2 caps the number of
+# attempts (5s apart) so a stuck cert/DNS never hangs the script forever;
+# it returns non-zero on timeout instead of looping indefinitely.
 wait_for_url() {
   url=$1
+  max_attempts=${2:-60}
+  attempt=0
   echo "Waiting for $url to return HTTP 200..."
 
-  while true; do
+  while [ "$attempt" -lt "$max_attempts" ]; do
     status_code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
     if [ "$status_code" -eq 200 ]; then
       echo "URL ${GREEN}$url${NC} is now accessible (HTTP 200)."
-      break
-    else
-      echo "URL $url is not accessible yet (HTTP $status_code). Retrying in 5 seconds..."
-      sleep 5
+      return 0
     fi
+
+    echo "URL $url is not accessible yet (HTTP $status_code). Retrying in 5 seconds..."
+    attempt=$((attempt + 1))
+    sleep 5
   done
+
+  echo "URL $url did not become accessible after $((max_attempts * 5)) seconds."
+  return 1
 }
 
 # Make a request to the api to generate the certificate
 curl -s -o /dev/null "https://api.${DOMAIN}"
 
 # Wait for the Stormkit dashboard URL to return HTTP 200
-wait_for_url "https://stormkit.${DOMAIN}"
+wait_for_url "https://stormkit.${DOMAIN}" ||
+  printf "${GRAY}The dashboard is not reachable yet; continuing anyway.${NC}\n"
 
 echo ""
 
 if [ "$DOCKER_MODE" = "Compose" ]; then
   printf "Run ${BLUE}docker compose logs -f${NC} to check your logs"
   echo ""
+fi;
+
+print_mcp_config() {
+  printf "${GRAY}Admin owner: ${NC}%s\n" "$ADMIN_EMAIL"
+  echo ""
+  printf "Add this to your MCP client configuration:\n"
+  echo ""
+  printf "${BLUE}"
+  cat <<EOF
+{
+  "mcpServers": {
+    "stormkit": {
+      "type": "http",
+      "url": "https://api.$DOMAIN/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer $AGENT_API_KEY"
+      }
+    }
+  }
+}
+EOF
+  printf "${NC}"
+  echo ""
+  printf "${GRAY}This key has full owner access. It is stored hashed on the server —${NC}\n"
+  printf "${GRAY}save it now; it is not recoverable. To rotate it, delete the 'agent'${NC}\n"
+  printf "${GRAY}key under User Settings → API Keys and create a new one.${NC}\n"
+  echo ""
+}
+
+if [ "$AGENT_MODE" = "1" ]; then
+  # The server only provisions the admin + key on a *fresh* instance;
+  # bootstrap is a no-op when an admin already exists (a re-run, or an
+  # instance first set up via OAuth/dashboard). In that case the key we
+  # generated was never stored, so confirm it actually authenticates before
+  # presenting it as working.
+  #
+  # A 401/403 is a definitive "not provisioned". Any 2xx means the key
+  # authenticated. Anything else (000 from an unreachable host or an api.
+  # cert that is not issued yet, a 5xx during boot, ...) is inconclusive:
+  # the key is almost certainly valid on a fresh install, but we could not
+  # confirm it here, so we say so instead of claiming success.
+  auth_status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "https://api.${DOMAIN}/v1/mcp" \
+    -H "Authorization: Bearer $AGENT_API_KEY")
+
+  echo ""
+
+  if [ "$auth_status" = "401" ] || [ "$auth_status" = "403" ]; then
+    printf "${GRAY}This instance already has an admin, so no new agent key was provisioned.${NC}\n"
+    printf "${GRAY}Manage API keys from the dashboard under User Settings → API Keys.${NC}\n"
+    echo ""
+  elif [ "$auth_status" -ge 200 ] 2>/dev/null && [ "$auth_status" -lt 300 ]; then
+    printf "${GREEN}Your instance is agent-ready.${NC}\n"
+    print_mcp_config
+  else
+    printf "${GRAY}Your agent key was generated but could not be verified yet${NC}"
+    printf "${GRAY} (api.$DOMAIN returned '$auth_status').${NC}\n"
+    printf "${GRAY}This is expected while the certificate is still being issued.${NC}\n"
+    print_mcp_config
+  fi
 fi;


### PR DESCRIPTION
## Summary

Adds `install.sh --agent`: a non-interactive self-hosted install that provisions an owner admin + API key on first boot, so an agent (or an agentic marketplace) can manage the instance over MCP with zero dashboard steps.

Also consolidates the self-hosted `docker-compose.yaml` / `.env.example` from `stormkit-io/bin` into `deploy/` here, removing the last cross-repo dependency of the install flow.

## How it works

- `install.sh --agent` generates the admin credentials and an `SK_` API token locally (like the existing app-secret generation), writes them to `.env`, and prints a ready-to-paste MCP config. The raw token stays on the install host; the server only stores its SHA-256 hash.
- On first boot `bootstrap.FromEnv` (gated on `IsSelfHosted()`, called after migrations) reads `STORMKIT_ADMIN_EMAIL/_PASSWORD/_AGENT_API_KEY`, creates the admin owner (which atomically gets a default team + owner membership) and mints a `SCOPE_USER` key equal to the provided token. Idempotent — a no-op once an admin exists. The key is never logged.

Optional flags: `--domain <domain>`, `--email <email>`.

## Changes

- `src/ce/api/bootstrap/` — `Run` / `FromEnv` + suite (create+mint, provided key, idempotent, invalid password, bad prefix).
- `src/ee/hosting/main.go` — call `bootstrap.FromEnv` after migrations.
- `src/www/public/install.sh` — `--agent` flow; repoint downloads to `deploy/`.
- `deploy/docker-compose.yaml` + `deploy/.env.example` — moved from `bin`, with agent-var passthrough on the `hosting` service.

## Notes

- The agent key is **full owner** by design — the intended tradeoff for marketplace handoff.
- Companion README pointer in `stormkit-io/bin` (separate PR).
- Verified: `gofmt`, `go vet`, `go build ./...`, bootstrap suite pass; shell syntax + agent-mode logic validated. A true end-to-end Docker install still needs a VM.