### PR TITLE
fix: stop serving public volume files for deleted apps

### DIFF
--- a/src/ce/api/app/volumes/volumeshandlers/handler_volumes_public_file.go
+++ b/src/ce/api/app/volumes/volumeshandlers/handler_volumes_public_file.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/volumes"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -42,6 +43,16 @@ func HandlerVolumesPublicFile(req *shttp.RequestContext) *shttp.Response {
 	}
 
 	if fileInfo == nil || fileInfo.EnvID != envID || !fileInfo.IsPublic {
+		return shttp.NotFound()
+	}
+
+	ownerApp, err := app.NewStore().AppByEnvID(req.Context(), envID)
+
+	if err != nil {
+		return shttp.Error(err)
+	}
+
+	if ownerApp == nil {
 		return shttp.NotFound()
 	}
 

--- a/src/ce/api/app/volumes/volumeshandlers/handler_volumes_public_file_test.go
+++ b/src/ce/api/app/volumes/volumeshandlers/handler_volumes_public_file_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/volumes"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/volumes/volumeshandlers"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
@@ -108,6 +109,27 @@ func (s *HandlerVolumesFileSuite) Test_Fail_NotPublic() {
 	app := s.MockApp(usr)
 	env := s.MockEnv(app)
 	parsed, err := url.Parse(s.prepareFile(false, env.ID))
+	s.NoError(err)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(volumeshandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		parsed.Path,
+		nil,
+		nil,
+	)
+
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
+func (s *HandlerVolumesFileSuite) Test_Fail_AppDeleted() {
+	usr := s.MockUser()
+	mockApp := s.MockApp(usr)
+	env := s.MockEnv(mockApp)
+	parsed, err := url.Parse(s.prepareFile(true, env.ID))
+	s.NoError(err)
+
+	_, err = app.NewStore().MarkAsDeleted(context.Background(), mockApp.ID)
 	s.NoError(err)
 
 	response := shttptest.RequestWithHeaders(


### PR DESCRIPTION
## Problem

Public volume files (served at `/volumes/file/{hash}`) remain accessible after their owning app is deleted.

Two independent gaps cause this:

1. **Read side** — `HandlerVolumesPublicFile` only checks that the `volumes` row exists, matches the env, and is public. It never verifies the owning app/env is still live.
2. **Cleanup side** — app deletion is soft-only (`deleted_at`) and never removes `volumes` rows or physical files; the `ON DELETE CASCADE` on `volumes.env_id` never fires because env rows are only ever soft-deleted.

## This PR

Adds the **read guard** (stop-the-bleed). After the existing public/env checks, the handler now resolves the owning app via `app.NewStore().AppByEnvID(envID)` and returns `404` if it comes back `nil`. Because `AppByEnvID` → `Apps` filters `a.deleted_at IS NULL AND envs.deleted_at IS NULL`, a soft-deleted app or env now yields a 404 instead of serving the file.

Adds `Test_Fail_AppDeleted`: creates a public file, soft-deletes the app, and asserts the public URL returns 404.

## Not in this PR

Storage reclamation (side 2) — leaked `volumes` rows and physical files still need a cleanup job on the deletion path. Tracked as follow-up.