### PR TITLE
feat: configurable access-log page size

### DIFF
--- a/docs/api/10-mcp.md
+++ b/docs/api/10-mcp.md
@@ -92,7 +92,7 @@ All tools return JSON. Errors are reported as MCP `isError` content while the tr
 
 | Tool              | Description                                                                    |
 | ----------------- | ------------------------------------------------------------------------------ |
-| `get_access_logs` | Return raw HTTP access logs for an environment, newest first (last 24h by default). |
+| `get_access_logs` | Return raw HTTP access logs for an environment, newest first (last 24h by default, 100 entries per page — pass `limit` for up to 1000). |
 
 ### Apps & environments
 

--- a/docs/api/12-access-logs.md
+++ b/docs/api/12-access-logs.md
@@ -46,6 +46,7 @@ All filters are optional and are combined with AND.
 | `isBot`    | boolean | No          | `true` returns only bot traffic, `false` only non-bot traffic. Omit to return both.                                                               |
 | `minDurationMs` | number | No       | Only return requests that took at least this many milliseconds to serve — e.g. `500` to inspect the latency tail. Requests logged before durations were recorded are excluded. |
 | `cursor`   | string  | No          | Pagination cursor. Pass `pagination.cursor` from the previous response back verbatim to fetch the next page. Treat it as opaque — its encoding may change. |
+| `limit`    | number  | No          | How many entries to return per page. Defaults to `100`, maximum `1000`. Values above the maximum are clamped rather than rejected.                 |
 
 > Queries are always bounded in time so that they only scan the relevant
 > partitions. If you omit `from`, the last 24 hours are returned.
@@ -54,7 +55,7 @@ All filters are optional and are combined with AND.
 
 | Field        | Type   | Description                                     |
 | ------------ | ------ | ----------------------------------------------- |
-| `accessLogs` | array  | Up to 100 entries, newest first.                |
+| `accessLogs` | array  | Up to `limit` entries (100 by default), newest first. |
 | `pagination` | object | `hasNextPage`, and `cursor` when there is a next page. |
 
 Each entry contains:

--- a/src/ce/api/accesslog/accesslog_query.go
+++ b/src/ce/api/accesslog/accesslog_query.go
@@ -49,8 +49,24 @@ func SelectLogsParamsFromQuery(q url.Values) SelectLogsParams {
 		To:            to,
 		BeforeID:      beforeID,
 		BeforeTS:      beforeTS,
-		Limit:         DefaultLimit,
+		Limit:         limitFromQuery(q.Get("limit")),
 	}
+}
+
+// limitFromQuery clamps a requested page size to [1, MaxLimit], falling back to
+// DefaultLimit when absent or unparseable.
+func limitFromQuery(v string) int {
+	limit := utils.StringToInt(v)
+
+	if limit <= 0 {
+		return DefaultLimit
+	}
+
+	if limit > MaxLimit {
+		return MaxLimit
+	}
+
+	return limit
 }
 
 // unixFromQuery parses a query value as unix seconds, returning an invalid Unix

--- a/src/ce/api/accesslog/accesslog_query_test.go
+++ b/src/ce/api/accesslog/accesslog_query_test.go
@@ -79,6 +79,26 @@ func (s *QuerySuite) Test_MinDurationMS_Absent() {
 	}
 }
 
+func (s *QuerySuite) Test_Limit() {
+	params := accesslog.SelectLogsParamsFromQuery(url.Values{"limit": {"250"}})
+
+	s.Equal(250, params.Limit)
+}
+
+// A missing or nonsensical page size falls back to the default, and an
+// oversized one is clamped rather than rejected — the caller still gets a page.
+func (s *QuerySuite) Test_Limit_Fallbacks() {
+	for _, v := range []string{"", "0", "-1", "abc"} {
+		params := accesslog.SelectLogsParamsFromQuery(url.Values{"limit": {v}})
+
+		s.Equal(accesslog.DefaultLimit, params.Limit, v)
+	}
+
+	params := accesslog.SelectLogsParamsFromQuery(url.Values{"limit": {"999999"}})
+
+	s.Equal(accesslog.MaxLimit, params.Limit)
+}
+
 func TestQuery(t *testing.T) {
 	suite.Run(t, &QuerySuite{})
 }

--- a/src/ce/api/accesslog/accesslog_store.go
+++ b/src/ce/api/accesslog/accesslog_store.go
@@ -23,8 +23,16 @@ const accessLogInsertFields = 16
 // attempted and lost.
 const MaxInsertRows = 65535 / accessLogInsertFields
 
-// DefaultLimit caps a single page of access-log results.
+// DefaultLimit caps a single page of access-log results when the caller does
+// not ask for a specific page size.
 const DefaultLimit = 100
+
+// MaxLimit is the largest page an API caller may ask for. Rows are wide (user
+// agent, referrer, path) and the whole page is serialized into a single
+// response, so this is kept well below what the index could stream. It bounds
+// what arrives over HTTP only — internal callers set SelectLogsParams.Limit
+// directly and are trusted with it.
+const MaxLimit = 1000
 
 var stmt = struct {
 	insertLogs string

--- a/src/ce/api/admin/adminhandlers/handler_access_logs.go
+++ b/src/ce/api/admin/adminhandlers/handler_access_logs.go
@@ -19,8 +19,8 @@ func handlerAccessLogs(req *user.RequestContext) *shttp.Response {
 
 	pagination := map[string]any{"hasNextPage": false}
 
-	if len(logs) > accesslog.DefaultLimit {
-		logs = logs[:accesslog.DefaultLimit]
+	if len(logs) > params.Limit {
+		logs = logs[:params.Limit]
 		last := logs[len(logs)-1]
 
 		pagination["hasNextPage"] = true

--- a/src/ce/api/public/v1/handler_access_logs_get.go
+++ b/src/ce/api/public/v1/handler_access_logs_get.go
@@ -7,9 +7,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
 
-// AccessLogsLimit is the maximum number of access log entries returned per page.
-var AccessLogsLimit = accesslog.DefaultLimit
-
 func handlerAccessLogsGet(req *RequestContext) *shttp.Response {
 	params := accesslog.SelectLogsParamsFromQuery(req.Query())
 
@@ -17,7 +14,6 @@ func handlerAccessLogsGet(req *RequestContext) *shttp.Response {
 	// filters are taken from the token rather than from the query string.
 	params.AppID = req.App.ID
 	params.EnvID = req.Env.ID
-	params.Limit = AccessLogsLimit
 
 	logs, err := accesslog.NewStore().SelectLogs(req.Context(), params)
 
@@ -26,10 +22,9 @@ func handlerAccessLogsGet(req *RequestContext) *shttp.Response {
 	}
 
 	pagination := map[string]any{"hasNextPage": false}
-	hasNextPage := len(logs) > AccessLogsLimit
 
-	if hasNextPage {
-		logs = logs[:AccessLogsLimit]
+	if len(logs) > params.Limit {
+		logs = logs[:params.Limit]
 		last := logs[len(logs)-1]
 
 		pagination["hasNextPage"] = true

--- a/src/ce/api/public/v1/handler_access_logs_get_test.go
+++ b/src/ce/api/public/v1/handler_access_logs_get_test.go
@@ -168,14 +168,7 @@ func (s *HandlerAccessLogsGetSuite) Test_Success_DefaultWindow() {
 }
 
 func (s *HandlerAccessLogsGetSuite) Test_Success_HasNextPage() {
-	original := publicapiv1.AccessLogsLimit
-	publicapiv1.AccessLogsLimit = 1
-
-	defer func() {
-		publicapiv1.AccessLogsLimit = original
-	}()
-
-	res := s.request("", usertest.Authorization(s.user.ID))
+	res := s.request("&limit=1", usertest.Authorization(s.user.ID))
 	paths, pagination := s.paths(res)
 
 	s.Equal(http.StatusOK, res.Code)
@@ -188,7 +181,7 @@ func (s *HandlerAccessLogsGetSuite) Test_Success_HasNextPage() {
 
 	// The cursor marks the last returned entry; paging with it returns the rest.
 	res = s.request(
-		fmt.Sprintf("&cursor=%s", pagination["cursor"]),
+		fmt.Sprintf("&limit=1&cursor=%s", pagination["cursor"]),
 		usertest.Authorization(s.user.ID),
 	)
 

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -93,6 +93,7 @@ func mcpAllTools() []mcpToolDef {
 					"status":   map[string]any{"type": "string", "description": "Only return requests answered with this HTTP status code."},
 					"isBot":    map[string]any{"type": "boolean", "description": "Filter bot traffic in or out. Omit to return both."},
 					"cursor":   map[string]any{"type": "string", "description": "Opaque pagination cursor. Pass pagination.cursor from the previous response back verbatim to fetch the next page."},
+					"limit":    map[string]any{"type": "number", "description": "How many entries to return per page. Defaults to 100, maximum 1000."},
 
 					"minDurationMs": map[string]any{"type": "number", "description": "Only return requests that took at least this many milliseconds to serve. Use to inspect the latency tail, e.g. 500. Requests logged before durations were recorded are excluded."},
 				},
@@ -751,6 +752,10 @@ func mcpGetAccessLogs(req *RequestContextMCP, args map[string]any) *shttp.Respon
 
 	if ms := intArg(args, "minDurationMs"); ms > 0 {
 		query["minDurationMs"] = strconv.Itoa(ms)
+	}
+
+	if limit := intArg(args, "limit"); limit > 0 {
+		query["limit"] = strconv.Itoa(limit)
 	}
 
 	req.setQuery(query)


### PR DESCRIPTION
## What

Access logs were hard-coded to **100 entries per page**. This makes the page size configurable via a `limit` query parameter.

- Default stays `100` (`accesslog.DefaultLimit`), maximum is `1000` (`accesslog.MaxLimit`).
- Out-of-range or unparseable values fall back / clamp rather than erroring — a caller always gets a page.
- Clamping happens at the HTTP boundary (`SelectLogsParamsFromQuery`), so internal callers that set `SelectLogsParams.Limit` directly (e.g. bulk reads) are unaffected.

Exposed on:

- `GET /v1/access-logs` (public API)
- the admin access-logs endpoint
- the `get_access_logs` MCP tool (new `limit` argument)

Cursor pagination is unchanged and keeps working with any page size.

## Why 1000

Rows are wide (path, user agent, referrer) and the whole page is serialized into one response, so 1000 keeps the worst-case response in the low single-digit MB while still cutting round trips 10x for log-pulling clients.

## Notes

`publicapiv1.AccessLogsLimit` — a var that only existed so tests could shrink the page — is gone; the test now passes `limit=1` instead.

## Tests

- New `Test_Limit` / `Test_Limit_Fallbacks` covering default, clamp and garbage input.
- `go test -p 1 ./src/ce/api/accesslog/ ./src/ce/api/admin/adminhandlers/ ./src/ce/api/public/v1/` passes.

Docs updated: `docs/api/12-access-logs.md`, `docs/api/10-mcp.md`.