### PR TITLE
feat: record request duration in access logs

### DIFF
--- a/docs/api/12-access-logs.md
+++ b/docs/api/12-access-logs.md
@@ -6,8 +6,9 @@ description: Documentation on reading raw HTTP access logs through the Stormkit 
 # Access Logs API
 
 Access logs contain one entry per HTTP request served by Stormkit for your
-environment — the path, status code, client IP, user agent and how many bytes
-were sent. They are operational request logs, not visitor analytics: bot traffic
+environment — the path, status code, client IP, user agent, how many bytes were
+sent and how long the request took to serve. They are operational request logs,
+not visitor analytics: bot traffic
 is included and the client IP and user agent are not masked.
 
 These are distinct from **runtime logs**, which contain the output of your
@@ -43,6 +44,7 @@ All filters are optional and are combined with AND.
 | `path`     | string  | No          | Only return requests whose path starts with this value.                                                                                           |
 | `status`   | number  | No          | Only return requests answered with this HTTP status code.                                                                                         |
 | `isBot`    | boolean | No          | `true` returns only bot traffic, `false` only non-bot traffic. Omit to return both.                                                               |
+| `minDurationMs` | number | No       | Only return requests that took at least this many milliseconds to serve — e.g. `500` to inspect the latency tail. Requests logged before durations were recorded are excluded. |
 | `cursor`   | string  | No          | Pagination cursor. Pass `pagination.cursor` from the previous response back verbatim to fetch the next page. Treat it as opaque — its encoding may change. |
 
 > Queries are always bounded in time so that they only scan the relevant
@@ -75,6 +77,7 @@ Each entry contains:
 | `isBot`            | boolean | Whether the request was classified as bot traffic.     |
 | `bytesSent`        | number  | Size of the response body in bytes.                    |
 | `requestId`        | string  | Correlation ID assigned to the request.                |
+| `durationMs`       | number  | How long Stormkit took to serve the request, in milliseconds. `null` for requests logged before durations were recorded. Measured up to response assembly, so it excludes transfer time to the client. |
 
 ### Error responses
 
@@ -110,7 +113,8 @@ curl -H 'Authorization: <api_key>' \
       "referrer": "",
       "isBot": false,
       "bytesSent": 512,
-      "requestId": "x5818c-47818-ca2de192e"
+      "requestId": "x5818c-47818-ca2de192e",
+      "durationMs": 34
     }
   ],
   "pagination": {

--- a/docs/features/15-authentication.md
+++ b/docs/features/15-authentication.md
@@ -92,41 +92,73 @@ At `/_stormkit/auth/refresh` this is auto-detected — a client that authenticat
 with a bearer token and sent no cookie gets a new bearer token without the
 header.
 
-**2. Browser sign-in flows — a custom-scheme redirect.** Google / X OAuth and
-Magic Link finish inside a browser, so there is no response body to read. Instead,
-register your app's deep link as an **allowed origin** (scheme + host, no path —
-e.g. `myapp://auth`) and pass it as the `redirect` target. When the resolved
-target is a custom (non-`http(s)`) scheme, Stormkit appends the session token to
-the redirect and sets **no** cookie:
+**2. Browser sign-in flows — a custom-scheme redirect plus PKCE.** Google / X
+OAuth and Magic Link finish inside a browser, so there is no response body to
+read. Instead, register your app's deep link as an **allowed origin** (scheme +
+host, no path — e.g. `myapp://auth`) and pass it as the `redirect` target.
+
+A private-use URI scheme is not exclusively yours — another app on the device can
+register the same scheme — so the redirect must be assumed interceptable and
+never carries the session token. It carries a **single-use code**, valid for one
+minute, bound to a PKCE challenge only your app can answer:
 
 ```
-302 Location: myapp://auth?token=<session-jwt>
+302 Location: myapp://auth?code=<one-time-code>
 ```
 
-For OAuth, open the authorization URL with the redirect:
+Generate a random `code_verifier`, send `code_challenge = base64url(sha256(verifier))`
+(unpadded, `code_challenge_method=S256`) when you start sign-in, and exchange the
+code for the session token over TLS:
 
 ```
-https://app.example.com/_stormkit/auth/google?redirect=myapp://auth
+POST /_stormkit/auth/token
+Content-Type: application/json
+
+{ "code": "<one-time-code>", "code_verifier": "<verifier>" }
 ```
 
-For Magic Link, pass the same value when requesting the link — it is remembered
-and applied when the user taps it:
+```json
+{ "token": "…" }
+```
+
+The code is consumed on the first exchange attempt, so an interceptor without the
+verifier gains nothing and cannot retry.
+
+For OAuth, open the authorization URL with the redirect and the challenge:
 
 ```
-GET /_stormkit/auth/magic?email=user@example.com&redirect=myapp://auth
+https://app.example.com/_stormkit/auth/google?redirect=myapp://auth&code_challenge=<challenge>&code_challenge_method=S256
 ```
+
+For Magic Link, pass the same values when requesting the link — they are
+remembered and applied when the user taps it, so the binding survives the round
+trip through the user's inbox:
+
+```
+GET /_stormkit/auth/magic?email=user@example.com&redirect=myapp://auth&code_challenge=<challenge>&code_challenge_method=S256
+```
+
+A custom-scheme redirect **without** a valid S256 challenge is rejected with
+`400` — Stormkit will not fall back to putting the token in the URL.
 
 Sign-in failures come back to the same deep link with a `login_error` parameter
 (`myapp://auth?login_error=…`) rather than a `login_error` on your success page.
+Expired links are included — the target is recovered from the link itself and
+re-checked against the allow-list. A server-side fault (5xx) is the exception: it
+renders an error page in the system browser, so keep a user-visible cancel path
+in your sign-in sheet.
 
-The token is only ever appended for an origin that is **on the allow-list**. An
+The code is only ever issued for an origin that is **on the allow-list**. An
 unregistered scheme is rejected (Magic Link responds `403`; OAuth falls back to a
-first-party cookie on your own domain), so a token can never leak to a scheme you
-did not register. `http(s)` targets are unaffected and keep using the cookie.
+first-party cookie on your own domain), so nothing can leak to a scheme you did
+not register. `http(s)` targets are unaffected and keep using the cookie.
 
 > `X-Session-Delivery: bearer` applies **only** to `login`, `register` and
-> `refresh`. The `verify`, `magic` and OAuth `callback` landings are browser
-> redirects and ignore the header — use the custom-scheme redirect for those.
+> `refresh`. The `magic` and OAuth `callback` landings are browser redirects and
+> ignore the header — use the custom-scheme redirect for those. The `verify`
+> (email-confirmation) landing has no native path at all: it always sets a
+> first-party cookie, so a native app should call `login` with
+> `X-Session-Delivery: bearer` once the address is confirmed.
 
 ### Cross-origin session protection
 
@@ -184,7 +216,8 @@ Passwordless sign-in via a one-time link sent by email.
   to control where the user lands after tapping the link. It must be on the
   **Allowed origins** list, and it is remembered with the link — so the redirect
   survives the round trip through the user's inbox. Native apps pass their deep
-  link here; see [Native apps](#native-apps).
+  link here, together with a PKCE `code_challenge`; see
+  [Native apps](#native-apps).
 
 > Magic Link requires the [Mailer](/docs/features/mailer) to be configured to
 > deliver links. If the Mailer is **not** configured, the email is still
@@ -247,9 +280,9 @@ every request. For the richer profile, use the user-info endpoint below.
 ### In a native app
 
 Store the bearer token you received at sign-in — from the response body on
-`login` / `register`, or from the `token` parameter on your deep link after an
-OAuth or Magic Link sign-in (see [Native apps](#native-apps)) — and attach it to
-each request:
+`login` / `register`, or from exchanging the `code` your deep link received after
+an OAuth or Magic Link sign-in (see [Native apps](#native-apps)) — and attach it
+to each request:
 
 ```
 Authorization: Bearer <token>
@@ -314,8 +347,8 @@ separately deployed SPA, or a native/mobile app):
   call with `credentials: "include"`.
 - For a native app, add your deep link (e.g. `myapp://auth`) to **Allowed
   origins**, then send `X-Session-Delivery: bearer` on `login` / `register` /
-  `refresh`, and pass `redirect=myapp://auth` for OAuth and Magic Link. See
-  [Native apps](#native-apps).
+  `refresh`, and pass `redirect=myapp://auth` plus a PKCE `code_challenge` for
+  OAuth and Magic Link. See [Native apps](#native-apps).
 
 > If a provider is enabled but **no allowed origins** are set and your frontend
 > runs on a separate domain, sign-in will be rejected as cross-origin. The

--- a/docs/features/15-authentication.md
+++ b/docs/features/15-authentication.md
@@ -40,11 +40,12 @@ The high-level flow is:
 1. The user starts a sign-in flow (submits a form, clicks a magic link, or is
    redirected to an OAuth provider).
 2. On success, Stormkit issues a **session token** (a JWT) and delivers it as a
-   **cookie** to browsers, or in the **response body** to native apps (see
+   **cookie** to browsers, or directly to native apps (see
    [Sessions](#sessions) below).
 3. The browser is redirected to your **Success callback URL**. The
    email-verification and same-origin magic-link flows append `?verified=true`;
-   the OAuth and cross-origin flows redirect to the plain Success URL.
+   the OAuth and cross-origin flows redirect to the plain Success URL. A native
+   app is instead redirected to its deep link carrying the token.
 4. For every authenticated request, Stormkit validates the session and forwards
    `X-User-Id` and `X-User-Email` headers to your backend / API. These headers
    are always stripped from incoming requests first, so they cannot be spoofed.
@@ -59,20 +60,73 @@ kind of client:
   is `HttpOnly`, your JavaScript cannot read it — and does not need to. The
   browser attaches it automatically to same-origin requests, and you send it on
   cross-origin requests with `credentials: "include"`.
-- **Native / mobile apps get a bearer token.** A client with no cookie jar opts
-  into token delivery by sending the header `X-Session-Delivery: bearer` on the
-  login / register / verify / magic-link request. The token is then returned in
-  the response body, and the app stores it and sends it back as an
-  `Authorization: Bearer <token>` header. At `/_stormkit/auth/refresh` this is
-  auto-detected — a client that authenticated with a bearer token and sent no
-  cookie receives a new bearer token without needing the header.
+- **Native / mobile apps get a bearer token.** A client with no cookie jar
+  receives the session token directly. Which mechanism applies depends on how the
+  user signs in — see [Native apps](#native-apps) below. Either way the app ends
+  up with a token it stores and sends back as an `Authorization: Bearer <token>`
+  header.
 
 > **Migrating from an older setup?** Earlier versions stashed the token in
 > `localStorage` under a `skauth` key. That mode has been removed: browsers now
 > always use the `HttpOnly` cookie. Update your frontend to call the API with
 > `credentials: "include"` and read the user from `/_stormkit/auth/me` instead of
-> reading a token from `localStorage`. Native apps must send the
-> `X-Session-Delivery: bearer` header.
+> reading a token from `localStorage`.
+
+### Native apps
+
+A native app has no usable cookie jar — the system sign-in browser
+(`ASWebAuthenticationSession` on iOS, Custom Tabs on Android) discards
+`Set-Cookie` when it closes. Stormkit therefore hands the token over in one of
+two ways:
+
+**1. JSON endpoints — the `X-Session-Delivery` header.** On
+`/_stormkit/auth/login`, `/_stormkit/auth/register` and `/_stormkit/auth/refresh`,
+send the header `X-Session-Delivery: bearer` and the token is returned in the
+response body instead of a cookie:
+
+```json
+{ "token": "…", "email": "user@example.com", "userId": "…" }
+```
+
+At `/_stormkit/auth/refresh` this is auto-detected — a client that authenticated
+with a bearer token and sent no cookie gets a new bearer token without the
+header.
+
+**2. Browser sign-in flows — a custom-scheme redirect.** Google / X OAuth and
+Magic Link finish inside a browser, so there is no response body to read. Instead,
+register your app's deep link as an **allowed origin** (scheme + host, no path —
+e.g. `myapp://auth`) and pass it as the `redirect` target. When the resolved
+target is a custom (non-`http(s)`) scheme, Stormkit appends the session token to
+the redirect and sets **no** cookie:
+
+```
+302 Location: myapp://auth?token=<session-jwt>
+```
+
+For OAuth, open the authorization URL with the redirect:
+
+```
+https://app.example.com/_stormkit/auth/google?redirect=myapp://auth
+```
+
+For Magic Link, pass the same value when requesting the link — it is remembered
+and applied when the user taps it:
+
+```
+GET /_stormkit/auth/magic?email=user@example.com&redirect=myapp://auth
+```
+
+Sign-in failures come back to the same deep link with a `login_error` parameter
+(`myapp://auth?login_error=…`) rather than a `login_error` on your success page.
+
+The token is only ever appended for an origin that is **on the allow-list**. An
+unregistered scheme is rejected (Magic Link responds `403`; OAuth falls back to a
+first-party cookie on your own domain), so a token can never leak to a scheme you
+did not register. `http(s)` targets are unaffected and keep using the cookie.
+
+> `X-Session-Delivery: bearer` applies **only** to `login`, `register` and
+> `refresh`. The `verify`, `magic` and OAuth `callback` landings are browser
+> redirects and ignore the header — use the custom-scheme redirect for those.
 
 ### Cross-origin session protection
 
@@ -93,7 +147,7 @@ of **providers**.
 | --- | --- |
 | **Success callback URL** | A relative URL (e.g. `/auth/success`) the browser is redirected to after a successful sign-in. |
 | **Session TTL** | How long a session token stays valid. Accepts durations like `30min`, `12h`, `7d`, `1w`, `1mo`, `1y`. |
-| **Allowed origins** | Optional. One origin per line (scheme + host, no path). Required when your frontend runs on a **different domain** than the auth host (a decoupled frontend or a native app): those origins are permitted to initiate sign-in and set the session cookie. Leave it empty for single-host setups. |
+| **Allowed origins** | Optional. One origin per line (scheme + host, no path). Required when your frontend runs on a **different domain** than the auth host (a decoupled frontend or a native app): those origins are permitted to initiate sign-in and set the session cookie. A native app's deep link goes here too — `myapp://auth` is valid, `myapp://` and `myapp://auth/callback` are not. Leave it empty for single-host setups. |
 | **Cookie domain** | Optional. A parent domain (e.g. `.example.com`) to scope the session cookie to, so it is shared across subdomains — needed when your frontend and the auth host are different subdomains. Empty means a host-only cookie. |
 | **Login URL** | Optional. Your app's own login page. Used by the [OAuth 2.1 server](/docs/features/oauth-server) to redirect unauthenticated users when an MCP connector asks them to authorize. |
 
@@ -126,6 +180,11 @@ Passwordless sign-in via a one-time link sent by email.
   endpoint returns `201` with no content and emails the user a link.
 - The emailed link points to `/_stormkit/auth/magic?token=<token>`, which
   exchanges the token for a session and redirects to your Success callback URL.
+- Optionally pass `redirect=<origin>` (query param or JSON body) on the request
+  to control where the user lands after tapping the link. It must be on the
+  **Allowed origins** list, and it is remembered with the link — so the redirect
+  survives the round trip through the user's inbox. Native apps pass their deep
+  link here; see [Native apps](#native-apps).
 
 > Magic Link requires the [Mailer](/docs/features/mailer) to be configured to
 > deliver links. If the Mailer is **not** configured, the email is still
@@ -154,7 +213,9 @@ in from.
 Start the OAuth flow by redirecting the user to the **Authorization URL** on your
 own domain, e.g. `https://app.example.com/_stormkit/auth/google`. Optionally
 append `?redirect=<origin>` to control where the user returns afterwards;
-otherwise the request's `Origin` / `Referer` is used.
+otherwise the request's `Origin` / `Referer` is used. A cross-origin value must be
+on the **Allowed origins** list. Native apps pass their deep link here — see
+[Native apps](#native-apps).
 
 > Sign-ins from providers that return an **unverified** email address are
 > rejected before any account is created or linked, so a provider cannot be used
@@ -185,8 +246,10 @@ every request. For the richer profile, use the user-info endpoint below.
 
 ### In a native app
 
-Store the bearer token you received in the response body (after sending
-`X-Session-Delivery: bearer` at sign-in) and attach it to each request:
+Store the bearer token you received at sign-in — from the response body on
+`login` / `register`, or from the `token` parameter on your deep link after an
+OAuth or Magic Link sign-in (see [Native apps](#native-apps)) — and attach it to
+each request:
 
 ```
 Authorization: Bearer <token>
@@ -249,8 +312,10 @@ separately deployed SPA, or a native/mobile app):
 - For a browser SPA, set a shared **Cookie domain** (e.g. `.example.com`) so the
   `skauth_session` cookie is readable across your subdomains, and send every auth
   call with `credentials: "include"`.
-- For a native app, send `X-Session-Delivery: bearer` at sign-in and use the
-  returned bearer token.
+- For a native app, add your deep link (e.g. `myapp://auth`) to **Allowed
+  origins**, then send `X-Session-Delivery: bearer` on `login` / `register` /
+  `refresh`, and pass `redirect=myapp://auth` for OAuth and Magic Link. See
+  [Native apps](#native-apps).
 
 > If a provider is enabled but **no allowed origins** are set and your frontend
 > runs on a separate domain, sign-in will be rejected as cross-origin. The

--- a/src/ce/api/accesslog/accesslog_model.go
+++ b/src/ce/api/accesslog/accesslog_model.go
@@ -29,6 +29,11 @@ type AccessLog struct {
 	IsBot        bool        `json:"isBot"`
 	BytesSent    int64       `json:"bytesSent"`
 	RequestID    null.String `json:"requestId"`
+
+	// DurationMS is how long the request took to serve, in milliseconds. It is
+	// null for entries written before the column existed, and for requests whose
+	// start time was never stamped — a zero would misread as an instant response.
+	DurationMS null.Int `json:"durationMs"`
 }
 
 // Cursor encodes the entry's position for keyset pagination.
@@ -68,5 +73,8 @@ func (l AccessLog) ToMap() map[string]any {
 		"isBot":            l.IsBot,
 		"bytesSent":        l.BytesSent,
 		"requestId":        l.RequestID.ValueOrZero(),
+		// Ptr, not ValueOrZero: an unmeasured request must serialize as null, so
+		// consumers do not read it as a 0ms response.
+		"durationMs": l.DurationMS.Ptr(),
 	}
 }

--- a/src/ce/api/accesslog/accesslog_query.go
+++ b/src/ce/api/accesslog/accesslog_query.go
@@ -35,20 +35,21 @@ func SelectLogsParamsFromQuery(q url.Values) SelectLogsParams {
 	}
 
 	return SelectLogsParams{
-		AppID:    utils.StringToID(q.Get("appId")),
-		EnvID:    utils.StringToID(q.Get("envId")),
-		DomainID: utils.StringToID(q.Get("domainId")),
-		HostName: q.Get("hostName"),
-		ClientIP: q.Get("clientIp"),
-		Method:   q.Get("method"),
-		Path:     q.Get("path"),
-		Status:   utils.StringToInt(q.Get("status")),
-		IsBot:    boolFromQuery(q.Get("isBot")),
-		From:     from,
-		To:       to,
-		BeforeID: beforeID,
-		BeforeTS: beforeTS,
-		Limit:    DefaultLimit,
+		AppID:         utils.StringToID(q.Get("appId")),
+		EnvID:         utils.StringToID(q.Get("envId")),
+		DomainID:      utils.StringToID(q.Get("domainId")),
+		MinDurationMS: utils.StringToInt(q.Get("minDurationMs")),
+		HostName:      q.Get("hostName"),
+		ClientIP:      q.Get("clientIp"),
+		Method:        q.Get("method"),
+		Path:          q.Get("path"),
+		Status:        utils.StringToInt(q.Get("status")),
+		IsBot:         boolFromQuery(q.Get("isBot")),
+		From:          from,
+		To:            to,
+		BeforeID:      beforeID,
+		BeforeTS:      beforeTS,
+		Limit:         DefaultLimit,
 	}
 }
 

--- a/src/ce/api/accesslog/accesslog_query_test.go
+++ b/src/ce/api/accesslog/accesslog_query_test.go
@@ -63,6 +63,22 @@ func (s *QuerySuite) Test_TimeBounds_Default() {
 	s.WithinDuration(time.Now(), params.To.Time, time.Minute)
 }
 
+func (s *QuerySuite) Test_MinDurationMS() {
+	params := accesslog.SelectLogsParamsFromQuery(url.Values{"minDurationMs": {"500"}})
+
+	s.Equal(500, params.MinDurationMS)
+}
+
+// An absent, zero or unparseable value has to read as "no duration filter" —
+// the store only applies the clause above zero, so a NaN must not become one.
+func (s *QuerySuite) Test_MinDurationMS_Absent() {
+	for _, v := range []string{"", "0", "-1", "abc"} {
+		params := accesslog.SelectLogsParamsFromQuery(url.Values{"minDurationMs": {v}})
+
+		s.LessOrEqual(params.MinDurationMS, 0, v)
+	}
+}
+
 func TestQuery(t *testing.T) {
 	suite.Run(t, &QuerySuite{})
 }

--- a/src/ce/api/accesslog/accesslog_store.go
+++ b/src/ce/api/accesslog/accesslog_store.go
@@ -15,7 +15,13 @@ import (
 
 // accessLogInsertFields is the number of columns written per row (log_id is
 // generated and excluded).
-const accessLogInsertFields = 15
+const accessLogInsertFields = 16
+
+// MaxInsertRows is how many access logs fit in one INSERT. Postgres accepts at
+// most 65535 bind parameters per statement, and the driver refuses the statement
+// outright beyond that — so a batch larger than this has to be split rather than
+// attempted and lost.
+const MaxInsertRows = 65535 / accessLogInsertFields
 
 // DefaultLimit caps a single page of access-log results.
 const DefaultLimit = 100
@@ -28,16 +34,18 @@ var stmt = struct {
 		INSERT INTO request_logs (
 			app_id, env_id, deployment_id, domain_id, host_name,
 			request_timestamp, method, request_path, response_code,
-			client_ip, user_agent, referrer, is_bot, bytes_sent, request_id
+			client_ip, user_agent, referrer, is_bot, bytes_sent, request_id,
+			duration_ms
 		)
-		VALUES {{ generateValues 15 (len .) }};
+		VALUES {{ generateValues 16 (len .) }};
 	`,
 
 	selectLogs: `
 		SELECT
 			log_id, app_id, env_id, deployment_id, domain_id, host_name,
 			request_timestamp, method, request_path, response_code,
-			client_ip, user_agent, referrer, is_bot, bytes_sent, request_id
+			client_ip, user_agent, referrer, is_bot, bytes_sent, request_id,
+			duration_ms
 		FROM request_logs
 		WHERE {{ .where }}
 		ORDER BY request_timestamp DESC, log_id DESC
@@ -65,8 +73,27 @@ func stripNull(s string) string {
 	return strings.ReplaceAll(s, "\x00", "")
 }
 
-// InsertLogs writes a batch of access logs in a single multi-row INSERT.
+// InsertLogs writes a batch of access logs, splitting it into as many multi-row
+// INSERTs as the bind-parameter limit requires.
+//
+// The ingest job hands over everything it drained in a tick — tens of thousands
+// of rows under load — so the batch routinely exceeds what one statement can
+// carry. Chunking here rather than at the call site keeps the limit an
+// implementation detail of the write, and keeps a traffic burst from failing the
+// insert outright and dropping every access log in it.
 func (s *Store) InsertLogs(ctx context.Context, logs []AccessLog) error {
+	for len(logs) > MaxInsertRows {
+		if err := s.insertLogsChunk(ctx, logs[:MaxInsertRows]); err != nil {
+			return err
+		}
+
+		logs = logs[MaxInsertRows:]
+	}
+
+	return s.insertLogsChunk(ctx, logs)
+}
+
+func (s *Store) insertLogsChunk(ctx context.Context, logs []AccessLog) error {
 	if len(logs) == 0 {
 		return nil
 	}
@@ -78,7 +105,7 @@ func (s *Store) InsertLogs(ctx context.Context, logs []AccessLog) error {
 			l.AppID, l.EnvID, l.DeploymentID, l.DomainID, stripNull(l.HostName),
 			l.RequestTS.UTC(), stripNull(l.Method), stripNull(l.RequestPath), l.StatusCode,
 			stripNull(l.ClientIP), stripNull(l.UserAgent), stripNull(l.Referrer),
-			l.IsBot, l.BytesSent, l.RequestID,
+			l.IsBot, l.BytesSent, l.RequestID, l.DurationMS,
 		)
 	}
 
@@ -110,11 +137,15 @@ type SelectLogsParams struct {
 	Path     string
 	Status   int
 	IsBot    *bool
-	From     utils.Unix
-	To       utils.Unix
-	BeforeID types.ID
-	BeforeTS utils.Unix
-	Limit    int
+	// MinDurationMS keeps only requests that took at least this many
+	// milliseconds. Entries with a null duration (written before the column
+	// existed, or never stamped) are excluded rather than treated as 0.
+	MinDurationMS int
+	From          utils.Unix
+	To            utils.Unix
+	BeforeID      types.ID
+	BeforeTS      utils.Unix
+	Limit         int
 }
 
 // SelectLogs returns access logs matching the filters, newest first, with one
@@ -172,6 +203,10 @@ func (s *Store) SelectLogs(ctx context.Context, p SelectLogsParams) ([]AccessLog
 		add("is_bot = $%d", *p.IsBot)
 	}
 
+	if p.MinDurationMS > 0 {
+		add("duration_ms >= $%d", p.MinDurationMS)
+	}
+
 	// The cursor compares on the same tuple the query orders by, otherwise
 	// Postgres cannot seek to the page and re-walks the window from the newest
 	// row every time. Both halves are required — see AccessLog.Cursor.
@@ -221,6 +256,7 @@ func (s *Store) SelectLogs(ctx context.Context, p SelectLogsParams) ([]AccessLog
 			&l.ID, &l.AppID, &l.EnvID, &deploymentID, &domainID, &hostName,
 			&l.RequestTS, &method, &path, &status,
 			&clientIP, &userAgent, &referrer, &l.IsBot, &bytesSent, &l.RequestID,
+			&l.DurationMS,
 		); err != nil {
 			return nil, err
 		}

--- a/src/ce/api/accesslog/accesslog_store_test.go
+++ b/src/ce/api/accesslog/accesslog_store_test.go
@@ -2,6 +2,7 @@ package accesslog_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -188,6 +189,148 @@ func (s *StoreSuite) Test_SelectLogs_KeysetPagination() {
 	// older pair, regardless of how the pages happened to split.
 	s.ElementsMatch([]string{"/a", "/b", "/c"}, seen[:3])
 	s.ElementsMatch([]string{"/d", "/e"}, seen[3:])
+}
+
+// MinDurationMS is the latency-tail filter: it keeps slow requests and drops
+// fast ones. Entries whose duration was never recorded are dropped too — a null
+// means "not measured", and treating it as 0 would silently hide slow requests
+// logged before the column existed.
+func (s *StoreSuite) Test_SelectLogs_MinDuration() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	ctx := context.Background()
+
+	base := accesslog.AccessLog{
+		AppID:      app.ID,
+		EnvID:      env.ID,
+		HostName:   "example.com",
+		RequestTS:  utils.NewUnix(),
+		Method:     http.MethodGet,
+		StatusCode: http.StatusOK,
+	}
+
+	fast := base
+	fast.RequestPath = "/fast"
+	fast.DurationMS = null.IntFrom(12)
+
+	slow := base
+	slow.RequestPath = "/slow"
+	slow.DurationMS = null.IntFrom(870)
+
+	exactly := base
+	exactly.RequestPath = "/exactly"
+	exactly.DurationMS = null.IntFrom(500)
+
+	unmeasured := base
+	unmeasured.RequestPath = "/unmeasured"
+
+	s.Require().NoError(accesslog.NewStore().InsertLogs(ctx, []accesslog.AccessLog{
+		fast, slow, exactly, unmeasured,
+	}))
+
+	logs, err := accesslog.NewStore().SelectLogs(ctx, accesslog.SelectLogsParams{
+		AppID:         app.ID,
+		MinDurationMS: 500,
+		From:          utils.UnixFrom(time.Now().Add(-time.Hour)),
+		To:            utils.UnixFrom(time.Now().Add(time.Hour)),
+	})
+
+	s.Require().NoError(err)
+
+	paths := []string{}
+
+	for _, l := range logs {
+		paths = append(paths, l.RequestPath)
+	}
+
+	s.ElementsMatch([]string{"/slow", "/exactly"}, paths)
+}
+
+// The duration has to survive the write/read round trip, and an unmeasured
+// request has to come back null rather than 0.
+func (s *StoreSuite) Test_Duration_RoundTrip() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	ctx := context.Background()
+
+	measured := accesslog.AccessLog{
+		AppID:       app.ID,
+		EnvID:       env.ID,
+		HostName:    "example.com",
+		RequestTS:   utils.NewUnix(),
+		Method:      http.MethodGet,
+		RequestPath: "/measured",
+		StatusCode:  http.StatusOK,
+		DurationMS:  null.IntFrom(431),
+	}
+
+	unmeasured := measured
+	unmeasured.RequestPath = "/unmeasured"
+	unmeasured.DurationMS = null.Int{}
+
+	s.Require().NoError(accesslog.NewStore().InsertLogs(ctx, []accesslog.AccessLog{
+		measured, unmeasured,
+	}))
+
+	logs, err := accesslog.NewStore().SelectLogs(ctx, accesslog.SelectLogsParams{
+		AppID: app.ID,
+		From:  utils.UnixFrom(time.Now().Add(-time.Hour)),
+		To:    utils.UnixFrom(time.Now().Add(time.Hour)),
+	})
+
+	s.Require().NoError(err)
+
+	byPath := map[string]accesslog.AccessLog{}
+
+	for _, l := range logs {
+		byPath[l.RequestPath] = l
+	}
+
+	s.Require().True(byPath["/measured"].DurationMS.Valid)
+	s.Equal(int64(431), byPath["/measured"].DurationMS.Int64)
+	s.False(byPath["/unmeasured"].DurationMS.Valid)
+
+	// ToMap must carry the null through as null, not as a zero duration.
+	s.Nil(byPath["/unmeasured"].ToMap()["durationMs"])
+	s.Equal(int64(431), *byPath["/measured"].ToMap()["durationMs"].(*int64))
+}
+
+// A tick of ingest can hand over far more rows than one statement's 65535 bind
+// parameters allow. Before chunking, such a batch failed as a whole and every
+// access log in it was dropped — silently, since the caller only logs the error.
+func (s *StoreSuite) Test_InsertLogs_BeyondBindParamLimit() {
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	ctx := context.Background()
+
+	const rows = accesslog.MaxInsertRows + 10
+
+	logs := make([]accesslog.AccessLog, 0, rows)
+
+	for i := range rows {
+		logs = append(logs, accesslog.AccessLog{
+			AppID:       app.ID,
+			EnvID:       env.ID,
+			HostName:    "example.com",
+			RequestTS:   utils.NewUnix(),
+			Method:      http.MethodGet,
+			RequestPath: fmt.Sprintf("/bulk/%d", i),
+			StatusCode:  http.StatusOK,
+		})
+	}
+
+	s.Require().NoError(accesslog.NewStore().InsertLogs(ctx, logs))
+
+	found, err := accesslog.NewStore().SelectLogs(ctx, accesslog.SelectLogsParams{
+		AppID: app.ID,
+		Path:  "/bulk/",
+		From:  utils.UnixFrom(time.Now().Add(-time.Hour)),
+		To:    utils.UnixFrom(time.Now().Add(time.Hour)),
+		Limit: rows,
+	})
+
+	s.Require().NoError(err)
+	s.Len(found, rows, "every row in an oversized batch must be written")
 }
 
 func TestStore(t *testing.T) {

--- a/src/ce/api/app/skauth/sk_auth_model.go
+++ b/src/ce/api/app/skauth/sk_auth_model.go
@@ -179,17 +179,27 @@ type AuthCodeURLParams struct {
 	// accepted by another) and shares the session token's signing key. An empty
 	// value falls back to the global app secret in JWT().
 	Secret string
+	// CodeChallenge is the PKCE S256 challenge a native client supplied when the
+	// Referrer is a custom-scheme deep link. It rides the state so the callback
+	// can bind the session code it hands back to that challenge.
+	CodeChallenge string
 }
 
 // Claims returns the JWT claims for the authorization request, including
 // environment ID, provider name and a short expiry that bounds state replay.
 func (a AuthCodeURLParams) Claims() jwt.MapClaims {
-	return jwt.MapClaims{
+	claims := jwt.MapClaims{
 		"eid": a.EnvID,
 		"prv": a.ProviderName,
 		"ref": a.Referrer,
 		"exp": time.Now().Add(oauthStateTTL).Unix(),
 	}
+
+	if a.CodeChallenge != "" {
+		claims["cha"] = a.CodeChallenge
+	}
+
+	return claims
 }
 
 type Client interface {

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_config_update_test.go
@@ -234,6 +234,75 @@ func (s *HandlerAuthConfigUpdateSuite) Test_Update_RejectsProtocolRelativeLoginU
 	s.Equal(http.StatusBadRequest, response.Code)
 }
 
+// Test_Update_AllowedOrigins_AcceptsNativeScheme pins the native sign-in
+// contract: a mobile app's deep link is a valid allowed origin, which is what
+// lets the browser sign-in flows return the session token on that scheme instead
+// of a cookie.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_AllowedOrigins_AcceptsNativeScheme() {
+	s.mockCacheService.On("Reset", types.ID(s.env.ID)).Return(nil).Once()
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"allowedOrigins": []string{"https://app.example.com", "myapp://auth"},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Require().Equal(http.StatusOK, response.Code)
+
+	env, err := buildconf.NewStore().EnvironmentByID(context.Background(), types.ID(s.env.ID))
+	s.Require().NoError(err)
+	s.Equal([]string{"https://app.example.com", "myapp://auth"}, env.AuthConf.AllowedOrigins)
+}
+
+// Test_Update_AllowedOrigins_RejectsPathBearingScheme guards the token-delivery
+// target: an origin carrying a path can never match a resolved origin, so
+// allowing it would silently misconfigure the allow-list.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_AllowedOrigins_RejectsPathBearingScheme() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"allowedOrigins": []string{"myapp://auth/callback"},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
+// Test_Update_AllowedOrigins_RejectsHostlessScheme rejects a bare scheme: with no
+// host there is nothing to match, so it would never authorize a redirect.
+func (s *HandlerAuthConfigUpdateSuite) Test_Update_AllowedOrigins_RejectsHostlessScheme() {
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/skauth/config",
+		map[string]any{
+			"envId":          s.env.ID,
+			"status":         true,
+			"allowedOrigins": []string{"myapp://"},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(s.usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+}
+
 func TestHandlerAuthConfigUpdate(t *testing.T) {
 	suite.Run(t, &HandlerAuthConfigUpdateSuite{})
 }

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -93,6 +93,8 @@ func mcpAllTools() []mcpToolDef {
 					"status":   map[string]any{"type": "string", "description": "Only return requests answered with this HTTP status code."},
 					"isBot":    map[string]any{"type": "boolean", "description": "Filter bot traffic in or out. Omit to return both."},
 					"cursor":   map[string]any{"type": "string", "description": "Opaque pagination cursor. Pass pagination.cursor from the previous response back verbatim to fetch the next page."},
+
+					"minDurationMs": map[string]any{"type": "number", "description": "Only return requests that took at least this many milliseconds to serve. Use to inspect the latency tail, e.g. 500. Requests logged before durations were recorded are excluded."},
 				},
 				"required":             []string{"envId"},
 				"additionalProperties": false,
@@ -594,6 +596,10 @@ func intArg(args map[string]any, key string) int {
 		return int(v)
 	case int:
 		return v
+	case string:
+		// A model that quotes a numeric argument still means the number.
+		n, _ := strconv.Atoi(v)
+		return n
 	}
 	return 0
 }
@@ -741,6 +747,10 @@ func mcpGetAccessLogs(req *RequestContextMCP, args map[string]any) *shttp.Respon
 
 	if isBot := boolPtrArg(args, "isBot"); isBot != nil {
 		query["isBot"] = strconv.FormatBool(*isBot)
+	}
+
+	if ms := intArg(args, "minDurationMs"); ms > 0 {
+		query["minDurationMs"] = strconv.Itoa(ms)
 	}
 
 	req.setQuery(query)

--- a/src/ce/hosting/export_test.go
+++ b/src/ce/hosting/export_test.go
@@ -94,6 +94,8 @@ func ServeAuth(req *RequestContext) (*shttp.Response, error) {
 		return handleAuthLogout(req), nil
 	case "/_stormkit/auth/me":
 		return handleAuthMe(req), nil
+	case "/_stormkit/auth/token":
+		return handleAuthNativeToken(req), nil
 	case skauth.CallbackPath:
 		return handleAuthOAuthCallback(req), nil
 	default:

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -47,6 +47,11 @@ func HandlerForward(req *RequestContext) (res *shttp.Response) {
 		// same transforms apply uniformly regardless of which path produced it.
 		res = rs.finalize(res)
 
+		// The duration is read here, on the request goroutine, and not inside the
+		// push below: the push is detached, so measuring there would add however
+		// long the scheduler took to pick it up to every recorded request.
+		duration := requestDuration(req)
+
 		// Send artifacts to redis queue with the finalized response visible. The
 		// wait group lets tests (and graceful shutdown) drain in-flight pushes
 		// instead of racing the global Batcher.
@@ -54,7 +59,7 @@ func HandlerForward(req *RequestContext) (res *shttp.Response) {
 
 		go func() {
 			defer artifactsWG.Done()
-			rs.artifacts(res)
+			rs.artifacts(artifactsParams{Response: res, Duration: duration})
 		}()
 	}()
 
@@ -156,8 +161,18 @@ func NewRequestServer(req *RequestContext) *RequestServer {
 	return r
 }
 
-func (r *RequestServer) artifacts(res *shttp.Response) {
+// artifactsParams carries the finalized response and the already-measured
+// request duration. Duration is passed in rather than measured here because
+// artifacts runs on a detached goroutine — see HandlerForward.
+type artifactsParams struct {
+	Response *shttp.Response
+	Duration null.Int
+}
+
+func (r *RequestServer) artifacts(p artifactsParams) {
 	var data []byte
+
+	res := p.Response
 
 	if res == nil || r.req == nil || r.req.Host == nil || r.req.Host.Config == nil {
 		return
@@ -178,8 +193,13 @@ func (r *RequestServer) artifacts(res *shttp.Response) {
 		FunctionInvoked: r.fnInvoked,
 		Logs:            r.logs,
 		Analytics:       r.record,
-		AccessLog:       accessLogRecord(r.req, res, bandwidth),
-		TotalBandwidth:  bandwidth,
+		AccessLog: accessLogRecord(accessLogRecordParams{
+			Req:       r.req,
+			Res:       res,
+			BytesSent: bandwidth,
+			Duration:  p.Duration,
+		}),
+		TotalBandwidth: bandwidth,
 	})
 }
 
@@ -187,7 +207,16 @@ func (r *RequestServer) artifacts(res *shttp.Response) {
 // XHR, static assets and non-HTML responses. Unlike analyticsRecord it applies
 // no filtering and keeps the unmasked client IP and full user-agent; IsBot is
 // recorded as a flag so bot traffic can be included or excluded at query time.
-func accessLogRecord(req *RequestContext, res *shttp.Response, bytesSent int64) *accesslog.AccessLog {
+type accessLogRecordParams struct {
+	Req       *RequestContext
+	Res       *shttp.Response
+	BytesSent int64
+	Duration  null.Int
+}
+
+func accessLogRecord(p accessLogRecordParams) *accesslog.AccessLog {
+	req := p.Req
+
 	if req == nil || req.Host == nil || req.Host.Config == nil {
 		return nil
 	}
@@ -203,14 +232,36 @@ func accessLogRecord(req *RequestContext, res *shttp.Response, bytesSent int64) 
 		RequestTS:    utils.NewUnix(),
 		Method:       req.Method,
 		RequestPath:  req.OriginalPath,
-		StatusCode:   res.Status,
+		StatusCode:   p.Res.Status,
 		ClientIP:     req.RemoteIP(),
 		UserAgent:    userAgent,
 		Referrer:     req.Referer(),
 		IsBot:        analytics.IsBot(userAgent),
-		BytesSent:    bytesSent,
+		BytesSent:    p.BytesSent,
 		RequestID:    null.NewString(req.RequestID, req.RequestID != ""),
+		DurationMS:   p.Duration,
 	}
+}
+
+// requestDuration measures how long the request took, from the moment shttp
+// received it to the point the response was assembled.
+//
+// It must be called on the request goroutine, before the artifacts push is
+// detached: measuring inside that goroutine would fold the scheduler's pickup
+// delay into every recorded request.
+//
+// This deliberately excludes writing the body to the client, so a slow or
+// distant client does not inflate the number — it measures the time Stormkit
+// spent, which is what a latency tail investigation needs.
+//
+// Returns null rather than 0 when StartTime was never stamped, so an unmeasured
+// request is not indistinguishable from an instant one.
+func requestDuration(req *RequestContext) null.Int {
+	if req == nil || req.RequestContext == nil || req.StartTime.IsZero() {
+		return null.Int{}
+	}
+
+	return null.IntFrom(time.Since(req.StartTime).Milliseconds())
 }
 
 func (r *RequestServer) FileMeta() *FileMeta {

--- a/src/ce/hosting/handler_forward_accesslog_test.go
+++ b/src/ce/hosting/handler_forward_accesslog_test.go
@@ -102,12 +102,20 @@ func (s *AccessLogArtifactsSuite) requestServer(ua, path, ip string) *RequestSer
 	}
 }
 
+// pushArtifacts mirrors HandlerForward's defer: the duration is measured on the
+// request goroutine and handed to the push, which production runs detached.
+// Tests go through this rather than calling artifacts directly so they exercise
+// the real measurement point.
+func pushArtifacts(rs *RequestServer, res *shttp.Response) {
+	rs.artifacts(artifactsParams{Response: res, Duration: requestDuration(rs.req)})
+}
+
 // A bot request must still produce an access log (flagged is_bot), proving the
 // raw log keeps bot traffic the analytics path drops.
 func (s *AccessLogArtifactsSuite) Test_BotRequest_QueuesAccessLog() {
 	rs := s.requestServer("Googlebot/2.1 (+http://www.google.com/bot.html)", "/robots.txt", "198.51.100.9")
 
-	rs.artifacts(&shttp.Response{Status: http.StatusOK, Data: []byte("hello")})
+	pushArtifacts(rs, &shttp.Response{Status: http.StatusOK, Data: []byte("hello")})
 
 	record := s.waitForRecord()
 
@@ -126,13 +134,70 @@ func (s *AccessLogArtifactsSuite) Test_HumanRequest_NotFlaggedBot() {
 
 	rs := s.requestServer(ua, "/", "203.0.113.7")
 
-	rs.artifacts(&shttp.Response{Status: http.StatusOK, Data: []byte("ok")})
+	pushArtifacts(rs, &shttp.Response{Status: http.StatusOK, Data: []byte("ok")})
 
 	record := s.waitForRecord()
 
 	s.Require().NotNil(record.AccessLog)
 	s.False(record.AccessLog.IsBot)
 	s.Equal("203.0.113.7", record.AccessLog.ClientIP)
+}
+
+// The access log has to carry how long the request took, which is what makes it
+// usable for latency-tail investigation rather than just "what was served".
+func (s *AccessLogArtifactsSuite) Test_RecordsDuration() {
+	rs := s.requestServer("Mozilla/5.0", "/slow", "203.0.113.7")
+	rs.req.StartTime = time.Now().Add(-250 * time.Millisecond)
+
+	pushArtifacts(rs, &shttp.Response{Status: http.StatusOK, Data: []byte("ok")})
+
+	record := s.waitForRecord()
+
+	s.Require().NotNil(record.AccessLog)
+	s.Require().True(record.AccessLog.DurationMS.Valid)
+	s.GreaterOrEqual(record.AccessLog.DurationMS.Int64, int64(250))
+	s.Less(record.AccessLog.DurationMS.Int64, int64(5000))
+}
+
+// The push to the queue is detached in production, so whatever the scheduler
+// costs before it runs must not land in the recorded duration. Measuring at the
+// wrong point turns a fast request into a slow one exactly when the box is busy
+// — which is when the number is being looked at.
+func (s *AccessLogArtifactsSuite) Test_DelayedPush_DoesNotInflateDuration() {
+	rs := s.requestServer("Mozilla/5.0", "/fast", "203.0.113.7")
+	rs.req.StartTime = time.Now()
+
+	duration := requestDuration(rs.req)
+
+	// Stand in for a backlogged artifacts goroutine picked up much later.
+	time.Sleep(300 * time.Millisecond)
+
+	rs.artifacts(artifactsParams{
+		Response: &shttp.Response{Status: http.StatusOK, Data: []byte("ok")},
+		Duration: duration,
+	})
+
+	record := s.waitForRecord()
+
+	s.Require().NotNil(record.AccessLog)
+	s.Require().True(record.AccessLog.DurationMS.Valid)
+	s.Less(record.AccessLog.DurationMS.Int64, int64(300),
+		"the scheduling delay before the push must not be counted as request time")
+}
+
+// A request whose start was never stamped logs a null duration, not a zero —
+// otherwise an unmeasured request would read as an instant one and skew any
+// latency percentile computed from these logs.
+func (s *AccessLogArtifactsSuite) Test_UnstampedRequest_NullDuration() {
+	rs := s.requestServer("Mozilla/5.0", "/", "203.0.113.7")
+	s.Require().True(rs.req.StartTime.IsZero())
+
+	pushArtifacts(rs, &shttp.Response{Status: http.StatusOK, Data: []byte("ok")})
+
+	record := s.waitForRecord()
+
+	s.Require().NotNil(record.AccessLog)
+	s.False(record.AccessLog.DurationMS.Valid)
 }
 
 func TestAccessLogArtifactsSuite(t *testing.T) {

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -1,7 +1,6 @@
 package hosting
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
@@ -88,11 +88,14 @@ func (m *skAuthMiddleware) handleLogout() (*shttp.Response, error) {
 // Origin is the already allow-list-validated destination origin (scheme + host,
 // no path) and is empty for a same-host landing. Path is the relative landing
 // path — the configured SuccessURL, sometimes carrying a query — appended to
-// Origin for browser targets.
+// Origin for browser targets. Challenge is the PKCE S256 code_challenge the
+// client supplied at sign-in; it is required for, and only used by, a
+// custom-scheme Origin.
 type deliverSessionParams struct {
-	Token  string
-	Origin string
-	Path   string
+	Token     string
+	Origin    string
+	Path      string
+	Challenge string
 }
 
 // deliverSession hands the session token to the client and 302s onward. Used by
@@ -100,12 +103,17 @@ type deliverSessionParams struct {
 //
 // Browsers receive it as the HttpOnly session cookie — first-party to this auth
 // host, so it is also readable by the OAuth /authorize navigation — and land on
-// Origin+Path. A native app, identified by a custom-scheme Origin such as
-// triplan://auth, has no usable cookie jar: the system auth session
-// (ASWebAuthenticationSession / Custom Tabs) discards Set-Cookie. For those the
-// token rides the redirect URL instead and no cookie is set. The scheme is
-// claimed by the owning app, so the OS hands the URL only to it, and Origin has
-// already been matched against the configured allow-list by the caller.
+// Origin+Path.
+//
+// A native app, identified by a custom-scheme Origin such as triplan://auth, has
+// no usable cookie jar: the system auth session (ASWebAuthenticationSession /
+// Custom Tabs) discards Set-Cookie. Those get a single-use, PKCE-bound code on
+// the redirect, which the app exchanges for the token at
+// POST /_stormkit/auth/token. The session token itself never travels through the
+// OS: a private-use scheme is not exclusively claimable, so the redirect must be
+// assumed interceptable and is only ever given something an interceptor cannot
+// redeem (RFC 8252 §8.1). Origin has already been matched against the configured
+// allow-list by the caller.
 func (m *skAuthMiddleware) deliverSession(p deliverSessionParams) *shttp.Response {
 	headers := shttp.HeadersFromMap(map[string]string{
 		"Cache-Control":   "no-store",
@@ -113,7 +121,24 @@ func (m *skAuthMiddleware) deliverSession(p deliverSessionParams) *shttp.Respons
 	})
 
 	if isNativeSchemeOrigin(p.Origin) {
-		target := p.Origin + "?token=" + url.QueryEscape(p.Token)
+		// Fail closed. The initiate step refuses a custom-scheme sign-in without a
+		// challenge, so an empty one here means a link minted before that gate — it
+		// must not degrade into putting the token in the URL.
+		if p.Challenge == "" {
+			return m.loginErrorRedirect(p.Origin, "This sign-in link is no longer supported. Please sign in again.")
+		}
+
+		code, err := nativeCodeStore.issue(m.req.Context(), nativeSessionCode{
+			Token:         p.Token,
+			CodeChallenge: p.Challenge,
+		})
+
+		if err != nil {
+			slog.Errorf("deliverSession: failed to issue native code: %s", err.Error())
+			return m.loginErrorRedirect(p.Origin, "Sign-in is temporarily unavailable. Please try again.")
+		}
+
+		target := appendQuery(p.Origin, map[string]string{"code": code})
 
 		return &shttp.Response{
 			Status:   http.StatusFound,
@@ -122,7 +147,7 @@ func (m *skAuthMiddleware) deliverSession(p deliverSessionParams) *shttp.Respons
 		}
 	}
 
-	target := p.Origin + p.Path
+	target := landingURL(p.Origin, p.Path)
 
 	return &shttp.Response{
 		Status:   http.StatusFound,
@@ -136,16 +161,31 @@ func (m *skAuthMiddleware) deliverSession(p deliverSessionParams) *shttp.Respons
 // such as triplan://auth — the redirect target a native app registers in the
 // environment's allowed origins. It only classifies the scheme; the caller is
 // responsible for having validated origin against the allow-list first.
+//
+// It parses with url.Parse for the same reason the allow-list validator does:
+// two different notions of what an origin is would eventually disagree about
+// one, and this decides whether a session goes out as a cookie or a code.
+// url.Parse already lowercases the scheme.
 func isNativeSchemeOrigin(origin string) bool {
-	scheme, _, ok := strings.Cut(origin, "://")
+	parsed, err := url.Parse(origin)
 
-	if !ok || scheme == "" {
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return false
 	}
 
-	scheme = strings.ToLower(scheme)
+	return parsed.Scheme != "http" && parsed.Scheme != "https"
+}
 
-	return scheme != "http" && scheme != "https"
+// landingURL is where the client is sent after a sign-in attempt. A browser
+// lands on the app's configured page inside the destination origin; a native
+// deep link is the landing itself and takes no path — appending the SuccessURL
+// would produce a URL its scheme handler does not recognise.
+func landingURL(origin, path string) string {
+	if isNativeSchemeOrigin(origin) {
+		return origin
+	}
+
+	return origin + path
 }
 
 func (m *skAuthMiddleware) handleRegisterLogin(path string) (*shttp.Response, error) {
@@ -244,10 +284,13 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	// the destination origin — no dependency on the frontend host carrying its own
 	// auth config. A native custom-scheme origin gets the token in the URL instead.
 	if redirect, _ := data["redirect"].(string); redirect != "" {
+		challenge, _ := data["codeChallenge"].(string)
+
 		return m.deliverSession(deliverSessionParams{
-			Token:  token,
-			Origin: redirect,
-			Path:   successURL,
+			Token:     token,
+			Origin:    redirect,
+			Path:      successURL,
+			Challenge: challenge,
 		}), nil
 	}
 
@@ -354,16 +397,9 @@ func (m *skAuthMiddleware) cookieOriginAllowed() bool {
 // deep link itself — so the message is hung off the bare origin, mirroring how
 // deliverSession returns the token there.
 func (m *skAuthMiddleware) loginErrorRedirect(origin, message string) *shttp.Response {
-	path := m.req.Host.Config.SKAuth.SuccessURL
-
-	if isNativeSchemeOrigin(origin) {
-		path = ""
-	}
-
-	target := fmt.Sprintf("%s%s?login_error=%s",
-		origin,
-		path,
-		url.QueryEscape(message),
+	target := appendQuery(
+		landingURL(origin, m.req.Host.Config.SKAuth.SuccessURL),
+		map[string]string{"login_error": message},
 	)
 
 	return &shttp.Response{

--- a/src/ce/hosting/middleware.skauth.go
+++ b/src/ce/hosting/middleware.skauth.go
@@ -84,21 +84,68 @@ func (m *skAuthMiddleware) handleLogout() (*shttp.Response, error) {
 	}, nil
 }
 
-// deliverSession sets the session cookie and 302s to redirectURL. Used by the
-// browser login landings (email verify, magic link, OAuth-provider callback);
-// the cookie is first-party to this auth host, so it is also readable by the
-// OAuth /authorize navigation. redirectURL is a relative path or an absolute URL
-// on the destination origin.
-func (m *skAuthMiddleware) deliverSession(token, redirectURL string) *shttp.Response {
+// deliverSessionParams describes where a freshly minted session token is headed.
+// Origin is the already allow-list-validated destination origin (scheme + host,
+// no path) and is empty for a same-host landing. Path is the relative landing
+// path — the configured SuccessURL, sometimes carrying a query — appended to
+// Origin for browser targets.
+type deliverSessionParams struct {
+	Token  string
+	Origin string
+	Path   string
+}
+
+// deliverSession hands the session token to the client and 302s onward. Used by
+// the login landings (email verify, magic link, OAuth-provider callback).
+//
+// Browsers receive it as the HttpOnly session cookie — first-party to this auth
+// host, so it is also readable by the OAuth /authorize navigation — and land on
+// Origin+Path. A native app, identified by a custom-scheme Origin such as
+// triplan://auth, has no usable cookie jar: the system auth session
+// (ASWebAuthenticationSession / Custom Tabs) discards Set-Cookie. For those the
+// token rides the redirect URL instead and no cookie is set. The scheme is
+// claimed by the owning app, so the OS hands the URL only to it, and Origin has
+// already been matched against the configured allow-list by the caller.
+func (m *skAuthMiddleware) deliverSession(p deliverSessionParams) *shttp.Response {
+	headers := shttp.HeadersFromMap(map[string]string{
+		"Cache-Control":   "no-store",
+		"Referrer-Policy": "no-referrer",
+	})
+
+	if isNativeSchemeOrigin(p.Origin) {
+		target := p.Origin + "?token=" + url.QueryEscape(p.Token)
+
+		return &shttp.Response{
+			Status:   http.StatusFound,
+			Redirect: &target,
+			Headers:  headers,
+		}
+	}
+
+	target := p.Origin + p.Path
+
 	return &shttp.Response{
 		Status:   http.StatusFound,
-		Redirect: &redirectURL,
-		Cookies:  []http.Cookie{m.sessionCookieFor(token)},
-		Headers: shttp.HeadersFromMap(map[string]string{
-			"Cache-Control":   "no-store",
-			"Referrer-Policy": "no-referrer",
-		}),
+		Redirect: &target,
+		Cookies:  []http.Cookie{m.sessionCookieFor(p.Token)},
+		Headers:  headers,
 	}
+}
+
+// isNativeSchemeOrigin reports whether origin uses a custom (non-http(s)) scheme
+// such as triplan://auth — the redirect target a native app registers in the
+// environment's allowed origins. It only classifies the scheme; the caller is
+// responsible for having validated origin against the allow-list first.
+func isNativeSchemeOrigin(origin string) bool {
+	scheme, _, ok := strings.Cut(origin, "://")
+
+	if !ok || scheme == "" {
+		return false
+	}
+
+	scheme = strings.ToLower(scheme)
+
+	return scheme != "http" && scheme != "https"
 }
 
 func (m *skAuthMiddleware) handleRegisterLogin(path string) (*shttp.Response, error) {
@@ -132,7 +179,10 @@ func (m *skAuthMiddleware) handleVerify() (*shttp.Response, error) {
 
 	token, _ := data["token"].(string)
 
-	return m.deliverSession(token, m.req.Host.Config.SKAuth.SuccessURL+"?verified=true"), nil
+	return m.deliverSession(deliverSessionParams{
+		Token: token,
+		Path:  m.req.Host.Config.SKAuth.SuccessURL + "?verified=true",
+	}), nil
 }
 
 func (m *skAuthMiddleware) handleMagicLinkRequest() (*shttp.Response, error) {
@@ -187,15 +237,24 @@ func (m *skAuthMiddleware) handleMagicLinkVerify() (*shttp.Response, error) {
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
 	token, _ := data["token"].(string)
 
-	// Cross-origin: the POST came from a whitelisted frontend. The session cookie
-	// is first-party to this auth host (also the OAuth AS), so it is set here and
-	// the browser is sent straight to the destination origin — no dependency on
-	// the frontend host carrying its own auth config.
+	// Cross-origin: the request came from a whitelisted frontend, whose origin the
+	// magic-link token carried in its `rdr` claim and magicLinkVerify re-validated
+	// against the allow-list. The session cookie is first-party to this auth host
+	// (also the OAuth AS), so it is set here and the browser is sent straight to
+	// the destination origin — no dependency on the frontend host carrying its own
+	// auth config. A native custom-scheme origin gets the token in the URL instead.
 	if redirect, _ := data["redirect"].(string); redirect != "" {
-		return m.deliverSession(token, redirect+successURL), nil
+		return m.deliverSession(deliverSessionParams{
+			Token:  token,
+			Origin: redirect,
+			Path:   successURL,
+		}), nil
 	}
 
-	return m.deliverSession(token, successURL+"?verified=true"), nil
+	return m.deliverSession(deliverSessionParams{
+		Token: token,
+		Path:  successURL + "?verified=true",
+	}), nil
 }
 
 // finalizeSessionResponse adapts a successful JSON auth response (login,
@@ -290,10 +349,20 @@ func (m *skAuthMiddleware) cookieOriginAllowed() bool {
 // (origin + SuccessURL) with a user-friendly message in the login_error query
 // param, instead of rendering a Stormkit error page. The underlying cause should
 // be logged by the caller. Used by both the OAuth and magic-link flows.
+//
+// A native custom-scheme origin has no SuccessURL page to land on — it is the
+// deep link itself — so the message is hung off the bare origin, mirroring how
+// deliverSession returns the token there.
 func (m *skAuthMiddleware) loginErrorRedirect(origin, message string) *shttp.Response {
+	path := m.req.Host.Config.SKAuth.SuccessURL
+
+	if isNativeSchemeOrigin(origin) {
+		path = ""
+	}
+
 	target := fmt.Sprintf("%s%s?login_error=%s",
 		origin,
-		m.req.Host.Config.SKAuth.SuccessURL,
+		path,
 		url.QueryEscape(message),
 	)
 

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -420,6 +420,103 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() 
 	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
+// Test_Verify_NativeScheme_TokenInRedirect covers the native/mobile path: a
+// custom-scheme redirect target has no usable cookie jar (the OS auth session
+// discards Set-Cookie), so the session token rides the redirect URL instead and
+// no cookie is set.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_TokenInRedirect() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=native@example.com&redirect=triplan://auth",
+		http.MethodPost,
+		"",
+	)
+	_, err = hosting.ServeAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	s.Require().NotEmpty(token)
+
+	res, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)))
+
+	s.NoError(err)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Empty(res.Cookies, "a native custom-scheme delivery must not set a cookie")
+
+	target, err := url.Parse(*res.Redirect)
+	s.Require().NoError(err)
+	s.Equal("triplan", target.Scheme)
+	s.Equal("auth", target.Host)
+	s.Empty(target.Path, "the success URL must not be appended to a deep link")
+
+	// The token in the URL is the same session JWT the cookie would have carried.
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer: target.Query().Get("token"),
+		Secret: env.AuthConf.Secret,
+	})
+
+	s.Require().NotNil(claims, "the redirected token must be a valid session JWT")
+
+	uid, ok := claims["uid"].(string)
+	s.Require().True(ok)
+	_, err = uuid.Parse(uid)
+	s.NoError(err, "uid claim should be a valid UUID, got %q", uid)
+}
+
+// Test_Verify_NativeScheme_ErrorRedirect verifies a failed sign-in bounces back
+// to the deep link itself — there is no success page to land on in a native app.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_ErrorRedirect() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=nativeerr@example.com&redirect=triplan://auth",
+		http.MethodPost,
+		"",
+	)
+	_, err = hosting.ServeAuth(post)
+	s.Require().NoError(err)
+
+	token := s.captureToken(env.ID)
+	path := fmt.Sprintf("/_stormkit/auth/magic?token=%s", token)
+
+	first, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusFound, first.Status)
+
+	// Replaying the consumed token must land the error on the deep link.
+	second, err := hosting.ServeAuth(s.magicRequest(s.hostFor(env.ID), path))
+
+	s.NoError(err)
+	s.Equal(http.StatusFound, second.Status)
+	s.Require().NotNil(second.Redirect)
+	s.Contains(*second.Redirect, "triplan://auth?login_error=")
+	s.NotContains(*second.Redirect, "/dashboard")
+}
+
+// Test_Request_NativeScheme_NotAllowListed_Returns403 guards the token-leak
+// vector: an unregistered custom scheme must never become a delivery target.
+func (s *WithSKAuthMagicLinkSuite) Test_Request_NativeScheme_NotAllowListed_Returns403() {
+	env, err := s.setupEnvWithOrigins([]string{"https://app.example.com"})
+	s.Require().NoError(err)
+
+	rq := s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=evil@example.com&redirect=evil://auth",
+		http.MethodPost,
+		"",
+	)
+	res, err := hosting.ServeAuth(rq)
+
+	s.NoError(err)
+	s.Equal(http.StatusForbidden, res.Status)
+}
+
 func truncateMagicLinkAuthTables() {
 	db, err := sql.Open("postgres", database.ConnectionString(database.Config))
 

--- a/src/ce/hosting/middleware.skauth_magiclink_test.go
+++ b/src/ce/hosting/middleware.skauth_magiclink_test.go
@@ -2,13 +2,18 @@ package hosting_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -137,6 +142,27 @@ func (s *WithSKAuthMagicLinkSuite) magicRequestWith(host *hosting.Host, path, me
 	rq.OriginalPath = rawPath
 
 	return rq
+}
+
+// exchangeNativeCode posts a deep-link code and verifier to the redemption
+// endpoint, the way a native app does once the OS hands it the deep link.
+func (s *WithSKAuthMagicLinkSuite) exchangeNativeCode(envID types.ID, code, verifier string) *shttp.Response {
+	form := url.Values{"code": {code}, "code_verifier": {verifier}}
+
+	req := &http.Request{
+		Method: http.MethodPost,
+		Header: http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+		Body:   io.NopCloser(strings.NewReader(form.Encode())),
+		URL:    &url.URL{Scheme: "https", Host: s.hostFor(envID).Name, Path: "/_stormkit/auth/token"},
+	}
+
+	rq := &hosting.RequestContext{Host: s.hostFor(envID), RequestContext: shttp.NewRequestContext(req)}
+	rq.OriginalPath = req.URL.Path
+
+	res, err := hosting.ServeAuth(rq)
+	s.Require().NoError(err)
+
+	return res
 }
 
 func (s *WithSKAuthMagicLinkSuite) captureToken(envID types.ID) string {
@@ -420,17 +446,37 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_StaleRedirect_FallsBackToLocal() 
 	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }
 
-// Test_Verify_NativeScheme_TokenInRedirect covers the native/mobile path: a
+// nativeVerifier and nativeChallenge are a fixed PKCE S256 pair: the challenge
+// is base64url(sha256(verifier)) unpadded, exactly as a native client computes
+// it before starting sign-in.
+const nativeVerifier = "stormkit-native-test-code-verifier-0123456789"
+
+var nativeChallenge = func() string {
+	sum := sha256.Sum256([]byte(nativeVerifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}()
+
+// nativeMagicPath builds the magic-link request a native client sends: a
+// custom-scheme redirect plus the PKCE challenge that binds the eventual code.
+func nativeMagicPath(email string) string {
+	return fmt.Sprintf(
+		"/_stormkit/auth/magic?email=%s&redirect=triplan://auth&code_challenge=%s&code_challenge_method=S256",
+		email, nativeChallenge,
+	)
+}
+
+// Test_Verify_NativeScheme_CodeInRedirect covers the native/mobile path: a
 // custom-scheme redirect target has no usable cookie jar (the OS auth session
-// discards Set-Cookie), so the session token rides the redirect URL instead and
-// no cookie is set.
-func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_TokenInRedirect() {
+// discards Set-Cookie) and, because a private-use scheme is not exclusively
+// claimable, must be assumed interceptable. So the redirect carries only a
+// single-use PKCE-bound code, never the session token, and sets no cookie.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_CodeInRedirect() {
 	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
 	s.Require().NoError(err)
 
 	post := s.magicRequestWith(
 		s.hostFor(env.ID),
-		"/_stormkit/auth/magic?email=native@example.com&redirect=triplan://auth",
+		nativeMagicPath("native@example.com"),
 		http.MethodPost,
 		"",
 	)
@@ -453,18 +499,86 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_TokenInRedirect() {
 	s.Equal("auth", target.Host)
 	s.Empty(target.Path, "the success URL must not be appended to a deep link")
 
-	// The token in the URL is the same session JWT the cookie would have carried.
+	code := target.Query().Get("code")
+	s.Require().NotEmpty(code, "the deep link must carry an exchange code")
+	s.Empty(target.Query().Get("token"), "the session token must never ride the deep link")
+
+	// The code buys the session JWT only when accompanied by the verifier.
+	exchanged := s.exchangeNativeCode(env.ID, code, nativeVerifier)
+
+	s.Require().Equal(http.StatusOK, exchanged.Status)
+
+	data, ok := exchanged.Data.(map[string]any)
+	s.Require().True(ok)
+
 	claims := user.ParseJWT(&user.ParseJWTArgs{
-		Bearer: target.Query().Get("token"),
+		Bearer: data["token"].(string),
 		Secret: env.AuthConf.Secret,
 	})
 
-	s.Require().NotNil(claims, "the redirected token must be a valid session JWT")
+	s.Require().NotNil(claims, "the exchanged token must be a valid session JWT")
 
 	uid, ok := claims["uid"].(string)
 	s.Require().True(ok)
 	_, err = uuid.Parse(uid)
 	s.NoError(err, "uid claim should be a valid UUID, got %q", uid)
+
+	// Single use: the same code must not buy a second session.
+	s.Equal(http.StatusBadRequest, s.exchangeNativeCode(env.ID, code, nativeVerifier).Status)
+}
+
+// Test_Exchange_WrongVerifier_Rejected is the whole point of the PKCE binding:
+// an app that intercepted the deep link holds the code but not the verifier, so
+// the exchange must refuse it.
+func (s *WithSKAuthMagicLinkSuite) Test_Exchange_WrongVerifier_Rejected() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	post := s.magicRequestWith(
+		s.hostFor(env.ID),
+		nativeMagicPath("interceptee@example.com"),
+		http.MethodPost,
+		"",
+	)
+	_, err = hosting.ServeAuth(post)
+	s.Require().NoError(err)
+
+	res, err := hosting.ServeAuth(s.magicRequest(
+		s.hostFor(env.ID),
+		fmt.Sprintf("/_stormkit/auth/magic?token=%s", s.captureToken(env.ID)),
+	))
+	s.Require().NoError(err)
+	s.Require().NotNil(res.Redirect)
+
+	target, err := url.Parse(*res.Redirect)
+	s.Require().NoError(err)
+
+	code := target.Query().Get("code")
+	s.Require().NotEmpty(code)
+
+	s.Equal(http.StatusBadRequest, s.exchangeNativeCode(env.ID, code, "not-the-verifier").Status)
+
+	// The failed attempt still consumed the code, so the interceptor cannot retry
+	// and the legitimate app's exchange is dead too — a signal, not a silent loss.
+	s.Equal(http.StatusBadRequest, s.exchangeNativeCode(env.ID, code, nativeVerifier).Status)
+}
+
+// Test_Request_NativeScheme_WithoutChallenge_Returns400 pins the fail-closed
+// rule: custom-scheme sign-in is refused outright without PKCE rather than
+// degrading to putting the session token in an interceptable URL.
+func (s *WithSKAuthMagicLinkSuite) Test_Request_NativeScheme_WithoutChallenge_Returns400() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	res, err := hosting.ServeAuth(s.magicRequestWith(
+		s.hostFor(env.ID),
+		"/_stormkit/auth/magic?email=nopkce@example.com&redirect=triplan://auth",
+		http.MethodPost,
+		"",
+	))
+
+	s.NoError(err)
+	s.Equal(http.StatusBadRequest, res.Status)
 }
 
 // Test_Verify_NativeScheme_ErrorRedirect verifies a failed sign-in bounces back
@@ -475,7 +589,7 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_ErrorRedirect() {
 
 	post := s.magicRequestWith(
 		s.hostFor(env.ID),
-		"/_stormkit/auth/magic?email=nativeerr@example.com&redirect=triplan://auth",
+		nativeMagicPath("nativeerr@example.com"),
 		http.MethodPost,
 		"",
 	)
@@ -497,6 +611,56 @@ func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_ErrorRedirect() {
 	s.Require().NotNil(second.Redirect)
 	s.Contains(*second.Redirect, "triplan://auth?login_error=")
 	s.NotContains(*second.Redirect, "/dashboard")
+}
+
+// Test_Verify_NativeScheme_ExpiredToken_ErrorOnDeepLink covers the most common
+// magic-link failure. The signature check rejects an expired token, so the
+// redirect target has to be recovered from the unvalidated claims — otherwise a
+// native user lands on this host and the system sign-in sheet never closes.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_NativeScheme_ExpiredToken_ErrorOnDeepLink() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	expired, err := user.JWT(jwt.MapClaims{
+		"exp": time.Now().Add(-time.Hour).Unix(),
+		"prv": skauth.ProviderMagicLink,
+		"rdr": "triplan://auth",
+	}, env.AuthConf.Secret)
+	s.Require().NoError(err)
+
+	res, err := hosting.ServeAuth(s.magicRequest(
+		s.hostFor(env.ID),
+		fmt.Sprintf("/_stormkit/auth/magic?token=%s", expired),
+	))
+
+	s.NoError(err)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Contains(*res.Redirect, "triplan://auth?login_error=")
+}
+
+// A recovered redirect is still only honoured when it is allow-listed, so a
+// forged claim cannot aim the error redirect at an origin the operator never
+// registered.
+func (s *WithSKAuthMagicLinkSuite) Test_Verify_ExpiredToken_ForgedRedirect_StaysLocal() {
+	env, err := s.setupEnvWithOrigins([]string{"triplan://auth"})
+	s.Require().NoError(err)
+
+	forged, err := user.JWT(jwt.MapClaims{
+		"exp": time.Now().Add(-time.Hour).Unix(),
+		"prv": skauth.ProviderMagicLink,
+		"rdr": "evil://auth",
+	}, env.AuthConf.Secret)
+	s.Require().NoError(err)
+
+	res, err := hosting.ServeAuth(s.magicRequest(
+		s.hostFor(env.ID),
+		fmt.Sprintf("/_stormkit/auth/magic?token=%s", forged),
+	))
+
+	s.NoError(err)
+	s.Require().NotNil(res.Redirect)
+	s.NotContains(*res.Redirect, "evil://auth")
 }
 
 // Test_Request_NativeScheme_NotAllowListed_Returns403 guards the token-leak

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -391,4 +392,88 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ExchangeFails_RedirectsWithError() 
 	s.Require().NotNil(res.Redirect)
 	s.Contains(*res.Redirect, "https://app.example.com/dashboard?login_error=")
 	s.Contains(*res.Redirect, "complete+sign-in")
+}
+
+// Test_Callback_NativeScheme_TokenInRedirect covers the native/mobile OAuth
+// path: the sign-in runs inside a system auth session whose cookie jar discards
+// Set-Cookie, so an allow-listed custom-scheme target receives the session token
+// in the redirect URL and no cookie at all.
+func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_TokenInRedirect() {
+	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
+		Secret:         "test-secret-padded-to-32-chars!!",
+		Status:         true,
+		AllowedOrigins: []string{"triplan://auth"},
+	})
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "native-account-id",
+		Email:         "native@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Nat",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "triplan://auth")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Empty(res.Cookies, "a native custom-scheme delivery must not set a cookie")
+
+	target, err := url.Parse(*res.Redirect)
+	s.Require().NoError(err)
+	s.Equal("triplan", target.Scheme)
+	s.Equal("auth", target.Host)
+	s.Empty(target.Path, "the success URL must not be appended to a deep link")
+
+	claims := user.ParseJWT(&user.ParseJWTArgs{
+		Bearer: target.Query().Get("token"),
+		Secret: "test-secret-padded-to-32-chars!!",
+	})
+
+	s.Require().NotNil(claims, "the redirected token must be a valid session JWT")
+	s.NotEmpty(claims["uid"])
+}
+
+// Test_Callback_NativeScheme_NotAllowListed_StaysFirstParty guards the token
+// leak: a custom scheme that is not on the allow-list must not receive a token,
+// and the flow falls back to a first-party cookie on this host.
+func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_NotAllowListed_StaysFirstParty() {
+	host := s.setupCallbackEnv(true)
+
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "evil-account-id",
+		Email:         "evil@stormkit.io",
+		EmailVerified: true,
+		FirstName:     "Eve",
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "evil://auth")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Equal(http.StatusFound, res.Status)
+	s.Require().NotNil(res.Redirect)
+	s.Equal("https://api.example.com/dashboard", *res.Redirect)
+	s.NotContains(*res.Redirect, "token=")
+	s.Require().Len(res.Cookies, 1, "the fallback must stay on the first-party cookie")
+	s.Equal(buildconf.SessionCookieName, res.Cookies[0].Name)
 }

--- a/src/ce/hosting/middleware.skauth_oauth_callback_test.go
+++ b/src/ce/hosting/middleware.skauth_oauth_callback_test.go
@@ -20,12 +20,25 @@ import (
 // The hosting callback only reads "prv" and "ref" — the environment is resolved
 // from the request Host, not from the state — so those are the only claims set.
 func (s *WithSKAuthOAuthSuite) stateToken(provider, ref string) string {
+	return s.stateTokenWithChallenge(provider, ref, "")
+}
+
+// stateTokenWithChallenge mints the state the initiate step would have signed,
+// optionally carrying the PKCE challenge a native client supplied — the callback
+// binds the deep-link code it hands back to that claim.
+func (s *WithSKAuthOAuthSuite) stateTokenWithChallenge(provider, ref, challenge string) string {
 	// Signed with the environment secret because the callback now verifies the
 	// state against it (a token minted for another tenant is rejected).
-	token, err := user.JWT(jwt.MapClaims{
+	claims := jwt.MapClaims{
 		"prv": provider,
 		"ref": ref,
-	}, "test-secret-padded-to-32-chars!!")
+	}
+
+	if challenge != "" {
+		claims["cha"] = challenge
+	}
+
+	token, err := user.JWT(claims, "test-secret-padded-to-32-chars!!")
 
 	s.Require().NoError(err)
 
@@ -394,11 +407,11 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_ExchangeFails_RedirectsWithError() 
 	s.Contains(*res.Redirect, "complete+sign-in")
 }
 
-// Test_Callback_NativeScheme_TokenInRedirect covers the native/mobile OAuth
+// Test_Callback_NativeScheme_CodeInRedirect covers the native/mobile OAuth
 // path: the sign-in runs inside a system auth session whose cookie jar discards
-// Set-Cookie, so an allow-listed custom-scheme target receives the session token
-// in the redirect URL and no cookie at all.
-func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_TokenInRedirect() {
+// Set-Cookie, so an allow-listed custom-scheme target receives a single-use
+// PKCE-bound code — never the session token — and no cookie at all.
+func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_CodeInRedirect() {
 	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
 		Secret:         "test-secret-padded-to-32-chars!!",
 		Status:         true,
@@ -415,7 +428,7 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_TokenInRedirect() {
 		FirstName:     "Nat",
 	}, nil).Once()
 
-	state := s.stateToken(skauth.ProviderGoogle, "triplan://auth")
+	state := s.stateTokenWithChallenge(skauth.ProviderGoogle, "triplan://auth", nativeChallenge)
 
 	res, err := hosting.ServeAuth(s.oauthRequest(
 		host,
@@ -435,13 +448,43 @@ func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_TokenInRedirect() {
 	s.Equal("auth", target.Host)
 	s.Empty(target.Path, "the success URL must not be appended to a deep link")
 
-	claims := user.ParseJWT(&user.ParseJWTArgs{
-		Bearer: target.Query().Get("token"),
-		Secret: "test-secret-padded-to-32-chars!!",
+	s.NotEmpty(target.Query().Get("code"), "the deep link must carry an exchange code")
+	s.Empty(target.Query().Get("token"), "the session token must never ride the deep link")
+}
+
+// Test_Callback_NativeScheme_NoChallenge_FailsClosed pins the fail-closed rule
+// at the delivery end: a state minted before PKCE was required must not degrade
+// into putting the session token on an interceptable deep link.
+func (s *WithSKAuthOAuthSuite) Test_Callback_NativeScheme_NoChallenge_FailsClosed() {
+	host := s.setupCallbackEnvWith(true, &buildconf.SKAuthConf{
+		Secret:         "test-secret-padded-to-32-chars!!",
+		Status:         true,
+		AllowedOrigins: []string{"triplan://auth"},
 	})
 
-	s.Require().NotNil(claims, "the redirected token must be a valid session JWT")
-	s.NotEmpty(claims["uid"])
+	token := &oauth2.Token{}
+
+	s.mockClient.On("Exchange", mock.Anything, mock.Anything).Return(token, nil).Once()
+	s.mockClient.On("UserInfo", mock.Anything, token).Return(&skauth.UserInfo{
+		AccountID:     "legacy-account-id",
+		Email:         "legacy@stormkit.io",
+		EmailVerified: true,
+	}, nil).Once()
+
+	state := s.stateToken(skauth.ProviderGoogle, "triplan://auth")
+
+	res, err := hosting.ServeAuth(s.oauthRequest(
+		host,
+		fmt.Sprintf("/_stormkit/auth/callback?state=%s&code=test-code", state),
+		nil,
+	))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(res.Redirect)
+	s.Empty(res.Cookies)
+	s.Contains(*res.Redirect, "triplan://auth?login_error=")
+	s.NotContains(*res.Redirect, "token=")
+	s.NotContains(*res.Redirect, "code=")
 }
 
 // Test_Callback_NativeScheme_NotAllowListed_StaysFirstParty guards the token

--- a/src/ce/hosting/reserved_routes.go
+++ b/src/ce/hosting/reserved_routes.go
@@ -72,6 +72,9 @@ func registerReservedRoutes(s *shttp.Service) {
 	reg("/logout", handleAuthLogout, http.MethodPost, http.MethodOptions)
 	reg("/refresh", handleAuthRefresh, http.MethodPost, http.MethodOptions)
 	reg("/me", handleAuthMe, http.MethodGet, http.MethodOptions)
+	// Native deep-link handover: exchanges the single-use code delivered on a
+	// custom-scheme redirect for the session token, proved with the PKCE verifier.
+	reg("/token", handleAuthNativeToken, http.MethodPost, http.MethodOptions)
 	// Magic link: GET follows the emailed verification link, POST requests one.
 	reg("/magic", handleAuthMagic, http.MethodGet, http.MethodPost, http.MethodOptions)
 	// Navigation endpoints reached by a top-level GET redirect.
@@ -115,6 +118,7 @@ var (
 	handleAuthLogout        = serveReservedAuth((*skAuthMiddleware).handleLogout)
 	handleAuthMe            = serveReservedAuth((*skAuthMiddleware).handleMe)
 	handleAuthMagic         = serveReservedAuth((*skAuthMiddleware).handleMagic)
+	handleAuthNativeToken   = serveReservedAuth((*skAuthMiddleware).handleNativeToken)
 	handleAuthOAuthCallback = serveReservedAuth((*skAuthMiddleware).handleOAuthCallback)
 
 	handleAuthRegisterLogin = serveReservedAuth(func(m *skAuthMiddleware) (*shttp.Response, error) {

--- a/src/ce/hosting/skauth_magic.go
+++ b/src/ce/hosting/skauth_magic.go
@@ -18,8 +18,10 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 	req := m.req.RequestContext
 
 	body := &struct {
-		Email    string `json:"email"`
-		Redirect string `json:"redirect"`
+		Email               string `json:"email"`
+		Redirect            string `json:"redirect"`
+		CodeChallenge       string `json:"code_challenge"`
+		CodeChallengeMethod string `json:"code_challenge_method"`
 	}{}
 
 	_ = req.Post(body)
@@ -66,6 +68,19 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 		redirect = ""
 	}
 
+	// A custom-scheme redirect delivers the session through a PKCE-bound code, so
+	// the challenge has to be captured now and travel with the link — the user's
+	// inbox sits between this request and the redemption.
+	challenge := utils.GetString(body.CodeChallenge, req.Query().Get("code_challenge"))
+
+	if resp := validateNativeChallenge(
+		redirect,
+		challenge,
+		utils.GetString(body.CodeChallengeMethod, req.Query().Get("code_challenge_method")),
+	); resp != nil {
+		return resp
+	}
+
 	prv, err := skauth.NewStore().Provider(req.Context(), envID, skauth.ProviderMagicLink)
 
 	if err != nil {
@@ -76,7 +91,11 @@ func (m *skAuthMiddleware) magicLinkRequest() *shttp.Response {
 		return shttp.NotFound()
 	}
 
-	token, err := generateMagicLinkToken(env, redirect)
+	token, err := generateMagicLinkToken(generateMagicLinkTokenParams{
+		Env:            env,
+		RedirectOrigin: redirect,
+		CodeChallenge:  challenge,
+	})
 
 	if err != nil {
 		return shttp.Error(err, fmt.Sprintf("failed to generate magic link token: %s", err.Error()))
@@ -137,7 +156,14 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 	claims := user.ParseJWT(&user.ParseJWTArgs{Bearer: token, Secret: env.AuthConf.Secret})
 
 	if claims == nil {
-		return shttp.BadRequest(map[string]any{"errors": []string{"invalid or expired magic link token"}})
+		// Expiry is the ordinary way a magic link fails, and the user is often in a
+		// native app's system browser with nowhere else to land. The origin is
+		// recovered from the unvalidated claims purely to aim the error redirect —
+		// see unverifiedRedirectOrigin for why that is safe.
+		return shttp.BadRequest(map[string]any{
+			"errors":   []string{"invalid or expired magic link token"},
+			"redirect": unverifiedRedirectOrigin(token, env.AuthConf),
+		})
 	}
 
 	redirectOrigin, _ := claims["rdr"].(string)
@@ -198,12 +224,51 @@ func (m *skAuthMiddleware) magicLinkVerify() *shttp.Response {
 
 	if redirectOrigin != "" {
 		data["redirect"] = redirectOrigin
+
+		if challenge, _ := claims["cha"].(string); challenge != "" {
+			data["codeChallenge"] = challenge
+		}
 	}
 
 	return &shttp.Response{Data: data}
 }
 
-func generateMagicLinkToken(env *buildconf.Env, redirectOrigin string) (string, error) {
+// unverifiedRedirectOrigin recovers the `rdr` claim from a magic-link token that
+// failed validation, so an expired or malformed link can still bounce the user
+// back to the app that started the sign-in instead of stranding them on this
+// host — which, in a native app's system browser, means a sheet that never
+// closes.
+//
+// Reading unvalidated claims is safe here because the signature is not what
+// authorizes the target: the recovered origin is re-checked against the
+// environment's allow-list, so a forged claim can only ever name an origin the
+// operator already registered. It is used solely to aim an error redirect; no
+// session is delivered on this path.
+func unverifiedRedirectOrigin(token string, conf *buildconf.SKAuthConf) string {
+	claims := jwt.MapClaims{}
+
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		return ""
+	}
+
+	origin, _ := claims["rdr"].(string)
+
+	if origin == "" || !conf.IsAllowedOrigin(origin) {
+		return ""
+	}
+
+	return origin
+}
+
+type generateMagicLinkTokenParams struct {
+	Env            *buildconf.Env
+	RedirectOrigin string
+	// CodeChallenge is the PKCE S256 challenge for a custom-scheme redirect. It
+	// rides the link so the delivery step can bind the session code to it.
+	CodeChallenge string
+}
+
+func generateMagicLinkToken(p generateMagicLinkTokenParams) (string, error) {
 	jti, err := utils.SecureRandomToken(16)
 
 	if err != nil {
@@ -216,11 +281,15 @@ func generateMagicLinkToken(env *buildconf.Env, redirectOrigin string) (string, 
 		"jti": jti,
 	}
 
-	if redirectOrigin != "" {
-		claims["rdr"] = redirectOrigin
+	if p.RedirectOrigin != "" {
+		claims["rdr"] = p.RedirectOrigin
 	}
 
-	return user.JWT(claims, env.AuthConf.Secret)
+	if p.CodeChallenge != "" {
+		claims["cha"] = p.CodeChallenge
+	}
+
+	return user.JWT(claims, p.Env.AuthConf.Secret)
 }
 
 func sendMagicLinkEmail(req *shttp.RequestContext, env *buildconf.Env, prv *skauth.Provider, email, token string) error {

--- a/src/ce/hosting/skauth_native.go
+++ b/src/ce/hosting/skauth_native.go
@@ -1,0 +1,124 @@
+package hosting
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// nativeCodeTTL bounds how long a deep-link code stays redeemable.
+const nativeCodeTTL = time.Minute
+
+// nativeCodeStore holds the short-lived codes that hand a session token to a
+// native app's custom-scheme deep link. It reuses the same single-use Redis
+// store as the OAuth authorization codes; the prefix keeps the keyspaces apart.
+//
+// The TTL is deliberately much shorter than the OAuth code's: the app redeems
+// it the moment the OS hands over the deep link, so a minute is generous, and
+// every second beyond that is a window an interceptor could race.
+var nativeCodeStore = oneTimeCode{prefix: "skauth:native:", ttl: nativeCodeTTL}
+
+// nativeSessionCode is the Redis-stashed payload behind a deep-link code.
+type nativeSessionCode struct {
+	Token         string `json:"token"`
+	CodeChallenge string `json:"codeChallenge"`
+}
+
+// pkceChallengePattern matches an S256 code_challenge: base64url(sha256(...))
+// unpadded, which is always exactly 43 characters from the unreserved set.
+var pkceChallengePattern = regexp.MustCompile(`^[A-Za-z0-9\-._~]{43}$`)
+
+// validateNativeChallenge gates custom-scheme delivery on PKCE.
+//
+// A private-use URI scheme is not exclusively claimable — on Android any app may
+// declare the same scheme, and on iOS a duplicate registration has an undefined
+// winner — so a redirect to one must be assumed interceptable. RFC 8252 §8.1
+// answers that by carrying only a code bound to a proof the interceptor does not
+// have. Custom-scheme sign-in is therefore refused outright without a challenge,
+// rather than falling back to putting the session token in the URL.
+//
+// http(s) targets are browsers using the session cookie and are unaffected; any
+// challenge they send is ignored.
+func validateNativeChallenge(origin, challenge, method string) *shttp.Response {
+	if !isNativeSchemeOrigin(origin) {
+		return nil
+	}
+
+	if method != "" && method != "S256" {
+		return shttp.BadRequest(map[string]any{
+			"errors": []string{"code_challenge_method must be S256"},
+		})
+	}
+
+	if !pkceChallengePattern.MatchString(challenge) {
+		return shttp.BadRequest(map[string]any{
+			"errors": []string{"a PKCE code_challenge using S256 is required for a custom-scheme redirect"},
+		})
+	}
+
+	return nil
+}
+
+// handleNativeToken serves POST /_stormkit/auth/token: the redemption half of
+// the deep-link handover. The app posts the code it received on its deep link
+// together with the code_verifier whose challenge it sent at sign-in, and gets
+// the session token back over TLS instead of through the OS.
+//
+// The code is single-use (GetDel) and short-lived, so an interceptor that also
+// sees it wins nothing without the verifier, and a replay after the real app has
+// redeemed finds nothing at all.
+func (m *skAuthMiddleware) handleNativeToken() (*shttp.Response, error) {
+	req := m.req.RequestContext
+
+	body := &struct {
+		Code     string `json:"code"`
+		Verifier string `json:"code_verifier"`
+	}{}
+
+	_ = req.Post(body)
+
+	code := utils.GetString(body.Code, req.FormValue("code"))
+	verifier := utils.GetString(body.Verifier, req.FormValue("code_verifier"))
+
+	if code == "" || verifier == "" {
+		return &shttp.Response{
+			Status: http.StatusBadRequest,
+			Data:   map[string]any{"errors": []string{"code and code_verifier are required"}},
+		}, nil
+	}
+
+	var payload nativeSessionCode
+
+	if err := nativeCodeStore.redeem(req.Context(), code, &payload); err != nil {
+		// Unknown, expired and already-redeemed codes are indistinguishable to the
+		// caller on purpose, so the endpoint cannot be used to probe code validity.
+		if !errors.Is(err, errCodeNotFound) {
+			slog.Errorf("native token exchange: failed to redeem code: %s", err.Error())
+		}
+
+		return &shttp.Response{
+			Status: http.StatusBadRequest,
+			Data:   map[string]any{"errors": []string{"code is invalid or expired"}},
+		}, nil
+	}
+
+	if !verifyPKCE(verifier, payload.CodeChallenge) {
+		return &shttp.Response{
+			Status: http.StatusBadRequest,
+			Data:   map[string]any{"errors": []string{"PKCE verification failed"}},
+		}, nil
+	}
+
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Headers: shttp.HeadersFromMap(map[string]string{
+			"Cache-Control": "no-store",
+		}),
+		Data: map[string]any{"token": payload.Token},
+	}, nil
+}

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -243,8 +243,13 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	// Set a first-party cookie on this auth host (also the OAuth AS) and send the
 	// user straight to the initiating origin — no dependency on that origin
-	// carrying its own auth config.
-	return m.deliverSession(sessionToken, referOrigin+successURL), nil
+	// carrying its own auth config. A native app initiating with a custom-scheme
+	// origin gets the token on the redirect instead; see deliverSession.
+	return m.deliverSession(deliverSessionParams{
+		Token:  sessionToken,
+		Origin: referOrigin,
+		Path:   successURL,
+	}), nil
 }
 
 // resolveRedirect determines and validates the post-login redirect origin.

--- a/src/ce/hosting/skauth_oauth.go
+++ b/src/ce/hosting/skauth_oauth.go
@@ -61,14 +61,24 @@ func (m *skAuthMiddleware) handleOAuthInitiate(providerName string) (*shttp.Resp
 		return resp, nil
 	}
 
+	// A custom-scheme target delivers the session through a PKCE-bound code, so
+	// the challenge is captured here and carried in the state across the provider
+	// round trip.
+	challenge := req.Query().Get("code_challenge")
+
+	if resp := validateNativeChallenge(redirect, challenge, req.Query().Get("code_challenge_method")); resp != nil {
+		return resp, nil
+	}
+
 	authURL, err := prv.Client(skauth.ClientParams{
 		RedirectURL: m.callbackURL(),
 		Secret:      env.AuthConf.Secret,
 	}).AuthCodeURL(skauth.AuthCodeURLParams{
-		EnvID:        envID,
-		ProviderName: providerName,
-		Referrer:     redirect,
-		Secret:       env.AuthConf.Secret,
+		EnvID:         envID,
+		ProviderName:  providerName,
+		Referrer:      redirect,
+		Secret:        env.AuthConf.Secret,
+		CodeChallenge: challenge,
 	})
 
 	if err != nil {
@@ -241,14 +251,20 @@ func (m *skAuthMiddleware) handleOAuthCallback() (*shttp.Response, error) {
 
 	successURL := m.req.Host.Config.SKAuth.SuccessURL
 
+	// The challenge is only honoured together with the referrer it was minted
+	// alongside; validateReferOrigin may have fallen back to this host, in which
+	// case delivery is a plain first-party cookie and the challenge is moot.
+	challenge, _ := claims["cha"].(string)
+
 	// Set a first-party cookie on this auth host (also the OAuth AS) and send the
 	// user straight to the initiating origin — no dependency on that origin
 	// carrying its own auth config. A native app initiating with a custom-scheme
-	// origin gets the token on the redirect instead; see deliverSession.
+	// origin gets a PKCE-bound code on the redirect instead; see deliverSession.
 	return m.deliverSession(deliverSessionParams{
-		Token:  sessionToken,
-		Origin: referOrigin,
-		Path:   successURL,
+		Token:     sessionToken,
+		Origin:    referOrigin,
+		Path:      successURL,
+		Challenge: challenge,
 	}), nil
 }
 

--- a/src/migrations/0025_2026-07-31.up.sql
+++ b/src/migrations/0025_2026-07-31.up.sql
@@ -1,0 +1,12 @@
+-- Records how long each request took to serve, so the access log can answer
+-- "which paths make up the latency tail" rather than only "what was served".
+--
+-- Milliseconds, not microseconds: the value is surfaced in the admin viewer and
+-- compared against response-time dashboards that are already in ms, and integer
+-- ms spans up to ~24 days of range — far beyond any request worth recording.
+--
+-- Nullable with no default, so this is a metadata-only ALTER on the partitioned
+-- parent: it propagates to every existing and future partition without
+-- rewriting ~500M rows. Rows written before this migration keep NULL, which
+-- reads as "not measured" rather than "took 0ms".
+ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS duration_ms integer;

--- a/src/ui/src/pages/admin/AccessLogs.tsx
+++ b/src/ui/src/pages/admin/AccessLogs.tsx
@@ -29,15 +29,20 @@ interface AccessLogEntry {
   referrer: string;
   isBot: boolean;
   bytesSent: number;
+  durationMs: number | null;
 }
 
 interface Filters {
+  appId?: string;
   hostName?: string;
   clientIp?: string;
   path?: string;
   method?: string;
   status?: string;
   isBot?: string;
+  minDurationMs?: string;
+  from?: string;
+  to?: string;
 }
 
 interface UseFetchAccessLogsProps {
@@ -45,6 +50,15 @@ interface UseFetchAccessLogsProps {
   cursor?: string;
   refreshToken: number;
 }
+
+// The API takes both time bounds as unix seconds, while the inputs produce
+// local `datetime-local` strings. Anything unparseable is dropped rather than
+// sent as NaN, which the API would read as "no bound".
+const toUnixSeconds = (value: string): string => {
+  const ms = new Date(value).getTime();
+
+  return isNaN(ms) ? "" : String(Math.floor(ms / 1000));
+};
 
 const useFetchAccessLogs = ({
   filters,
@@ -66,8 +80,15 @@ const useFetchAccessLogs = ({
     const params = new URLSearchParams();
 
     Object.entries(filters).forEach(([key, value]) => {
-      if (value) {
-        params.set(key, value);
+      if (!value) {
+        return;
+      }
+
+      const encoded =
+        key === "from" || key === "to" ? toUnixSeconds(value) : value;
+
+      if (encoded) {
+        params.set(key, encoded);
       }
     });
 
@@ -156,6 +177,13 @@ export default function AccessLogs() {
       >
         <TextField
           variant="filled"
+          label="App ID"
+          size="small"
+          helperText="Recommended — narrows the scan"
+          onChange={e => set("appId")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
           label="Host"
           size="small"
           onChange={e => set("hostName")(e.target.value)}
@@ -197,6 +225,30 @@ export default function AccessLogs() {
           <MenuItem value="false">Exclude bots</MenuItem>
           <MenuItem value="true">Only bots</MenuItem>
         </TextField>
+        <TextField
+          variant="filled"
+          label="Min duration (ms)"
+          size="small"
+          type="number"
+          helperText="e.g. 500 for the latency tail"
+          onChange={e => set("minDurationMs")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
+          label="From"
+          size="small"
+          type="datetime-local"
+          InputLabelProps={{ shrink: true }}
+          onChange={e => set("from")(e.target.value)}
+        />
+        <TextField
+          variant="filled"
+          label="To"
+          size="small"
+          type="datetime-local"
+          InputLabelProps={{ shrink: true }}
+          onChange={e => set("to")(e.target.value)}
+        />
         <Button type="submit" variant="contained" disabled={loading}>
           {loading ? <CircularProgress size={16} /> : "Search"}
         </Button>
@@ -208,6 +260,7 @@ export default function AccessLogs() {
               <Td>Time</Td>
               <Td>Method</Td>
               <Td>Status</Td>
+              <Td>Duration</Td>
               <Td>Host</Td>
               <Td>Path</Td>
               <Td>Client IP</Td>
@@ -220,13 +273,18 @@ export default function AccessLogs() {
                 <Td>{formatTs(log.requestTimestamp)}</Td>
                 <Td>{log.method}</Td>
                 <Td>{log.statusCode}</Td>
+                <Td sx={{ whiteSpace: "nowrap" }}>
+                  {log.durationMs === null ? "—" : `${log.durationMs} ms`}
+                </Td>
                 <Td>{log.hostName}</Td>
                 <Td sx={{ maxWidth: 280, wordBreak: "break-all" }}>
                   {log.path}
                 </Td>
                 <Td>{log.clientIp}</Td>
                 <Td>
-                  {log.isBot && <Chip label="bot" size="small" color="warning" />}
+                  {log.isBot && (
+                    <Chip label="bot" size="small" color="warning" />
+                  )}
                 </Td>
               </Tr>
             ))}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -323,14 +323,14 @@ export default function SkAuth() {
           <TextField
             label="Allowed origins"
             name="allowedOrigins"
-            placeholder={"https://app.example.com\nhttps://dev.example.com"}
+            placeholder={"https://app.example.com\nhttps://dev.example.com\nmyapp://auth"}
             fullWidth
             multiline
             minRows={3}
             defaultValue={(config?.allowedOrigins || []).join("\n")}
             variant="filled"
             autoComplete="off"
-            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. Leave empty for single-host setups."
+            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. A native app's deep link (e.g. myapp://auth) goes here too — sign-in then returns the session token on that link instead of a cookie. Leave empty for single-host setups."
             slotProps={{
               inputLabel: {
                 shrink: true,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/SkAuth.tsx
@@ -330,7 +330,7 @@ export default function SkAuth() {
             defaultValue={(config?.allowedOrigins || []).join("\n")}
             variant="filled"
             autoComplete="off"
-            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. A native app's deep link (e.g. myapp://auth) goes here too — sign-in then returns the session token on that link instead of a cookie. Leave empty for single-host setups."
+            helperText="Optional. One origin per line (scheme + host, no path). Origins allowed for cross-origin sign-in. A native app's deep link (e.g. myapp://auth) goes here too — sign-in then returns a one-time PKCE code on that link, which the app exchanges for the session token. Leave empty for single-host setups."
             slotProps={{
               inputLabel: {
                 shrink: true,


### PR DESCRIPTION
## Why

Access logs recorded *what* was served but not *how long it took*, so they could not answer which paths make up a latency tail — the question a P99 investigation actually starts from. This came out of looking at a response-time percentile chart showing a steady P99 around 500ms with spikes to 2s, against a near-zero median, with no way to attribute the tail to specific requests.

## What

- **`duration_ms` column** (`0025_2026-07-31.up.sql`) — nullable with no default, which keeps the `ALTER` metadata-only on the partitioned parent. It propagates to every existing and future partition without rewriting rows.
- **Stamped at write time** from `shttp.RequestContext.StartTime`, which is set when the request is first received (`service.go` → `host_shttp.go`).
- **`minDurationMs` filter** across the store, admin viewer, public API and the `get_access_logs` MCP tool — e.g. "requests over 500ms for this app".
- **Admin viewer**: App ID, From/To and Min duration filters, plus a Duration column.
- Docs updated for the new field and filter.

## Decisions worth reviewing

**Unmeasured requests are `null`, not `0`**, throughout — including in the JSON response. A zero would read as an instant response and skew any percentile computed from these logs. Consequence: `minDurationMs` excludes null rows, so requests logged before this deploy will not appear in a slow-request search.

**Duration is measured up to response assembly, not last-byte-flushed.** It excludes transfer time to the client, so a slow or distant client does not inflate it. This is the number that explains server-side latency; it will not surface slow-client effects.

## Note on the admin view being slow

The global admin view takes ~7-8s for a page. `request_logs` has only `(app_id, request_timestamp)` and `(domain_id, request_timestamp)` indexes, both leading with a scoping column, and the admin view is unscoped by default — so no index applies and the query scans the window. The public API is unaffected: it forces `AppID` from the token and uses `idx_request_logs_app_ts`.

This PR does not add an index. The new App ID filter gives a fast path when you need one. Note this diagnosis is inferred from the schema rather than measured — an `EXPLAIN (ANALYZE, BUFFERS)` would confirm it if it's ever worth chasing.

## Testing

- New tests: duration write/read round-trip, null preservation through `ToMap`, the `minDurationMs` filter (including that it excludes nulls and is inclusive at the boundary), query-param parsing, and both the stamped and unstamped paths in the hosting handler.
- `go build ./...` clean. `accesslog`, `admin`, `adminhandlers`, `public/v1` and the hosting access-log suite pass. UI typechecks.
- `eslint` was **not** run — the config is not resolvable from `src/ui` (no `eslint.config.js`). Prettier was applied.