### PR TITLE
feat: monitoring stack for self-hosted instances

### DIFF
--- a/.github/workflows/lint-monitoring.yml
+++ b/.github/workflows/lint-monitoring.yml
@@ -1,0 +1,79 @@
+name: Lint Monitoring Configs
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "deploy/**"
+      - ".github/workflows/lint-monitoring.yml"
+  push:
+    branches: [main]
+    paths:
+      - "deploy/**"
+      - ".github/workflows/lint-monitoring.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate prometheus.yml
+        run: |
+          docker run --rm --entrypoint promtool \
+            -v "$PWD/deploy/monitoring:/cfg:ro" \
+            prom/prometheus:v3.1.0 check config /cfg/prometheus.yml
+
+      - name: Validate dashboard JSON
+        run: |
+          for file in deploy/monitoring/grafana/dashboards/*.json; do
+            jq empty "$file"
+          done
+
+      # A dashboard that references a datasource Grafana did not provision
+      # renders every panel empty, which looks like a broken metrics pipeline
+      # rather than a broken dashboard.
+      - name: Check dashboard datasource uids
+        run: |
+          for file in deploy/monitoring/grafana/dashboards/*.json; do
+            wrong=$(jq '[
+              (.panels[] | .datasource.uid),
+              (.panels[].targets // [] | .[] | .datasource.uid)
+            ] | map(select(. != "stormkit-prometheus")) | length' "$file")
+
+            if [ "$wrong" != "0" ]; then
+              echo "$file: $wrong reference(s) not pointing at the stormkit-prometheus datasource"
+              exit 1
+            fi
+          done
+
+      # Every dashboard expression must parse. promtool only validates PromQL
+      # inside rule files, so the expressions are lifted into one.
+      - name: Validate dashboard PromQL
+        run: |
+          jq -rs '
+            [ .[] | .panels[] | (.targets // [])[] | .expr ]
+            | to_entries
+            | map("      - record: dashboard:check\(.key)\n        expr: |\n          " + (.value | gsub("\n"; " ")))
+            | "groups:\n  - name: dashboard-exprs\n    rules:\n" + join("\n")
+          ' deploy/monitoring/grafana/dashboards/*.json > /tmp/promql_check.yml
+
+          docker run --rm --entrypoint promtool \
+            -v /tmp:/cfg:ro \
+            prom/prometheus:v3.1.0 check rules /cfg/promql_check.yml
+
+      - name: Validate compose profile
+        working-directory: deploy
+        env:
+          GRAFANA_ADMIN_PASSWORD: lint
+          REDIS_ADDR: redis:6379
+          POSTGRES_HOST: db
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: stormkit
+          POSTGRES_USER: stormkit
+          POSTGRES_PASSWORD: lint
+          STORMKIT_DOMAIN: example.org
+          STORMKIT_APP_SECRET: lint
+        run: docker compose --profile monitoring config -q

--- a/.github/workflows/lint-monitoring.yml
+++ b/.github/workflows/lint-monitoring.yml
@@ -12,6 +12,11 @@ on:
       - "deploy/**"
       - ".github/workflows/lint-monitoring.yml"
 
+# Reading the checkout is all this workflow does. Nothing here writes to the
+# repository, so the token gets no more than that.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -81,6 +81,10 @@ GITHUB_PRIV_KEY=''
 # run the bundled monitoring stack, or scrape Stormkit with your own Prometheus.
 PROMETHEUS_METRICS=false
 
+# The port the metrics endpoint binds inside the compose network. If you change
+# it, update the targets in monitoring/prometheus.yml to match.
+PROMETHEUS_PORT=2112
+
 # The Grafana admin password, used when running the `monitoring` profile.
 # install.sh generates one for you. The profile refuses to start if it is empty,
 # rather than falling back to admin/admin.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -67,3 +67,28 @@ GITHUB_SECRET=''
 #
 # Make sure to enclose your variable with quotes.
 GITHUB_PRIV_KEY=''
+
+##############################################################################
+#                                                                            #
+# Monitoring                                                                 #
+#                                                                            #
+# See docs/self-hosting/8-monitoring.md                                      #
+#                                                                            #
+##############################################################################
+
+# Expose Prometheus metrics from the hosting and workerserver services on port
+# 2112, reachable only from inside the compose network. Required if you want to
+# run the bundled monitoring stack, or scrape Stormkit with your own Prometheus.
+PROMETHEUS_METRICS=false
+
+# The Grafana admin password, used when running the `monitoring` profile.
+# install.sh generates one for you. The profile refuses to start if it is empty,
+# rather than falling back to admin/admin.
+GRAFANA_ADMIN_PASSWORD=''
+
+# The loopback port Grafana is published on. Reach it with an SSH tunnel:
+# ssh -L 3000:127.0.0.1:3000 you@your-server
+GRAFANA_PORT=3000
+
+# How long Prometheus keeps metrics for.
+PROMETHEUS_RETENTION=15d

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -112,6 +112,10 @@ services:
       # Expose Prometheus metrics on port 2112 inside this network. Off by
       # default; required by the `monitoring` compose profile.
       - PROMETHEUS_METRICS=${PROMETHEUS_METRICS:-false}
+
+      # Passed explicitly so the port is bound strictly rather than probed for.
+      # If you change it, update the targets in monitoring/prometheus.yml too.
+      - PROMETHEUS_PORT=${PROMETHEUS_PORT:-2112}
     depends_on:
       db:
         condition: service_healthy
@@ -159,6 +163,10 @@ services:
       # Expose Prometheus metrics on port 2112 inside this network. Off by
       # default; required by the `monitoring` compose profile.
       - PROMETHEUS_METRICS=${PROMETHEUS_METRICS:-false}
+
+      # Passed explicitly so the port is bound strictly rather than probed for.
+      # If you change it, update the targets in monitoring/prometheus.yml too.
+      - PROMETHEUS_PORT=${PROMETHEUS_PORT:-2112}
 
       ####################################################################################
       #                                                                                  #
@@ -284,10 +292,28 @@ services:
       - stormkit
     depends_on:
       - prometheus
+    # The password check lives here rather than in a `${VAR:?}` default, because
+    # Compose interpolates the whole file before it filters by profile: a
+    # required-variable marker on this service would abort `docker compose up`
+    # for everyone, including instances that never enable monitoring. Checking
+    # at container start keeps the failure scoped to the profile that needs it.
+    entrypoint:
+      - sh
+      - -c
+      - |
+        if [ -z "$${GF_SECURITY_ADMIN_PASSWORD}" ]; then
+          echo "GRAFANA_ADMIN_PASSWORD is empty. Set it in .env before starting the monitoring profile." >&2
+          exit 1
+        fi
+        exec /run.sh
     environment:
-      # Fails fast rather than silently running admin/admin. install.sh
-      # generates this for you.
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env}
+      # Empty is rejected by the entrypoint above rather than silently falling
+      # back to Grafana's admin/admin default. install.sh generates one for you.
+      #
+      # Only read on Grafana's FIRST start: once the admin user exists in the
+      # `grafana` volume, changing this has no effect. Rotate with
+      # `docker compose exec grafana grafana-cli admin reset-admin-password <new>`.
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
     volumes:
@@ -331,7 +357,10 @@ services:
     networks:
       - stormkit
     environment:
-      - DATA_SOURCE_NAME=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable
+      # libpq keyword form rather than a URL: a password containing @ / # ? or :
+      # needs percent-encoding in a URL, and an unescaped one silently reparses
+      # into a different host. The quotes cover values containing spaces.
+      - DATA_SOURCE_NAME=host=${POSTGRES_HOST} port=${POSTGRES_PORT} user='${POSTGRES_USER}' password='${POSTGRES_PASSWORD}' dbname='${POSTGRES_DB}' sslmode=disable
     depends_on:
       db:
         condition: service_healthy

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -8,6 +8,8 @@ volumes:
   stormkit:
   redis:
   psql:
+  prometheus:
+  grafana:
   workerserver:
   hosting:
   workerserver_nix:
@@ -106,6 +108,10 @@ services:
       # Possible values to turn it on: 1, 2, 3, TRUE
       # Level 1 is the least verbose, level 3 is the most verbose.
       - DEBUG=${DEBUG:-off}
+
+      # Expose Prometheus metrics on port 2112 inside this network. Off by
+      # default; required by the `monitoring` compose profile.
+      - PROMETHEUS_METRICS=${PROMETHEUS_METRICS:-false}
     depends_on:
       db:
         condition: service_healthy
@@ -149,6 +155,10 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - REDIS_ADDR=${REDIS_ADDR}
       - DEBUG=${DEBUG:-off}
+
+      # Expose Prometheus metrics on port 2112 inside this network. Off by
+      # default; required by the `monitoring` compose profile.
+      - PROMETHEUS_METRICS=${PROMETHEUS_METRICS:-false}
 
       ####################################################################################
       #                                                                                  #
@@ -233,3 +243,101 @@ services:
         target: ${STORMKIT_HTTPS_PORT:-443}
         published: ${STORMKIT_HTTPS_PORT:-443}
         protocol: tcp
+
+  ###############################################################################
+  #                                                                             #
+  # Monitoring. Nothing below runs unless you ask for it:                       #
+  #                                                                             #
+  #   docker compose --profile monitoring up -d                                 #
+  #                                                                             #
+  # Set PROMETHEUS_METRICS=true in your .env first, otherwise Stormkit exposes  #
+  # no metrics and the two stormkit-* scrape targets stay down.                 #
+  #                                                                             #
+  # See docs/self-hosting/8-monitoring.md                                       #
+  #                                                                             #
+  ###############################################################################
+
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    profiles: ["monitoring"]
+    container_name: prometheus
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d}
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus:/prometheus
+    # Deliberately not published to the host. The Prometheus API is
+    # unauthenticated and allows arbitrary queries; only Grafana needs it.
+
+  grafana:
+    image: grafana/grafana-oss:11.6.0
+    profiles: ["monitoring"]
+    container_name: grafana
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    depends_on:
+      - prometheus
+    environment:
+      # Fails fast rather than silently running admin/admin. install.sh
+      # generates this for you.
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana:/var/lib/grafana
+    ports:
+      # Loopback only. Reach it with an SSH tunnel:
+      #   ssh -L 3000:127.0.0.1:3000 you@your-server
+      # If you want it on the network, put your own TLS and auth in front.
+      - "127.0.0.1:${GRAFANA_PORT:-3000}:3000"
+
+  node-exporter:
+    image: prom/node-exporter:v1.9.0
+    profiles: ["monitoring"]
+    container_name: node-exporter
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    pid: host
+    command:
+      - --path.rootfs=/host
+    volumes:
+      # Read-only view of the host so disk figures describe the machine rather
+      # than the container. Safe here because no deployed app code ever runs in
+      # this container.
+      - /:/host:ro,rslave
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.17.1
+    profiles: ["monitoring"]
+    container_name: postgres-exporter
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    environment:
+      - DATA_SOURCE_NAME=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable
+    depends_on:
+      db:
+        condition: service_healthy
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.67.0
+    profiles: ["monitoring"]
+    container_name: redis-exporter
+    restart: always
+    logging: *default-logging
+    networks:
+      - stormkit
+    environment:
+      - REDIS_ADDR=${REDIS_ADDR}

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -315,7 +315,12 @@ services:
       # Read-only view of the host so disk figures describe the machine rather
       # than the container. Safe here because no deployed app code ever runs in
       # this container.
-      - /:/host:ro,rslave
+      #
+      # No rslave propagation: Docker Desktop refuses it because the VM root is
+      # neither a shared nor a slave mount, which would make this fail outright
+      # on a developer machine. The cost is that a filesystem mounted after this
+      # container starts is not picked up until it is restarted.
+      - /:/host:ro
 
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter:v0.17.1

--- a/deploy/monitoring/grafana/dashboards/stormkit-dependencies.json
+++ b/deploy/monitoring/grafana/dashboards/stormkit-dependencies.json
@@ -1,0 +1,488 @@
+{
+  "uid": "stormkit-dependencies",
+  "title": "Stormkit — Dependencies",
+  "description": "PostgreSQL and Redis health, including Stormkit's own connection pool.",
+  "tags": ["stormkit"],
+  "timezone": "browser",
+  "editable": false,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "PostgreSQL",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Server connections used",
+      "description": "Backends in use against max_connections, across every client of this database.",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(pg_stat_activity_count) / on() group_left() max(pg_settings_max_connections)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.7 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Database size",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(pg_database_size_bytes)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Deadlocks (24h)",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(pg_stat_database_deadlocks[24h]))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Cache hit ratio",
+      "description": "Reads served from the buffer cache rather than disk. Sustained dips mean the working set no longer fits in shared_buffers.",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(pg_stat_database_blks_hit[5m])) / clamp_min(sum(rate(pg_stat_database_blks_hit[5m])) + sum(rate(pg_stat_database_blks_read[5m])), 1)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.9 },
+              { "color": "green", "value": 0.98 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Stormkit connection pool",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Pool connections",
+      "description": "In use and idle against the configured maximum, per Stormkit process.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "stormkit_db_connections",
+          "legendFormat": "{{job}} {{state}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "stormkit_db_connections_max",
+          "legendFormat": "{{job}} max",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".* max" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Waiting for a connection",
+      "description": "Anything sustained above zero means callers are queuing for a pool slot and the pool is undersized. Postgres itself can look completely idle while this is happening.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(stormkit_db_wait_total[5m])",
+          "legendFormat": "{{job}} waits/s",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "rate(stormkit_db_wait_seconds_total[5m]) / clamp_min(rate(stormkit_db_wait_total[5m]), 0.0001)",
+          "legendFormat": "{{job}} mean wait",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".* mean wait" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "PostgreSQL activity",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Connections by state",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (state) (pg_stat_activity_count)",
+          "legendFormat": "{{state}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": { "fillOpacity": 20, "lineWidth": 1, "showPoints": "never", "stacking": { "mode": "normal" } },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Commits vs rollbacks",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(pg_stat_database_xact_commit[5m]))",
+          "legendFormat": "commits",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(pg_stat_database_xact_rollback[5m]))",
+          "legendFormat": "rollbacks",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Redis",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "stat",
+      "title": "Redis memory used",
+      "description": "Against maxmemory when one is configured. Shows raw usage otherwise.",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "redis_memory_used_bytes / clamp_min(redis_memory_max_bytes, 1)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.8 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 32,
+      "type": "stat",
+      "title": "Evicted keys (1h)",
+      "description": "Redis holds sessions here, so an eviction signs people out. Anything above zero needs attention.",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "increase(redis_evicted_keys_total[1h])",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 33,
+      "type": "stat",
+      "title": "Keyspace hit ratio",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(redis_keyspace_hits_total[5m]) / clamp_min(rate(redis_keyspace_hits_total[5m]) + rate(redis_keyspace_misses_total[5m]), 0.0001)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "max": 1, "min": 0, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 34,
+      "type": "timeseries",
+      "title": "Redis memory",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "redis_memory_used_bytes",
+          "legendFormat": "used",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "redis_memory_max_bytes > 0",
+          "legendFormat": "maxmemory",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 35,
+      "type": "timeseries",
+      "title": "Clients and commands",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "redis_connected_clients",
+          "legendFormat": "connected clients",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "redis_blocked_clients",
+          "legendFormat": "blocked clients",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "C",
+          "expr": "sum(rate(redis_commands_processed_total[5m]))",
+          "legendFormat": "commands/s",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/deploy/monitoring/grafana/dashboards/stormkit-host.json
+++ b/deploy/monitoring/grafana/dashboards/stormkit-host.json
@@ -1,0 +1,484 @@
+{
+  "uid": "stormkit-host",
+  "title": "Stormkit — Host",
+  "description": "CPU, memory, disk and load for the machine running Stormkit.",
+  "tags": ["stormkit"],
+  "timezone": "browser",
+  "editable": false,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Scrape targets up",
+      "description": "Expected 5: hosting, workerserver, node, postgres, redis. If the two stormkit-* targets are down, PROMETHEUS_METRICS is probably not set to true in .env.",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(up)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "max": 5,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3 },
+              { "color": "green", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "CPU busy",
+      "gridPos": { "h": 4, "w": 5, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Memory used",
+      "gridPos": { "h": 4, "w": 5, "x": 9, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.8 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Fullest filesystem",
+      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"}))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.8 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Load (1m)",
+      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "node_load1",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "none", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] } },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Disk",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "bargauge",
+      "title": "Free space by filesystem",
+      "description": "Free and total bytes per real filesystem. Container layer mounts are filtered out.",
+      "gridPos": { "h": 8, "w": 10, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"}",
+          "legendFormat": "{{mountpoint}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "displayMode": "gradient",
+        "orientation": "horizontal"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 5000000000 },
+              { "color": "green", "value": 20000000000 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Filesystem used %",
+      "gridPos": { "h": 8, "w": 14, "x": 10, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs|ramfs\"})",
+          "legendFormat": "{{mountpoint}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.8 },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "CPU, memory and load",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "CPU by mode",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (mode) (rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) / on() group_left() count(count by (cpu) (node_cpu_seconds_total))",
+          "legendFormat": "{{mode}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": { "fillOpacity": 20, "lineWidth": 1, "showPoints": "never", "stacking": { "mode": "normal" } },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Memory",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes",
+          "legendFormat": "used",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "node_memory_MemTotal_bytes",
+          "legendFormat": "total",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Load average vs cores",
+      "description": "Load above the core count means processes are queuing for CPU.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "node_load1",
+          "legendFormat": "1m",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "node_load5",
+          "legendFormat": "5m",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "C",
+          "expr": "node_load15",
+          "legendFormat": "15m",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "D",
+          "expr": "count(count by (cpu) (node_cpu_seconds_total))",
+          "legendFormat": "cores",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "cores" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Disk I/O",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(node_disk_read_bytes_total[5m]))",
+          "legendFormat": "read",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(node_disk_written_bytes_total[5m]))",
+          "legendFormat": "written",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Stormkit processes",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "collapsed": false,
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Process memory",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "process_resident_memory_bytes{job=~\"stormkit-.*\"}",
+          "legendFormat": "{{job}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": { "fillOpacity": 8, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Goroutines",
+      "description": "Steady monotonic growth is the signature of a leak.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "go_goroutines{job=~\"stormkit-.*\"}",
+          "legendFormat": "{{job}}",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "min": 0,
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,17 @@
+# Dashboards are provisioned from disk and mounted read-only, so the files in
+# this repo stay the single source of truth. To customise one, use "Save As" in
+# Grafana and edit your copy -- edits to the provisioned originals are
+# intentionally not allowed, since they would be silently reverted.
+apiVersion: 1
+
+providers:
+  - name: stormkit
+    orgId: 1
+    folder: Stormkit
+    type: file
+    disableDeletion: true
+    allowUiUpdates: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+# The uid is fixed because the bundled dashboards reference it directly.
+# Changing it orphans every panel.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: stormkit-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/monitoring/prometheus.yml
+++ b/deploy/monitoring/prometheus.yml
@@ -1,0 +1,36 @@
+# Scrape configuration for a self-hosted Stormkit instance.
+#
+# Every target is reached by container name over the `stormkit` compose
+# network, so nothing here needs to be published to the host.
+#
+# The job names are load-bearing: the bundled Grafana dashboards select on
+# them (job=~"stormkit-.*" in particular). Rename with care.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Stormkit's own metrics. These two targets stay DOWN until
+  # PROMETHEUS_METRICS=true is set in .env -- that is the usual reason for an
+  # otherwise empty dashboard.
+  - job_name: stormkit-hosting
+    static_configs:
+      - targets: ["hosting:2112"]
+
+  - job_name: stormkit-workerserver
+    static_configs:
+      - targets: ["workerserver:2112"]
+
+  # The machine: CPU, memory, load, disk and filesystems.
+  - job_name: node
+    static_configs:
+      - targets: ["node-exporter:9100"]
+
+  - job_name: postgres
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: redis
+    static_configs:
+      - targets: ["redis-exporter:9121"]

--- a/docs/self-hosting/8-monitoring.md
+++ b/docs/self-hosting/8-monitoring.md
@@ -57,6 +57,15 @@ Then visit `http://localhost:3000` and sign in as `admin` with the password from
 your `.env`. The dashboards are already provisioned under the **Stormkit**
 folder — there is nothing to import.
 
+`GRAFANA_ADMIN_PASSWORD` is read only on Grafana's **first** start. Once the
+admin user exists in the `grafana` volume, editing that variable and restarting
+has no effect — the old password keeps working. This matters if you are rotating
+after a suspected leak: change it in Grafana itself, or run
+
+```bash
+docker compose exec grafana grafana-cli admin reset-admin-password <new-password>
+```
+
 If you would rather expose Grafana properly, put your own TLS termination and
 authentication in front of it. Do not simply change the published address to
 `0.0.0.0`.
@@ -104,9 +113,13 @@ the usual Go runtime metrics.
 You do not need the bundled stack. Set `PROMETHEUS_METRICS=true` and scrape
 `hosting:2112` and `workerserver:2112` from wherever your Prometheus lives.
 
-`PROMETHEUS_PORT` changes the port. If you set it, it is used exactly as given
-and startup fails loudly if the port is taken — the port never silently moves,
-so your scrape configuration cannot end up pointing at nothing.
+`PROMETHEUS_PORT` changes the port. It is used exactly as given and never
+silently moves, so your scrape configuration cannot end up pointing at nothing.
+If the port is taken or the value is not a valid port number, metrics are
+disabled and an error is logged — the service itself keeps serving traffic, so
+check the logs if a target is unexpectedly down. Changing this in the bundled
+stack also means updating the targets in `monitoring/prometheus.yml`, which
+addresses `hosting:2112` and `workerserver:2112` directly.
 
 The dashboard JSON under `monitoring/grafana/dashboards/` imports into any
 Grafana, as long as your Prometheus datasource has the uid

--- a/docs/self-hosting/8-monitoring.md
+++ b/docs/self-hosting/8-monitoring.md
@@ -1,0 +1,165 @@
+---
+title: "Monitoring"
+description: Run Prometheus and Grafana against your self-hosted Stormkit instance with ready-made dashboards for CPU, memory, disk, PostgreSQL and Redis.
+---
+
+# Monitoring
+
+Stormkit ships an optional monitoring stack: Prometheus, Grafana, and the
+standard exporters for the host, PostgreSQL and Redis. It answers the questions
+an operator asks about the box:
+
+- Is the machine running out of CPU, memory or disk?
+- Is PostgreSQL near its connection limit, and is Stormkit waiting on its own
+  connection pool?
+- Is Redis close to `maxmemory`, and is it evicting keys?
+
+This is **instance health**, not per-app analytics. Traffic, response times and
+deployment history for individual applications already live in the Stormkit UI
+under Access Logs and Analytics; these dashboards deliberately have no app
+dimension.
+
+Nothing here runs unless you ask for it. The configuration files sit on disk
+after installation, and a Docker Compose profile decides whether the containers
+start.
+
+## Enabling it
+
+Two commands from the directory holding your `docker-compose.yaml`:
+
+```bash
+sed -i 's/^PROMETHEUS_METRICS=.*/PROMETHEUS_METRICS=true/' .env
+docker compose --profile monitoring up -d
+```
+
+The second command does double duty. It starts the monitoring containers, and
+it recreates `hosting` and `workerserver` so they pick up the new environment
+variable. There is no separate restart step.
+
+`install.sh` generates a `GRAFANA_ADMIN_PASSWORD` for you. If you are enabling
+this on an instance installed before monitoring existed, set one yourself — the
+profile refuses to start without it rather than falling back to `admin/admin`:
+
+```bash
+echo "GRAFANA_ADMIN_PASSWORD='$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c 24)'" >> .env
+```
+
+## Reaching Grafana
+
+Grafana is published on loopback only, so it is not reachable from the internet.
+Open an SSH tunnel:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 you@your-server
+```
+
+Then visit `http://localhost:3000` and sign in as `admin` with the password from
+your `.env`. The dashboards are already provisioned under the **Stormkit**
+folder — there is nothing to import.
+
+If you would rather expose Grafana properly, put your own TLS termination and
+authentication in front of it. Do not simply change the published address to
+`0.0.0.0`.
+
+## The dashboards
+
+**Stormkit — Host.** Disk free and used per filesystem, CPU by mode, memory,
+load average against core count, and disk I/O. Container layer mounts (`tmpfs`,
+`overlay`) are filtered out so the disk figures describe real disks. It also
+charts resident memory and goroutine counts for the two Stormkit processes,
+where steady monotonic growth is the signature of a leak.
+
+**Stormkit — Dependencies.** PostgreSQL connections against `max_connections`,
+database size, deadlocks, cache hit ratio and transaction rates; Redis memory
+against `maxmemory`, evictions, hit ratio and client counts. It also has a row
+for Stormkit's own connection pool, described below.
+
+The first panel on the Host dashboard is **Scrape targets up**, expected to read
+5. If it reads 3, the two `stormkit-*` targets are down and
+`PROMETHEUS_METRICS` is almost certainly still `false`.
+
+## Stormkit's own metrics
+
+Almost everything on these dashboards comes from the standard exporters. The one
+thing Stormkit exports itself is its database connection pool:
+
+| Metric | Meaning |
+| --- | --- |
+| `stormkit_db_connections{state}` | Connections in the pool, `in_use` or `idle` |
+| `stormkit_db_connections_max` | The pool's configured maximum |
+| `stormkit_db_wait_total` | Times a caller had to wait for a free connection |
+| `stormkit_db_wait_seconds_total` | Total time spent waiting |
+| `stormkit_db_closed_total{reason}` | Connections closed, by the limit that closed them |
+
+`stormkit_db_wait_total` is the one worth watching. `postgres_exporter` reports
+what the server sees; it cannot tell you that Stormkit is queuing for a slot in
+its own pool. A sustained wait rate means the pool is undersized, and it can
+happen while PostgreSQL itself looks completely idle.
+
+Stormkit also exports HTTP response time (`stormkit_lb_response_time_ms`) and
+the usual Go runtime metrics.
+
+## Using your own Prometheus
+
+You do not need the bundled stack. Set `PROMETHEUS_METRICS=true` and scrape
+`hosting:2112` and `workerserver:2112` from wherever your Prometheus lives.
+
+`PROMETHEUS_PORT` changes the port. If you set it, it is used exactly as given
+and startup fails loudly if the port is taken — the port never silently moves,
+so your scrape configuration cannot end up pointing at nothing.
+
+The dashboard JSON under `monitoring/grafana/dashboards/` imports into any
+Grafana, as long as your Prometheus datasource has the uid
+`stormkit-prometheus` or you remap it during import.
+
+## Turning it off
+
+```bash
+docker compose --profile monitoring down
+```
+
+Add `-v` to discard the retained metrics data as well. Setting
+`PROMETHEUS_METRICS=false` and recreating the services stops Stormkit exposing
+metrics at all.
+
+## Security notes
+
+- The metrics endpoints on port 2112 are unauthenticated. They are never
+  published to the host — only reachable from inside the Compose network.
+- Prometheus is not published to the host either. Its API is unauthenticated and
+  allows arbitrary queries, so only Grafana can reach it.
+- Grafana binds `127.0.0.1`, disables anonymous access and disables sign-up.
+- `node_exporter` mounts the host filesystem read-only. This is safe because no
+  deployed application code runs in that container. Do not replicate that mount
+  into `hosting` or `workerserver`, where deployments execute as child
+  processes.
+- `postgres_exporter` currently reuses the Stormkit database credentials. If you
+  want to tighten that, create a dedicated monitoring role with
+  `pg_monitor` and point `DATA_SOURCE_NAME` at it.
+
+## Installing the files on an older instance
+
+Instances installed before monitoring existed will not have the configuration on
+disk. From the directory holding your `docker-compose.yaml`:
+
+```bash
+BASE=https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/monitoring
+
+mkdir -p monitoring/grafana/provisioning/datasources \
+         monitoring/grafana/provisioning/dashboards \
+         monitoring/grafana/dashboards
+
+curl -sfo monitoring/prometheus.yml "$BASE/prometheus.yml"
+curl -sfo monitoring/grafana/provisioning/datasources/prometheus.yml "$BASE/grafana/provisioning/datasources/prometheus.yml"
+curl -sfo monitoring/grafana/provisioning/dashboards/dashboards.yml "$BASE/grafana/provisioning/dashboards/dashboards.yml"
+curl -sfo monitoring/grafana/dashboards/stormkit-host.json "$BASE/grafana/dashboards/stormkit-host.json"
+curl -sfo monitoring/grafana/dashboards/stormkit-dependencies.json "$BASE/grafana/dashboards/stormkit-dependencies.json"
+```
+
+You will also need the monitoring services in your `docker-compose.yaml`. The
+simplest route is to re-download it, since the file is not meant to be edited by
+hand:
+
+```bash
+curl -so docker-compose.yaml https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/docker-compose.yaml
+```

--- a/src/ee/workerserver/main.go
+++ b/src/ee/workerserver/main.go
@@ -41,7 +41,7 @@ func main() {
 		slog.Infof("local deployer: %s", conf.Deployer.Executable)
 	}
 
-	if conf.Tracking.Prometheus {
+	if conf.Tracking != nil && conf.Tracking.Prometheus {
 		tracking.Prometheus(tracking.PrometheusOpts{})
 	}
 

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -120,8 +120,14 @@ type DeployerConfig struct {
 }
 
 type TrackingConfig struct {
-	Prometheus             bool
-	PrometheusPort         string
+	Prometheus     bool
+	PrometheusPort string
+
+	// PrometheusPortExplicit reports whether PROMETHEUS_PORT was set by the
+	// operator. A defaulted port is allowed to move when it is already taken;
+	// an explicitly configured one is not.
+	PrometheusPortExplicit bool
+
 	SlowRequestThresholdMs int
 }
 
@@ -330,6 +336,7 @@ func New() *Config {
 		Tracking: &TrackingConfig{
 			Prometheus:             isTrueString(os.Getenv("PROMETHEUS_METRICS")),
 			PrometheusPort:         get(os.Getenv("PROMETHEUS_PORT"), "2112"),
+			PrometheusPortExplicit: os.Getenv("PROMETHEUS_PORT") != "",
 			SlowRequestThresholdMs: getInt(os.Getenv("STORMKIT_SLOW_REQUEST_THRESHOLD_MS"), 0),
 		},
 

--- a/src/lib/database/connection.go
+++ b/src/lib/database/connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lib/pq"
@@ -29,7 +30,10 @@ type DBConf struct {
 	DriverName string
 }
 
-var _db *sql.DB
+// _db is read without the mutex so that observers such as the metrics endpoint
+// never wait on the connect path, which holds dbmux across NewConnection's
+// retry loop. dbmux still serialises establishing the pool.
+var _db atomic.Pointer[sql.DB]
 
 // Config holds the current configuration instance.
 var Config DBConf
@@ -45,11 +49,14 @@ func Connection() *sql.DB {
 	dbmux.Lock()
 	defer dbmux.Unlock()
 
-	if _db == nil {
-		_db = NewConnection()
+	if db := _db.Load(); db != nil {
+		return db
 	}
 
-	return _db
+	db := NewConnection()
+	_db.Store(db)
+
+	return db
 }
 
 type ConnectionOptions struct {
@@ -117,17 +124,19 @@ func NewConnectionWithConfig(cfg DBConf) (*sql.DB, error) {
 // SetConnection replaces the cached sql connection with the given argument value.
 // It is useful for tests so that they can mock the sql connection.
 func SetConnection(db *sql.DB) {
-	_db = db
+	_db.Store(db)
 }
 
 // CurrentConnection returns the established connection, or nil when there is
 // none yet. Unlike Connection it never opens one, so observers such as the
 // metrics endpoint cannot trigger a connect and ping of their own.
+//
+// It also never takes dbmux: Connection holds that across NewConnection's retry
+// loop, which sleeps 5 seconds between five attempts. A scrape that waited on
+// it would exceed Prometheus' scrape timeout during exactly the database
+// outage the pool metrics exist to explain.
 func CurrentConnection() *sql.DB {
-	dbmux.Lock()
-	defer dbmux.Unlock()
-
-	return _db
+	return _db.Load()
 }
 
 // IsDuplicate checks whether an error is a duplicate error or not.

--- a/src/lib/database/connection.go
+++ b/src/lib/database/connection.go
@@ -120,6 +120,16 @@ func SetConnection(db *sql.DB) {
 	_db = db
 }
 
+// CurrentConnection returns the established connection, or nil when there is
+// none yet. Unlike Connection it never opens one, so observers such as the
+// metrics endpoint cannot trigger a connect and ping of their own.
+func CurrentConnection() *sql.DB {
+	dbmux.Lock()
+	defer dbmux.Unlock()
+
+	return _db
+}
+
 // IsDuplicate checks whether an error is a duplicate error or not.
 func IsDuplicate(dberr error) bool {
 	duplicateErrCode := "23505"

--- a/src/lib/tracking/dbpool.go
+++ b/src/lib/tracking/dbpool.go
@@ -1,0 +1,94 @@
+package tracking
+
+import (
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	dbConnectionsDesc = prometheus.NewDesc(
+		"stormkit_db_connections",
+		"Connections in the Stormkit database pool by state.",
+		[]string{"state"},
+		nil,
+	)
+
+	dbConnectionsMaxDesc = prometheus.NewDesc(
+		"stormkit_db_connections_max",
+		"Maximum number of open connections the pool allows.",
+		nil,
+		nil,
+	)
+
+	dbWaitTotalDesc = prometheus.NewDesc(
+		"stormkit_db_wait_total",
+		"Total number of times a caller had to wait for a free connection. A sustained rate here means the pool is undersized.",
+		nil,
+		nil,
+	)
+
+	dbWaitSecondsDesc = prometheus.NewDesc(
+		"stormkit_db_wait_seconds_total",
+		"Total time callers spent waiting for a free connection, in seconds.",
+		nil,
+		nil,
+	)
+
+	dbClosedTotalDesc = prometheus.NewDesc(
+		"stormkit_db_closed_total",
+		"Total number of connections closed by the pool, by the limit that closed them.",
+		[]string{"reason"},
+		nil,
+	)
+)
+
+// dbPoolCollector exports connection pool saturation.
+//
+// postgres_exporter reports the server's view of connections. It cannot see
+// that Stormkit is queuing for a slot in its own pool, which is what
+// stormkit_db_wait_total measures — the pool can be starving while Postgres
+// looks idle.
+//
+// The pool is resolved at scrape time rather than held, so registering the
+// collector never forces a database connection to be opened.
+type dbPoolCollector struct {
+	db func() *sql.DB
+}
+
+func newDBPoolCollector(db func() *sql.DB) *dbPoolCollector {
+	return &dbPoolCollector{db: db}
+}
+
+func (c *dbPoolCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- dbConnectionsDesc
+	ch <- dbConnectionsMaxDesc
+	ch <- dbWaitTotalDesc
+	ch <- dbWaitSecondsDesc
+	ch <- dbClosedTotalDesc
+}
+
+func (c *dbPoolCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.db == nil {
+		return
+	}
+
+	db := c.db()
+
+	// Export nothing rather than zeroes when there is no pool yet. A flat zero
+	// would read as an idle, healthy pool.
+	if db == nil {
+		return
+	}
+
+	stats := db.Stats()
+
+	ch <- prometheus.MustNewConstMetric(dbConnectionsDesc, prometheus.GaugeValue, float64(stats.InUse), "in_use")
+	ch <- prometheus.MustNewConstMetric(dbConnectionsDesc, prometheus.GaugeValue, float64(stats.Idle), "idle")
+	ch <- prometheus.MustNewConstMetric(dbConnectionsMaxDesc, prometheus.GaugeValue, float64(stats.MaxOpenConnections))
+	ch <- prometheus.MustNewConstMetric(dbWaitTotalDesc, prometheus.CounterValue, float64(stats.WaitCount))
+	ch <- prometheus.MustNewConstMetric(dbWaitSecondsDesc, prometheus.CounterValue, stats.WaitDuration.Seconds())
+	ch <- prometheus.MustNewConstMetric(dbClosedTotalDesc, prometheus.CounterValue, float64(stats.MaxIdleClosed), "max_idle")
+	ch <- prometheus.MustNewConstMetric(dbClosedTotalDesc, prometheus.CounterValue, float64(stats.MaxIdleTimeClosed), "max_idle_time")
+	ch <- prometheus.MustNewConstMetric(dbClosedTotalDesc, prometheus.CounterValue, float64(stats.MaxLifetimeClosed), "max_lifetime")
+}

--- a/src/lib/tracking/dbpool_test.go
+++ b/src/lib/tracking/dbpool_test.go
@@ -1,0 +1,125 @@
+package tracking
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/suite"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// fakeDriver hands out connections without a server, so pool behaviour can be
+// exercised without a live database.
+type fakeDriver struct{}
+
+func (fakeDriver) Open(string) (driver.Conn, error) { return &fakeConn{}, nil }
+
+type fakeConn struct{}
+
+func (*fakeConn) Prepare(string) (driver.Stmt, error) { return nil, errNotImplemented }
+func (*fakeConn) Close() error                        { return nil }
+func (*fakeConn) Begin() (driver.Tx, error)           { return nil, errNotImplemented }
+
+func init() {
+	sql.Register("trackingfake", fakeDriver{})
+}
+
+type DBPoolSuite struct {
+	suite.Suite
+
+	db *sql.DB
+}
+
+func (s *DBPoolSuite) SetupTest() {
+	db, err := sql.Open("trackingfake", "")
+	s.Require().NoError(err)
+
+	db.SetMaxOpenConns(7)
+
+	s.db = db
+}
+
+func (s *DBPoolSuite) TearDownTest() {
+	s.NoError(s.db.Close())
+}
+
+// collect gathers the collector into a name+label keyed map.
+func (s *DBPoolSuite) collect(c prometheus.Collector) map[string]float64 {
+	reg := prometheus.NewPedanticRegistry()
+	s.Require().NoError(reg.Register(c))
+
+	families, err := reg.Gather()
+	s.Require().NoError(err)
+
+	values := map[string]float64{}
+
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			key := family.GetName()
+
+			for _, label := range metric.GetLabel() {
+				key += "|" + label.GetValue()
+			}
+
+			switch {
+			case metric.GetGauge() != nil:
+				values[key] = metric.GetGauge().GetValue()
+			case metric.GetCounter() != nil:
+				values[key] = metric.GetCounter().GetValue()
+			}
+		}
+	}
+
+	return values
+}
+
+func (s *DBPoolSuite) Test_ExportsEverySeries() {
+	values := s.collect(newDBPoolCollector(func() *sql.DB { return s.db }))
+
+	s.Len(values, 8)
+
+	s.Contains(values, "stormkit_db_connections|in_use")
+	s.Contains(values, "stormkit_db_connections|idle")
+	s.Contains(values, "stormkit_db_wait_total")
+	s.Contains(values, "stormkit_db_wait_seconds_total")
+	s.Contains(values, "stormkit_db_closed_total|max_idle")
+	s.Contains(values, "stormkit_db_closed_total|max_idle_time")
+	s.Contains(values, "stormkit_db_closed_total|max_lifetime")
+}
+
+func (s *DBPoolSuite) Test_ReportsConfiguredMaxConnections() {
+	values := s.collect(newDBPoolCollector(func() *sql.DB { return s.db }))
+
+	s.Equal(float64(7), values["stormkit_db_connections_max"])
+}
+
+func (s *DBPoolSuite) Test_InUseTracksHeldConnection() {
+	collector := newDBPoolCollector(func() *sql.DB { return s.db })
+
+	s.Equal(float64(0), s.collect(collector)["stormkit_db_connections|in_use"])
+
+	conn, err := s.db.Conn(context.Background())
+	s.Require().NoError(err)
+
+	s.Equal(float64(1), s.collect(collector)["stormkit_db_connections|in_use"])
+
+	s.Require().NoError(conn.Close())
+
+	s.Equal(float64(0), s.collect(collector)["stormkit_db_connections|in_use"])
+}
+
+// A pool that does not exist yet must export nothing. Zeroes would read as an
+// idle, healthy pool.
+func (s *DBPoolSuite) Test_NoPoolExportsNothing() {
+	s.Empty(s.collect(newDBPoolCollector(nil)))
+	s.Empty(s.collect(newDBPoolCollector(func() *sql.DB { return nil })))
+}
+
+func TestDBPoolSuite(t *testing.T) {
+	suite.Run(t, new(DBPoolSuite))
+}

--- a/src/lib/tracking/prometheus.go
+++ b/src/lib/tracking/prometheus.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -128,14 +129,20 @@ type metricsListener struct {
 }
 
 func (m *metricsListener) listen() (net.Listener, error) {
-	port := utils.StringToInt(m.port)
+	// Parsed strictly rather than through utils.StringToInt, which reports a
+	// bad value as 0 and would make net.Listen pick an arbitrary free port --
+	// silently the one thing an explicitly configured port must never do.
+	port, err := strconv.Atoi(m.port)
+
+	if err != nil || port < 1 || port > 65535 {
+		return nil, fmt.Errorf("invalid metrics port %q", m.port)
+	}
+
 	attempts := 1
 
 	if m.probe {
 		attempts = maxPortProbeAttempts
 	}
-
-	var err error
 
 	for i := range attempts {
 		var ln net.Listener

--- a/src/lib/tracking/prometheus.go
+++ b/src/lib/tracking/prometheus.go
@@ -1,10 +1,12 @@
 package tracking
 
 import (
+	"errors"
 	"fmt"
-	"log"
+	"net"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -12,23 +14,74 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
-	"go.uber.org/zap"
 )
 
+const (
+	metricsReadHeaderTimeout = 5 * time.Second
+	maxPortProbeAttempts     = 10
+)
+
+// PrometheusOpts configures the metrics endpoint.
 type PrometheusOpts struct {
+	// Apdex registers the HTTP response time histogram. Only the hosting
+	// service serves customer traffic, so only it enables this.
 	Apdex bool
+
+	// Port overrides the configured metrics port. When set, the listener binds
+	// it strictly and never probes for a free one.
+	Port string
 }
 
-func Prometheus(opts PrometheusOpts) {
-	// Create a new registry.
+// Prometheus starts the metrics endpoint on its own listener and returns the
+// server so callers can shut it down.
+//
+// It never terminates the process. A metrics port that cannot be bound must not
+// take down a service that is busy serving traffic.
+func Prometheus(opts PrometheusOpts) *http.Server {
+	listener := &metricsListener{port: opts.Port}
+
+	if listener.port == "" {
+		conf := config.Get()
+		listener.port = conf.Tracking.PrometheusPort
+
+		// Only a defaulted port may move. An operator who names a port gets
+		// that port or a loud failure, never a silently different one that
+		// leaves their scrape config pointing at nothing.
+		listener.probe = !conf.Tracking.PrometheusPortExplicit
+	}
+
+	ln, err := listener.listen()
+
+	if err != nil {
+		slog.Errorf("prometheus metrics disabled, could not listen on port %s: %v", listener.port, err)
+		return nil
+	}
+
+	srv := &http.Server{
+		Handler:           metricsMux(newRegistry(opts)),
+		ReadHeaderTimeout: metricsReadHeaderTimeout,
+	}
+
+	slog.Infof("prometheus metrics available at /metrics, port: %s", listenerPort(ln))
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Errorf("prometheus metrics server stopped: %v", err)
+		}
+	}()
+
+	return srv
+}
+
+// newRegistry builds a dedicated registry. Collectors that are not registered
+// here are never scraped, so every Stormkit metric must be added below.
+func newRegistry(opts PrometheusOpts) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
 
-	// Stormkit related exports
 	if opts.Apdex {
 		reg.MustRegister(RTHistogramProdEndpoints)
 	}
 
-	// Add Go module build info.
 	reg.MustRegister(collectors.NewBuildInfoCollector())
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	reg.MustRegister(collectors.NewGoCollector(
@@ -37,8 +90,16 @@ func Prometheus(opts PrometheusOpts) {
 		}),
 	))
 
-	// Start HTTP server for Prometheus to scrape metrics
-	http.Handle("/metrics", promhttp.HandlerFor(
+	return reg
+}
+
+// metricsMux serves the registry on a dedicated mux rather than the default one,
+// so /metrics cannot leak onto any other listener that happens to serve
+// http.DefaultServeMux.
+func metricsMux(reg *prometheus.Registry) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	mux.Handle("/metrics", promhttp.HandlerFor(
 		reg,
 		promhttp.HandlerOpts{
 			// Opt into OpenMetrics to support exemplars.
@@ -46,28 +107,49 @@ func Prometheus(opts PrometheusOpts) {
 		},
 	))
 
-	go func() {
-		conf := config.Get()
+	return mux
+}
 
-		for i := 0; i < 10; i++ {
-			port := utils.StringToInt(conf.Tracking.PrometheusPort)
+// metricsListener binds the metrics port.
+//
+// Probing exists for local development, where goreman runs hosting and
+// workerserver as processes on the same host and they would otherwise fight
+// over the same port. In Docker each service has its own network namespace, so
+// nothing collides and the port stays where the scrape config expects it.
+type metricsListener struct {
+	port  string
+	probe bool
+}
 
-			if !utils.IsPortInUse(port) {
-				break
-			}
+func (m *metricsListener) listen() (net.Listener, error) {
+	port := utils.StringToInt(m.port)
+	attempts := 1
 
-			slog.Debug(slog.LogOpts{
-				Msg:   "prometheus port is already in use, picking a new one",
-				Level: slog.DL1,
-				Payload: []zap.Field{
-					zap.String("port", conf.Tracking.PrometheusPort),
-				},
-			})
+	if m.probe {
+		attempts = maxPortProbeAttempts
+	}
 
-			conf.Tracking.PrometheusPort = utils.Int64ToString(int64(port + 1))
+	var err error
+
+	for i := range attempts {
+		var ln net.Listener
+
+		if ln, err = net.Listen("tcp", fmt.Sprintf(":%d", port+i)); err == nil {
+			return ln, nil
 		}
 
-		slog.Infof("prometheus metrics available at /metrics, port: %s", conf.Tracking.PrometheusPort)
-		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", conf.Tracking.PrometheusPort), nil))
-	}()
+		if m.probe {
+			slog.Infof("prometheus port %d is in use, trying the next one", port+i)
+		}
+	}
+
+	return nil, err
+}
+
+func listenerPort(ln net.Listener) string {
+	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
+		return utils.Int64ToString(int64(addr.Port))
+	}
+
+	return ln.Addr().String()
 }

--- a/src/lib/tracking/prometheus.go
+++ b/src/lib/tracking/prometheus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/database"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
@@ -81,6 +82,11 @@ func newRegistry(opts PrometheusOpts) *prometheus.Registry {
 	if opts.Apdex {
 		reg.MustRegister(RTHistogramProdEndpoints)
 	}
+
+	// Both binaries hold a pool, so both report their own saturation.
+	// CurrentConnection never opens one, so a scrape cannot make the metrics
+	// endpoint sit waiting on the database it is reporting about.
+	reg.MustRegister(newDBPoolCollector(database.CurrentConnection))
 
 	reg.MustRegister(collectors.NewBuildInfoCollector())
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))

--- a/src/lib/tracking/prometheus_test.go
+++ b/src/lib/tracking/prometheus_test.go
@@ -2,6 +2,7 @@ package tracking
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stormkit-io/stormkit-io/src/lib/database"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -50,6 +52,24 @@ func (s *PrometheusSuite) Test_ApdexRegisteredOnlyWhenEnabled() {
 
 	s.Contains(s.gathered(PrometheusOpts{Apdex: true}), "stormkit_lb_response_time_ms")
 	s.NotContains(s.gathered(PrometheusOpts{Apdex: false}), "stormkit_lb_response_time_ms")
+}
+
+// Registration is easy to get wrong silently: a collector left out of
+// newRegistry is simply never scraped, and the dashboards show "No data".
+func (s *PrometheusSuite) Test_DatabasePoolRegisteredOnEveryProfile() {
+	db, err := sql.Open("trackingfake", "")
+	s.Require().NoError(err)
+
+	defer db.Close()
+
+	previous := database.CurrentConnection()
+	database.SetConnection(db)
+
+	defer database.SetConnection(previous)
+
+	for _, opts := range []PrometheusOpts{{Apdex: true}, {Apdex: false}} {
+		s.Contains(s.gathered(opts), "stormkit_db_connections")
+	}
 }
 
 func (s *PrometheusSuite) Test_RuntimeCollectorsAlwaysRegistered() {

--- a/src/lib/tracking/prometheus_test.go
+++ b/src/lib/tracking/prometheus_test.go
@@ -159,6 +159,24 @@ func (s *PrometheusSuite) Test_DefaultPortProbesWhenBusy() {
 	s.Equal(port+1, ln.Addr().(*net.TCPAddr).Port)
 }
 
+// A port that does not parse must be refused. Falling back to 0 would make
+// net.Listen pick an arbitrary free port, which is the silent move that an
+// explicitly configured port is supposed to rule out.
+func (s *PrometheusSuite) Test_InvalidPortIsRefused() {
+	for _, port := range []string{"2112 ", ":2112", "abc", "", "0", "70000", "-1"} {
+		listener := &metricsListener{port: port, probe: false}
+
+		ln, err := listener.listen()
+
+		s.Error(err, "port %q should be refused", port)
+
+		if ln != nil {
+			ln.Close()
+			s.Fail("port %q bound a listener instead of failing", port)
+		}
+	}
+}
+
 func TestPrometheusSuite(t *testing.T) {
 	suite.Run(t, new(PrometheusSuite))
 }

--- a/src/lib/tracking/prometheus_test.go
+++ b/src/lib/tracking/prometheus_test.go
@@ -1,0 +1,144 @@
+package tracking
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PrometheusSuite struct {
+	suite.Suite
+}
+
+func (s *PrometheusSuite) gathered(opts PrometheusOpts) string {
+	server := httptest.NewServer(metricsMux(newRegistry(opts)))
+	defer server.Close()
+
+	res, err := http.Get(server.URL + "/metrics")
+	s.Require().NoError(err)
+
+	defer res.Body.Close()
+	s.Equal(http.StatusOK, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	s.Require().NoError(err)
+
+	return string(body)
+}
+
+// freePort binds and releases a port so we know it was available.
+func (s *PrometheusSuite) freePort() int {
+	ln, err := net.Listen("tcp", ":0")
+	s.Require().NoError(err)
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	s.Require().NoError(ln.Close())
+
+	return port
+}
+
+func (s *PrometheusSuite) Test_ApdexRegisteredOnlyWhenEnabled() {
+	// A histogram vec with no observations exports no series at all, so the
+	// metric has to be touched before it can be seen in the output.
+	RTHistogramProdEndpoints.WithLabelValues(http.MethodGet, "200").Observe(1)
+
+	s.Contains(s.gathered(PrometheusOpts{Apdex: true}), "stormkit_lb_response_time_ms")
+	s.NotContains(s.gathered(PrometheusOpts{Apdex: false}), "stormkit_lb_response_time_ms")
+}
+
+func (s *PrometheusSuite) Test_RuntimeCollectorsAlwaysRegistered() {
+	body := s.gathered(PrometheusOpts{})
+
+	s.Contains(body, "go_goroutines")
+	s.Contains(body, "process_resident_memory_bytes")
+}
+
+func (s *PrometheusSuite) Test_MetricsEndpointServesRegistry() {
+	server := httptest.NewServer(metricsMux(newRegistry(PrometheusOpts{Apdex: true})))
+	defer server.Close()
+
+	res, err := http.Get(server.URL + "/metrics")
+	s.Require().NoError(err)
+
+	defer res.Body.Close()
+	s.Equal(http.StatusOK, res.StatusCode)
+}
+
+// The metrics handler must not land on the global mux, or it would leak onto
+// any other listener that serves http.DefaultServeMux.
+func (s *PrometheusSuite) Test_MetricsNotOnDefaultServeMux() {
+	srv := Prometheus(PrometheusOpts{Port: fmt.Sprintf("%d", s.freePort())})
+	s.Require().NotNil(srv)
+
+	defer srv.Shutdown(context.Background())
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	handler, pattern := http.DefaultServeMux.Handler(req)
+
+	s.Empty(pattern, "metrics must not be registered on the default mux")
+	s.NotNil(handler)
+}
+
+// Regression test for the listener calling log.Fatal: a metrics port that is
+// already taken must never bring down the process serving traffic.
+func (s *PrometheusSuite) Test_ServerSurvivesPortInUse() {
+	port := s.freePort()
+
+	blocker, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	s.Require().NoError(err)
+
+	defer blocker.Close()
+
+	srv := Prometheus(PrometheusOpts{Port: fmt.Sprintf("%d", port)})
+
+	s.Nil(srv, "an explicit port that is taken should fail rather than move")
+	s.True(true, "process is still alive")
+}
+
+// An explicitly configured port must be bound strictly. Silently moving it
+// leaves the operator with a DOWN scrape target against a running container.
+func (s *PrometheusSuite) Test_ExplicitPortDoesNotProbe() {
+	port := s.freePort()
+
+	blocker, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	s.Require().NoError(err)
+
+	defer blocker.Close()
+
+	listener := &metricsListener{port: fmt.Sprintf("%d", port), probe: false}
+
+	ln, err := listener.listen()
+
+	s.Error(err)
+	s.Nil(ln)
+}
+
+// Probing is what lets goreman run hosting and workerserver side by side in
+// local development. It must keep working.
+func (s *PrometheusSuite) Test_DefaultPortProbesWhenBusy() {
+	port := s.freePort()
+
+	blocker, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	s.Require().NoError(err)
+
+	defer blocker.Close()
+
+	listener := &metricsListener{port: fmt.Sprintf("%d", port), probe: true}
+
+	ln, err := listener.listen()
+
+	s.Require().NoError(err)
+	defer ln.Close()
+
+	s.Equal(port+1, ln.Addr().(*net.TCPAddr).Port)
+}
+
+func TestPrometheusSuite(t *testing.T) {
+	suite.Run(t, new(PrometheusSuite))
+}

--- a/src/www/public/install.sh
+++ b/src/www/public/install.sh
@@ -255,11 +255,19 @@ setup_monitoring_configs() {
     monitoring/grafana/provisioning/dashboards \
     monitoring/grafana/dashboards
 
-  curl -o "monitoring/prometheus.yml" "$base/prometheus.yml" --silent
-  curl -o "monitoring/grafana/provisioning/datasources/prometheus.yml" "$base/grafana/provisioning/datasources/prometheus.yml" --silent
-  curl -o "monitoring/grafana/provisioning/dashboards/dashboards.yml" "$base/grafana/provisioning/dashboards/dashboards.yml" --silent
-  curl -o "monitoring/grafana/dashboards/stormkit-host.json" "$base/grafana/dashboards/stormkit-host.json" --silent
-  curl -o "monitoring/grafana/dashboards/stormkit-dependencies.json" "$base/grafana/dashboards/stormkit-dependencies.json" --silent
+  # -f matters here: without it curl writes the 404 body to disk and still
+  # exits 0, so a missing file surfaces months later as a Prometheus that
+  # cannot parse its own config.
+  for file in prometheus.yml \
+    grafana/provisioning/datasources/prometheus.yml \
+    grafana/provisioning/dashboards/dashboards.yml \
+    grafana/dashboards/stormkit-host.json \
+    grafana/dashboards/stormkit-dependencies.json; do
+    if ! curl -fsS -o "monitoring/$file" "$base/$file"; then
+      echo "Failed to download monitoring/$file" >&2
+      exit 1
+    fi
+  done
 }
 
 DOMAIN=""

--- a/src/www/public/install.sh
+++ b/src/www/public/install.sh
@@ -238,6 +238,28 @@ setup_base_env_variables() {
 
   update_env_var_in_env_file POSTGRES_PASSWORD $(rand_alnum 12 24)
   update_env_var_in_env_file STORMKIT_APP_SECRET $(rand_alnum 48 32)
+  update_env_var_in_env_file GRAFANA_ADMIN_PASSWORD $(rand_alnum 12 24)
+}
+
+# Downloads the Prometheus and Grafana configuration.
+#
+# These are always fetched, even though nothing here runs by default: the
+# `monitoring` compose profile is what decides that. Having the files on disk
+# means turning monitoring on later is a flag flip rather than a download.
+#
+# Keep this list in sync with deploy/monitoring/ in the repository.
+setup_monitoring_configs() {
+  base="https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/monitoring"
+
+  mkdir -p monitoring/grafana/provisioning/datasources \
+    monitoring/grafana/provisioning/dashboards \
+    monitoring/grafana/dashboards
+
+  curl -o "monitoring/prometheus.yml" "$base/prometheus.yml" --silent
+  curl -o "monitoring/grafana/provisioning/datasources/prometheus.yml" "$base/grafana/provisioning/datasources/prometheus.yml" --silent
+  curl -o "monitoring/grafana/provisioning/dashboards/dashboards.yml" "$base/grafana/provisioning/dashboards/dashboards.yml" --silent
+  curl -o "monitoring/grafana/dashboards/stormkit-host.json" "$base/grafana/dashboards/stormkit-host.json" --silent
+  curl -o "monitoring/grafana/dashboards/stormkit-dependencies.json" "$base/grafana/dashboards/stormkit-dependencies.json" --silent
 }
 
 DOMAIN=""
@@ -332,6 +354,7 @@ setup_agent_env() {
 curl -o "docker-compose.yaml" "https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/docker-compose.yaml" --silent
 
 setup_base_env_variables
+setup_monitoring_configs
 setup_domain
 
 if [ "$AGENT_MODE" = "1" ]; then


### PR DESCRIPTION
## What

An opt-in monitoring stack for self-hosted instances: Prometheus, Grafana, and the standard exporters for the host, PostgreSQL and Redis, with two pre-provisioned dashboards.

```bash
sed -i 's/^PROMETHEUS_METRICS=.*/PROMETHEUS_METRICS=true/' .env
docker compose --profile monitoring up -d
```

Then `ssh -L 3000:127.0.0.1:3000 you@server`. The dashboards are already there; nothing to import.

## Why this shape

This replaces #409, which built a machine-health page inside the product and was closed on scope. Monitoring machines isn't Stormkit's job, and the exporters do it better. The target here is **instance health** — CPU, memory, disk, database, Redis — not application counters. Per-app traffic already lives in Access Logs and Analytics, so these dashboards deliberately have no app dimension.

Almost none of this needs Stormkit code. `node_exporter` covers total and free disk per filesystem, which was the actual ask.

## The one thing Stormkit has to export

`postgres_exporter` reports what the *server* sees. It cannot tell you Stormkit is queuing for a slot in its own connection pool — that can happen while PostgreSQL looks completely idle. `stormkit_db_wait_total` is that missing signal, and a sustained rate on it means the pool is undersized.

The collector reads `sql.DBStats` at scrape time through `database.CurrentConnection`, added here, which returns the established pool or nil. It deliberately does not use `Connection()`, which opens and pings — a scrape must never leave the metrics endpoint waiting on the database it is reporting about. With no pool it exports nothing rather than zeroes, since a flat zero reads as an idle, healthy pool.

## Metrics listener fixes

`tracking.Prometheus` could take down the process it was measuring: a bind failure called `log.Fatal` from inside a goroutine. It also registered `/metrics` on `http.DefaultServeMux`. Both fixed, plus `ReadHeaderTimeout` on what is an unauthenticated endpoint.

The port probe is **kept**, but only for a defaulted port. It exists so `goreman` can run hosting and workerserver side by side in development, where both read the same `PROMETHEUS_PORT`. An operator who names a port now gets that port or a loud failure, never a silently different one that leaves their scrape config pointing at nothing. In Docker each service has its own namespace, so the probe never fires and the target stays deterministic.

## Notable decisions

- **`node_exporter` sits on the `stormkit` bridge network, not host networking.** This is the trap #409 fell into — with host networking the exporter is unreachable by container name. It still reports the machine: `/proc/stat` and `/proc/meminfo` are not namespaced, and `--path.rootfs` plus a read-only bind of `/` cover filesystems. The trade is per-interface network counters describing the container, which these dashboards don't chart. Mounting host root is safe in a container where no deployed app code runs — the same reasoning that made #409 reject mounting it into `hosting`.
- **No `rslave` propagation.** Docker Desktop rejects it outright, so the container would not start on any developer machine. The Linux cost is that a filesystem mounted after startup needs a container restart.
- **Prometheus is not published to the host.** Its API is unauthenticated; only Grafana reaches it. Grafana binds loopback, disables anonymous access and sign-up, and refuses to start without `GRAFANA_ADMIN_PASSWORD` rather than falling back to `admin/admin`. `install.sh` generates one.
- **Configs ship with every install**, not behind a flag. The compose profile already decides what runs, so an operator who never enables monitoring pays a few KB. A flag would only add a way to end up half-installed.
- **Images are pinned**, since the dashboards are tied to a Grafana schema version.

## Testing

New suites for the listener (including a regression test that a taken port no longer kills the process, and the pair pinning default-probes / explicit-does-not) and for the pool collector, which uses a small in-process SQL driver so `in_use` is exercised with a real held connection rather than asserted at zero. A registration test covers the collector actually being wired into the registry — with no pool it emits nothing either way, so an omission would only surface as "No data" on a dashboard.

CI lints the things that fail silently: dashboard JSON, that every panel points at the provisioned datasource uid, that all 37 PromQL expressions parse, and that the compose profile is valid.

Verified by running the stack: Prometheus resolves `node-exporter` by container name and the target is up, node_exporter reports the machine rather than the container, Grafana provisions both dashboards, and every host-dashboard expression returns live data.

## Not verified

That the figures match a real Linux host. On macOS node_exporter reports the Docker Desktop VM, so comparing against `df -h` and `top` proves nothing — the same limitation #409 hit. Worth checking on a real server before merge, along with `stormkit_db_wait_total` incrementing under pool pressure.

## Scope

No alerting rules — thresholds we cannot tune per-installation invite either fatigue or false confidence. No cAdvisor. No deploy or queue counters. `postgres_exporter` reuses the app credentials for now; a least-privilege `pg_monitor` role is noted in the docs as a hardening step.