### PR TITLE
feat: interpolate env vars in periodic triggers

### DIFF
--- a/content/blog/whats-new.md
+++ b/content/blog/whats-new.md
@@ -5,6 +5,10 @@ description: Discover the latest changes and improvements to Stormkit. Stay up-t
 
 Follow the latest developments on Stormkit.
 
+## July 29th, 2026
+
+**Periodic Triggers** now support environment variable interpolation. Reference a variable with `$NAME` or `${NAME}` in a trigger's URL, header values, or payload — for example `Authorization: Bearer $CRON_SECRET` — and it is resolved at run time from the environment's own configuration. Secrets live in your env config instead of the trigger, so rotating them is a one-line change. [Learn more](/docs/features/periodic-triggers).
+
 ## May 25th, 2026
 
 Custom headers now apply to **all** responses — not just static files. Rules defined in your `_headers` file or the Environment Config headers editor are matched against the request URL path and applied to static files, SSR, serverless functions, and proxied responses alike. User-configured headers take precedence over Stormkit's defaults. [Learn more](/docs/features/custom-headers).

--- a/docs/features/13-periodic-triggers.md
+++ b/docs/features/13-periodic-triggers.md
@@ -26,6 +26,34 @@ This will call the specified endpoint with the configured cron periodicity. The 
 
 </section>
 
+## Environment variables
+
+<section>
+
+The trigger's **URL**, **header values** and **payload** support environment
+variable interpolation. Reference a variable with `$NAME` or `${NAME}` and it is
+replaced at run time with the value of the matching variable from the
+**environment's configuration** (**Environment** > **Config** > **Environment
+variables**).
+
+For example, define a `CRON_SECRET` variable on your environment and reference
+it in the trigger's `Authorization` header:
+
+```
+Authorization: Bearer $CRON_SECRET
+```
+
+At run time `$CRON_SECRET` is replaced with the variable's value, so the secret
+lives in your environment config instead of the trigger itself — and rotating it
+is just an env-var change, no trigger edit needed.
+
+A reference with no matching variable is left untouched (it is sent literally),
+and variables are resolved **only when the trigger runs** — the stored trigger
+always keeps the raw `$NAME` reference. Only the environment's own variables are
+available; host/system variables are never exposed to a trigger.
+
+</section>
+
 ## Debugging
 
 Stormkit saves the request and response for each periodic task. You can view the last 25 logs for each trigger by expanding the dot menu `(...)` and clicking on the `Past triggers` menu item.

--- a/src/ce/api/app/functiontrigger/function_trigger_interpolate.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_interpolate.go
@@ -1,0 +1,66 @@
+package functiontrigger
+
+import (
+	"regexp"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+// varRefPattern matches an environment-variable reference in the shell style
+// $NAME or ${NAME}, where NAME is a standard identifier. It is used to
+// interpolate a trigger's URL, header values and payload at run time.
+var varRefPattern = regexp.MustCompile(`\$\{[a-zA-Z_][a-zA-Z0-9_]*\}|\$[a-zA-Z_][a-zA-Z0-9_]*`)
+
+// interpolate replaces every $NAME / ${NAME} reference in s with the matching
+// value from vars. A reference with no matching key is left untouched, so an
+// unresolved reference passes through literally rather than collapsing to an
+// empty string.
+func interpolate(s string, vars map[string]string) string {
+	if s == "" || len(vars) == 0 {
+		return s
+	}
+
+	return varRefPattern.ReplaceAllStringFunc(s, func(match string) string {
+		name := match[1:] // strip the leading $
+
+		if name[0] == '{' {
+			name = name[1 : len(name)-1] // strip the surrounding { }
+		}
+
+		if val, ok := vars[name]; ok {
+			return val
+		}
+
+		return match
+	})
+}
+
+// Interpolate returns a copy of the options with $NAME / ${NAME} references in
+// the URL, header values and payload replaced by the matching environment
+// variable. Header keys are left untouched; only values are interpolated. The
+// receiver is not mutated, so the stored trigger keeps its raw references and
+// secrets are resolved only at run time.
+func (o Options) Interpolate(vars map[string]string) Options {
+	if len(vars) == 0 {
+		return o
+	}
+
+	out := o
+	out.URL = interpolate(o.URL, vars)
+
+	if len(o.Payload) > 0 {
+		out.Payload = []byte(interpolate(string(o.Payload), vars))
+	}
+
+	if len(o.Headers) > 0 {
+		headers := make(shttp.Headers, len(o.Headers))
+
+		for k, v := range o.Headers {
+			headers[k] = interpolate(v, vars)
+		}
+
+		out.Headers = headers
+	}
+
+	return out
+}

--- a/src/ce/api/app/functiontrigger/function_trigger_interpolate_test.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_interpolate_test.go
@@ -1,0 +1,71 @@
+package functiontrigger_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+)
+
+type InterpolateSuite struct {
+	suite.Suite
+}
+
+func (s *InterpolateSuite) Test_Interpolate_ReplacesReferencesInAllFields() {
+	vars := map[string]string{
+		"CRON_SECRET": "s3cr3t",
+		"BASE_URL":    "https://api.example.com",
+	}
+
+	opts := functiontrigger.Options{
+		Method:  "POST",
+		URL:     "$BASE_URL/cron?token=${CRON_SECRET}",
+		Headers: shttp.Headers{"Authorization": "Bearer $CRON_SECRET"},
+		Payload: []byte(`{"key":"$CRON_SECRET"}`),
+	}
+
+	out := opts.Interpolate(vars)
+
+	s.Equal("https://api.example.com/cron?token=s3cr3t", out.URL)
+	s.Equal("Bearer s3cr3t", out.Headers["Authorization"])
+	s.Equal(`{"key":"s3cr3t"}`, string(out.Payload))
+	s.Equal("POST", out.Method)
+}
+
+func (s *InterpolateSuite) Test_Interpolate_LeavesUnknownReferencesLiteral() {
+	opts := functiontrigger.Options{
+		URL:     "https://example.com/$NOT_SET",
+		Headers: shttp.Headers{"X-Token": "$MISSING"},
+	}
+
+	out := opts.Interpolate(map[string]string{"OTHER": "value"})
+
+	s.Equal("https://example.com/$NOT_SET", out.URL)
+	s.Equal("$MISSING", out.Headers["X-Token"])
+}
+
+func (s *InterpolateSuite) Test_Interpolate_DoesNotMutateReceiver() {
+	opts := functiontrigger.Options{
+		URL:     "$BASE_URL",
+		Headers: shttp.Headers{"Authorization": "Bearer $CRON_SECRET"},
+	}
+
+	opts.Interpolate(map[string]string{"BASE_URL": "https://x", "CRON_SECRET": "s3cr3t"})
+
+	s.Equal("$BASE_URL", opts.URL)
+	s.Equal("Bearer $CRON_SECRET", opts.Headers["Authorization"])
+}
+
+func (s *InterpolateSuite) Test_Interpolate_NoVarsIsNoOp() {
+	opts := functiontrigger.Options{URL: "https://example.com/$CRON_SECRET"}
+
+	out := opts.Interpolate(nil)
+
+	s.Equal("https://example.com/$CRON_SECRET", out.URL)
+}
+
+func TestInterpolateSuite(t *testing.T) {
+	suite.Run(t, new(InterpolateSuite))
+}

--- a/src/ce/api/public/v1/handler_function_trigger_invoke.go
+++ b/src/ce/api/public/v1/handler_function_trigger_invoke.go
@@ -33,12 +33,20 @@ func handlerFunctionTriggerInvoke(req *RequestContext) *shttp.Response {
 		return shttp.NotFound()
 	}
 
+	// Resolve $VAR references against the environment's own variables so
+	// secrets live in the env config, not in the stored trigger.
+	opts := trigger.Options
+
+	if req.Env.Data != nil {
+		opts = opts.Interpolate(req.Env.Data.Vars)
+	}
+
 	log, _ := functiontrigger.Run(functiontrigger.RunParams{
 		TriggerID: trigger.ID,
-		Method:    trigger.Options.Method,
-		URL:       trigger.Options.URL,
-		Headers:   trigger.Options.Headers,
-		Payload:   trigger.Options.Payload,
+		Method:    opts.Method,
+		URL:       opts.URL,
+		Headers:   opts.Headers,
+		Payload:   opts.Payload,
 	})
 
 	if err := store.InsertLogs(req.Context(), []functiontrigger.TriggerLog{log}); err != nil {

--- a/src/ce/workerserver/job_trigger_functions.go
+++ b/src/ce/workerserver/job_trigger_functions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/adhocore/gronx"
 	"github.com/hibiken/asynq"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
@@ -36,7 +37,32 @@ func InvokeDueFunctionTriggers(ctx context.Context) error {
 
 	messages := []FunctionTriggerMessage{}
 
+	// Cache each environment's variables so a batch that shares an environment
+	// resolves references with a single lookup. A nil entry is cached too, so a
+	// missing/failed environment is not retried for every trigger.
+	varsByEnv := map[types.ID]map[string]string{}
+
 	for _, tf := range tfs {
+		vars, ok := varsByEnv[tf.EnvID]
+
+		if !ok {
+			env, err := buildconf.NewStore().EnvironmentByID(ctx, tf.EnvID)
+
+			if err != nil {
+				slog.Errorf("error while fetching environment %s for trigger interpolation: %v", tf.EnvID, err)
+			}
+
+			if env != nil && env.Data != nil {
+				vars = env.Data.Vars
+			}
+
+			varsByEnv[tf.EnvID] = vars
+		}
+
+		// Resolve $VAR references against the environment's own variables so
+		// secrets live in the env config, not in the stored trigger.
+		opts := tf.Options.Interpolate(vars)
+
 		nextRunAt, err := gronx.NextTickAfter(tf.Cron, time.Now().UTC(), false)
 
 		if err != nil {
@@ -44,10 +70,10 @@ func InvokeDueFunctionTriggers(ctx context.Context) error {
 		}
 
 		messages = append(messages, FunctionTriggerMessage{
-			URL:       tf.Options.URL,
-			Payload:   tf.Options.Payload,
-			Headers:   tf.Options.Headers,
-			Method:    tf.Options.Method,
+			URL:       opts.URL,
+			Payload:   opts.Payload,
+			Headers:   opts.Headers,
+			Method:    opts.Method,
 			ID:        tf.ID,
 			NextRunAt: utils.UnixFrom(nextRunAt),
 		})


### PR DESCRIPTION
## Summary

Periodic triggers (cron jobs) now support environment-variable interpolation. Reference a variable with `$NAME` or `${NAME}` in a trigger's **URL**, **header values**, or **payload** and it is resolved at run time from the environment's own configured variables (`env.Data.Vars`).

For example, define `CRON_SECRET` on the environment and use it in a header:

```
Authorization: Bearer $CRON_SECRET
```

The secret now lives in the env config rather than the stored trigger, so rotating it is a one-line change with no trigger edit.

## How it works

- New `functiontrigger.Options.Interpolate(vars)` returns a copy with `$NAME`/`${NAME}` replaced in the URL, header values and payload. It does **not** mutate the receiver, so the stored trigger keeps its raw reference — secrets are resolved only at run time. An unresolved reference is left literal (never collapsed to empty).
- Wired into both run paths:
  - **Scheduled worker** (`job_trigger_functions.go`): resolves at enqueue time, caching each environment's vars so a batch sharing an environment does a single lookup.
  - **Manual invoke** (`handler_function_trigger_invoke.go`): resolves against `req.Env.Data.Vars`.

## Security

Only the environment's **own** variables are exposed — never host/OS secrets — consistent with the existing `systmVars()` boundary, so this is safe on multi-tenant cloud.

## Changes

- `src/ce/api/app/functiontrigger/function_trigger_interpolate.go` (+ test) — interpolation helper.
- `src/ce/workerserver/job_trigger_functions.go` — interpolate scheduled runs.
- `src/ce/api/public/v1/handler_function_trigger_invoke.go` — interpolate manual invokes.
- `docs/features/13-periodic-triggers.md` + `content/blog/whats-new.md` — docs & what's new.

## Verification

`gofmt`, `go vet`, `go build ./...` pass; new interpolation suite (all-fields replacement, unknown-reference passthrough, no-mutation, nil-vars no-op) and the full functiontrigger suite pass (`-p 1`).

## Note

For scheduled runs the resolved value transits the internal asynq/Redis queue (same as any hardcoded header secret today). If preferred, interpolation can move into the worker so the queue carries only the reference — happy to adjust.