### PR TITLE
fix: purge volume files of deleted environments

### DIFF
--- a/src/ce/workerserver/job_environments.go
+++ b/src/ce/workerserver/job_environments.go
@@ -3,7 +3,9 @@ package jobs
 import (
 	"context"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/volumes"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -15,8 +17,9 @@ type staleSchema struct {
 	SchemaName string
 }
 
-// RemoveStaleEnvironments marks soft deleted environment's deployments soft deleted and
-// drops the per-environment Postgres schema (and its roles) when one was provisioned.
+// RemoveStaleEnvironments marks soft deleted environment's deployments soft deleted,
+// drops the per-environment Postgres schema (and its roles) when one was provisioned,
+// and removes volume files (physical bytes + DB rows) that belong to those environments.
 func RemoveStaleEnvironments(ctx context.Context) error {
 	store := NewStore()
 
@@ -31,6 +34,11 @@ func RemoveStaleEnvironments(ctx context.Context) error {
 
 	if err := dropStaleSchemas(ctx, store); err != nil {
 		slog.Errorf("error while dropping stale schemas: %v", err)
+		return err
+	}
+
+	if err := removeStaleVolumes(ctx, store); err != nil {
+		slog.Errorf("error while removing stale volumes: %v", err)
 		return err
 	}
 
@@ -103,4 +111,104 @@ func dropStaleSchemas(ctx context.Context, store *Store) error {
 	}
 
 	return nil
+}
+
+// removeStaleVolumes deletes volume files (physical bytes + DB rows) that belong
+// to soft-deleted environments. App/environment deletion is soft-only, so the
+// volumes_env_id_fkey ON DELETE CASCADE never fires; without this cleanup public
+// files for deleted apps would keep being served and leak on disk/S3 forever.
+// Per-env failures are logged and skipped so one broken volume backend does not
+// block the rest of the batch; anything left behind retries on the next run.
+func removeStaleVolumes(ctx context.Context, store *Store) error {
+	cfg, err := admin.Store().Config(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	if cfg.VolumesConfig == nil {
+		return nil
+	}
+
+	rows, err := store.Query(ctx, stmt.selectStaleVolumeEnvs)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	var envIDs []types.ID
+
+	for rows.Next() {
+		var envID types.ID
+
+		if err := rows.Scan(&envID); err != nil {
+			return err
+		}
+
+		envIDs = append(envIDs, envID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, envID := range envIDs {
+		if err := purgeEnvVolumes(ctx, purgeEnvVolumesParams{config: cfg.VolumesConfig, envID: envID}); err != nil {
+			slog.Errorf("failed to purge volumes for env %d: %v", envID, err)
+			continue
+		}
+
+		slog.Debug(slog.LogOpts{
+			Msg:     "removed stale volumes",
+			Level:   slog.DL1,
+			Payload: []zap.Field{zap.Int64("env_id", int64(envID))},
+		})
+	}
+
+	return nil
+}
+
+type purgeEnvVolumesParams struct {
+	config *admin.VolumesConfig
+	envID  types.ID
+}
+
+// purgeEnvVolumes removes every volume file of a single environment, one page at
+// a time. Rows are only deleted from the database once their bytes are gone, so
+// a failing physical delete surfaces as an error and the surviving rows retry on
+// the next run rather than looping forever.
+func purgeEnvVolumes(ctx context.Context, p purgeEnvVolumesParams) error {
+	const batchSize = 100
+
+	store := volumes.Store()
+
+	for {
+		files, err := store.SelectFiles(ctx, volumes.SelectFilesArgs{EnvID: p.envID, Limit: batchSize})
+
+		if err != nil {
+			return err
+		}
+
+		if len(files) == 0 {
+			return nil
+		}
+
+		removed, removeErr := volumes.RemoveFiles(p.config, files)
+
+		if len(removed) > 0 {
+			if err := store.RemoveFiles(ctx, removed, p.envID); err != nil {
+				return err
+			}
+		}
+
+		if removeErr != nil {
+			return removeErr
+		}
+
+		if len(files) < batchSize {
+			return nil
+		}
+	}
 }

--- a/src/ce/workerserver/job_volumes_test.go
+++ b/src/ce/workerserver/job_volumes_test.go
@@ -1,0 +1,115 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/volumes"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+type JobVolumesSuite struct {
+	suite.Suite
+	*factory.Factory
+	conn   databasetest.TestDB
+	tmpdir string
+}
+
+func (s *JobVolumesSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+
+	tmpdir, err := os.MkdirTemp("", "tmp-stale-volumes-")
+	s.NoError(err)
+	s.tmpdir = tmpdir
+
+	s.NoError(admin.Store().UpsertConfig(context.Background(), admin.InstanceConfig{
+		VolumesConfig: &admin.VolumesConfig{
+			MountType: volumes.FileSys,
+			RootPath:  tmpdir,
+		},
+	}))
+}
+
+func (s *JobVolumesSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+	os.RemoveAll(s.tmpdir)
+}
+
+func (s *JobVolumesSuite) writeFile(envID types.ID, name string) *volumes.File {
+	content := []byte("Hello world!")
+
+	file := &volumes.File{
+		EnvID:     envID,
+		Name:      name,
+		Size:      int64(len(content)),
+		Path:      s.tmpdir,
+		IsPublic:  true,
+		CreatedAt: utils.NewUnix(),
+	}
+
+	s.NoError(os.WriteFile(file.FullPath(), content, 0664))
+	s.NoError(volumes.Store().Insert(context.Background(), []*volumes.File{file}, envID))
+
+	return file
+}
+
+func (s *JobVolumesSuite) countVolumes(envID types.ID) int {
+	var count int
+
+	s.NoError(s.conn.
+		QueryRow("SELECT COUNT(*) FROM volumes WHERE env_id = $1", envID).
+		Scan(&count),
+	)
+
+	return count
+}
+
+func (s *JobVolumesSuite) Test_RemoveStaleVolumes() {
+	app := s.MockApp(nil)
+
+	deletedEnv := s.MockEnv(app, map[string]any{
+		"DeletedAt": utils.Unix{Time: time.Now(), Valid: true},
+	})
+
+	liveEnv := s.MockEnv(app)
+
+	staleFile := s.writeFile(deletedEnv.ID, "stale.txt")
+	liveFile := s.writeFile(liveEnv.ID, "live.txt")
+
+	s.NoError(removeStaleVolumes(context.Background(), NewStore()))
+
+	s.Equal(0, s.countVolumes(deletedEnv.ID), "volume rows for the deleted env should be removed")
+	s.NoFileExists(staleFile.FullPath(), "physical file for the deleted env should be removed")
+
+	s.Equal(1, s.countVolumes(liveEnv.ID), "volume rows for the live env must be preserved")
+	s.FileExists(liveFile.FullPath(), "physical file for the live env must be preserved")
+}
+
+func (s *JobVolumesSuite) Test_RemoveStaleVolumes_NoVolumesConfig() {
+	s.NoError(admin.Store().UpsertConfig(context.Background(), admin.InstanceConfig{}))
+
+	app := s.MockApp(nil)
+
+	deletedEnv := s.MockEnv(app, map[string]any{
+		"DeletedAt": utils.Unix{Time: time.Now(), Valid: true},
+	})
+
+	s.writeFile(deletedEnv.ID, "stale.txt")
+
+	// Without a configured volume backend the physical bytes cannot be removed,
+	// so the rows must be left intact for a later run rather than orphaning files.
+	s.NoError(removeStaleVolumes(context.Background(), NewStore()))
+	s.Equal(1, s.countVolumes(deletedEnv.ID))
+}
+
+func TestJobVolumesSuite(t *testing.T) {
+	suite.Run(t, &JobVolumesSuite{})
+}

--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -24,6 +24,7 @@ type statement struct {
 	syncAnalyticsEvents             string
 	selectUserIDsWithoutAPIKeys     string
 	selectStaleSchemas              string
+	selectStaleVolumeEnvs           string
 	clearSchemaConf                 string
 	selectAccessLogPartitions       string
 	selectAuthEnabledEnvs           string
@@ -266,6 +267,18 @@ var stmt = &statement{
 			schema_conf IS NOT NULL
 		ORDER BY
 			deleted_at ASC, env_id ASC
+		LIMIT 50;
+	`,
+
+	selectStaleVolumeEnvs: `
+		SELECT DISTINCT
+			v.env_id
+		FROM
+			volumes v
+		JOIN
+			apps_build_conf e ON e.env_id = v.env_id
+		WHERE
+			e.deleted_at IS NOT NULL
 		LIMIT 50;
 	`,
 


### PR DESCRIPTION
## Problem

Follow-up to the read guard (#386). App/environment deletion is soft-only (`deleted_at`) and never removes `volumes` rows or their physical bytes. The `ON DELETE CASCADE` on `volumes.env_id` only fires on a *physical* row delete of `apps_build_conf`, which never happens — so volume files for deleted apps leak forever on disk/S3 and in the database.

## This PR

Extends the existing `RemoveStaleEnvironments` worker job (runs every 6h) to also reclaim volume storage for soft-deleted environments:

- New `selectStaleVolumeEnvs` statement finds soft-deleted envs that still have `volumes` rows.
- `removeStaleVolumes` iterates those envs; per-env failures are logged and skipped so one broken backend doesn't block the batch.
- `purgeEnvVolumes` pages through each env's files, removing the physical bytes first (via `volumes.RemoveFiles`) and only deleting the DB rows once the bytes are gone — so a failing physical delete surfaces as an error and retries next run instead of orphaning files or looping forever.
- When no volume backend is configured, the job is a no-op (rows are kept for a later run rather than orphaning bytes).

## Tests

New internal `job_volumes_test.go`:
- `Test_RemoveStaleVolumes` — files of a deleted env are removed (rows + disk); a live env's files are preserved.
- `Test_RemoveStaleVolumes_NoVolumesConfig` — rows are kept when no backend is configured.

Tested `removeStaleVolumes` directly rather than through the full `RemoveStaleEnvironments` job: the sibling schema/deployment steps commit outside the test's txdb transaction (see the pre-existing schema-store test-leak behavior), which aborts the shared transaction under txdb and is unrelated to this change. In production those steps run as separate autocommit statements, so the ordering is fine.