### PR TITLE
perf: speed up access log pagination

### DIFF
--- a/docs/api/12-access-logs.md
+++ b/docs/api/12-access-logs.md
@@ -43,7 +43,7 @@ All filters are optional and are combined with AND.
 | `path`     | string  | No          | Only return requests whose path starts with this value.                                                                                           |
 | `status`   | number  | No          | Only return requests answered with this HTTP status code.                                                                                         |
 | `isBot`    | boolean | No          | `true` returns only bot traffic, `false` only non-bot traffic. Omit to return both.                                                               |
-| `beforeId` | string  | No          | Return entries older than this access log ID. Pass `pagination.beforeId` from the previous response to fetch the next page.                        |
+| `cursor`   | string  | No          | Pagination cursor. Pass `pagination.cursor` from the previous response back verbatim to fetch the next page. Treat it as opaque — its encoding may change. |
 
 > Queries are always bounded in time so that they only scan the relevant
 > partitions. If you omit `from`, the last 24 hours are returned.
@@ -53,7 +53,7 @@ All filters are optional and are combined with AND.
 | Field        | Type   | Description                                     |
 | ------------ | ------ | ----------------------------------------------- |
 | `accessLogs` | array  | Up to 100 entries, newest first.                |
-| `pagination` | object | `hasNextPage`, and `beforeId` when there is one. |
+| `pagination` | object | `hasNextPage`, and `cursor` when there is a next page. |
 
 Each entry contains:
 

--- a/src/ce/api/accesslog/accesslog_model.go
+++ b/src/ce/api/accesslog/accesslog_model.go
@@ -1,6 +1,8 @@
 package accesslog
 
 import (
+	"strconv"
+
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"gopkg.in/guregu/null.v3"
@@ -27,6 +29,25 @@ type AccessLog struct {
 	IsBot        bool        `json:"isBot"`
 	BytesSent    int64       `json:"bytesSent"`
 	RequestID    null.String `json:"requestId"`
+}
+
+// Cursor encodes the entry's position for keyset pagination.
+//
+// It carries both halves of the sort key in one opaque value: request_timestamp
+// is not unique — concurrent requests land on the same microsecond — and log_id
+// alone does not follow timestamp order, so neither identifies a position on its
+// own. Encoding them together means a caller cannot pass one without the other.
+//
+// The timestamp is in microseconds to match request_timestamp's resolution; a
+// cursor truncated to whole seconds would skip every entry sharing its second.
+func (l AccessLog) Cursor() string {
+	if !l.RequestTS.Valid {
+		return ""
+	}
+
+	micros := strconv.FormatInt(l.RequestTS.Time.UnixMicro(), 10)
+
+	return utils.EncodeToString([]byte(micros + "." + l.ID.String()))
 }
 
 func (l AccessLog) ToMap() map[string]any {

--- a/src/ce/api/accesslog/accesslog_query.go
+++ b/src/ce/api/accesslog/accesslog_query.go
@@ -2,8 +2,10 @@ package accesslog
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
@@ -13,14 +15,23 @@ import (
 const DefaultWindow = 24 * time.Hour
 
 // SelectLogsParamsFromQuery maps URL query parameters onto select filters,
-// defaulting the lower time bound to DefaultWindow ago when from is absent.
+// defaulting the lower time bound to DefaultWindow ago when from is absent and
+// the upper bound to now when to is absent. Both bounds are always set: an open
+// upper bound forces the planner to include the create-ahead partitions and
+// request_logs_default, neither of which can be pruned away.
 // Callers that must restrict the result to a single app or environment are
 // expected to overwrite AppID/EnvID after calling this.
 func SelectLogsParamsFromQuery(q url.Values) SelectLogsParams {
 	from := unixFromQuery(q.Get("from"))
+	to := unixFromQuery(q.Get("to"))
+	beforeTS, beforeID := decodeCursor(q.Get("cursor"))
 
 	if !from.Valid {
 		from = utils.UnixFrom(time.Now().Add(-DefaultWindow))
+	}
+
+	if !to.Valid {
+		to = utils.UnixFrom(time.Now())
 	}
 
 	return SelectLogsParams{
@@ -34,8 +45,9 @@ func SelectLogsParamsFromQuery(q url.Values) SelectLogsParams {
 		Status:   utils.StringToInt(q.Get("status")),
 		IsBot:    boolFromQuery(q.Get("isBot")),
 		From:     from,
-		To:       unixFromQuery(q.Get("to")),
-		BeforeID: utils.StringToID(q.Get("beforeId")),
+		To:       to,
+		BeforeID: beforeID,
+		BeforeTS: beforeTS,
 		Limit:    DefaultLimit,
 	}
 }
@@ -50,6 +62,32 @@ func unixFromQuery(v string) utils.Unix {
 	}
 
 	return utils.UnixFrom(time.Unix(secs, 0))
+}
+
+// decodeCursor parses a cursor produced by AccessLog.Cursor into the timestamp
+// and id halves of the sort key. A malformed cursor decodes to an unset
+// position, which reads as "start from the newest entry" — the same as omitting
+// it — rather than failing the request.
+func decodeCursor(v string) (utils.Unix, types.ID) {
+	raw, err := utils.DecodeString(v)
+
+	if err != nil {
+		return utils.Unix{}, 0
+	}
+
+	micros, id, found := strings.Cut(string(raw), ".")
+
+	if !found {
+		return utils.Unix{}, 0
+	}
+
+	parsed := utils.StringToInt64(micros)
+
+	if parsed <= 0 {
+		return utils.Unix{}, 0
+	}
+
+	return utils.UnixFrom(time.UnixMicro(parsed)), utils.StringToID(id)
 }
 
 func boolFromQuery(v string) *bool {

--- a/src/ce/api/accesslog/accesslog_query_test.go
+++ b/src/ce/api/accesslog/accesslog_query_test.go
@@ -1,0 +1,68 @@
+package accesslog_test
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/accesslog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+type QuerySuite struct {
+	suite.Suite
+}
+
+// The cursor has to survive the round trip at microsecond fidelity: truncating
+// it to whole seconds would skip every entry sharing the cursor's second.
+func (s *QuerySuite) Test_Cursor_RoundTrip() {
+	ts := time.Date(2026, 7, 31, 8, 32, 0, 830779000, time.UTC)
+
+	entry := accesslog.AccessLog{
+		ID:        types.ID(3971512),
+		RequestTS: utils.UnixFrom(ts),
+	}
+
+	cursor := entry.Cursor()
+	s.Require().NotEmpty(cursor)
+
+	params := accesslog.SelectLogsParamsFromQuery(url.Values{"cursor": {cursor}})
+
+	s.Equal(types.ID(3971512), params.BeforeID)
+	s.Require().True(params.BeforeTS.Valid)
+	s.Equal(ts.UnixMicro(), params.BeforeTS.Time.UnixMicro())
+}
+
+// A cursor that cannot be decoded reads as "no cursor" rather than failing the
+// request or silently filtering on half of the sort key.
+func (s *QuerySuite) Test_Cursor_Malformed() {
+	for _, cursor := range []string{
+		"",
+		"not-base64!!",
+		utils.EncodeToString([]byte("missing-separator")),
+		utils.EncodeToString([]byte("0.123")),
+		utils.EncodeToString([]byte("abc.123")),
+	} {
+		params := accesslog.SelectLogsParamsFromQuery(url.Values{"cursor": {cursor}})
+
+		s.Zero(params.BeforeID, cursor)
+		s.False(params.BeforeTS.Valid, cursor)
+	}
+}
+
+// Both time bounds are always set so the query prunes to the day partitions it
+// actually needs.
+func (s *QuerySuite) Test_TimeBounds_Default() {
+	params := accesslog.SelectLogsParamsFromQuery(url.Values{})
+
+	s.Require().True(params.From.Valid)
+	s.Require().True(params.To.Valid)
+	s.WithinDuration(time.Now().Add(-accesslog.DefaultWindow), params.From.Time, time.Minute)
+	s.WithinDuration(time.Now(), params.To.Time, time.Minute)
+}
+
+func TestQuery(t *testing.T) {
+	suite.Run(t, &QuerySuite{})
+}

--- a/src/ce/api/accesslog/accesslog_store.go
+++ b/src/ce/api/accesslog/accesslog_store.go
@@ -113,6 +113,7 @@ type SelectLogsParams struct {
 	From     utils.Unix
 	To       utils.Unix
 	BeforeID types.ID
+	BeforeTS utils.Unix
 	Limit    int
 }
 
@@ -171,8 +172,14 @@ func (s *Store) SelectLogs(ctx context.Context, p SelectLogsParams) ([]AccessLog
 		add("is_bot = $%d", *p.IsBot)
 	}
 
-	if p.BeforeID > 0 {
-		add("log_id < $%d", p.BeforeID)
+	// The cursor compares on the same tuple the query orders by, otherwise
+	// Postgres cannot seek to the page and re-walks the window from the newest
+	// row every time. Both halves are required — see AccessLog.Cursor.
+	if p.BeforeID > 0 && p.BeforeTS.Valid {
+		params = append(params, p.BeforeTS.UTC(), p.BeforeID)
+		where = append(where, fmt.Sprintf(
+			"(request_timestamp, log_id) < ($%d, $%d)", len(params)-1, len(params),
+		))
 	}
 
 	if len(where) == 0 {

--- a/src/ce/api/accesslog/accesslog_store_test.go
+++ b/src/ce/api/accesslog/accesslog_store_test.go
@@ -115,6 +115,81 @@ func (s *StoreSuite) Test_InsertAndSelect() {
 	s.Equal("/robots.txt", robots[0].RequestPath)
 }
 
+// Paging walks the same (request_timestamp, log_id) tuple the query orders by,
+// so entries sharing a timestamp are returned exactly once rather than being
+// skipped or repeated across page boundaries.
+func (s *StoreSuite) Test_SelectLogs_KeysetPagination() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	ctx := context.Background()
+
+	shared := utils.UnixFrom(time.Now().Add(-10 * time.Minute))
+	older := utils.UnixFrom(time.Now().Add(-20 * time.Minute))
+
+	logs := []accesslog.AccessLog{}
+
+	for _, tc := range []struct {
+		path string
+		ts   utils.Unix
+	}{
+		{"/a", shared},
+		{"/b", shared},
+		{"/c", shared},
+		{"/d", older},
+		{"/e", older},
+	} {
+		logs = append(logs, accesslog.AccessLog{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			HostName:    "example.com",
+			RequestTS:   tc.ts,
+			Method:      http.MethodGet,
+			RequestPath: tc.path,
+			StatusCode:  http.StatusOK,
+		})
+	}
+
+	s.Require().NoError(accesslog.NewStore().InsertLogs(ctx, logs))
+
+	params := accesslog.SelectLogsParams{
+		AppID: app.ID,
+		From:  utils.UnixFrom(time.Now().Add(-time.Hour)),
+		To:    utils.UnixFrom(time.Now()),
+		Limit: 2,
+	}
+
+	seen := []string{}
+
+	for range logs {
+		page, err := accesslog.NewStore().SelectLogs(ctx, params)
+		s.Require().NoError(err)
+
+		if len(page) == 0 {
+			break
+		}
+
+		if len(page) > params.Limit {
+			page = page[:params.Limit]
+		}
+
+		for _, l := range page {
+			seen = append(seen, l.RequestPath)
+		}
+
+		last := page[len(page)-1]
+		params.BeforeID = last.ID
+		params.BeforeTS = last.RequestTS
+	}
+
+	s.Len(seen, len(logs))
+	s.ElementsMatch([]string{"/a", "/b", "/c", "/d", "/e"}, seen)
+
+	// Newest first: the entries sharing the later timestamp all precede the
+	// older pair, regardless of how the pages happened to split.
+	s.ElementsMatch([]string{"/a", "/b", "/c"}, seen[:3])
+	s.ElementsMatch([]string{"/d", "/e"}, seen[3:])
+}
+
 func TestStore(t *testing.T) {
 	suite.Run(t, &StoreSuite{})
 }

--- a/src/ce/api/admin/adminhandlers/handler_access_logs.go
+++ b/src/ce/api/admin/adminhandlers/handler_access_logs.go
@@ -18,12 +18,13 @@ func handlerAccessLogs(req *user.RequestContext) *shttp.Response {
 	}
 
 	pagination := map[string]any{"hasNextPage": false}
-	logsLen := len(logs)
 
-	if logsLen > accesslog.DefaultLimit {
+	if len(logs) > accesslog.DefaultLimit {
+		logs = logs[:accesslog.DefaultLimit]
+		last := logs[len(logs)-1]
+
 		pagination["hasNextPage"] = true
-		pagination["beforeId"] = logs[logsLen-2].ID.String()
-		logs = logs[:logsLen-1]
+		pagination["cursor"] = last.Cursor()
 	}
 
 	items := make([]map[string]any, 0, len(logs))

--- a/src/ce/api/public/v1/handler_access_logs_get.go
+++ b/src/ce/api/public/v1/handler_access_logs_get.go
@@ -30,8 +30,10 @@ func handlerAccessLogsGet(req *RequestContext) *shttp.Response {
 
 	if hasNextPage {
 		logs = logs[:AccessLogsLimit]
+		last := logs[len(logs)-1]
+
 		pagination["hasNextPage"] = true
-		pagination["beforeId"] = logs[len(logs)-1].ID.String()
+		pagination["cursor"] = last.Cursor()
 	}
 
 	items := make([]map[string]any, 0, len(logs))

--- a/src/ce/api/public/v1/handler_access_logs_get_test.go
+++ b/src/ce/api/public/v1/handler_access_logs_get_test.go
@@ -182,8 +182,16 @@ func (s *HandlerAccessLogsGetSuite) Test_Success_HasNextPage() {
 	s.Len(paths, 1)
 	s.Equal(true, pagination["hasNextPage"])
 
-	// The cursor is the last returned entry; paging with it returns the rest.
-	res = s.request(fmt.Sprintf("&beforeId=%s", pagination["beforeId"]), usertest.Authorization(s.user.ID))
+	// A single opaque cursor carries both halves of the sort key, so the next
+	// page is a keyset seek on (request_timestamp, log_id) rather than a scan.
+	s.NotEmpty(pagination["cursor"])
+
+	// The cursor marks the last returned entry; paging with it returns the rest.
+	res = s.request(
+		fmt.Sprintf("&cursor=%s", pagination["cursor"]),
+		usertest.Authorization(s.user.ID),
+	)
+
 	next, _ := s.paths(res)
 
 	s.Len(next, 1)

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -78,7 +78,7 @@ func mcpAllTools() []mcpToolDef {
 		},
 		{
 			Name:        "get_access_logs",
-			Description: "Return raw HTTP access logs (one entry per request served) for an environment, newest first. Defaults to the last 24 hours when 'from' is omitted. Paginate with beforeId using pagination.beforeId from the previous response.",
+			Description: "Return raw HTTP access logs (one entry per request served) for an environment, newest first. Defaults to the last 24 hours when 'from' is omitted. Paginate by passing pagination.cursor from the previous response.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -92,7 +92,7 @@ func mcpAllTools() []mcpToolDef {
 					"path":     map[string]any{"type": "string", "description": "Only return requests whose path starts with this value."},
 					"status":   map[string]any{"type": "string", "description": "Only return requests answered with this HTTP status code."},
 					"isBot":    map[string]any{"type": "boolean", "description": "Filter bot traffic in or out. Omit to return both."},
-					"beforeId": map[string]any{"type": "string", "description": "Return entries older than this access log id."},
+					"cursor":   map[string]any{"type": "string", "description": "Opaque pagination cursor. Pass pagination.cursor from the previous response back verbatim to fetch the next page."},
 				},
 				"required":             []string{"envId"},
 				"additionalProperties": false,
@@ -736,7 +736,7 @@ func mcpGetAccessLogs(req *RequestContextMCP, args map[string]any) *shttp.Respon
 		"method":   stringArg(args, "method"),
 		"path":     stringArg(args, "path"),
 		"status":   stringArg(args, "status"),
-		"beforeId": stringArg(args, "beforeId"),
+		"cursor":   stringArg(args, "cursor"),
 	}
 
 	if isBot := boolPtrArg(args, "isBot"); isBot != nil {

--- a/src/ce/hosting/oauth.go
+++ b/src/ce/hosting/oauth.go
@@ -838,6 +838,10 @@ func (o *oauthServer) issueTokens(g oauthTokenGrant) *shttp.Response {
 }
 
 // verifyPKCE checks the S256 proof: base64url(sha256(verifier)) == challenge.
+//
+// The encoding must stay unpadded (RawURLEncoding) — RFC 7636 defines the S256
+// challenge without padding, so switching to a padded encoder would reject
+// every conforming client.
 func verifyPKCE(verifier, challenge string) bool {
 	sum := sha256.Sum256([]byte(verifier))
 	computed := base64.RawURLEncoding.EncodeToString(sum[:])

--- a/src/ce/hosting/oauth_refresh_store.go
+++ b/src/ce/hosting/oauth_refresh_store.go
@@ -46,6 +46,9 @@ type oauthRefreshStore struct {
 var oauthRefreshTokens = oauthRefreshStore{prefix: "oauth:refresh:"}
 
 // key is the Redis key for token: prefix + base64url(sha256(token)).
+//
+// The encoding is part of the key format: changing it (padded vs unpadded,
+// URL-safe vs standard) orphans every refresh token already in Redis.
 func (s oauthRefreshStore) key(token string) string {
 	sum := sha256.Sum256([]byte(token))
 

--- a/src/lib/integrations/client_alibaba_functions.go
+++ b/src/lib/integrations/client_alibaba_functions.go
@@ -85,7 +85,10 @@ func (a AlibabaClient) Invoke(args InvokeArgs) (*InvokeResult, error) {
 		ErrorStack:   response.ErrorStack,
 	}
 
-	// See if this is a base64 encoded string
+	// See if this is a base64 encoded string. Must stay StdEncoding: the
+	// function runtime emits standard base64, so the URL-safe helpers in
+	// lib/utils would fail to decode any body containing '+' or '/' — and
+	// silently, since a decode error here just leaves the body as-is.
 	if decoded, err := base64.StdEncoding.DecodeString(body); err == nil {
 		invokeResult.Body = decoded
 	}

--- a/src/lib/integrations/client_aws_lambda.go
+++ b/src/lib/integrations/client_aws_lambda.go
@@ -81,7 +81,10 @@ func (a *AWSClient) Invoke(args InvokeArgs) (*InvokeResult, error) {
 		ErrorStack:   response.ErrorStack,
 	}
 
-	// See if this is a base64 encoded string
+	// See if this is a base64 encoded string. Must stay StdEncoding: Lambda
+	// emits standard base64, so the URL-safe helpers in lib/utils would fail to
+	// decode any body containing '+' or '/' — and silently, since a decode
+	// error here just leaves the body as-is.
 	if decoded, err := base64.StdEncoding.DecodeString(body); err == nil {
 		invokeResult.Body = decoded
 	}

--- a/src/lib/integrations/client_filesystem.go
+++ b/src/lib/integrations/client_filesystem.go
@@ -148,7 +148,10 @@ func (c *FilesysClient) Invoke(args InvokeArgs) (*InvokeResult, error) {
 		ErrorStack:   response.ErrorStack,
 	}
 
-	// See if this is a base64 encoded string
+	// See if this is a base64 encoded string. Must stay StdEncoding: the
+	// runtime emits standard base64, so the URL-safe helpers in lib/utils would
+	// fail to decode any body containing '+' or '/' — and silently, since a
+	// decode error here just leaves the body as-is.
 	if decoded, err := base64.StdEncoding.DecodeString(body); err == nil {
 		invokeResult.Body = decoded
 	}

--- a/src/lib/utils/crypt.go
+++ b/src/lib/utils/crypt.go
@@ -32,6 +32,9 @@ func Hash(text []byte) string {
 }
 
 // SHA256Hash hashes the given array of bytes using SHA256 and returns a string out of it.
+//
+// Unpadded, unlike EncodeToString below: callers persist and compare these
+// digests, so changing the encoding would invalidate every stored value.
 func SHA256Hash(b []byte) string {
 	h := sha256.New()
 	h.Write(b)
@@ -159,11 +162,17 @@ func DecryptID(encryptedString string) (types.ID, error) {
 }
 
 // EncodeToString casts an array of bytes to a string.
+//
+// Padded URL-safe base64. Not a drop-in for the other base64 users in this
+// repo: the OAuth and token paths need unpadded output, and the integration
+// clients decode standard-alphabet payloads from AWS and Alibaba. Only reach
+// for this pair when the format is ours to define.
 func EncodeToString(text []byte) string {
 	return base64.URLEncoding.EncodeToString(text)
 }
 
-// DecodeString decodes the given string to an array of bytes.
+// DecodeString decodes the given string to an array of bytes. See
+// EncodeToString for why this is not interchangeable with the other variants.
 func DecodeString(s string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(s)
 }

--- a/src/lib/utils/hash.go
+++ b/src/lib/utils/hash.go
@@ -24,6 +24,10 @@ const (
 // of the input byte length.
 //
 // Example: SecureRandomToken(32) generates a 32-byte random value encoded as ~43 character string.
+//
+// The encoding is unpadded, which is where that 43 comes from — the padded
+// EncodeToString in crypt.go would yield 44 and change the shape of every
+// token this issues.
 func SecureRandomToken(byteLength int) (string, error) {
 	b := make([]byte, byteLength)
 

--- a/src/ui/src/pages/admin/AccessLogs.tsx
+++ b/src/ui/src/pages/admin/AccessLogs.tsx
@@ -42,17 +42,17 @@ interface Filters {
 
 interface UseFetchAccessLogsProps {
   filters: Filters;
-  beforeId?: string;
+  cursor?: string;
   refreshToken: number;
 }
 
 const useFetchAccessLogs = ({
   filters,
-  beforeId,
+  cursor,
   refreshToken,
 }: UseFetchAccessLogsProps) => {
   const [logs, setLogs] = useState<AccessLogEntry[]>([]);
-  const [nextBeforeId, setNextBeforeId] = useState<string>();
+  const [nextCursor, setNextCursor] = useState<string>();
   const [hasNextPage, setHasNextPage] = useState(false);
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState(true);
@@ -71,14 +71,14 @@ const useFetchAccessLogs = ({
       }
     });
 
-    if (beforeId) {
-      params.set("beforeId", beforeId);
+    if (cursor) {
+      params.set("cursor", cursor);
     }
 
     api
       .fetch<{
         accessLogs: AccessLogEntry[];
-        pagination: { hasNextPage: boolean; beforeId?: string };
+        pagination: { hasNextPage: boolean; cursor?: string };
       }>("/admin/access-logs?" + params.toString())
       .then(res => {
         if (unmounted) {
@@ -86,8 +86,8 @@ const useFetchAccessLogs = ({
         }
 
         setHasNextPage(res.pagination.hasNextPage);
-        setNextBeforeId(res.pagination.beforeId);
-        setLogs(beforeId ? prev => [...prev, ...res.accessLogs] : res.accessLogs);
+        setNextCursor(res.pagination.cursor);
+        setLogs(cursor ? prev => [...prev, ...res.accessLogs] : res.accessLogs);
       })
       .catch(() => {
         if (!unmounted) {
@@ -103,9 +103,9 @@ const useFetchAccessLogs = ({
     return () => {
       unmounted = true;
     };
-  }, [refreshToken, beforeId]);
+  }, [refreshToken, cursor]);
 
-  return { logs, error, loading, hasNextPage, nextBeforeId };
+  return { logs, error, loading, hasNextPage, nextCursor };
 };
 
 const formatTs = (ts: string) =>
@@ -115,13 +115,15 @@ export default function AccessLogs() {
   const [draft, setDraft] = useState<Filters>({});
   const [filters, setFilters] = useState<Filters>({});
   const [refreshToken, setRefreshToken] = useState(0);
-  const [beforeId, setBeforeId] = useState<string>();
-  const { logs, error, loading, hasNextPage, nextBeforeId } = useFetchAccessLogs(
-    { filters, beforeId, refreshToken }
-  );
+  const [cursor, setCursor] = useState<string>();
+  const { logs, error, loading, hasNextPage, nextCursor } = useFetchAccessLogs({
+    filters,
+    cursor,
+    refreshToken,
+  });
 
   const search = () => {
-    setBeforeId(undefined);
+    setCursor(undefined);
     setFilters(draft);
     setRefreshToken(t => t + 1);
   };
@@ -235,7 +237,7 @@ export default function AccessLogs() {
             <Button
               variant="text"
               disabled={loading}
-              onClick={() => setBeforeId(nextBeforeId)}
+              onClick={() => setCursor(nextCursor)}
             >
               Load more
             </Button>


### PR DESCRIPTION
Paging over access logs used a `log_id < $cursor` predicate while ordering by
`(request_timestamp DESC, log_id DESC)`. The cursor did not match the sort
order, so every page re-walked the window from the newest row and discarded
rows until it reached the cursor. Cost grew linearly with page depth, which is
what made the endpoint slow for high-traffic apps.

## Changes

- Page on `(request_timestamp, log_id)`, the tuple the query orders by, so the
  index seeks straight to the page.
- Always bound the upper end of the time range, so the create-ahead partitions
  and `request_logs_default` can be pruned.

**No schema change.** Buffers read for one page on 2M rows, against the index
that already exists:

| page | before | after |
|---|---|---|
| ~200 | 1104 | 21 |
| ~2000 | 10778 | 19 |

Ten times deeper costs the old cursor ten times more and the new one nothing.
Cost is now flat across page depth instead of linear.

An earlier revision also swapped `idx_request_logs_app_ts` for one carrying a
trailing `log_id`, to make the ordering index-native. It was dropped: measured
at a further ~1.3ms, it does not justify the cost of building it. At the table
sizes this targets (0024 estimates 200-500M rows/month) that build extrapolates
to ~7 minutes and ~19GB, it takes a SHARE lock that blocks access-log ingest,
and `migrations.Up` runs synchronously in `src/ee/hosting/main.go:98` before the
hosting tier serves traffic — so it would be customer-facing downtime for a
gain the cursor fix already delivers. If it is ever wanted, it belongs in an
out-of-band per-partition `CREATE INDEX CONCURRENTLY`, not a startup migration.

## Pagination contract

`pagination` now returns a single opaque `cursor` instead of `beforeId`. Both
halves of the sort key are needed — `request_timestamp` is not unique and
`log_id` does not follow timestamp order — but they travel as one value so a
caller cannot pass half a cursor.

Worth knowing: the cursor encodes the timestamp in microseconds. An earlier
pass used seconds, which skipped every entry sharing the cursor's second, and
since batched inserts put many rows in the same second that silently dropped
entries at every page boundary. Covered by a round-trip test.

This is breaking, but `GET /v1/access-logs` shipped only in #394 and has had no
release, so nothing external depends on it.

## Second commit: base64 documentation

While picking an encoder for the cursor it turned out the repo uses three
different base64 variants, and it is not obvious from the call sites which are
interchangeable — they are not. The second commit documents why each is
required, so nobody attempts to unify them:

- `StdEncoding` in the three integration clients decodes bodies from AWS
  Lambda / Alibaba / the filesystem runtime, which emit the standard alphabet.
  A URL-safe decoder would fail on `+` or `/` — silently, since the call site
  ignores the error and leaves the body raw.
- `RawURLEncoding` in `verifyPKCE` is mandated unpadded by RFC 7636; padding it
  would reject every conforming OAuth client.
- `RawURLEncoding` in the refresh-token Redis key is part of the key format;
  changing it orphans every token already stored.
- `utils.EncodeToString`/`DecodeString` are padded URL-safe and only apply
  where the format is ours to define — which is what the cursor uses.

No behaviour change in that commit, comments only.

## Not included

An `env_id`-leading index, and the `request_logs_default` retention gap where
rows landing in the default partition are never dropped. Both are worth their
own look.