### PR TITLE
fix: reject publishing running deployments

### DIFF
--- a/src/ce/api/public/v1/handler_deployment_publish.go
+++ b/src/ce/api/public/v1/handler_deployment_publish.go
@@ -30,6 +30,13 @@ func handlerDeploymentPublish(req *RequestContext) *shttp.Response {
 		return shttp.NotFound()
 	}
 
+	// A running deployment has no exit code yet.
+	if !depl.ExitCode.Valid {
+		return shttp.BadRequest(map[string]any{
+			"errors": []string{"Deployment is still running and cannot be published"},
+		})
+	}
+
 	if depl.ExitCode.ValueOrZero() != deploy.ExitCodeSuccess {
 		return shttp.BadRequest(map[string]any{
 			"errors": []string{"Deployment must have a successful build before it can be published"},

--- a/src/ce/api/public/v1/handler_deployment_publish_test.go
+++ b/src/ce/api/public/v1/handler_deployment_publish_test.go
@@ -46,7 +46,7 @@ func (s *HandlerDeploymentPublishSuite) Test_Success() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
 	env := s.MockEnv(appl)
-	depl := s.MockDeployment(env)
+	depl := s.MockDeployment(env, map[string]any{"ExitCode": null.IntFrom(0)})
 	key := s.MockAPIKey(appl, env)
 
 	response := shttptest.RequestWithHeaders(
@@ -71,7 +71,7 @@ func (s *HandlerDeploymentPublishSuite) Test_PublishedStateReflected() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
 	env := s.MockEnv(appl)
-	depl := s.MockDeployment(env)
+	depl := s.MockDeployment(env, map[string]any{"ExitCode": null.IntFrom(0)})
 	key := s.MockAPIKey(appl, env)
 
 	shttptest.RequestWithHeaders(
@@ -212,6 +212,29 @@ func (s *HandlerDeploymentPublishSuite) Test_BadRequest_FailedDeployment() {
 
 	body := response.Map()
 	s.Equal([]any{"Deployment must have a successful build before it can be published"}, body["errors"])
+}
+
+// Test_BadRequest_RunningDeployment verifies that a deployment which has not
+// finished building yet (NULL exit code) cannot be published.
+func (s *HandlerDeploymentPublishSuite) Test_BadRequest_RunningDeployment() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	depl := s.MockDeployment(env)
+	key := s.MockAPIKey(appl, env)
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodPost,
+		s.publishURL(depl.ID),
+		nil,
+		map[string]string{"Authorization": key.Value},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+
+	body := response.Map()
+	s.Equal([]any{"Deployment is still running and cannot be published"}, body["errors"])
 }
 
 func TestHandlerDeploymentPublish(t *testing.T) {

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -831,7 +831,7 @@ func (s *HandlerMCPSuite) Test_PublishDeployment_Success() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
 	mockEnv := s.MockEnv(appl)
-	depl := s.MockDeployment(mockEnv)
+	depl := s.MockDeployment(mockEnv, map[string]any{"ExitCode": null.IntFrom(0)})
 	key := s.userKey(usr)
 
 	resp := s.post(key.Value, mcpToolCall(1, "publish_deployment", map[string]any{
@@ -843,6 +843,23 @@ func (s *HandlerMCPSuite) Test_PublishDeployment_Success() {
 	data := s.toolContent(env)
 
 	s.Equal(true, data["ok"])
+}
+
+func (s *HandlerMCPSuite) Test_PublishDeployment_RunningDeployment() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	depl := s.MockDeployment(mockEnv)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "publish_deployment", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"deploymentId": depl.ID.String(),
+	}))
+
+	env := s.rpcOK(resp)
+	result := env["result"].(map[string]any)
+	s.True(result["isError"].(bool))
 }
 
 func (s *HandlerMCPSuite) Test_CreateEnvironment_MissingAppId() {


### PR DESCRIPTION
## Problem

The public API publish endpoint — which the MCP `publish_deployment` tool calls — only rejected failed builds:

```go
if depl.ExitCode.ValueOrZero() != deploy.ExitCodeSuccess // ExitCodeSuccess == 0
```

A running deployment has a NULL `exit_code`, so `ValueOrZero()` returns `0` — exactly the success value — and the check passed. Agents connecting through MCP could publish deployments mid-build.

## Fix

Reject the request with a 400 when the deployment has no exit code yet.

## Tests

Regression coverage for publishing a running deployment through the public API endpoint and the MCP tool. `go test -p 1 ./src/ce/api/public/v1/...` passes.