### PR TITLE
feat: resolve volume and defanged urls in admin search

### DIFF
--- a/src/ce/api/admin/adminhandlers/handler_admin_app_get.go
+++ b/src/ce/api/admin/adminhandlers/handler_admin_app_get.go
@@ -1,6 +1,7 @@
 package adminhandlers
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -9,18 +10,22 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
+
+// volumeFilePathPrefix is the URL path prefix used by public volume file links
+// (see volumes.File.PublicLink).
+const volumeFilePathPrefix = "/volumes/file/"
 
 // handlerAdminAppGet returns the app information, with the associated user.
 func handlerAdminAppGet(req *user.RequestContext) *shttp.Response {
-	addrs := req.Query().Get("url")
+	addrs := defangURL(req.Query().Get("url"))
 	store := app.NewStore()
 
 	if !strings.HasPrefix(addrs, "http") && !strings.HasPrefix(addrs, "//") {
 		addrs = fmt.Sprintf("https://%s", addrs)
 	}
 
-	addrs = strings.ReplaceAll(addrs, "[.]", ".") // AWS trust report format fix
 	parsed, err := url.Parse(addrs)
 
 	if err != nil {
@@ -29,15 +34,7 @@ func handlerAdminAppGet(req *user.RequestContext) *shttp.Response {
 		})
 	}
 
-	hostname := parsed.Hostname()
-
-	var appl *app.App
-
-	if appconf.IsStormkitDev(addrs) {
-		appl, err = store.AppByDisplayName(req.Context(), strings.Split(hostname, ".")[0])
-	} else {
-		appl, err = store.AppByDomainName(req.Context(), hostname)
-	}
+	appl, err := resolveApp(req.Context(), store, addrs, parsed)
 
 	if err != nil {
 		return shttp.Error(err)
@@ -59,4 +56,60 @@ func handlerAdminAppGet(req *user.RequestContext) *shttp.Response {
 			"user": usr.JSON(),
 		},
 	}
+}
+
+// defangURL reverses the common "defanging" applied to URLs in abuse and threat
+// reports (e.g. AWS trust reports) so they can be parsed again: hxxp(s):// back
+// to http(s):// and [.] back to a literal dot.
+func defangURL(addrs string) string {
+	replacer := strings.NewReplacer(
+		"[.]", ".",
+		"hxxps://", "https://",
+		"hxxp://", "http://",
+	)
+
+	return replacer.Replace(addrs)
+}
+
+// resolveApp finds the app a URL points to. It first tries to resolve a public
+// volume file URL (which embeds the environment ID) and otherwise falls back to
+// hostname-based resolution (stormkit.dev display name or custom domain).
+func resolveApp(ctx context.Context, store *app.Store, addrs string, parsed *url.URL) (*app.App, error) {
+	if appl, err := appByVolumeURL(ctx, store, parsed); err != nil || appl != nil {
+		return appl, err
+	}
+
+	hostname := parsed.Hostname()
+
+	if appconf.IsStormkitDev(addrs) {
+		return store.AppByDisplayName(ctx, strings.Split(hostname, ".")[0])
+	}
+
+	return store.AppByDomainName(ctx, hostname)
+}
+
+// appByVolumeURL resolves the app owning a public volume file URL of the form
+// /volumes/file/<token>, where <token> is the encrypted "<fileID>:<envID>" pair
+// produced by volumes.File.PublicLink. It returns (nil, nil) when the URL is not
+// a volume file URL or its token cannot be decoded, so the caller falls back to
+// hostname-based resolution.
+func appByVolumeURL(ctx context.Context, store *app.Store, parsed *url.URL) (*app.App, error) {
+	if !strings.HasPrefix(parsed.Path, volumeFilePathPrefix) {
+		return nil, nil
+	}
+
+	token := strings.TrimPrefix(parsed.Path, volumeFilePathPrefix)
+	decrypted := utils.DecryptToString(token)
+
+	if decrypted == "" {
+		return nil, nil
+	}
+
+	pieces := strings.Split(decrypted, ":")
+
+	if len(pieces) != 2 {
+		return nil, nil
+	}
+
+	return store.AppByEnvID(ctx, utils.StringToID(pieces[1]))
 }

--- a/src/ce/api/admin/adminhandlers/handler_admin_app_get_test.go
+++ b/src/ce/api/admin/adminhandlers/handler_admin_app_get_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -95,6 +96,72 @@ func (s *HandlerAdminAppGetSuite) Test_Get_ByDomainName() {
 	s.Equal(app.DisplayName, data["app"]["displayName"])
 	s.Equal(app.Repo, data["app"]["repo"])
 	s.Equal(app.ID.String(), data["app"]["id"])
+}
+
+func (s *HandlerAdminAppGetSuite) Test_Get_ByDefangedURL() {
+	usr := s.MockUser(map[string]any{"IsAdmin": true})
+	app := s.MockApp(usr)
+
+	// Reports defang URLs as e.g. hxxps://<display>[.]stormkit[.]dev.
+	defanged := fmt.Sprintf("hxxp://%s[.]stormkit:8888", app.DisplayName)
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/admin/cloud/app?url="+url.QueryEscape(defanged),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	data := map[string]map[string]any{}
+
+	s.Equal(http.StatusOK, resp.Code)
+	s.NoError(json.Unmarshal(resp.Byte(), &data))
+	s.Equal(app.ID.String(), data["app"]["id"])
+}
+
+func (s *HandlerAdminAppGetSuite) Test_Get_ByVolumeFileURL() {
+	usr := s.MockUser(map[string]any{"IsAdmin": true})
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	// Mirrors volumes.File.PublicLink: the token encrypts "<fileID>:<envID>".
+	token := utils.EncryptToString(fmt.Sprintf("42:%s", env.ID))
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/admin/cloud/app?url="+url.QueryEscape("https://api.stormkit.io/volumes/file/"+token),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	data := map[string]map[string]any{}
+
+	s.Equal(http.StatusOK, resp.Code)
+	s.NoError(json.Unmarshal(resp.Byte(), &data))
+	s.Equal(app.ID.String(), data["app"]["id"])
+	s.Equal(usr.ID.String(), data["user"]["id"])
+}
+
+func (s *HandlerAdminAppGetSuite) Test_Get_ByVolumeFileURL_InvalidToken() {
+	usr := s.MockUser(map[string]any{"IsAdmin": true})
+
+	resp := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(adminhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		"/admin/cloud/app?url="+url.QueryEscape("https://api.stormkit.io/volumes/file/not-a-valid-token"),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusNoContent, resp.Code)
 }
 
 func (s *HandlerAdminAppGetSuite) Test_Get_Unauthorized_NonAdmin() {

--- a/src/ui/src/pages/admin/CloudApps.spec.tsx
+++ b/src/ui/src/pages/admin/CloudApps.spec.tsx
@@ -29,7 +29,7 @@ describe("~/pages/admin/CloudApps.tsx", () => {
     expect(wrapper.getByLabelText("Search")).toBeTruthy();
     expect(
       wrapper.getByPlaceholderText(
-        "Search an app by it's display or domain name and press Enter"
+        "Search an app by its display name, domain, or a volume file URL and press Enter"
       )
     ).toBeTruthy();
     expect(wrapper.getByText("Apps")).toBeTruthy();

--- a/src/ui/src/pages/admin/CloudApps.tsx
+++ b/src/ui/src/pages/admin/CloudApps.tsx
@@ -84,7 +84,7 @@ export default function CloudApps() {
         <TextField
           variant="filled"
           label="Search"
-          placeholder="Search an app by it's display or domain name and press Enter"
+          placeholder="Search an app by its display name, domain, or a volume file URL and press Enter"
           onKeyUp={e => {
             if (e.key !== "Enter") {
               return;


### PR DESCRIPTION
## What

Extends the admin **Cloud Apps** search (`/admin/cloud/apps`) so it can resolve two more kinds of URLs that show up in abuse/threat reports:

1. **Public volume file URLs** — e.g. `https://api.stormkit.io/volumes/file/<token>`. The token is the encrypted `<fileID>:<envID>` pair produced by `volumes.File.PublicLink`. The handler decrypts it, extracts the `envID`, and resolves the owning app via the existing `store.AppByEnvID`. From the URL alone this mapping is opaque (authenticated encryption with the instance secret), so it can only be done in-process — which is exactly what this admin tool is.

2. **Defanged URLs** — e.g. `hxxps://paladinrag-jrcz9h[.]stormkit[.]dev`. The prior `[.]` → `.` fix is consolidated into a `defangURL` helper that also maps `hxxp(s)://` → `http(s)://`, so reports can be pasted as-is.

Resolution order: volume-file URL → stormkit.dev display name → custom domain. Non-matching URLs fall through to the existing hostname lookup unchanged.

## Notes

- Volume resolution reads only the `envID`; it does not gate on the file's public flag, so it still resolves apps for files that were later made private — the right behaviour for abuse triage.
- Frontend: updated the search placeholder (and spec) to mention volume URLs.

## Tests

- `Test_Get_ByVolumeFileURL` — token → correct app + user
- `Test_Get_ByVolumeFileURL_InvalidToken` — garbage token → 204
- `Test_Get_ByDefangedURL` — `hxxp://…[.]…` resolves via display name
- Existing display-name / domain-name / auth tests unchanged and green
- `CloudApps.spec.tsx` (13 tests) green