### PR TITLE
feat(monitoring): add request metrics dashboard

### DIFF
--- a/.github/workflows/lint-monitoring.yml
+++ b/.github/workflows/lint-monitoring.yml
@@ -5,11 +5,15 @@ on:
     branches: [main]
     paths:
       - "deploy/**"
+      - "src/www/public/install.sh"
+      - "docs/self-hosting/8-monitoring.md"
       - ".github/workflows/lint-monitoring.yml"
   push:
     branches: [main]
     paths:
       - "deploy/**"
+      - "src/www/public/install.sh"
+      - "docs/self-hosting/8-monitoring.md"
       - ".github/workflows/lint-monitoring.yml"
 
 # Reading the checkout is all this workflow does. Nothing here writes to the
@@ -36,6 +40,27 @@ jobs:
           for file in deploy/monitoring/grafana/dashboards/*.json; do
             jq empty "$file"
           done
+
+      # A dashboard committed here but missing from the installer or the
+      # upgrade docs exists only in the repository: Grafana provisions from
+      # whatever is on the operator's disk, so the panel simply never appears
+      # and nothing errors. Both lists are hand-maintained, so check them.
+      - name: Check dashboards are shipped
+        run: |
+          missing=0
+
+          for file in deploy/monitoring/grafana/dashboards/*.json; do
+            name=$(basename "$file")
+
+            for consumer in src/www/public/install.sh docs/self-hosting/8-monitoring.md; do
+              if ! grep -q "$name" "$consumer"; then
+                echo "$name is not downloaded by $consumer"
+                missing=1
+              fi
+            done
+          done
+
+          exit "$missing"
 
       # A dashboard that references a datasource Grafana did not provision
       # renders every panel empty, which looks like a broken metrics pipeline

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -94,5 +94,11 @@ GRAFANA_ADMIN_PASSWORD=''
 # ssh -L 3000:127.0.0.1:3000 you@your-server
 GRAFANA_PORT=3000
 
+# The absolute URL Grafana builds its post-login redirect and share links from.
+# Defaults to http://localhost:$GRAFANA_PORT, which is right for the SSH tunnel.
+# Set it only when you put Grafana behind a reverse proxy on a public hostname,
+# otherwise logging in bounces the browser back to localhost.
+# GRAFANA_ROOT_URL=https://grafana.example.org
+
 # How long Prometheus keeps metrics for.
 PROMETHEUS_RETENTION=15d

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -316,6 +316,18 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_AUTH_ANONYMOUS_ENABLED=false
+
+      # Installing a plugin from the UI runs that plugin's code inside this
+      # container, which sits on the same network as Postgres and Redis. That
+      # turns the admin password into remote code execution next to the
+      # database, so the catalogue is off. Mount a plugin into the image if you
+      # genuinely need one.
+      - GF_PLUGINS_PLUGIN_ADMIN_ENABLED=false
+
+      # Grafana derives absolute URLs (the post-login redirect, share links)
+      # from this. It only needs setting if you put Grafana behind a proxy on a
+      # public hostname; the loopback default is right for the SSH tunnel.
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost:${GRAFANA_PORT:-3000}}
     volumes:
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro

--- a/deploy/monitoring/grafana/dashboards/stormkit-requests.json
+++ b/deploy/monitoring/grafana/dashboards/stormkit-requests.json
@@ -22,15 +22,15 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Apdex (T = 100ms)",
-      "description": "Requests under 100ms count as satisfied, under 500ms as tolerating at half weight. 500ms is the nearest histogram bucket to the textbook 4T, since there is no 400ms boundary.",
+      "title": "Apdex (T = 250ms)",
+      "description": "Successful requests under 250ms count as satisfied, under 1s as tolerating at half weight. T is 250ms because 250 and 4T = 1000 are both exact histogram bucket boundaries, so the standard Apdex definition applies with no approximation. Only 2xx and 3xx responses can score; errors stay in the denominator, so a fast 500 counts as frustrated rather than satisfied. The expression is the standard (satisfied + tolerating/2) / total, algebraically reduced.",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
       "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
       "targets": [
         {
           "refId": "A",
           "legendFormat": "Apdex",
-          "expr": "(\n  sum(rate(stormkit_lb_response_time_ms_bucket{le=\"100.0\"}[5m]))\n  + (\n      sum(rate(stormkit_lb_response_time_ms_bucket{le=\"500.0\"}[5m]))\n      - sum(rate(stormkit_lb_response_time_ms_bucket{le=\"100.0\"}[5m]))\n    ) * 0.5\n) / sum(rate(stormkit_lb_response_time_ms_bucket{le=\"+Inf\"}[5m]))",
+          "expr": "(\n  sum(rate(stormkit_lb_response_time_ms_bucket{le=\"250.0\",status_code=~\"2..|3..\"}[5m]))\n  + sum(rate(stormkit_lb_response_time_ms_bucket{le=\"1000.0\",status_code=~\"2..|3..\"}[5m]))\n) / (2 * sum(rate(stormkit_lb_response_time_ms_bucket{le=\"+Inf\"}[5m])))",
           "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
         }
       ],
@@ -145,7 +145,7 @@
       "id": 4,
       "type": "timeseries",
       "title": "Response time percentiles",
-      "description": "GET and POST requests that returned 2xx or 3xx. Errors are excluded because a fast 404 would otherwise flatter the percentiles.",
+      "description": "GET and POST requests that returned 2xx or 3xx. Errors are excluded because a fast 404 would otherwise flatter the percentiles. Percentiles cannot exceed 5s, the histogram's top bucket: a line sitting flat at exactly 5s means the real value is somewhere above it, and the average response time panel below is unbounded and will show how far.",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
       "targets": [

--- a/deploy/monitoring/grafana/dashboards/stormkit-requests.json
+++ b/deploy/monitoring/grafana/dashboards/stormkit-requests.json
@@ -1,0 +1,268 @@
+{
+  "uid": "stormkit-requests",
+  "title": "Stormkit — Requests",
+  "description": "Throughput, status codes and response times for traffic served by the hosting service. Aggregate only: there is no per-application dimension here, that lives in the Stormkit UI under Analytics.",
+  "tags": ["stormkit"],
+  "editable": false,
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Apdex (T = 100ms)",
+      "description": "Requests under 100ms count as satisfied, under 500ms as tolerating at half weight. 500ms is the nearest histogram bucket to the textbook 4T, since there is no 400ms boundary.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "Apdex",
+          "expr": "(\n  sum(rate(stormkit_lb_response_time_ms_bucket{le=\"100.0\"}[5m]))\n  + (\n      sum(rate(stormkit_lb_response_time_ms_bucket{le=\"500.0\"}[5m]))\n      - sum(rate(stormkit_lb_response_time_ms_bucket{le=\"100.0\"}[5m]))\n    ) * 0.5\n) / sum(rate(stormkit_lb_response_time_ms_bucket{le=\"+Inf\"}[5m]))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.85 },
+              { "color": "green", "value": 0.94 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Requests per minute",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "requests",
+          "expr": "sum(rate(stormkit_lb_response_time_ms_count[5m])) * 60",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqpm",
+          "min": 0,
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Requests by status code",
+      "description": "Requests in each 5 minute window. Status codes are recorded exactly for 200 and 304 and collapsed to a class otherwise, so 4xx covers every client error.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "{{status_code}}",
+          "expr": "sum by (status_code) (increase(stormkit_lb_response_time_ms_count[5m]))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "custom": { "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "200" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "2xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "semi-dark-green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "304" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "3xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "semi-dark-blue" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "4xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "5xx" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "other" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "purple" } }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Response time percentiles",
+      "description": "GET and POST requests that returned 2xx or 3xx. Errors are excluded because a fast 404 would otherwise flatter the percentiles.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "p50",
+          "expr": "histogram_quantile(0.5, sum(rate(stormkit_lb_response_time_ms_bucket{method=~\"GET|POST\",status_code=~\"2..|3..\"}[5m])) by (le))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "B",
+          "legendFormat": "p95",
+          "expr": "histogram_quantile(0.95, sum(rate(stormkit_lb_response_time_ms_bucket{method=~\"GET|POST\",status_code=~\"2..|3..\"}[5m])) by (le))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        },
+        {
+          "refId": "C",
+          "legendFormat": "p99",
+          "expr": "histogram_quantile(0.99, sum(rate(stormkit_lb_response_time_ms_bucket{method=~\"GET|POST\",status_code=~\"2..|3..\"}[5m])) by (le))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Request rate by method",
+      "description": "PUT, PATCH and DELETE are recorded as POST; anything else as OTHER.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "{{method}}",
+          "expr": "sum by (method) (rate(stormkit_lb_response_time_ms_count[5m]))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Request rate by method and status",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "{{method}} — {{status_code}}",
+          "expr": "sum by (method, status_code) (rate(stormkit_lb_response_time_ms_count[5m]))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Average response time by method and status",
+      "description": "The mean is shown per method and status class, which the percentile panel deliberately collapses. Useful for spotting one status class getting slower while the overall percentiles stay flat.",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "legendFormat": "{{method}} — {{status_code}}",
+          "expr": "sum by (method, status_code) (rate(stormkit_lb_response_time_ms_sum[5m]))\n/\nsum by (method, status_code) (rate(stormkit_lb_response_time_ms_count[5m]))",
+          "datasource": { "type": "prometheus", "uid": "stormkit-prometheus" }
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "custom": { "fillOpacity": 0, "lineWidth": 1, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/docs/self-hosting/8-monitoring.md
+++ b/docs/self-hosting/8-monitoring.md
@@ -83,6 +83,14 @@ database size, deadlocks, cache hit ratio and transaction rates; Redis memory
 against `maxmemory`, evictions, hit ratio and client counts. It also has a row
 for Stormkit's own connection pool, described below.
 
+**Stormkit — Requests.** Requests per minute, status codes, request rate by
+method, response time percentiles and an Apdex score, for the traffic served by
+the `hosting` service. Like the other two it has no per-application dimension —
+per-app traffic lives in the Stormkit UI under Analytics. Status codes are
+recorded exactly for `200` and `304` and collapsed to a class (`4xx`, `5xx`)
+otherwise, and every method other than `GET` and the body-carrying verbs shows
+up as `OTHER`.
+
 The first panel on the Host dashboard is **Scrape targets up**, expected to read
 5. If it reads 3, the two `stormkit-*` targets are down and
 `PROMETHEUS_METRICS` is almost certainly still `false`.
@@ -105,7 +113,8 @@ what the server sees; it cannot tell you that Stormkit is queuing for a slot in
 its own pool. A sustained wait rate means the pool is undersized, and it can
 happen while PostgreSQL itself looks completely idle.
 
-Stormkit also exports HTTP response time (`stormkit_lb_response_time_ms`) and
+Stormkit also exports HTTP response time (`stormkit_lb_response_time_ms`, the
+histogram behind the Requests dashboard) and
 the usual Go runtime metrics.
 
 ## Using your own Prometheus
@@ -138,10 +147,23 @@ metrics at all.
 ## Security notes
 
 - The metrics endpoints on port 2112 are unauthenticated. They are never
-  published to the host — only reachable from inside the Compose network.
+  published to the host, so they are not reachable from outside the machine.
 - Prometheus is not published to the host either. Its API is unauthenticated and
-  allows arbitrary queries, so only Grafana can reach it.
-- Grafana binds `127.0.0.1`, disables anonymous access and disables sign-up.
+  allows arbitrary queries. Note that "not published" means not reachable from
+  *outside*: the Compose network is flat, so any container on it can reach
+  Prometheus by name — including `hosting`, where deployed application code runs
+  as child processes. The same is true of the exporters and of Redis, which has
+  no password of its own on a default install.
+- Grafana is published on `127.0.0.1` only, disables anonymous access and
+  disables sign-up. Inside the Compose network it still listens on all
+  interfaces, so the loopback binding protects it from the internet, not from
+  the other containers.
+- Grafana's plugin catalogue is disabled, because installing a plugin from the
+  UI runs its code inside the Grafana container. Treat this as defence in depth
+  rather than a cap on what an admin session is worth: an admin can still point
+  a new datasource at any address on the Compose network and query it through
+  Grafana's datasource proxy. Guard the admin password accordingly, especially
+  if you put Grafana behind a public hostname rather than the SSH tunnel.
 - `node_exporter` mounts the host filesystem read-only. This is safe because no
   deployed application code runs in that container. Do not replicate that mount
   into `hosting` or `workerserver`, where deployments execute as child
@@ -167,6 +189,7 @@ curl -sfo monitoring/grafana/provisioning/datasources/prometheus.yml "$BASE/graf
 curl -sfo monitoring/grafana/provisioning/dashboards/dashboards.yml "$BASE/grafana/provisioning/dashboards/dashboards.yml"
 curl -sfo monitoring/grafana/dashboards/stormkit-host.json "$BASE/grafana/dashboards/stormkit-host.json"
 curl -sfo monitoring/grafana/dashboards/stormkit-dependencies.json "$BASE/grafana/dashboards/stormkit-dependencies.json"
+curl -sfo monitoring/grafana/dashboards/stormkit-requests.json "$BASE/grafana/dashboards/stormkit-requests.json"
 ```
 
 You will also need the monitoring services in your `docker-compose.yaml`. The

--- a/src/www/public/install.sh
+++ b/src/www/public/install.sh
@@ -247,7 +247,9 @@ setup_base_env_variables() {
 # `monitoring` compose profile is what decides that. Having the files on disk
 # means turning monitoring on later is a flag flip rather than a download.
 #
-# Keep this list in sync with deploy/monitoring/ in the repository.
+# Keep this list in sync with deploy/monitoring/ in the repository. The
+# lint-monitoring workflow fails the build if a dashboard is added there
+# without being added here.
 setup_monitoring_configs() {
   base="https://raw.githubusercontent.com/stormkit-io/stormkit-io/main/deploy/monitoring"
 
@@ -262,7 +264,8 @@ setup_monitoring_configs() {
     grafana/provisioning/datasources/prometheus.yml \
     grafana/provisioning/dashboards/dashboards.yml \
     grafana/dashboards/stormkit-host.json \
-    grafana/dashboards/stormkit-dependencies.json; do
+    grafana/dashboards/stormkit-dependencies.json \
+    grafana/dashboards/stormkit-requests.json; do
     if ! curl -fsS -o "monitoring/$file" "$base/$file"; then
       echo "Failed to download monitoring/$file" >&2
       exit 1


### PR DESCRIPTION
## What

A third provisioned Grafana dashboard, **Stormkit — Requests**: requests per
minute, status codes, request rate by method, response time percentiles and an
Apdex score.

`stormkit_lb_response_time_ms` was already exported by the hosting service but
nothing charted it, so the only way to see traffic shape was to write PromQL by
hand.

Aggregate only, no per-application dimension — consistent with the other two
dashboards. Per-app traffic belongs in the UI under Analytics.

## Notes

Panels are written against what the metric actually emits, which is narrower
than it looks. `RecordResponseTime` collapses status codes to a class except for
`200` and `304`, and folds `PUT`/`PATCH`/`DELETE` into `POST` and everything
else into `OTHER`. So the colour overrides cover `200`, `304`, `2xx`, `3xx`,
`4xx`, `5xx`, `other` and nothing else.

The Apdex panel uses 100ms as T and 500ms as the tolerating threshold. The
textbook value is 4T, but the histogram has no 400ms boundary — 500 is the
nearest bucket, and the panel description says so.

## Grafana hardening

Two env vars on the grafana service, both prompted by putting Grafana behind a
public hostname rather than the SSH tunnel:

- `GF_PLUGINS_PLUGIN_ADMIN_ENABLED=false`. Installing a plugin from the UI runs
  its code inside the Grafana container, which can reach `db:5432` and
  `redis:6379` over the Compose network — and Redis has no password on a default
  self-hosted install. That made the admin password a path to code execution
  next to the database, which is far more than a dashboard viewer should be
  worth.
- `GF_SERVER_ROOT_URL`, defaulting to the existing loopback URL. Behind a proxy,
  Grafana's post-login redirect otherwise sends the browser to `localhost:3000`.

## Verification

Ran the `lint-monitoring` checks locally: `jq empty`, the datasource-uid check,
`promtool check rules` over all 46 dashboard expressions, `promtool check
config`, and `docker compose --profile monitoring config -q`.

Also ran every new expression against a live instance with the stack enabled —
all nine return series, none empty.