### PR TITLE
chore: lead hero copy with agent operability

### DIFF
--- a/src/www/src/pages/_components/Hero.tsx
+++ b/src/www/src/pages/_components/Hero.tsx
@@ -55,9 +55,10 @@ export default function Hero() {
           color: grey[400],
         }}
       >
-        Stormkit gives development teams full control, faster CI/CD, and up to
-        47% lower infrastructure costs, all on your own terms. From
-        side-projects, to Enterprise scale.
+        Your agent can run the whole platform through MCP: provision a server,
+        deploy, publish, read the logs when something breaks. You keep the
+        infrastructure, the data, and full control. From side-projects, to
+        Enterprise scale.
       </Typography>
       <ToggleButtonGroup
         exclusive


### PR DESCRIPTION
## Change

Rewrites the hero subheadline on the marketing site to lead with what actually differentiates Stormkit right now: agents can operate the whole platform through MCP — provision, deploy, publish, read logs — not just write code that gets deployed to it.

Before:

> Stormkit gives development teams full control, faster CI/CD, and up to 47% lower infrastructure costs, all on your own terms. From side-projects, to Enterprise scale.

After:

> Your agent can run the whole platform through MCP: provision a server, deploy, publish, read the logs when something breaks. You keep the infrastructure, the data, and full control. From side-projects, to Enterprise scale.

## Why

The hero already has a **For Humans / For Agents** install toggle directly below this line, but the copy did nothing to set it up. This makes the toggle land.

The 47% figure is dropped here because the `Statistics` component further down the page already carries it — no need to spend the strongest line on a stat the page states twice.