### PR TITLE
feat: deliver session token to native deep links

### DIFF
--- a/docs/features/15-authentication.md
+++ b/docs/features/15-authentication.md
@@ -40,11 +40,12 @@ The high-level flow is:
 1. The user starts a sign-in flow (submits a form, clicks a magic link, or is
    redirected to an OAuth provider).
 2. On success, Stormkit issues a **session token** (a JWT) and delivers it as a
-   **cookie** to browsers, or in the **response body** to native apps (see
+   **cookie** to browsers, or directly to native apps (see
    [Sessions](#sessions) below).
 3. The browser is redirected to your **Success callback URL**. The
    email-verification and same-origin magic-link flows append `?verified=true`;
-   the OAuth and cross-origin flows redirect to the plain Success URL.
+   the OAuth and cross-origin flows redirect to the plain Success URL. A native
+   app is instead redirected to its deep link carrying the token.
 4. For every authenticated request, Stormkit validates the session and forwards
    `X-User-Id` and `X-User-Email` headers to your backend / API. These headers
    are always stripped from incoming requests first, so they cannot be spoofed.
@@ -59,20 +60,73 @@ kind of client:
   is `HttpOnly`, your JavaScript cannot read it — and does not need to. The
   browser attaches it automatically to same-origin requests, and you send it on
   cross-origin requests with `credentials: "include"`.
-- **Native / mobile apps get a bearer token.** A client with no cookie jar opts
-  into token delivery by sending the header `X-Session-Delivery: bearer` on the
-  login / register / verify / magic-link request. The token is then returned in
-  the response body, and the app stores it and sends it back as an
-  `Authorization: Bearer <token>` header. At `/_stormkit/auth/refresh` this is
-  auto-detected — a client that authenticated with a bearer token and sent no
-  cookie receives a new bearer token without needing the header.
+- **Native / mobile apps get a bearer token.** A client with no cookie jar
+  receives the session token directly. Which mechanism applies depends on how the
+  user signs in — see [Native apps](#native-apps) below. Either way the app ends
+  up with a token it stores and sends back as an `Authorization: Bearer <token>`
+  header.
 
 > **Migrating from an older setup?** Earlier versions stashed the token in
 > `localStorage` under a `skauth` key. That mode has been removed: browsers now
 > always use the `HttpOnly` cookie. Update your frontend to call the API with
 > `credentials: "include"` and read the user from `/_stormkit/auth/me` instead of
-> reading a token from `localStorage`. Native apps must send the
-> `X-Session-Delivery: bearer` header.
+> reading a token from `localStorage`.
+
+### Native apps
+
+A native app has no usable cookie jar — the system sign-in browser
+(`ASWebAuthenticationSession` on iOS, Custom Tabs on Android) discards
+`Set-Cookie` when it closes. Stormkit therefore hands the token over in one of
+two ways:
+
+**1. JSON endpoints — the `X-Session-Delivery` header.** On
+`/_stormkit/auth/login`, `/_stormkit/auth/register` and `/_stormkit/auth/refresh`,
+send the header `X-Session-Delivery: bearer` and the token is returned in the
+response body instead of a cookie:
+
+```json
+{ "token": "…", "email": "user@example.com", "userId": "…" }
+```
+
+At `/_stormkit/auth/refresh` this is auto-detected — a client that authenticated
+with a bearer token and sent no cookie gets a new bearer token without the
+header.
+
+**2. Browser sign-in flows — a custom-scheme redirect.** Google / X OAuth and
+Magic Link finish inside a browser, so there is no response body to read. Instead,
+register your app's deep link as an **allowed origin** (scheme + host, no path —
+e.g. `myapp://auth`) and pass it as the `redirect` target. When the resolved
+target is a custom (non-`http(s)`) scheme, Stormkit appends the session token to
+the redirect and sets **no** cookie:
+
+```
+302 Location: myapp://auth?token=<session-jwt>
+```
+
+For OAuth, open the authorization URL with the redirect:
+
+```
+https://app.example.com/_stormkit/auth/google?redirect=myapp://auth
+```
+
+For Magic Link, pass the same value when requesting the link — it is remembered
+and applied when the user taps it:
+
+```
+GET /_stormkit/auth/magic?email=user@example.com&redirect=myapp://auth
+```
+
+Sign-in failures come back to the same deep link with a `login_error` parameter
+(`myapp://auth?login_error=…`) rather than a `login_error` on your success page.
+
+The token is only ever appended for an origin that is **on the allow-list**. An
+unregistered scheme is rejected (Magic Link responds `403`; OAuth falls back to a
+first-party cookie on your own domain), so a token can never leak to a scheme you
+did not register. `http(s)` targets are unaffected and keep using the cookie.
+
+> `X-Session-Delivery: bearer` applies **only** to `login`, `register` and
+> `refresh`. The `verify`, `magic` and OAuth `callback` landings are browser
+> redirects and ignore the header — use the custom-scheme redirect for those.
 
 ### Cross-origin session protection
 
@@ -93,7 +147,7 @@ of **providers**.
 | --- | --- |
 | **Success callback URL** | A relative URL (e.g. `/auth/success`) the browser is redirected to after a successful sign-in. |
 | **Session TTL** | How long a session token stays valid. Accepts durations like `30min`, `12h`, `7d`, `1w`, `1mo`, `1y`. |
-| **Allowed origins** | Optional. One origin per line (scheme + host, no path). Required when your frontend runs on a **different domain** than the auth host (a decoupled frontend or a native app): those origins are permitted to initiate sign-in and set the session cookie. Leave it empty for single-host setups. |
+| **Allowed origins** | Optional. One origin per line (scheme + host, no path). Required when your frontend runs on a **different domain** than the auth host (a decoupled frontend or a native app): those origins are permitted to initiate sign-in and set the session cookie. A native app's deep link goes here too — `myapp://auth` is valid, `myapp://` and `myapp://auth/callback` are not. Leave it empty for single-host setups. |
 | **Cookie domain** | Optional. A parent domain (e.g. `.example.com`) to scope the session cookie to, so it is shared across subdomains — needed when your frontend and the auth host are different subdomains. Empty means a host-only cookie. |
 | **Login URL** | Optional. Your app's own login page. Used by the [OAuth 2.1 server](/docs/features/oauth-server) to redirect unauthenticated users when an MCP connector asks them to authorize. |
 
@@ -126,6 +180,11 @@ Passwordless sign-in via a one-time link sent by email.
   endpoint returns `201` with no content and emails the user a link.
 - The emailed link points to `/_stormkit/auth/magic?token=<token>`, which
   exchanges the token for a session and redirects to your Success callback URL.
+- Optionally pass `redirect=<origin>` (query param or JSON body) on the request
+  to control where the user lands after tapping the link. It must be on the
+  **Allowed origins** list, and it is remembered with the link — so the redirect
+  survives the round trip through the user's inbox. Native apps pass their deep
+  link here; see [Native apps](#native-apps).
 
 > Magic Link requires the [Mailer](/docs/features/mailer) to be configured to
 > deliver links. If the Mailer is **not** configured, the email is still
@@ -154,7 +213,9 @@ in from.
 Start the OAuth flow by redirecting the user to the **Authorization URL** on your
 own domain, e.g. `https://app.example.com/_stormkit/auth/google`. Optionally
 append `?redirect=<origin>` to control where the user returns afterwards;
-otherwise the request's `Origin` / `Referer` is used.
+otherwise the request's `Origin` / `Referer` is used. A cross-origin value must be
+on the **Allowed origins** list. Native apps pass their deep link here — see
+[Native apps](#native-apps).
 
 > Sign-ins from providers that return an **unverified** email address are
 > rejected before any account is created or linked, so a provider cannot be used
@@ -185,8 +246,10 @@ every request. For the richer profile, use the user-info endpoint below.
 
 ### In a native app
 
-Store the bearer token you received in the response body (after sending
-`X-Session-Delivery: bearer` at sign-in) and attach it to each request:
+Store the bearer token you received at sign-in — from the response body on
+`login` / `register`, or from the `token` parameter on your deep link after an
+OAuth or Magic Link sign-in (see [Native apps](#native-apps)) — and attach it to
+each request:
 
 ```
 Authorization: Bearer <token>
@@ -249,8 +312,10 @@ separately deployed SPA, or a native/mobile app):
 - For a browser SPA, set a shared **Cookie domain** (e.g. `.example.com`) so the
   `skauth_session` cookie is readable across your subdomains, and send every auth
   call with `credentials: "include"`.
-- For a native app, send `X-Session-Delivery: bearer` at sign-in and use the
-  returned bearer token.
+- For a native app, add your deep link (e.g. `myapp://auth`) to **Allowed
+  origins**, then send `X-Session-Delivery: bearer` on `login` / `register` /
+  `refresh`, and pass `redirect=myapp://auth` for OAuth and Magic Link. See
+  [Native apps](#native-apps).
 
 > If a provider is enabled but **no allowed origins** are set and your frontend
 > runs on a separate domain, sign-in will be rejected as cross-origin. The

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
@@ -234,6 +234,75 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_RejectsProtocolRelativeLoginU
 	s.Equal(http.StatusBadRequest, response.Code)
 }
 
+// Test_Update_AllowedOrigins_AcceptsNativeScheme pins the native sign-in
+// contract: a mobile app's deep link is a valid allowed origin, which is what
+// lets the browser sign-in flows return the session token on that scheme instead
+// of a cookie.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_AllowedOrigins_AcceptsNativeScheme() {
+	s.mockCacheService.On("Reset", types.ID(s.env.ID)).Return(nil).Once()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"allowedOrigins": []string{"https://app.example.com", "myapp://auth"},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Require().Equal(http.StatusOK, response.Code)
+
+	env, err := buildconf.NewStore().EnvironmentByID(context.Background(), types.ID(s.env.ID))
+	s.Require().NoError(err)
+	s.Equal([]string{"https://app.example.com", "myapp://auth"}, env.AuthConf.AllowedOrigins)
+}
+
+// Test_Update_AllowedOrigins_RejectsPathBearingScheme guards the token-delivery
+// target: an origin carrying a path can never match a resolved origin, so
+// allowing it would silently misconfigure the allow-list.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_AllowedOrigins_RejectsPathBearingScheme() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"allowedOrigins": []string{"myapp://auth/callback"},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_Update_AllowedOrigins_RejectsHostlessScheme rejects a bare scheme: with no
+// host there is nothing to match, so it would never authorize a redirect.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_AllowedOrigins_RejectsHostlessScheme() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"allowedOrigins": []string{"myapp://"},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
 func TestHandlerAuthConfigUpdate(t *testing.T) {
 	suite.Run(t, &HandlerAuthConfigUpdateSuite{})
 }

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -84,21 +84,68 @@ func (m *skAuthMiddleware) handleLogout() (*shttp.Response, error) {
 	}, nil
 }
 
-// deliverSession sets the session cookie and 302s to redirectURL. Used by the
-// browser login landings (email verify, magic link, OAuth-provider callback);
-// the cookie is first-party to this auth host, so it is also readable by the
-// OAuth /authorize navigation. redirectURL is a relative path or an absolute URL
-// on the destination origin.
-func (m *skAuthMiddleware) deliverSession(token, redirectURL string) *shttp.Response {
+// deliverSessionParams describes where a freshly minted session token is headed.
+// Origin is the already allow-list-validated destination origin (scheme + host,
+// no path) and is empty for a same-host landing. Path is the relative landing
+// path — the configured SuccessURL, sometimes carrying a query — appended to
+// Origin for browser targets.
+type deliverSessionParams struct {
+	Token  string
+	Origin string
+	Path   string
+}
+
+// deliverSession hands the session token to the client and 302s onward. Used by
+// the login landings (email verify, magic link, OAuth-provider callback).
+//
+// Browsers receive it as the HttpOnly session cookie — first-party to this auth
+// host, so it is also readable by the OAuth /authorize navigation — and land on
+// Origin+Path. A native app, identified by a custom-scheme Origin such as
+// triplan://auth, has no usable cookie jar: the system auth session
+// (ASWebAuthenticationSession / Custom Tabs) discards Set-Cookie. For those the
+// token rides the redirect URL instead and no cookie is set. The scheme is
+// claimed by the owning app, so the OS hands the URL only to it, and Origin has
+// already been matched against the configured allow-list by the caller.
+func (m *skAuthMiddleware) deliverSession(p deliverSessionParams) *shttp.Response {
+	headers := shttp.HeadersFromMap(map[string]string{
+		"Cache-Control":   "no-store",
+		"Referrer-Policy": "no-referrer",
+	})
+
+	if isNativeSchemeOrigin(p.Origin) {
+		target := p.Origin + "?token=" + url.QueryEscape(p.Token)
+
+		return &shttp.Response{
+			Status:   http.StatusFound,
+			Redirect: &target,
+			Headers:  headers,
+		}
+	}
+
+	target := p.Origin + p.Path
+
 	return &shttp.Response{
 		Status:   http.StatusFound,
-		Redirect: &redirectURL,
-		Cookies:  []http.Cookie{m.sessionCookieFor(token)},
-		Headers: shttp.HeadersFromMap(map[string]string{
-			"Cache-Control":   "no-store",
-			"Referrer-Policy": "no-referrer",
-		}),
+		Redirect: &target,
+		Cookies:  []http.Cookie{m.sessionCookieFor(p.Token)},
+		Headers:  headers,
 	}
+}
+
+// isNativeSchemeOrigin reports whether origin uses a custom (non-http(s)) scheme
+// such as triplan://auth — the redirect target a native app registers in the
+// environment's allowed origins. It only classifies the scheme; the caller is
+// responsible for having validated origin against the allow-list first.
+func isNativeSchemeOrigin(origin string) bool {
+	scheme, _, ok := strings.Cut(origin, "://")
+
+	if !ok || scheme == "" {
+		return false
+	}
+
+	scheme = strings.ToLower(scheme)
+
+	return scheme != "http" && scheme != "https"
 }
 
 func (m *skAuthMiddleware) handleRegisterLogin(path string) (*shttp.Response, error) {
@@ -132,7 +179,10 @@ func (m *skAuthMiddleware) handleVerify() (*shttp.Response, error) {
 
 	token, _ := data["token"].(string)
 
-	return m.deliverSession(token, m.req.Host.Config.SKAuth.SuccessURL+"?verified=true"), nil
+	return m.deliverSession(deliverSessionParams{
+		Token: token,
+		Path:  m.req.Host.Config.SKAuth.SuccessURL + "?verified=true",
+	}), nil
 }
 
 func (m *skAuthMiddleware) handleMagicLinkRequest() (*shttp.Response, error) {
@@ -187,15 +237,24 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
 	token, _ := data["token"].(string)
 
-	// Cross-origin: the POST came from a whitelisted frontend. The session cookie
-	// is first-party to this auth host (also the OAuth AS), so it is set here and
-	// the browser is sent straight to the destination origin — no dependency on
-	// the frontend host carrying its own auth config.
+	// Cross-origin: the request came from a whitelisted frontend, whose origin the
+	// magic-link token carried in its `rdr` claim and magicLinkVerify re-validated
+	// against the allow-list. The session cookie is first-party to this auth host
+	// (also the OAuth AS), so it is set here and the browser is sent straight to
+	// the destination origin — no dependency on the frontend host carrying its own
+	// auth config. A native custom-scheme origin gets the token in the URL instead.
 	if redirect, _ := data["redirect"].(string); redirect != "" {
-		return m.deliverSession(token, redirect+successURL), nil
+		return m.deliverSession(deliverSessionParams{
+			Token:  token,
+			Origin: redirect,
+			Path:   successURL,
+		}), nil
 	}
 
-	return m.deliverSession(token, successURL+"?verified=true"), nil
+	return m.deliverSession(deliverSessionParams{
+		Token: token,
+		Path:  successURL + "?verified=true",
+	}), nil
 }
 
 // finalizeSessionResponse adapts a successful JSON auth response (login,
@@ -290,10 +349,20 @@ func (m *skAuthMiddleware) cookieOriginAllowed() bool {
 // (origin + SuccessURL) with a user-friendly message in the login_error query
 // param, instead of rendering a Stormkit error page. The underlying cause should
 // be logged by the caller. Used by both the OAuth and magic-link flows.
+//
+// A native custom-scheme origin has no SuccessURL page to land on — it is the
+// deep link itself — so the message is hung off the bare origin, mirroring how
+// deliverSession returns the token there.
 func (m *skAuthMiddleware) loginErrorRedirect(origin, message string) *shttp.Response {
+	path := m.req.Host.Config.SKAuth.SuccessURL
+
+	if isNativeSchemeOrigin(origin) {
+		path = ""
+	}
+
 	target := fmt.Sprintf("%s%s?login_error=%s",
 		origin,
-		m.req.Host.Config.SKAuth.SuccessURL,
+		path,
 		url.QueryEscape(message),
 	)
 

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -420,6 +420,103 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() 
 	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
+// Test_Verify_NativeScheme_TokenInRedirect covers the native/mobile path: a
+// custom-scheme redirect target has no usable cookie jar (the OS auth session
+// discards Set-Cookie), so the session token rides the redirect URL instead and
+// no cookie is set.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_TokenInRedirect() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=native@example.com&redirect=triplan://auth",
+		http.MethodPost,
+		"",
+	)
+	_, err = hosting.ServeAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+
+	s.NoError(err)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Empty(res.Cookies, "a native custom-scheme delivery must not set a cookie")
+
+	target, err := url.Parse(*res.Redirect)
+	s.Require().NoError(err)
+	s.Equal("triplan", target.Scheme)
+	s.Equal("auth", target.Host)
+	s.Empty(target.Path, "the success URL must not be appended to a deep link")
+
+	// The token in the URL is the same session JWT the cookie would have carried.
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer: target.Query().Get("token"),
+		Secret: env.AuthConf.Secret,
+	})
+
+	s.Require().NotNil(claims, "the redirected token must be a valid session JWT")
+
+	uid, ok := claims["uid"].(string)
+	s.Require().True(ok)
+	_, err = uuid.Parse(uid)
+	s.NoError(err, "uid claim should be a valid UUID, got %q", uid)
+}
+
+// Test_Verify_NativeScheme_ErrorRedirect verifies a failed sign-in bounces back
+// to the deep link itself — there is no success page to land on in a native app.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_ErrorRedirect() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=nativeerr@example.com&redirect=triplan://auth",
+		http.MethodPost,
+		"",
+	)
+	_, err = hosting.ServeAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	path := fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)
+
+	first, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusFound, first.Status)
+
+	// Replaying the consumed token must land the error on the deep link.
+	second, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
+
+	s.NoError(err)
+	s.Equal(http.StatusFound, second.Status)
+	s.Require().NotNil(second.Redirect)
+	s.Contains(*second.Redirect, "triplan://auth?login_error=")
+	s.NotContains(*second.Redirect, "/dashboard")
+}
+
+// Test_Request_NativeScheme_NotAllowListed_Returns403 guards the token-leak
+// vector: an unregistered custom scheme must never become a delivery target.
+func (s *WithSKAuthMagicLinkSuite) Test_Request_NativeScheme_NotAllowListed_Returns403() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	rq := s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=evil@example.com&redirect=evil://auth",
+		http.MethodPost,
+		"",
+	)
+	res, err := hosting.ServeAuth(rq)
+
+	s.NoError(err)
+	s.Equal(http.StatusForbidden, res.Status)
+}
+
 func truncateMagicLinkAuthTables() {
 	db, err := sql.Open("postgres", database.ConnectionString(database.Config))
 

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -391,4 +392,88 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ExchangeFails_RedirectsWithError() 
 	s.Require().NotNil(res.Redirect)
 	s.Contains(*res.Redirect, "https://app.example.com/dashboard?login_error=")
 	s.Contains(*res.Redirect, "complete+sign-in")
+}
+
+// Test_Callback_NativeScheme_TokenInRedirect covers the native/mobile OAuth
+// path: the sign-in runs inside a system auth session whose cookie jar discards
+// Set-Cookie, so an allow-listed custom-scheme target receives the session token
+// in the redirect URL and no cookie at all.
+func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_TokenInRedirect() {
+	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
+		Secret:         "test-secret-padded-to-32-chars!!",
+		Status:         true,
+		AllowedOrigins: []string{"triplan://auth"},
+	})
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "native-account-id",
+		Email:         "native@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Nat",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "triplan://auth")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Empty(res.Cookies, "a native custom-scheme delivery must not set a cookie")
+
+	target, err := url.Parse(*res.Redirect)
+	s.Require().NoError(err)
+	s.Equal("triplan", target.Scheme)
+	s.Equal("auth", target.Host)
+	s.Empty(target.Path, "the success URL must not be appended to a deep link")
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer: target.Query().Get("token"),
+		Secret: "test-secret-padded-to-32-chars!!",
+	})
+
+	s.Require().NotNil(claims, "the redirected token must be a valid session JWT")
+	s.NotEmpty(claims["uid"])
+}
+
+// Test_Callback_NativeScheme_NotAllowListed_StaysFirstParty guards the token
+// leak: a custom scheme that is not on the allow-list must not receive a token,
+// and the flow falls back to a first-party cookie on this host.
+func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_NotAllowListed_StaysFirstParty() {
+	host := s.setupCallbackEnv(true)
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "evil-account-id",
+		Email:         "evil@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Eve",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "evil://auth")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Equal("https://api.example.com/dashboard", *res.Redirect)
+	s.NotContains(*res.Redirect, "token=")
+	s.Require().Len(res.Cookies, 1, "the fallback must stay on the first-party cookie")
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -243,8 +243,13 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	// Set a first-party cookie on this auth host (also the OAuth AS) and send the
 	// user straight to the initiating origin — no dependency on that origin
-	// carrying its own auth config.
-	return m.deliverSession(sessionToken, referOrigin+successURL), nil
+	// carrying its own auth config. A native app initiating with a custom-scheme
+	// origin gets the token on the redirect instead; see deliverSession.
+	return m.deliverSession(deliverSessionParams{
+		Token:  sessionToken,
+		Origin: referOrigin,
+		Path:   successURL,
+	}), nil
 }
 
 // resolveRedirect determines and validates the post-login redirect origin.

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -323,14 +323,14 @@ export default function SkAuth() {
           <TextField
             label="Allowed origins"
             name="allowedOrigins"
-            placeholder={"https://app.example.com\nhttps://dev.example.com"}
+            placeholder={"https://app.example.com\nhttps://dev.example.com\nmyapp://auth"}
             fullWidth
             multiline
             minRows={3}
             defaultValue={(config?.allowedOrigins || []).join("\n")}
             variant="filled"
             autoComplete="off"
-            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. Leave empty for single-host setups."
+            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. A native app's deep link (e.g. myapp://auth) goes here too — sign-in then returns the session token on that link instead of a cookie. Leave empty for single-host setups."
             slotProps={{
               inputLabel: {
                 shrink: true,


### PR DESCRIPTION
Closes #398.

Native apps sign in through a system browser (`ASWebAuthenticationSession` / Custom Tabs) whose cookie jar is discarded when it closes. The OAuth callback and magic-link landings both end in `deliverSession`, which unconditionally set a cookie and 302'd — so the app came back with nothing. `X-Session-Delivery: bearer` only covers the JSON endpoints (`login` / `register` / `refresh`); neither landing consults it.

## Change

`deliverSession` previously received a pre-concatenated `origin + successURL` string, which is why this branch could not exist — by the time it saw the target, the deep link and the success path were already fused. It now takes them separately:

```go
type deliverSessionParams struct {
	Token  string
	Origin string
	Path   string
}
```

When `Origin` is an allow-listed custom (non-`http(s)`) scheme:

```
302 Location: myapp://auth?token=<session-jwt>    (no Set-Cookie)
```

`http(s)` targets are unchanged. Because both browser flows funnel through this one function, the single change covers both. `loginErrorRedirect` mirrors it, so failures reach `myapp://auth?login_error=…` rather than a success page a native app cannot render.

## Notes for review

**The magic-link plumbing the issue flagged as ⚠️ already exists.** The redirect origin survives the round trip through the user's inbox in the magic token's `rdr` claim, re-validated against the allow-list at click time (`skauth_magic.go:143-149`). No new persistence was needed.

**Origin validation is untouched.** An unregistered scheme still `403`s on magic-link request and falls back to a first-party cookie on OAuth callback, so a token cannot reach a scheme that was not registered.

**`?token=` over `#token=`.** The issue left this open and preferred query for Expo's result parser. No server ever observes a custom-scheme URL, so the fragment's logging argument does not apply. Easy to flip.

## Tests

Five new tests in `hosting` covering both flows: token-in-redirect with no cookie and a valid session JWT, the native error redirect, and the non-allow-listed rejection for each flow.

Three new tests in `skauthhandlers` covering `allowedOrigins` scheme validation. This was not requested in the issue, but the feature rests on `myapp://auth` being storable while `myapp://` and `myapp://auth/callback` are rejected — behaviour that had no coverage at all, leaving acceptance criterion 5 only half-verifiable.

Criterion 3 (`http(s)` unchanged) is carried by the pre-existing tests, deliberately left unmodified.

## Docs

New **Native apps** section documenting both mechanisms, and a correction to the false claim at `docs/features/15-authentication.md:62-68` that `verify` and `magic` honour `X-Session-Delivery` — they never did. Fixed in all four places it had propagated. Dashboard helper text and placeholder for Allowed origins now mention deep links, since the feature is otherwise undiscoverable.