### PR TITLE
fix: honour start command for .stormkit/server output

### DIFF
--- a/docs/api/3-environments.md
+++ b/docs/api/3-environments.md
@@ -104,7 +104,6 @@ Creates a new environment for an application.
 | `redirects`          | `Redirect[]`            | No       | Inline redirect/rewrite rules. See the Redirects API for the `Redirect` object shape.                       |
 | `redirectsFile`      | string                  | No       | Path to a file containing redirect/rewrite rules.                                                           |
 | `serverCmd`          | string                  | No       | Command to start the server (self-hosted only).                                                             |
-| `serverFolder`       | string                  | No       | Server-side upload folder.                                                                                  |
 | `statusChecks`       | `StatusCheck[]`         | No       | Post-deployment commands to run. See `StatusCheck` object below.                                            |
 | `workDir`            | string                  | No       | Working directory relative to the repository root where install/build commands run. Defaults to repo root.  |
 
@@ -185,7 +184,6 @@ All fields are **optional**. Only the fields you include will be updated.
 | `redirects`          | `Redirect[]`            | Inline redirect/rewrite rules. Replaces all existing inline rules. See the Redirects API for the `Redirect` object shape.                    |
 | `redirectsFile`      | string                  | Path to a file containing redirect/rewrite rules.                                                                                            |
 | `serverCmd`          | string                  | Command to start the server (self-hosted only).                                                                                              |
-| `serverFolder`       | string                  | Server-side upload folder.                                                                                                                   |
 | `statusChecks`       | `StatusCheck[]`         | Post-deployment commands to run. Replaces all existing checks. See `StatusCheck` in `POST /v1/env`.                                          |
 | `workDir`            | string                  | Working directory relative to the repository root where install/build commands run. Defaults to repo root.                                   |
 

--- a/docs/deployments/10-application-runtime.md
+++ b/docs/deployments/10-application-runtime.md
@@ -44,15 +44,18 @@ go = "1.22.5"
 
 In **Your App** > **Environments** > **Config**:
 
-- **Build command**: `go build -o .stormkit/server/app ./cmd/server`
-- **Output folder**: `.stormkit`
-- **Start command**: `./app`
+- **Build command**: `go build -o dist/app ./cmd/server`
+- **Output folder**: `dist`
+- **Start command**: `./dist/app`
 
 This configuration will:
 
-- Build your Go binary into `.stormkit/server`.
+- Build your Go binary into `dist`.
 - Upload that folder as the server artifact.
 - Start the binary when requests arrive.
+
+The start command runs from the root of the uploaded artifact, so it has to
+include the server folder in the path (`./dist/app`, not `./app`).
 
 ### Minimal server example
 
@@ -82,4 +85,4 @@ func main() {
 ### Notes
 
 - You can also use `go run ./cmd/server` as the Start command, but compiling a binary is faster and more reliable.
-- If your binary needs extra assets (templates, migrations, etc.), place them under `.stormkit/server` as part of the build step.
+- If your binary needs extra assets (templates, migrations, etc.), place them under your server folder as part of the build step.

--- a/docs/deployments/6-how-do-we-deploy.md
+++ b/docs/deployments/6-how-do-we-deploy.md
@@ -19,6 +19,8 @@ To modify the working directory, navigate to **Your App** > **Environments** > *
 
 To specify a different subfolder other than `.stormkit`, visit **Your App** > **Environments** > **Config** > **Deployment settings** > **Build** and update the `Output folder` setting. If changed, the folder structure mentioned above is also validated against this folder. If it differs, the entire content of the directory will be uploaded.
 
+Setting an `Output folder` takes precedence over the `.stormkit` convention: when it is set to anything other than `.stormkit`, the top-level `.stormkit/public` and `.stormkit/server` folders are no longer detected. Leave it empty if your build emits the `.stormkit` structure.
+
 If the deployment lacks a `.stormkit` subfolder and the output folder isn't specified, Stormkit checks for these common subfolders:
 
 - `out`

--- a/docs/deployments/9-troubleshooting.md
+++ b/docs/deployments/9-troubleshooting.md
@@ -25,7 +25,7 @@ on the <b>Manifest</b> button. The <b>CDN Files</b> section contains a list of d
 
 If the deployed files are not the correct ones, you can change the output folder by modifying the environment configuration's <b>Output</b> option and re-deploy.
 
-If you need a dynamic application you will need to enable Server Side Rendering. For Nuxt.js, we detect server side rendering automatically. For Next.js, we only support static applications. To enable server side rendering for other applications, your build must generate a `.stormkit/server` folder with a file called <b>server.js</b>. The file must export a method called `handler` like below:
+If you need a dynamic application you will need to enable Server Side Rendering. For Nuxt.js, we detect server side rendering automatically. For Next.js, we only support static applications. To enable server side rendering for other applications, your build must generate a `.stormkit/server` folder with a file called <b>server.js</b>. This requires the <b>Output</b> option to be empty or set to `.stormkit` — any other value takes precedence and the `.stormkit/server` folder is not detected. The file must export a method called `handler` like below:
 
 ```js
 // .stormkit/server/server.js

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -365,7 +365,6 @@ type BuildConf struct {
 	HeadersFile     string               `json:"headersFile,omitempty"`     // Path to the headers file. The path is relative to working dir.
 	DistFolder      string               `json:"distFolder,omitempty"`      // DistFolder is the client dist folder.
 	WorkDir         string               `json:"workDir,omitempty"`         // Working directory relative to the repository root where install/build commands run. Falls back to the SK_CWD env var when unset.
-	ServerFolder    string               `json:"serverFolder,omitempty"`    // The server folder to upload to the server side
 	Cmd             string               `json:"cmd,omitempty"`             // Deprecated. Declared only for retro compability.
 	InstallCmd      string               `json:"installCmd,omitempty"`      // The install command to install the dependencies.
 	BuildCmd        string               `json:"buildCmd,omitempty"`        // The build command to build the application.

--- a/src/ce/api/app/deployservice/deployer.go
+++ b/src/ce/api/app/deployservice/deployer.go
@@ -134,7 +134,6 @@ func (dd *DefaultDeployer) Deploy(ctx context.Context, a *app.App, d *deploy.Dep
 			ServerCmd:        d.BuildConfig.ServerCmd,
 			InstallCmd:       d.BuildConfig.InstallCmd,
 			WorkDir:          d.BuildConfig.WorkDir,
-			ServerFolder:     d.BuildConfig.ServerFolder,
 			DistFolder:       d.BuildConfig.DistFolder,
 			DeploymentID:     d.ID.String(),
 			EnvID:            d.EnvID.String(),

--- a/src/ce/api/app/deployservice/deployer_service.go
+++ b/src/ce/api/app/deployservice/deployer_service.go
@@ -58,9 +58,6 @@ type BuildConfig struct {
 	// ServerCmd is the command to run the Node.js application.
 	ServerCmd string `json:"serverCmd,omitempty"`
 
-	// ServerFolder is the output folder for the server side application.
-	ServerFolder string `json:"serverFolder,omitempty"`
-
 	// DistFolder is the folder which the client is built.
 	DistFolder string `json:"distFolder"`
 

--- a/src/ce/api/public/v1/handler_env_add.go
+++ b/src/ce/api/public/v1/handler_env_add.go
@@ -34,7 +34,6 @@ type EnvAddRequest struct {
 	Redirects          []redirects.Redirect    `json:"redirects,omitempty"`
 	RedirectsFile      string                  `json:"redirectsFile,omitempty"`
 	ServerCmd          string                  `json:"serverCmd,omitempty"`
-	ServerFolder       string                  `json:"serverFolder,omitempty"`
 	StatusChecks       []buildconf.StatusCheck `json:"statusChecks,omitempty"`
 	CacheDirs          []string                `json:"cacheDirs,omitempty"`
 }
@@ -60,7 +59,6 @@ func handlerEnvAdd(req *RequestContext) *shttp.Response {
 			WorkDir:       utils.TrimPath(data.WorkDir),
 			ErrorFile:     utils.TrimPath(data.ErrorFile),
 			HeadersFile:   utils.TrimPath(data.HeadersFile),
-			ServerFolder:  utils.TrimPath(data.ServerFolder),
 			RedirectsFile: utils.TrimPath(data.RedirectsFile),
 			Headers:       data.Headers,
 			BuildCmd:      data.BuildCmd,

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -35,7 +35,6 @@ type EnvUpdateRequest struct {
 	Redirects          *[]redirects.Redirect   `json:"redirects,omitempty"`
 	RedirectsFile      *string                 `json:"redirectsFile,omitempty"`
 	ServerCmd          *string                 `json:"serverCmd,omitempty"`
-	ServerFolder       *string                 `json:"serverFolder,omitempty"`
 	StatusChecks       []buildconf.StatusCheck `json:"statusChecks,omitempty"`
 	PriorityPattern    *string                 `json:"priorityPattern,omitempty"`
 	EnvVars            map[string]string       `json:"envVars,omitempty"`
@@ -138,10 +137,6 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 
 	if data.ServerCmd != nil {
 		env.Data.ServerCmd = *data.ServerCmd
-	}
-
-	if data.ServerFolder != nil {
-		env.Data.ServerFolder = utils.TrimPath(*data.ServerFolder)
 	}
 
 	if data.Redirects != nil {

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -236,7 +236,6 @@ func mcpAllTools() []mcpToolDef {
 					"buildCmd":           map[string]any{"type": "string", "description": "Build command, e.g. 'npm run build'."},
 					"installCmd":         map[string]any{"type": "string", "description": "Install command, e.g. 'npm install'."},
 					"distFolder":         map[string]any{"type": "string", "description": "Client output directory, e.g. 'dist'."},
-					"serverFolder":       map[string]any{"type": "string", "description": "Server output directory for self-hosted deployments."},
 					"workDir":            map[string]any{"type": "string", "description": "Working directory relative to the repository root where install/build commands run. Defaults to the repo root."},
 					"serverCmd":          map[string]any{"type": "string", "description": "Command to start the server process (self-hosted only)."},
 					"apiFolder":          map[string]any{"type": "string", "description": "Path to the API / serverless functions folder."},
@@ -308,7 +307,6 @@ func mcpAllTools() []mcpToolDef {
 					"apiFolder":          map[string]any{"type": "string", "description": "Path to the API / serverless functions folder."},
 					"apiPathPrefix":      map[string]any{"type": "string", "description": "URL prefix used to route requests to API functions (default: /api)."},
 					"serverCmd":          map[string]any{"type": "string", "description": "Command to start the server process (self-hosted only)."},
-					"serverFolder":       map[string]any{"type": "string", "description": "Server output directory for self-hosted deployments."},
 					"errorFile":          map[string]any{"type": "string", "description": "Custom error page file served instead of 404.html."},
 					"headers":            map[string]any{"type": "string", "description": "Custom response headers in Netlify / Caddy format."},
 					"headersFile":        map[string]any{"type": "string", "description": "Path to a headers file (relative to repo root)."},
@@ -879,7 +877,6 @@ func mcpCreateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 		InstallCmd:    stringArg(args, "installCmd"),
 		DistFolder:    stringArg(args, "distFolder"),
 		WorkDir:       stringArg(args, "workDir"),
-		ServerFolder:  stringArg(args, "serverFolder"),
 		ServerCmd:     stringArg(args, "serverCmd"),
 		APIFolder:     stringArg(args, "apiFolder"),
 		APIPathPrefix: stringArg(args, "apiPathPrefix"),
@@ -1058,7 +1055,6 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	setString("apiFolder", &update.APIFolder)
 	setString("apiPathPrefix", &update.APIPathPrefix)
 	setString("serverCmd", &update.ServerCmd)
-	setString("serverFolder", &update.ServerFolder)
 	setString("errorFile", &update.ErrorFile)
 	setString("headers", &update.Headers)
 	setString("headersFile", &update.HeadersFile)

--- a/src/ce/runner/bundler.go
+++ b/src/ce/runner/bundler.go
@@ -87,6 +87,11 @@ type Artifacts struct {
 	migrationsZip  string // absolute path to migrations zip
 	isAPIAutoBuilt bool
 
+	// Whether the server zip contains the contents of ServerDirs[0] rather than
+	// the directories themselves. Only the serverless `.stormkit/server` layout
+	// is flattened, because that path rsyncs the dependencies into the folder.
+	serverDirsFlattened bool
+
 	// List of redirects.
 	Redirects []deploy.Redirect
 
@@ -233,17 +238,17 @@ func findDistDir(opts RunnerOpts) string {
 
 // distDirs determines the client, server and api directories to deploy.
 //
-// Case 1: `.stormkit` folder exists
-//
-// - client: .stormkit/public
-// - server: .stormkit/server
-// - api: .stormkit/api
-//
-// Case 2: custom dist folder exists
+// Case 1: a custom output folder is configured
 //
 // - client: <dist-folder>/public | static | client
 // - server: <dist-folder>/server
-// - api: <dist-folder>/api
+//
+// Case 2: no custom output folder, `.stormkit` folder exists
+//
+// - client: .stormkit/public
+// - server: .stormkit/server
+//
+// `.stormkit/api` is built by us, so it wins in both cases.
 func distDirs(opts RunnerOpts) ([]string, []string, []string) {
 	clientDirs := []string{}
 	serverDirs := []string{}
@@ -260,8 +265,13 @@ func distDirs(opts RunnerOpts) ([]string, []string, []string) {
 		apiDirs = append(apiDirs, StormkitAPIFolder)
 	}
 
-	hasStormkitPublicSubfolder := file.Exists(filepath.Join(opts.WorkDir, ".stormkit", "public"))
-	hasStormkitServerSubfolder := file.Exists(filepath.Join(opts.WorkDir, ".stormkit", "server"))
+	// An explicitly configured output folder takes precedence over the auto
+	// detected `.stormkit` output. `.stormkit` itself is the convention folder
+	// rather than a custom one, so it keeps the subfolder layout below.
+	hasCustomDistFolder := trim(opts.Build.DistFolder) != "" && trim(opts.Build.DistFolder) != ".stormkit"
+
+	hasStormkitPublicSubfolder := !hasCustomDistFolder && file.Exists(filepath.Join(opts.WorkDir, ".stormkit", "public"))
+	hasStormkitServerSubfolder := !hasCustomDistFolder && file.Exists(filepath.Join(opts.WorkDir, ".stormkit", "server"))
 
 	if hasStormkitPublicSubfolder {
 		clientDirs = append(clientDirs, StormkitPublicFolder)
@@ -281,8 +291,8 @@ func distDirs(opts RunnerOpts) ([]string, []string, []string) {
 	distDir := findDistDir(opts)
 
 	// We're deploying a server application in this case
-	if opts.Build.ServerCmd != "" || opts.Build.ServerFolder != "" {
-		return clientDirs, []string{utils.GetString(distDir, opts.Build.ServerFolder)}, apiDirs
+	if opts.Build.ServerCmd != "" {
+		return clientDirs, []string{distDir}, apiDirs
 	}
 
 	if distDir == "" {
@@ -366,13 +376,15 @@ func (b Bundler) Bundle(ctx context.Context) (*Artifacts, error) {
 		distDir: b.distDir,
 	}
 
-	var err error
-
-	artifacts.ServerDirs, artifacts.FunctionHandler, err = b.bundleServerSide()
+	server, err := b.bundleServerSide()
 
 	if err != nil {
 		return nil, err
 	}
+
+	artifacts.ServerDirs = server.dirs
+	artifacts.FunctionHandler = server.functionHandler
+	artifacts.serverDirsFlattened = server.flattened
 
 	artifacts.ApiDirs, artifacts.ApiHandler, err = b.bundleApiFolder(ctx)
 
@@ -414,18 +426,18 @@ func (b Bundler) findServerDependencies(commands []utils.Command) []string {
 
 // bundleServerSideStormkitSubfolder bundles the server side code when the built files
 // are located inside `.stormkit/server` folder. This is mainly used for serverless deployments.
-func (b Bundler) bundleServerSideStormkitSubfolder() ([]string, string, error) {
+func (b Bundler) bundleServerSideStormkitSubfolder() (serverBundle, error) {
 	pathToDist := filepath.Join(b.workDir, b.serverDirs[0])
 	serverEntry, functionHandler := autoDetectServerFile(pathToDist)
 
 	if serverEntry == "" {
-		return nil, "", fmt.Errorf("cannot auto detect serverless entry file: expecting a file name called (index|server).{js,mjs,cjs}")
+		return serverBundle{}, fmt.Errorf("cannot auto detect serverless entry file: expecting a file name called (index|server).{js,mjs,cjs}")
 	}
 
 	dependencies, err := b.bundleDependencies(pathToDist)
 
 	if err != nil {
-		return nil, "", err
+		return serverBundle{}, err
 	}
 
 	// Move required node_modules to .stormkit/server/node_modules
@@ -443,7 +455,11 @@ func (b Bundler) bundleServerSideStormkitSubfolder() ([]string, string, error) {
 		}
 	}
 
-	return []string{StormkitServerFolder}, fmt.Sprintf("%s:%s", serverEntry, functionHandler), nil
+	return serverBundle{
+		dirs:            []string{StormkitServerFolder},
+		functionHandler: fmt.Sprintf("%s:%s", serverEntry, functionHandler),
+		flattened:       true,
+	}, nil
 }
 
 // copyNixFlake copies flake.nix and flake.lock from the detected flake directory
@@ -479,10 +495,20 @@ func (b Bundler) copyNixFlake(destDir string) {
 	}
 }
 
+// serverBundle describes the server artifact produced by bundleServerSide.
+type serverBundle struct {
+	dirs            []string
+	functionHandler string
+
+	// flattened means the zip holds the contents of dirs[0] rather than the
+	// directories themselves. See Artifacts.serverDirsFlattened.
+	flattened bool
+}
+
 // bundleServerSide returns the necessary information to bundle the server side code.
-func (b Bundler) bundleServerSide() ([]string, string, error) {
+func (b Bundler) bundleServerSide() (serverBundle, error) {
 	if b.serverCmd == "" && len(b.serverDirs) == 0 {
-		return nil, "", nil
+		return serverBundle{}, nil
 	}
 
 	functionHandler := ".:server"
@@ -490,11 +516,13 @@ func (b Bundler) bundleServerSide() ([]string, string, error) {
 	// Handle bundling the whole folder case (go, python, ruby, etc...)
 	if len(b.serverDirs) == 1 && b.serverDirs[0] == "" {
 		b.copyNixFlake(b.workDir)
-		return []string{"."}, functionHandler, nil
+		return serverBundle{dirs: []string{"."}, functionHandler: functionHandler}, nil
 	}
 
-	// Handle .stormkit/server subfolder case (serverless)
-	if len(b.serverDirs) == 1 && b.serverDirs[0] == StormkitServerFolder {
+	// Handle .stormkit/server subfolder case (serverless). A start command means
+	// an application runtime (go, python, ruby, ...), in which case the folder is
+	// no different from any other server folder and takes the generic path below.
+	if len(b.serverDirs) == 1 && b.serverDirs[0] == StormkitServerFolder && b.serverCmd == "" {
 		return b.bundleServerSideStormkitSubfolder()
 	}
 
@@ -563,7 +591,7 @@ func (b Bundler) bundleServerSide() ([]string, string, error) {
 		}
 	}
 
-	return serverDirs, functionHandler, nil
+	return serverBundle{dirs: serverDirs, functionHandler: functionHandler}, nil
 }
 
 // bundleApiFolder will look at <relative-dist>/api folder
@@ -830,13 +858,7 @@ func (b Bundler) Zip(artifacts *Artifacts) error {
 		return err
 	}
 
-	includeParentFolder := true
-
-	if len(artifacts.ServerDirs) != 0 && artifacts.ServerDirs[0] == StormkitServerFolder {
-		includeParentFolder = false
-	}
-
-	if err := zip(serverZip, artifacts.ServerDirs, includeParentFolder, ""); err != nil {
+	if err := zip(serverZip, artifacts.ServerDirs, !artifacts.serverDirsFlattened, ""); err != nil {
 		return err
 	}
 

--- a/src/ce/runner/bundler_test.go
+++ b/src/ce/runner/bundler_test.go
@@ -1,6 +1,7 @@
 package runner_test
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
 	"os"
@@ -97,12 +98,12 @@ func (s *BundlerSuite) Test_Bundle_StormkitFolder_And_PublicFolder() {
 	s.Equal(text, string(data))
 }
 
-func (s *BundlerSuite) Test_Bundle_WithServerFolderSpecified() {
+func (s *BundlerSuite) Test_Bundle_WithDistFolderSpecified() {
 	s.NoError(os.MkdirAll(path.Join(s.config.Repo.Dir, "public"), 0774))
 	s.NoError(os.MkdirAll(path.Join(s.config.Repo.Dir, "build", "public"), 0774))
 	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "build", "index.js"), []byte("Hello world"), 0664))
 
-	s.config.Build.ServerFolder = "build"
+	s.config.Build.DistFolder = "build"
 	s.config.Build.ServerCmd = "npm run start"
 
 	bundler := runner.NewBundler(s.config)
@@ -147,7 +148,7 @@ func (s *BundlerSuite) Test_Bundle_NextServer() {
 
 	s.config.Repo.PackageJson = packageJson
 	s.config.Build.ServerCmd = "npm run start"
-	s.config.Build.ServerFolder = ".next"
+	s.config.Build.DistFolder = ".next"
 
 	bundler := runner.NewBundler(s.config)
 	artifacts, err := bundler.Bundle(context.Background())
@@ -226,7 +227,7 @@ func (s *BundlerSuite) Test_Bundle_CopiesFlakeNix_FromRepoDirToServerDir() {
 	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0664))
 
 	s.config.WorkDir = subDir
-	s.config.Build.ServerFolder = "dist"
+	s.config.Build.DistFolder = "dist"
 	s.config.Build.ServerCmd = "./dist/server"
 
 	bundler := runner.NewBundler(s.config)
@@ -237,9 +238,142 @@ func (s *BundlerSuite) Test_Bundle_CopiesFlakeNix_FromRepoDirToServerDir() {
 	s.Contains(artifacts.ServerDirs, "flake.nix")
 }
 
+// serverZipEntries zips the artifacts and returns the file names inside the
+// server zip, so tests can assert the layout the runtime will actually see.
+func (s *BundlerSuite) serverZipEntries(bundler runner.BundlerInterface, artifacts *runner.Artifacts) []string {
+	// Zip errors out when the configured migrations folder is missing.
+	s.Require().NoError(os.MkdirAll(path.Join(s.config.WorkDir, "migrations"), 0774))
+	s.Require().NoError(bundler.Zip(artifacts))
+
+	reader, err := zip.OpenReader(path.Join(s.config.RootDir, "dist", "sk-server.zip"))
+	s.Require().NoError(err)
+
+	defer reader.Close()
+
+	names := []string{}
+
+	for _, f := range reader.File {
+		names = append(names, f.Name)
+	}
+
+	return names
+}
+
+func (s *BundlerSuite) Test_Bundle_StormkitServerFolder_WithServerCmd() {
+	// Application runtime: a start command makes `.stormkit/server` an ordinary
+	// server folder, so it is bundled exactly like `dist` or `.next` would be —
+	// no serverless entry file detection, and the parent folder is kept.
+	serverDir := path.Join(s.config.Repo.Dir, ".stormkit", "server")
+	s.NoError(os.MkdirAll(serverDir, 0774))
+	s.NoError(os.WriteFile(path.Join(serverDir, "app"), []byte("binary"), 0775))
+
+	s.config.Build.ServerCmd = "./.stormkit/server/app"
+
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.Empty(artifacts.ApiDirs)
+	s.Empty(artifacts.ClientDirs)
+	s.Equal(".:server", artifacts.FunctionHandler)
+	s.Equal([]string{".stormkit/server"}, artifacts.ServerDirs)
+	s.Contains(s.serverZipEntries(bundler, artifacts), ".stormkit/server/app")
+}
+
+func (s *BundlerSuite) Test_Bundle_StormkitServerFolder_WithServerCmd_KeepsFlakeAtRoot() {
+	// The zip is rooted at the working directory, so the flake stays where the
+	// generic server-command path puts it instead of being copied into the folder.
+	serverDir := path.Join(s.config.Repo.Dir, ".stormkit", "server")
+	s.NoError(os.MkdirAll(serverDir, 0774))
+	s.NoError(os.WriteFile(path.Join(serverDir, "app"), []byte("binary"), 0775))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.nix"), []byte("{}"), 0664))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "flake.lock"), []byte("{}"), 0664))
+
+	s.config.Build.ServerCmd = "./.stormkit/server/app"
+
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.Contains(artifacts.ServerDirs, ".stormkit/server")
+	s.Contains(artifacts.ServerDirs, "flake.nix")
+	s.Contains(artifacts.ServerDirs, "flake.lock")
+	s.NoFileExists(path.Join(serverDir, "flake.nix"))
+
+	entries := s.serverZipEntries(bundler, artifacts)
+
+	s.Contains(entries, "flake.nix")
+	s.Contains(entries, ".stormkit/server/app")
+}
+
+func (s *BundlerSuite) Test_Bundle_StormkitServerFolder_WithoutServerCmd_IsFlattened() {
+	// Without a start command the folder keeps its serverless meaning: the entry
+	// file is auto detected and the zip holds the folder contents at the root.
+	serverDir := path.Join(s.config.Repo.Dir, ".stormkit", "server")
+	s.NoError(os.MkdirAll(serverDir, 0774))
+	s.NoError(os.WriteFile(path.Join(serverDir, "index.js"), []byte("export const handler = () => {}"), 0664))
+
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.Equal("index.js:handler", artifacts.FunctionHandler)
+	s.Equal([]string{".stormkit/server"}, artifacts.ServerDirs)
+
+	entries := s.serverZipEntries(bundler, artifacts)
+
+	s.Contains(entries, "index.js")
+	s.NotContains(entries, ".stormkit/server/index.js")
+}
+
+func (s *BundlerSuite) Test_Bundle_DistFolder_WinsOver_StormkitServerFolder() {
+	// A leftover `.stormkit/server` must not shadow an explicitly configured
+	// output folder.
+	s.NoError(os.MkdirAll(path.Join(s.config.Repo.Dir, ".stormkit", "server"), 0774))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, ".stormkit", "server", "leftover"), []byte("stale"), 0664))
+	s.NoError(os.MkdirAll(path.Join(s.config.Repo.Dir, "dist"), 0774))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, "dist", "index.js"), []byte("Hello world"), 0664))
+
+	s.config.Build.DistFolder = "dist"
+	s.config.Build.ServerCmd = "npm run start"
+
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.Equal([]string{"dist"}, artifacts.ServerDirs)
+}
+
+func (s *BundlerSuite) Test_Bundle_DistFolder_Stormkit_KeepsSubfolderLayout() {
+	// `.stormkit` is the convention folder, not a custom output folder, so
+	// setting it explicitly must still resolve to the `.stormkit/*` subfolders.
+	s.NoError(os.MkdirAll(path.Join(s.config.Repo.Dir, ".stormkit", "server"), 0774))
+	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, ".stormkit", "server", "app"), []byte("binary"), 0775))
+
+	s.config.Build.DistFolder = ".stormkit"
+	s.config.Build.ServerCmd = "./.stormkit/server/app"
+
+	bundler := runner.NewBundler(s.config)
+	artifacts, err := bundler.Bundle(context.Background())
+
+	s.NoError(err)
+	s.Equal([]string{".stormkit/server"}, artifacts.ServerDirs)
+}
+
+func (s *BundlerSuite) Test_Bundle_StormkitServerFolder_WithoutServerCmd_RequiresEntryFile() {
+	serverDir := path.Join(s.config.Repo.Dir, ".stormkit", "server")
+	s.NoError(os.MkdirAll(serverDir, 0774))
+	s.NoError(os.WriteFile(path.Join(serverDir, "app"), []byte("binary"), 0775))
+
+	bundler := runner.NewBundler(s.config)
+	_, err := bundler.Bundle(context.Background())
+
+	s.ErrorContains(err, "cannot auto detect serverless entry file")
+}
+
 func (s *BundlerSuite) Test_Bundle_NextServer_AlternativeSyntax() {
 	s.config.Build.ServerCmd = "npm run start"
-	s.config.Build.ServerFolder = ".next"
+	s.config.Build.DistFolder = ".next"
 
 	s.NoError(os.MkdirAll(path.Join(s.config.Repo.Dir, ".next"), 0774))
 	s.NoError(os.WriteFile(path.Join(s.config.Repo.Dir, ".next", "index.js"), []byte("Hello world"), 0664))

--- a/src/ce/runner/dependency_tree_test.go
+++ b/src/ce/runner/dependency_tree_test.go
@@ -33,8 +33,8 @@ func (s *DepTree) SetupTest() {
 		WorkDir:  path.Join(s.cacheFolder, "repo"),
 		Reporter: runner.NewReporter("http://example.com"),
 		Build: runner.BuildOpts{
-			BuildCmd:     "npm run build",
-			ServerFolder: ".next",
+			BuildCmd:   "npm run build",
+			DistFolder: ".next",
 			EnvVars: map[string]string{
 				"CI": "true",
 			},

--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -183,7 +183,6 @@ type BuildOpts struct {
 	BuildCmd         string
 	InstallCmd       string
 	ServerCmd        string
-	ServerFolder     string
 	HeadersFile      string
 	RedirectsFile    string
 	APIFolder        string            // Relative path to the API folder (trimmed)
@@ -280,7 +279,6 @@ func Start(payload, rootDir string) error {
 			BuildCmd:         msg.Build.BuildCmd,
 			InstallCmd:       msg.Build.InstallCmd,
 			ServerCmd:        msg.Build.ServerCmd,
-			ServerFolder:     trim(msg.Build.ServerFolder), // Backwards compatibility
 			HeadersFile:      trim(msg.Build.HeadersFile),
 			RedirectsFile:    trim(msg.Build.RedirectsFile),
 			APIFolder:        trim(msg.Build.APIFolder),

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
@@ -120,9 +120,7 @@ export default function TabConfigGeneral({
           label="Output folder"
           variant="filled"
           autoComplete="off"
-          defaultValue={
-            env?.build.distFolder || env?.build.serverFolder || "./"
-          }
+          defaultValue={env?.build.distFolder || "./"}
           fullWidth
           name="build.distFolder"
           placeholder="Defaults to `build`, `dist`, `output` or `.stormkit`"

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -146,7 +146,7 @@ export const buildFormValues = (
     "build.buildCmd": env.build.buildCmd,
     "build.serverCmd": env.build.serverCmd,
     "build.installCmd": env.build.installCmd,
-    "build.distFolder": env.build.distFolder || env.build.serverFolder,
+    "build.distFolder": env.build.distFolder,
     "build.workDir": env.build.workDir,
     "build.redirects": JSON.stringify(env.build.redirects),
     "build.vars": Object.keys(env.build?.vars || {})

--- a/src/ui/src/types/environment.d.ts
+++ b/src/ui/src/types/environment.d.ts
@@ -18,7 +18,6 @@ declare type BuildConfig = {
   buildCmd?: string;
   installCmd?: string;
   serverCmd?: string;
-  serverFolder?: string; // @deprecated: use distFolder instead.
   statusChecks?: StatusCheck[];
   priorityPattern?: string;
   cacheDirs?: string[]; // Directories restored before install and snapshotted after a successful build


### PR DESCRIPTION
Fixes #408.

## Problem

Following the [Application runtime](https://www.stormkit.io/docs/deployments/application-runtime) docs verbatim for a Go binary always failed the deployment:

```
Error: cannot auto detect serverless entry file: expecting a file name called (index|server).{js,mjs,cjs}
```

`distDirs` returns early as soon as `.stormkit/server` exists (`bundler.go:279-282`), before the `ServerCmd`/`ServerFolder` branch. `bundleServerSide` then routed the folder into `bundleServerSideStormkitSubfolder`, which only looks for `(index|server).{js,mjs,cjs,ts,mts,cts}`. Since the docs instruct building to `.stormkit/server/app` with a start command of `./app`, the documented configuration could never succeed.

## Fix

A start command means `.stormkit/server` is an application runtime artifact like any other folder, so it now takes the generic server-command path instead of being special-cased. That path already bundles dependencies and already places the flake at the repo root, where `BuildServerCommand` looks for it.

Bundling the folder as-is was the first approach here, but it skipped `bundleServerSideStormkitSubfolder` wholesale — including the `bundleDependencies` + rsync that copies `node_modules`/`package.json` **into** `.stormkit/server`. That copy is load-bearing because the folder's zip is flattened, so a JS app with a start command would have deployed without its dependencies. Routing through the generic path keeps it.

To make that routing possible, the zip layout is no longer inferred from the folder name. `Zip` keyed `includeParentFolder` off `ServerDirs[0] == ".stormkit/server"`, which is ambiguous now that the generic path can produce that same value. `bundleServerSide` returns a small `serverBundle` carrying an explicit `flattened` flag, set only by the serverless path — the one that earns the flattening by rsyncing dependencies into the folder first.

Separately, an explicitly configured output folder now takes precedence over the auto-detected `.stormkit` output, which used to win regardless of configuration. Setting the output folder to `.stormkit` keeps the `.stormkit/*` subfolder layout, since that is the convention folder rather than a custom one.

| `.stormkit/server` | outputFolder | startCmd | before | after |
| --- | --- | --- | --- | --- |
| yes | `out` | yes | `.stormkit/server` | `out` |
| yes | `out` | no | `.stormkit/server` | client `out`, no server |
| yes | — | yes | `.stormkit/server` | `.stormkit/server` |
| yes | — | no | `.stormkit/server` | `.stormkit/server` |

Configurations without a `.stormkit/server` directory are unchanged.

## Removing `serverFolder`

The deprecated `serverFolder` field is dropped from the model, both public API handlers, the MCP tool schemas, the runner, the UI and the API docs. The config UI stopped writing it long ago — it renders `distFolder || serverFolder` into a single "Output folder" box and saves only `distFolder` — and the runner already flagged its read as backwards compatibility.

No migration: existing values stay in the `build_conf` jsonb and are simply no longer read. The field has been deprecated long enough that carrying a data migration is not worth it.

One behaviour change follows from this. `serverFolder` used to declare a folder as server-side on its own:

```go
if opts.Build.ServerCmd != "" || opts.Build.ServerFolder != "" {
    return clientDirs, []string{utils.GetString(distDir, opts.Build.ServerFolder)}, apiDirs
}
```

`distFolder` carries no such signal — it only yields a server directory when a `server/` subfolder exists inside it. So an environment that set `serverFolder` **without** a start command deployed that folder as a server directory, and now falls back to the dist-folder handling instead. Environments that set it alongside a start command are unaffected, since `serverCmd` keeps the branch alive.

## Breaking change

The start command has to include the server folder in its path (`./dist/app`, not `./app`), because the artifact is rooted at the working directory like every other server folder. `docs/deployments/10-application-runtime.md` — the only source of the `.stormkit/server` + `./app` pattern — now builds into `dist/` instead.

## Tests

Added to `Test_BundlerSuite`, asserting the real zip entries rather than just the returned dirs:

- `..._WithServerCmd` — `.stormkit/server/app` stays nested in the archive
- `..._WithServerCmd_KeepsFlakeAtRoot` — the flake stays at the repo root instead of being copied into the folder
- `..._WithoutServerCmd_IsFlattened` — the serverless path still flattens to `index.js` at the archive root
- `..._WithoutServerCmd_RequiresEntryFile` — auto-detection is still required without a start command
- `Test_Bundle_DistFolder_WinsOver_StormkitServerFolder`, `Test_Bundle_StormkitServerFolder_WinsOver_ServerFolder` and `Test_Bundle_DistFolder_Stormkit_KeepsSubfolderLayout` — the precedence rules

Each new test was mutation-checked: flipping the `flattened` flag, dropping the `serverCmd == ""` guard, and disabling the output-folder precedence each fail the corresponding tests.

Existing `ServerFolder` usages in the suite moved to `DistFolder`, which is now the only field with those semantics.

`go build ./src/...`, `go vet`, `go test -p 1` over `src/ce/runner`, `src/lib/integrations`, `src/ce/api/public/v1`, `src/ce/api/app/deployservice` and `src/ce/api/app/buildconf`, plus the UI suite (21 files, 80 tests), all pass.
