### PR TITLE
feat: add markdown documentation to triggers

### DIFF
--- a/docs/api/10-mcp.md
+++ b/docs/api/10-mcp.md
@@ -118,7 +118,7 @@ All tools return JSON. Errors are reported as MCP `isError` content while the tr
 | ------------------ | --------------------------------------------------------------------------- |
 | `list_triggers`    | List periodic triggers configured for an environment.                       |
 | `create_trigger`   | Create a periodic trigger that calls a URL on a cron schedule (UTC).         |
-| `update_trigger`   | Update an existing periodic trigger.                                         |
+| `update_trigger`   | Update an existing periodic trigger. Partial: only the fields you pass change. |
 | `delete_trigger`   | Delete a periodic trigger.                                                   |
 | `invoke_trigger`   | Run a trigger immediately and return the execution log.                      |
 | `get_trigger_logs` | Return the last 25 executions (scheduled or manual) of a trigger.           |

--- a/docs/api/11-triggers.md
+++ b/docs/api/11-triggers.md
@@ -39,6 +39,7 @@ interface Request {
   envId?: string // Required when the API key is not environment-scoped.
   cron: string // Cron expression, evaluated in UTC.
   status: boolean // Whether the trigger is active.
+  documentation?: string // Markdown notes describing the trigger. Max 64KB.
   options: {
     method: string // GET, POST, HEAD, PATCH or DELETE.
     url: string // http/https URL to call.
@@ -62,6 +63,7 @@ curl -X POST \
      -d '{
        "cron": "*/5 * * * *",
        "status": true,
+       "documentation": "Nightly rollup. Ping #data if it fails.",
        "options": {
          "method": "POST",
          "url": "https://www.example.org/cron",
@@ -77,6 +79,7 @@ curl -X POST \
     "id": "18914",
     "envId": "1500",
     "cron": "*/5 * * * *",
+    "documentation": "Nightly rollup. Ping #data if it fails.",
     "status": true,
     "nextRunAt": 1712418330,
     "options": {
@@ -95,6 +98,9 @@ curl -X POST \
 Validation errors return `400` with a map of field errors, e.g.
 `{ "cron": "Invalid cron format" }` or `{ "url": "Invalid URL" }`.
 
+`documentation` is free-form markdown shown in the Stormkit UI next to the
+trigger. It is never sent with the request and never affects execution.
+
 </details>
 
 <details>
@@ -106,19 +112,25 @@ Validation errors return `400` with a map of field errors, e.g.
 Update an existing trigger. The `id` must belong to the authenticated
 environment.
 
-> `options.headers` is replaced wholesale with what you send. Because list
+This is a **partial update**: only the fields present in the body are changed
+and everything else keeps its current value. To clear a field, send its empty
+value explicitly (e.g. `"documentation": ""`).
+
+> `options.headers` is replaced wholesale when you send it. Because list
 > responses mask header values, always re-send the real values you want to keep
 > — sending back the masked (blanked) values will overwrite the stored ones.
+> Omitting `options.headers` leaves the stored headers untouched.
 
 ```typescript
 interface Request {
   id: string
   envId?: string // Required when the API key is not environment-scoped.
-  cron: string
-  status: boolean
-  options: {
-    method: string
-    url: string
+  cron?: string
+  status?: boolean
+  documentation?: string
+  options?: {
+    method?: string
+    url?: string
     payload?: string
     headers?: Record<string, string> | string
   }
@@ -130,7 +142,8 @@ interface Response {
 ```
 
 ```bash
-# Example
+# Example — changes the schedule only; status, documentation and every
+# option keep their current values.
 
 curl -X PATCH \
      -H 'Authorization: <api_key>' \
@@ -138,9 +151,7 @@ curl -X PATCH \
      'https://api.stormkit.io/v1/trigger' \
      -d '{
        "id": "18914",
-       "cron": "0 * * * *",
-       "status": false,
-       "options": { "method": "GET", "url": "https://www.example.org/cron" }
+       "cron": "0 * * * *"
      }'
 ```
 
@@ -271,6 +282,7 @@ curl -X GET \
       "id": "18914",
       "envId": "1500",
       "cron": "*/5 * * * *",
+      "documentation": "Nightly rollup. Ping #data if it fails.",
       "status": true,
       "nextRunAt": 1712418330,
       "options": {
@@ -345,6 +357,7 @@ interface Trigger {
   id: string
   envId: string
   cron: string
+  documentation: string // Markdown notes. Empty when undocumented.
   status: boolean
   nextRunAt: number // Unix timestamp of the next scheduled run.
   options: {
@@ -373,11 +386,12 @@ interface TriggerLog {
 }
 ```
 
-| Property    | Definition                                                                  |
-| ----------- | --------------------------------------------------------------------------- |
-| id          | The unique id of the trigger.                                               |
-| envId       | The environment the trigger belongs to.                                     |
-| cron        | The cron expression, evaluated in UTC.                                       |
-| status      | Whether the trigger is active. Inactive triggers are not scheduled.         |
-| nextRunAt   | Unix timestamp of the next scheduled run. `0` when the trigger is inactive. |
-| options     | The HTTP request executed on each run.                                      |
+| Property      | Definition                                                                  |
+| ------------- | --------------------------------------------------------------------------- |
+| id            | The unique id of the trigger.                                               |
+| envId         | The environment the trigger belongs to.                                     |
+| cron          | The cron expression, evaluated in UTC.                                       |
+| documentation | Markdown notes describing the trigger, shown in the UI. Max 64KB.           |
+| status        | Whether the trigger is active. Inactive triggers are not scheduled.         |
+| nextRunAt     | Unix timestamp of the next scheduled run. `0` when the trigger is inactive. |
+| options       | The HTTP request executed on each run.                                      |

--- a/docs/features/13-periodic-triggers.md
+++ b/docs/features/13-periodic-triggers.md
@@ -26,6 +26,26 @@ This will call the specified endpoint with the configured cron periodicity. The 
 
 </section>
 
+## Documentation
+
+<section>
+
+A trigger's cron and URL say when and where it fires, but not why it exists or
+what breaks when it stops. The **Documentation** field on the trigger modal
+holds that context: free-form **markdown**, with an Edit/Preview toggle while
+you write it.
+
+It is shown alongside the trigger's run details (expand the dot menu `(...)` >
+**Past triggers** > a run), so whoever is looking at a failed run also sees what
+the trigger is for and who to contact. The text is never sent with the request
+and never affects execution.
+
+Documentation can also be set through the [API](/docs/api/triggers) and the MCP
+`create_trigger` / `update_trigger` tools, which is a convenient way to have an
+agent write up a trigger it just created.
+
+</section>
+
 ## Environment variables
 
 <section>

--- a/src/ce/api/app/functiontrigger/function_trigger_model.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_model.go
@@ -37,14 +37,17 @@ func (a *Options) Scan(value any) error {
 }
 
 type FunctionTrigger struct {
-	ID        types.ID   `json:"id,string"`
-	EnvID     types.ID   `json:"envId,string"`
-	Cron      string     `json:"cron"`
-	Status    bool       `json:"status"`
-	Options   Options    `json:"options,omitempty"`
-	NextRunAt utils.Unix `json:"nextRunAt,omitempty"`
-	CreatedAt utils.Unix `json:"-"`
-	UpdatedAt utils.Unix `json:"-"`
+	ID    types.ID `json:"id,string"`
+	EnvID types.ID `json:"envId,string"`
+	Cron  string   `json:"cron"`
+	// Documentation is free-form markdown describing what the trigger is for.
+	// Rendered by the UI, never interpreted when the trigger runs.
+	Documentation string     `json:"documentation,omitempty"`
+	Status        bool       `json:"status"`
+	Options       Options    `json:"options,omitempty"`
+	NextRunAt     utils.Unix `json:"nextRunAt,omitempty"`
+	CreatedAt     utils.Unix `json:"-"`
+	UpdatedAt     utils.Unix `json:"-"`
 }
 
 // MaskHeaders returns a copy of headers with every VALUE blanked (keys kept).
@@ -71,11 +74,12 @@ func MaskHeaders(h shttp.Headers) shttp.Headers {
 // directly and never go through here.
 func (t *FunctionTrigger) ToMap() map[string]any {
 	return map[string]any{
-		"id":        t.ID.String(),
-		"envId":     t.EnvID.String(),
-		"cron":      t.Cron,
-		"status":    t.Status,
-		"nextRunAt": t.NextRunAt.Unix(),
+		"id":            t.ID.String(),
+		"envId":         t.EnvID.String(),
+		"cron":          t.Cron,
+		"documentation": t.Documentation,
+		"status":        t.Status,
+		"nextRunAt":     t.NextRunAt.Unix(),
 		"options": map[string]any{
 			"url":     t.Options.URL,
 			"headers": MaskHeaders(t.Options.Headers),

--- a/src/ce/api/app/functiontrigger/function_trigger_store.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_store.go
@@ -25,8 +25,9 @@ var stmts = struct {
 }{
 	selectTriggers: `
 		SELECT
-			trigger_id, env_id, cron, trigger_options, 
-			trigger_status, created_at, next_run_at, updated_at
+			trigger_id, env_id, cron, trigger_options,
+			trigger_status, created_at, next_run_at, updated_at,
+			COALESCE(documentation, '')
         FROM
 			function_triggers
 		WHERE
@@ -54,9 +55,9 @@ var stmts = struct {
 	`,
 	insertTrigger: `
 		INSERT INTO function_triggers
-		    (env_id, cron, next_run_at, trigger_options, trigger_status)
+		    (env_id, cron, next_run_at, trigger_options, trigger_status, documentation)
 		VALUES
-			($1, $2, $3, $4, $5)
+			($1, $2, $3, $4, $5, $6)
     	RETURNING
 			trigger_id;
 	`,
@@ -68,9 +69,10 @@ var stmts = struct {
 			trigger_options = $2,
 			trigger_status = $3,
 			next_run_at = $4,
+			documentation = $5,
 			updated_at = timezone('utc', now())
 		WHERE
-			trigger_id = $5;
+			trigger_id = $6;
 	`,
 	updateNextRunAt: `
 		UPDATE
@@ -200,6 +202,7 @@ func (s *Store) Insert(ctx context.Context, ft *FunctionTrigger) error {
 		ft.NextRunAt,
 		opts,
 		ft.Status,
+		ft.Documentation,
 	)
 
 	if err != nil {
@@ -253,7 +256,7 @@ func (s *Store) Update(ctx context.Context, ft *FunctionTrigger) error {
 		ft.NextRunAt = utils.Unix{Valid: false}
 	}
 
-	_, err = s.Exec(ctx, stmts.updateTrigger, ft.Cron, opts, ft.Status, ft.NextRunAt, ft.ID)
+	_, err = s.Exec(ctx, stmts.updateTrigger, ft.Cron, opts, ft.Status, ft.NextRunAt, ft.Documentation, ft.ID)
 	return err
 }
 
@@ -329,7 +332,7 @@ func (s *Store) selectRows(ctx context.Context, query string, args ...any) ([]*F
 		err := rows.Scan(
 			&tmp.ID, &tmp.EnvID, &tmp.Cron,
 			&tmp.Options, &tmp.Status, &tmp.CreatedAt,
-			&tmp.NextRunAt, &tmp.UpdatedAt,
+			&tmp.NextRunAt, &tmp.UpdatedAt, &tmp.Documentation,
 		)
 
 		if err != nil {

--- a/src/ce/api/app/functiontrigger/function_trigger_store_test.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_store_test.go
@@ -1,0 +1,100 @@
+package functiontrigger_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type TriggerFunctionStoreSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *TriggerFunctionStoreSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *TriggerFunctionStoreSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+// insertDueTrigger inserts a trigger that is already due, optionally with
+// documentation. Rows written before the documentation column existed have it
+// as NULL, which is what a nil value reproduces here.
+func (s *TriggerFunctionStoreSuite) insertDueTrigger(envID types.ID, documentation any) types.ID {
+	tid := types.ID(0)
+
+	err := s.conn.QueryRow(`
+		INSERT INTO
+			function_triggers (env_id, trigger_status, trigger_options, cron, next_run_at, documentation)
+		VALUES
+			($1, true, $2, '* * * * *', timezone('utc', now()) - interval '1 hour', $3)
+		RETURNING
+			trigger_id;
+	`, envID, []byte(`{"url": "https://example.com"}`), documentation).Scan(&tid)
+
+	s.Require().NoError(err)
+
+	return tid
+}
+
+// Test_NullDocumentationReadsAsEmpty covers rows written before the column
+// existed: they hold NULL and must scan into an empty string rather than
+// failing, which would drop the trigger from every listing.
+func (s *TriggerFunctionStoreSuite) Test_NullDocumentationReadsAsEmpty() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	tid := s.insertDueTrigger(env.ID, nil)
+
+	tf, err := functiontrigger.NewStore().ByID(context.Background(), tid)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(tf)
+	s.Empty(tf.Documentation)
+
+	list, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+
+	s.Require().NoError(err)
+	s.Len(list, 1)
+}
+
+// Test_DueTriggersCarryDocumentation verifies the scheduler's rows
+// carry the notes the same way the display paths do, so the column list and the
+// scan stay identical across every select.
+func (s *TriggerFunctionStoreSuite) Test_DueTriggersCarryDocumentation() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	tid := s.insertDueTrigger(env.ID, "Ping #data when this fails.")
+
+	store := functiontrigger.NewStore()
+	due, err := store.DueTriggers(context.Background())
+
+	s.Require().NoError(err)
+	s.Require().NotEmpty(due)
+
+	for _, tf := range due {
+		s.Equal("Ping #data when this fails.", tf.Documentation)
+	}
+
+	tf, err := store.ByID(context.Background(), tid)
+
+	s.Require().NoError(err)
+	s.Equal("Ping #data when this fails.", tf.Documentation)
+}
+
+func TestTriggerFunctionStore(t *testing.T) {
+	suite.Run(t, &TriggerFunctionStoreSuite{})
+}

--- a/src/ce/api/public/v1/handler_function_trigger_create.go
+++ b/src/ce/api/public/v1/handler_function_trigger_create.go
@@ -1,6 +1,7 @@
 package publicapiv1
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,26 +12,83 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 )
 
+// functionTriggerRequest is the body shared by create and update. Every field
+// but the ID is a pointer so that "not mentioned" is distinguishable from
+// "set to the zero value": an update applies only the fields it carries and
+// leaves the rest of the trigger alone, and a field is cleared by sending its
+// empty value explicitly.
 type functionTriggerRequest struct {
-	ID      types.ID `json:"id,string"`
-	Cron    string   `json:"cron"`
-	Status  bool     `json:"status"`
-	Options struct {
-		Headers shttp.Headers `json:"headers"`
-		Method  string        `json:"method"`
-		Payload string        `json:"payload"`
-		URL     string        `json:"url"`
+	ID            types.ID `json:"id,string"`
+	Cron          *string  `json:"cron"`
+	Documentation *string  `json:"documentation"`
+	Status        *bool    `json:"status"`
+	Options       *struct {
+		Headers *shttp.Headers `json:"headers"`
+		Method  *string        `json:"method"`
+		Payload *string        `json:"payload"`
+		URL     *string        `json:"url"`
 	} `json:"options"`
 }
 
-func validateFunctionTrigger(data *functionTriggerRequest) map[string]string {
+// applyTo overlays the fields the request carries onto a trigger, leaving every
+// omitted field at its current value.
+func (r *functionTriggerRequest) applyTo(ft *functiontrigger.FunctionTrigger) {
+	if r.Cron != nil {
+		ft.Cron = *r.Cron
+	}
+
+	if r.Documentation != nil {
+		ft.Documentation = *r.Documentation
+	}
+
+	if r.Status != nil {
+		ft.Status = *r.Status
+	}
+
+	if r.Options == nil {
+		return
+	}
+
+	if r.Options.Method != nil {
+		ft.Options.Method = *r.Options.Method
+	}
+
+	if r.Options.URL != nil {
+		ft.Options.URL = *r.Options.URL
+	}
+
+	if r.Options.Payload != nil {
+		ft.Options.Payload = []byte(*r.Options.Payload)
+	}
+
+	if r.Options.Headers != nil {
+		ft.Options.Headers = *r.Options.Headers
+	}
+}
+
+// maxDocumentationLength bounds the free-form notes. The column is plain text
+// and every trigger listing returns the field in full, so it is capped at a
+// size that is generous for a runbook and far short of a paste-the-logs
+// accident.
+const maxDocumentationLength = 64 * 1024
+
+// validateFunctionTrigger checks the trigger as it will be stored, so that an
+// update is validated against the merged record rather than the partial body
+// that produced it.
+func validateFunctionTrigger(ft *functiontrigger.FunctionTrigger) map[string]string {
 	errors := map[string]string{}
 
-	if !gronx.New().IsValid(data.Cron) {
+	if !gronx.New().IsValid(ft.Cron) {
 		errors["cron"] = "Invalid cron format"
 	}
 
-	parsedURL, err := url.Parse(data.Options.URL)
+	if len(ft.Documentation) > maxDocumentationLength {
+		errors["documentation"] = fmt.Sprintf(
+			"Documentation cannot exceed %d characters", maxDocumentationLength,
+		)
+	}
+
+	parsedURL, err := url.Parse(ft.Options.URL)
 
 	if err != nil ||
 		parsedURL.Host == "" ||
@@ -46,21 +104,6 @@ func validateFunctionTrigger(data *functionTriggerRequest) map[string]string {
 	return errors
 }
 
-func (r *functionTriggerRequest) toRecord(envID types.ID) *functiontrigger.FunctionTrigger {
-	return &functiontrigger.FunctionTrigger{
-		ID:     r.ID,
-		Cron:   r.Cron,
-		EnvID:  envID,
-		Status: r.Status,
-		Options: functiontrigger.Options{
-			Method:  r.Options.Method,
-			Headers: r.Options.Headers,
-			URL:     r.Options.URL,
-			Payload: []byte(r.Options.Payload),
-		},
-	}
-}
-
 func handlerFunctionTriggerCreate(req *RequestContext) *shttp.Response {
 	tf := &functionTriggerRequest{}
 
@@ -68,15 +111,15 @@ func handlerFunctionTriggerCreate(req *RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
-	if errs := validateFunctionTrigger(tf); errs != nil {
+	record := &functiontrigger.FunctionTrigger{EnvID: req.Env.ID}
+	tf.applyTo(record)
+
+	if errs := validateFunctionTrigger(record); errs != nil {
 		return &shttp.Response{
 			Status: http.StatusBadRequest,
 			Data:   errs,
 		}
 	}
-
-	record := tf.toRecord(req.Env.ID)
-	record.ID = 0
 
 	if err := functiontrigger.NewStore().Insert(req.Context(), record); err != nil {
 		return shttp.Error(err)

--- a/src/ce/api/public/v1/handler_function_trigger_create_test.go
+++ b/src/ce/api/public/v1/handler_function_trigger_create_test.go
@@ -3,6 +3,7 @@ package publicapiv1_test
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
@@ -85,6 +86,113 @@ func (s *HandlerFunctionTriggerCreateSuite) Test_Success_Enabled() {
 	s.Equal(tfs[0].Options.URL, "https://test.com/")
 	s.Equal(tfs[0].Options.Headers.String(), "name:joe;surname:doe")
 	s.Equal(string(tfs[0].Options.Payload), triggerRequestPayload)
+}
+
+func (s *HandlerFunctionTriggerCreateSuite) Test_Success_Documentation() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	documentation := "# Nightly rollup\n\nPings `/cron/rollup`. Ask **#data** if it fails."
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/v1/trigger",
+
+		map[string]any{
+			"appId":         env.AppID.String(),
+			"envId":         env.ID.String(),
+			"cron":          "*/1 * * * *",
+			"status":        true,
+			"documentation": documentation,
+			"options": map[string]any{
+				"method": "GET",
+				"url":    "https://test.com/",
+			},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(env.GetApp().UserID),
+		},
+	)
+
+	s.Equal(http.StatusCreated, response.Code)
+
+	tfs, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+	s.NoError(err)
+	s.Len(tfs, 1)
+	s.Equal(documentation, tfs[0].Documentation)
+}
+
+// Test_Fail_DocumentationTooLong verifies that the free-form notes are bounded:
+// the column is plain text and every listing returns it in full.
+func (s *HandlerFunctionTriggerCreateSuite) Test_Fail_DocumentationTooLong() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/v1/trigger",
+
+		map[string]any{
+			"appId":         env.AppID.String(),
+			"envId":         env.ID.String(),
+			"cron":          "*/1 * * * *",
+			"status":        true,
+			"documentation": strings.Repeat("a", 64*1024+1),
+			"options": map[string]any{
+				"method": "GET",
+				"url":    "https://test.com/",
+			},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(env.GetApp().UserID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "documentation")
+
+	tfs, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+	s.Require().NoError(err)
+	s.Empty(tfs)
+}
+
+// Test_Success_NoDocumentation verifies that a trigger created without
+// documentation reads back as an empty string rather than failing the scan.
+func (s *HandlerFunctionTriggerCreateSuite) Test_Success_NoDocumentation() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/v1/trigger",
+
+		map[string]any{
+			"appId":  env.AppID.String(),
+			"envId":  env.ID.String(),
+			"cron":   "*/1 * * * *",
+			"status": true,
+			"options": map[string]any{
+				"method": "GET",
+				"url":    "https://test.com/",
+			},
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(env.GetApp().UserID),
+		},
+	)
+
+	s.Equal(http.StatusCreated, response.Code)
+
+	tfs, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+	s.NoError(err)
+	s.Len(tfs, 1)
+	s.Empty(tfs[0].Documentation)
 }
 
 func (s *HandlerFunctionTriggerCreateSuite) Test_Success_Disabled() {

--- a/src/ce/api/public/v1/handler_function_trigger_update.go
+++ b/src/ce/api/public/v1/handler_function_trigger_update.go
@@ -14,13 +14,6 @@ func handlerFunctionTriggerUpdate(req *RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
-	if errs := validateFunctionTrigger(tf); errs != nil {
-		return &shttp.Response{
-			Status: http.StatusBadRequest,
-			Data:   errs,
-		}
-	}
-
 	store := functiontrigger.NewStore()
 	existing, err := store.ByID(req.Context(), tf.ID)
 
@@ -32,7 +25,20 @@ func handlerFunctionTriggerUpdate(req *RequestContext) *shttp.Response {
 		return shttp.NotFound()
 	}
 
-	if err := store.Update(req.Context(), tf.toRecord(req.Env.ID)); err != nil {
+	// A partial update: the fields the body carries are applied to the stored
+	// trigger and the rest keep their current values, so a caller that only
+	// means to change the cron cannot destroy headers or documentation it never
+	// mentioned.
+	tf.applyTo(existing)
+
+	if errs := validateFunctionTrigger(existing); errs != nil {
+		return &shttp.Response{
+			Status: http.StatusBadRequest,
+			Data:   errs,
+		}
+	}
+
+	if err := store.Update(req.Context(), existing); err != nil {
 		return shttp.Error(err)
 	}
 

--- a/src/ce/api/public/v1/handler_function_trigger_update_test.go
+++ b/src/ce/api/public/v1/handler_function_trigger_update_test.go
@@ -84,6 +84,78 @@ func (s *HandlerFunctionTriggerUpdateSuite) Test_Success() {
 	s.Equal(string(record.Cron), "5 5 * * *")
 }
 
+// Test_Partial verifies that PATCH applies only the fields the body carries:
+// a request that mentions the cron alone keeps the documentation, status, URL
+// and headers it never mentioned, and an explicit empty value still clears.
+func (s *HandlerFunctionTriggerUpdateSuite) Test_Partial() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+	tf := s.MockTriggerFunction(env)
+
+	store := functiontrigger.NewStore()
+	before, err := store.ByID(context.Background(), tf.ID)
+	s.Require().NoError(err)
+
+	before.Documentation = "Ping #data when this fails."
+	before.Options = functiontrigger.Options{
+		Method:  "POST",
+		URL:     "https://test.com/rollup",
+		Payload: []byte(`{"full":true}`),
+		Headers: shttp.Headers{"name": "joe"},
+	}
+
+	s.Require().NoError(store.Update(context.Background(), before))
+
+	handler := shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler()
+	auth := map[string]string{"Authorization": usertest.Authorization(usr.ID)}
+
+	response := shttptest.RequestWithHeaders(
+		handler,
+		shttp.MethodPatch,
+		"/v1/trigger",
+		map[string]any{
+			"id":    tf.ID.String(),
+			"appId": app.ID.String(),
+			"envId": env.ID.String(),
+			"cron":  "5 5 * * *",
+		},
+		auth,
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	record, err := store.ByID(context.Background(), tf.ID)
+	s.Require().NoError(err)
+	s.Equal("5 5 * * *", record.Cron)
+	s.Equal("Ping #data when this fails.", record.Documentation)
+	s.Equal(before.Status, record.Status)
+	s.Equal("POST", record.Options.Method)
+	s.Equal("https://test.com/rollup", record.Options.URL)
+	s.Equal(`{"full":true}`, string(record.Options.Payload))
+	s.Equal("name:joe", record.Options.Headers.String())
+
+	response = shttptest.RequestWithHeaders(
+		handler,
+		shttp.MethodPatch,
+		"/v1/trigger",
+		map[string]any{
+			"id":            tf.ID.String(),
+			"appId":         app.ID.String(),
+			"envId":         env.ID.String(),
+			"documentation": "",
+		},
+		auth,
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	record, err = store.ByID(context.Background(), tf.ID)
+	s.Require().NoError(err)
+	s.Empty(record.Documentation)
+	s.Equal("5 5 * * *", record.Cron)
+}
+
 func (s *HandlerFunctionTriggerUpdateSuite) Test_Permission() {
 	usr := s.MockUser()
 	app := s.MockApp(usr)

--- a/src/ce/api/public/v1/handler_function_triggers_get_test.go
+++ b/src/ce/api/public/v1/handler_function_triggers_get_test.go
@@ -64,6 +64,7 @@ func (s *HandlerTriggerFunctionGetSuite) Test_Success() {
 			"id": "1",
 			"envId": "1",
 			"cron": "*/1 * * * *",
+			"documentation": "",
 			"nextRunAt": 1712418330,
 			"options": {
 				"method": "POST",

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -409,13 +409,14 @@ func mcpAllTools() []mcpToolDef {
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"envId":   map[string]any{"type": "string", "description": "Environment ID to attach the trigger to."},
-					"cron":    map[string]any{"type": "string", "description": "Cron expression, evaluated in UTC, e.g. '*/5 * * * *'."},
-					"status":  map[string]any{"type": "boolean", "description": "Whether the trigger is active. Inactive triggers are not scheduled."},
-					"method":  map[string]any{"type": "string", "description": "HTTP method: GET, POST, HEAD, PATCH or DELETE. Defaults to GET."},
-					"url":     map[string]any{"type": "string", "description": "http/https URL to call."},
-					"payload": map[string]any{"type": "string", "description": "Request body, sent for non-GET methods."},
-					"headers": map[string]any{"type": "object", "description": "Request headers as a key/value map.", "additionalProperties": map[string]any{"type": "string"}},
+					"envId":         map[string]any{"type": "string", "description": "Environment ID to attach the trigger to."},
+					"cron":          map[string]any{"type": "string", "description": "Cron expression, evaluated in UTC, e.g. '*/5 * * * *'."},
+					"status":        map[string]any{"type": "boolean", "description": "Whether the trigger is active. Inactive triggers are not scheduled."},
+					"documentation": map[string]any{"type": "string", "description": "Markdown notes describing what the trigger is for. Displayed in the UI only; never affects execution."},
+					"method":        map[string]any{"type": "string", "description": "HTTP method: GET, POST, HEAD, PATCH or DELETE. Defaults to GET."},
+					"url":           map[string]any{"type": "string", "description": "http/https URL to call."},
+					"payload":       map[string]any{"type": "string", "description": "Request body, sent for non-GET methods."},
+					"headers":       map[string]any{"type": "object", "description": "Request headers as a key/value map.", "additionalProperties": map[string]any{"type": "string"}},
 				},
 				"required":             []string{"envId", "cron", "url"},
 				"additionalProperties": false,
@@ -423,20 +424,21 @@ func mcpAllTools() []mcpToolDef {
 		},
 		{
 			Name:        "update_trigger",
-			Description: "Update an existing periodic trigger. The trigger must belong to the given environment.",
+			Description: "Update an existing periodic trigger. The trigger must belong to the given environment. This is a partial update: only the fields you pass are changed and everything else keeps its current value, so pass just what you want to change. To clear a field, pass its empty value explicitly (e.g. an empty string for documentation or payload).",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"envId":     map[string]any{"type": "string", "description": "Environment the trigger belongs to."},
-					"triggerId": map[string]any{"type": "string", "description": "ID of the trigger to update (from list_triggers or create_trigger)."},
-					"cron":      map[string]any{"type": "string", "description": "Cron expression, evaluated in UTC."},
-					"status":    map[string]any{"type": "boolean", "description": "Whether the trigger is active."},
-					"method":    map[string]any{"type": "string", "description": "HTTP method: GET, POST, HEAD, PATCH or DELETE."},
-					"url":       map[string]any{"type": "string", "description": "http/https URL to call."},
-					"payload":   map[string]any{"type": "string", "description": "Request body, sent for non-GET methods."},
-					"headers":   map[string]any{"type": "object", "description": "Request headers as a key/value map.", "additionalProperties": map[string]any{"type": "string"}},
+					"envId":         map[string]any{"type": "string", "description": "Environment the trigger belongs to."},
+					"triggerId":     map[string]any{"type": "string", "description": "ID of the trigger to update (from list_triggers or create_trigger)."},
+					"cron":          map[string]any{"type": "string", "description": "Cron expression, evaluated in UTC."},
+					"status":        map[string]any{"type": "boolean", "description": "Whether the trigger is active."},
+					"documentation": map[string]any{"type": "string", "description": "Markdown notes describing what the trigger is for. Displayed in the UI only; never affects execution."},
+					"method":        map[string]any{"type": "string", "description": "HTTP method: GET, POST, HEAD, PATCH or DELETE."},
+					"url":           map[string]any{"type": "string", "description": "http/https URL to call."},
+					"payload":       map[string]any{"type": "string", "description": "Request body, sent for non-GET methods."},
+					"headers":       map[string]any{"type": "object", "description": "Request headers as a key/value map.", "additionalProperties": map[string]any{"type": "string"}},
 				},
-				"required":             []string{"envId", "triggerId", "cron", "url"},
+				"required":             []string{"envId", "triggerId"},
 				"additionalProperties": false,
 			},
 		},
@@ -1149,22 +1151,32 @@ func mcpListTriggers(req *RequestContextMCP, args map[string]any) *shttp.Respons
 // triggerBodyFromArgs builds the request body shared by create_trigger and
 // update_trigger from the tool arguments. The headers map is forwarded as-is so
 // that shttp.Headers unmarshals it the same way the REST handler does.
+//
+// Only the arguments the caller actually supplied are forwarded: an update is a
+// partial one, so filling in a zero value for an absent argument here would
+// clear the stored field instead of leaving it alone.
 func triggerBodyFromArgs(args map[string]any) map[string]any {
-	options := map[string]any{
-		"method":  stringArg(args, "method"),
-		"url":     stringArg(args, "url"),
-		"payload": stringArg(args, "payload"),
+	options := map[string]any{}
+
+	for _, key := range []string{"method", "url", "payload", "headers"} {
+		if v, ok := args[key]; ok {
+			options[key] = v
+		}
 	}
 
-	if h, ok := args["headers"]; ok {
-		options["headers"] = h
+	body := map[string]any{}
+
+	for _, key := range []string{"cron", "status", "documentation"} {
+		if v, ok := args[key]; ok {
+			body[key] = v
+		}
 	}
 
-	return map[string]any{
-		"cron":    stringArg(args, "cron"),
-		"status":  boolArg(args, "status"),
-		"options": options,
+	if len(options) > 0 {
+		body["options"] = options
 	}
+
+	return body
 }
 
 func mcpCreateTrigger(req *RequestContextMCP, id any, args map[string]any) *shttp.Response {

--- a/src/ce/api/public/v1/handler_mcp_triggers_test.go
+++ b/src/ce/api/public/v1/handler_mcp_triggers_test.go
@@ -88,6 +88,105 @@ func (s *HandlerMCPSuite) Test_UpdateTrigger() {
 	s.Equal("https://www.example.org/updated", record.Options.URL)
 }
 
+func (s *HandlerMCPSuite) Test_Trigger_Documentation() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	documentation := "Rebuilds the **search index**. Safe to disable."
+
+	resp := s.post(key.Value, mcpToolCall(1, "create_trigger", map[string]any{
+		"envId":         env.ID.String(),
+		"cron":          "*/5 * * * *",
+		"status":        true,
+		"method":        "POST",
+		"url":           "https://www.example.org/cron",
+		"documentation": documentation,
+	}))
+
+	trigger := s.toolContent(s.rpcOK(resp))["trigger"].(map[string]any)
+	s.Equal(documentation, trigger["documentation"])
+
+	stored, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+	s.Require().NoError(err)
+	s.Len(stored, 1)
+	s.Equal(documentation, stored[0].Documentation)
+
+	updateResp := s.post(key.Value, mcpToolCall(2, "update_trigger", map[string]any{
+		"envId":         env.ID.String(),
+		"triggerId":     stored[0].ID.String(),
+		"cron":          "*/5 * * * *",
+		"status":        true,
+		"url":           "https://www.example.org/cron",
+		"documentation": "Now documented differently.",
+	}))
+
+	s.rpcOK(updateResp)
+
+	record, err := functiontrigger.NewStore().ByID(context.Background(), stored[0].ID)
+	s.Require().NoError(err)
+	s.Equal("Now documented differently.", record.Documentation)
+	s.True(record.Status)
+}
+
+// Test_UpdateTrigger_Partial verifies that an update changes only the fields it
+// carries: a caller changing the cron alone keeps the documentation, status,
+// URL, headers and payload it never mentioned.
+func (s *HandlerMCPSuite) Test_UpdateTrigger_Partial() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	documentation := "Rebuilds the search index. Ping #data if it fails."
+
+	s.rpcOK(s.post(key.Value, mcpToolCall(1, "create_trigger", map[string]any{
+		"envId":         env.ID.String(),
+		"cron":          "*/5 * * * *",
+		"status":        true,
+		"method":        "POST",
+		"url":           "https://www.example.org/cron",
+		"payload":       `{"full":true}`,
+		"headers":       map[string]any{"authorization": "Bearer sk-1"},
+		"documentation": documentation,
+	})))
+
+	stored, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+	s.Require().NoError(err)
+	s.Require().Len(stored, 1)
+
+	s.rpcOK(s.post(key.Value, mcpToolCall(2, "update_trigger", map[string]any{
+		"envId":     env.ID.String(),
+		"triggerId": stored[0].ID.String(),
+		"cron":      "*/10 * * * *",
+	})))
+
+	record, err := functiontrigger.NewStore().ByID(context.Background(), stored[0].ID)
+	s.Require().NoError(err)
+	s.Equal("*/10 * * * *", record.Cron)
+	s.Equal(documentation, record.Documentation)
+	s.True(record.Status)
+	s.Equal("POST", record.Options.Method)
+	s.Equal("https://www.example.org/cron", record.Options.URL)
+	s.Equal(`{"full":true}`, string(record.Options.Payload))
+	s.Equal("Bearer sk-1", record.Options.Headers["authorization"])
+
+	// An explicit empty value still clears a field.
+	s.rpcOK(s.post(key.Value, mcpToolCall(3, "update_trigger", map[string]any{
+		"envId":         env.ID.String(),
+		"triggerId":     stored[0].ID.String(),
+		"documentation": "",
+		"status":        false,
+	})))
+
+	record, err = functiontrigger.NewStore().ByID(context.Background(), stored[0].ID)
+	s.Require().NoError(err)
+	s.Empty(record.Documentation)
+	s.False(record.Status)
+	s.Equal("*/10 * * * *", record.Cron)
+}
+
 func (s *HandlerMCPSuite) Test_DeleteTrigger() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)

--- a/src/lib/factory/trigger_function.go
+++ b/src/lib/factory/trigger_function.go
@@ -23,9 +23,9 @@ func (tf MockFunctionTrigger) Insert(conn databasetest.TestDB) error {
 
 	insertQuery := `
 		INSERT INTO skitapi.function_triggers
-			(env_id, cron, next_run_at, trigger_options, trigger_status, updated_at, created_at)
+			(env_id, cron, next_run_at, trigger_options, trigger_status, updated_at, created_at, documentation)
 		VALUES
-			($1, $2, $3, $4, $5, $6, $7)
+			($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING
 			trigger_id;
 	`
@@ -38,6 +38,7 @@ func (tf MockFunctionTrigger) Insert(conn databasetest.TestDB) error {
 		tf.Status,
 		tf.UpdatedAt,
 		tf.CreatedAt,
+		tf.Documentation,
 	).Scan(&tf.ID)
 }
 

--- a/src/migrations/0026_2026-08-08.up.sql
+++ b/src/migrations/0026_2026-08-08.up.sql
@@ -1,0 +1,12 @@
+-- Free-form notes describing what a periodic trigger is for, rendered as
+-- markdown in the UI. A trigger's cron and URL say when and where it fires, but
+-- not why it exists or what breaks if it stops — that context previously lived
+-- outside Stormkit.
+--
+-- A column rather than a key inside trigger_options: the text documents the
+-- trigger, not the HTTP request that Options models, and keeping it top level
+-- leaves it searchable without digging through jsonb.
+--
+-- Nullable with no default, so existing triggers read as "undocumented" rather
+-- than carrying an empty string.
+ALTER TABLE function_triggers ADD COLUMN IF NOT EXISTS documentation text;

--- a/src/migrations/structure.sql
+++ b/src/migrations/structure.sql
@@ -701,7 +701,8 @@ CREATE TABLE skitapi.function_triggers (
     cron text NOT NULL,
     next_run_at timestamp without time zone,
     created_at timestamp without time zone DEFAULT (now() AT TIME ZONE 'UTC'::text) NOT NULL,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    documentation text
 );
 
 

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -21,6 +21,8 @@
         "@codemirror/lang-json": "^6.0.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.2.3",
         "@mui/icons-material": "^7.3.2",
         "@mui/lab": "^7.0.0-beta.17",
         "@mui/material": "^7.3.2",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -26,6 +26,8 @@
     "@codemirror/lang-html": "^6.4.9",
     "@codemirror/lang-json": "^6.0.1",
     "@emotion/react": "^11.14.0",
+    "@lezer/common": "^1.5.1",
+    "@lezer/highlight": "^1.2.3",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.2",
     "@mui/lab": "^7.0.0-beta.17",

--- a/src/ui/src/components/CodeBlock/CodeBlock.spec.tsx
+++ b/src/ui/src/components/CodeBlock/CodeBlock.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import CodeBlock from "./CodeBlock";
+
+describe("~/components/CodeBlock/CodeBlock.tsx", () => {
+  it("highlights json content", () => {
+    const wrapper = render(<CodeBlock>{'{"a": 1}'}</CodeBlock>);
+
+    expect(wrapper.getByTestId("code-block").innerHTML).toContain(
+      "tok-propertyName"
+    );
+  });
+
+  it("highlights html content", () => {
+    const wrapper = render(
+      <CodeBlock>{"<!DOCTYPE html>\n<html lang=\"en\"></html>"}</CodeBlock>
+    );
+
+    const block = wrapper.getByTestId("code-block");
+
+    expect(block.innerHTML).toContain("tok-");
+    // The markup is shown as text, not parsed into the page.
+    expect(block.querySelector("html")).toBe(null);
+    expect(block.textContent).toContain("<!DOCTYPE html>");
+  });
+
+  it("renders plain text as is", () => {
+    const wrapper = render(<CodeBlock>No payload</CodeBlock>);
+
+    const block = wrapper.getByTestId("code-block");
+
+    expect(block.textContent).toBe("No payload");
+    expect(block.innerHTML).not.toContain("tok-");
+  });
+
+  it("renders oversized content as plain text", () => {
+    const big = `{"a": "${"x".repeat(100_000)}"}`;
+    const wrapper = render(<CodeBlock>{big}</CodeBlock>);
+
+    const block = wrapper.getByTestId("code-block");
+
+    expect(block.textContent).toBe(big);
+    expect(block.innerHTML).not.toContain("tok-");
+  });
+
+  it("honours an explicit language over detection", () => {
+    const wrapper = render(<CodeBlock language="json">{"[1]"}</CodeBlock>);
+
+    expect(wrapper.getByTestId("code-block").innerHTML).toContain("tok-number");
+  });
+});

--- a/src/ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/ui/src/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,64 @@
+import type { SxProps } from "@mui/material";
+import { useMemo } from "react";
+import Box from "@mui/material/Box";
+import {
+  detectLanguage,
+  highlightToHtml,
+  tokenStyles,
+  type Language,
+} from "~/utils/helpers/highlight";
+
+interface Props {
+  children: string;
+  /** Defaults to detecting json/html from the content. */
+  language?: Language;
+  sx?: SxProps;
+}
+
+const preStyles = {
+  bgcolor: "container.transparent",
+  p: 2,
+  maxWidth: "100%",
+  overflow: "auto",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+};
+
+// Detecting and highlighting both parse the whole input synchronously during
+// render, and expand it into one element per token. Trigger log bodies are
+// whatever the remote endpoint returned, with no cap, so above this size the
+// block renders as plain text — the same way it did before it was highlighted.
+const MAX_HIGHLIGHT_LENGTH = 100_000;
+
+/**
+ * Renders a block of code, syntax highlighted when the language is one we can
+ * parse and as plain text otherwise.
+ */
+export default function CodeBlock({ children, language, sx }: Props) {
+  const html = useMemo(() => {
+    if (children.length > MAX_HIGHLIGHT_LENGTH) {
+      return null;
+    }
+
+    return highlightToHtml(children, language ?? detectLanguage(children));
+  }, [children, language]);
+
+  const styles = { ...preStyles, ...tokenStyles, ...sx };
+
+  if (html === null) {
+    return (
+      <Box component="pre" data-testid="code-block" sx={styles}>
+        {children}
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      component="pre"
+      data-testid="code-block"
+      sx={styles}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/ui/src/components/CodeBlock/index.ts
+++ b/src/ui/src/components/CodeBlock/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CodeBlock";

--- a/src/ui/src/components/Markdown/Markdown.spec.tsx
+++ b/src/ui/src/components/Markdown/Markdown.spec.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import Markdown, { toSafeHtml } from "./Markdown";
+
+describe("~/components/Markdown/Markdown.tsx", () => {
+  it("renders markdown formatting", () => {
+    const wrapper = render(
+      <Markdown>{"# Title\n\nSome **bold** text and `code`."}</Markdown>
+    );
+
+    const html = wrapper.getByTestId("markdown").innerHTML;
+
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<code>code</code>");
+  });
+
+  it("renders nothing when the content is empty", () => {
+    const wrapper = render(<Markdown>{""}</Markdown>);
+
+    expect(wrapper.queryByTestId("markdown")).toBe(null);
+  });
+
+  it("strips scripts and event handlers", () => {
+    const html = toSafeHtml(
+      '<script>alert(1)</script><img src=x onerror="alert(1)"><p onclick="alert(1)">hi</p>'
+    );
+
+    expect(html).not.toContain("script");
+    expect(html).not.toContain("onerror");
+    expect(html).not.toContain("onclick");
+    expect(html).toContain("hi");
+  });
+
+  it("strips javascript: and data: links but keeps regular ones", () => {
+    expect(toSafeHtml("[click](javascript:alert(1))")).not.toContain(
+      "javascript:"
+    );
+
+    expect(
+      toSafeHtml('<a href="data:text/html,<script>alert(1)</script>">x</a>')
+    ).not.toContain("data:");
+
+    expect(toSafeHtml("[docs](https://www.stormkit.io)")).toContain(
+      'href="https://www.stormkit.io"'
+    );
+  });
+
+  it("opens links in a new tab without handing over the opener", () => {
+    const html = toSafeHtml("[docs](https://www.stormkit.io)");
+
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer nofollow"');
+  });
+
+  it("keeps in-app paths and anchors, navigating them in place", () => {
+    const path = toSafeHtml("[runbook](/apps/12/deployments)");
+
+    expect(path).toContain('href="/apps/12/deployments"');
+    expect(path).not.toContain("target=");
+
+    const anchor = toSafeHtml("[jump](#section)");
+
+    expect(anchor).toContain('href="#section"');
+    expect(anchor).not.toContain("target=");
+  });
+
+  // A protocol-relative URL leaves the app while looking like a path.
+  it("strips protocol-relative links", () => {
+    expect(toSafeHtml("[x](//evil.test/p)")).not.toContain("evil.test");
+  });
+
+  it("does not execute injected script when rendered", () => {
+    const fired: string[] = [];
+    (window as any).__xss = () => fired.push("fired");
+
+    const wrapper = render(
+      <Markdown>
+        {'<script>window.__xss()</script>' +
+          '<img src=x onerror="window.__xss()">' +
+          '<svg><animate onbegin="window.__xss()" /></svg>' +
+          "\n\nsafe text"}
+      </Markdown>
+    );
+
+    expect(wrapper.getByTestId("markdown").querySelector("script")).toBe(null);
+    expect(wrapper.getByTestId("markdown").innerHTML).not.toContain("__xss");
+    expect(fired).toEqual([]);
+
+    delete (window as any).__xss;
+  });
+
+  it("highlights json code fences", () => {
+    const html = toSafeHtml('```json\n{"a": 1, "b": true}\n```');
+
+    expect(html).toContain('<span class="tok-propertyName">"a"</span>');
+    expect(html).toContain('<span class="tok-number">1</span>');
+    expect(html).toContain('<span class="tok-bool">true</span>');
+  });
+
+  it("highlights html code fences", () => {
+    const html = toSafeHtml('```html\n<a href="/x">hi</a>\n```');
+
+    expect(html).toContain('<span class="tok-typeName">a</span>');
+    expect(html).toContain('<span class="tok-propertyName">href</span>');
+    // The fenced markup stays escaped rather than becoming a real element.
+    expect(html).toContain("&lt;");
+    expect(html).not.toContain('<a href="/x"');
+  });
+
+  it("leaves fences in unsupported languages alone", () => {
+    const html = toSafeHtml("```python\nprint(1)\n```");
+
+    expect(html).not.toContain("tok-");
+    expect(html).toContain("print(1)");
+  });
+
+  // A fence named after an inherited object key used to resolve to a truthy
+  // parser and throw mid-render, blanking the page.
+  it("renders a fence named after an object property", () => {
+    const wrapper = render(
+      <Markdown>{"Docs\n\n```constructor\nhello\n```"}</Markdown>
+    );
+
+    const html = wrapper.getByTestId("markdown").innerHTML;
+
+    expect(html).toContain("hello");
+    expect(html).not.toContain("tok-");
+  });
+
+  it("keeps only language- classes on code blocks", () => {
+    const html = toSafeHtml(
+      '<p class="MuiButton-root">x</p><pre><code class="language-json">1</code></pre>'
+    );
+
+    expect(html).not.toContain("MuiButton-root");
+    expect(html).toContain('class="language-json"');
+  });
+
+  it("drops images by default and keeps them when allowed", () => {
+    expect(toSafeHtml("![x](https://www.stormkit.io/a.png)")).not.toContain(
+      "<img"
+    );
+
+    const allowed = toSafeHtml("![x](https://www.stormkit.io/a.png)", {
+      allowImages: true,
+    });
+
+    expect(allowed).toContain('src="https://www.stormkit.io/a.png"');
+
+    // The URI allowlist still applies, so no data:/javascript: sources.
+    expect(
+      toSafeHtml('<img src="data:image/svg+xml,<svg/onload=alert(1)>">', {
+        allowImages: true,
+      })
+    ).not.toContain("data:");
+  });
+
+  it("drops embedding and styling tags", () => {
+    const html = toSafeHtml(
+      '<iframe src="https://evil.test"></iframe>' +
+        "<style>body{display:none}</style>" +
+        '<form action="https://evil.test"><input name="pw"></form>' +
+        "<p>kept</p>"
+    );
+
+    expect(html).not.toContain("iframe");
+    expect(html).not.toContain("<style");
+    expect(html).not.toContain("<form");
+    expect(html).not.toContain("<input");
+    expect(html).toContain("<p>kept</p>");
+  });
+});

--- a/src/ui/src/components/Markdown/Markdown.tsx
+++ b/src/ui/src/components/Markdown/Markdown.tsx
@@ -1,0 +1,242 @@
+import type { SxProps } from "@mui/material";
+import { useMemo } from "react";
+import createDOMPurify from "dompurify";
+import { marked } from "marked";
+import Typography from "@mui/material/Typography";
+import {
+  highlightToHtml,
+  tokenStyles,
+  type Language,
+} from "~/utils/helpers/highlight";
+
+interface Props {
+  children: string;
+  /** See SafeHtmlOptions.allowImages. */
+  allowImages?: boolean;
+  sx?: SxProps;
+}
+
+interface SafeHtmlOptions {
+  /**
+   * Permits `img`. Off by default: an image is fetched the moment the content
+   * renders, so it reports the reader's IP to whatever host the author picked,
+   * without the reader choosing to go there the way a link requires. Worth it
+   * for first-party content like the changelog, not for text any teammate can
+   * store on a record.
+   */
+  allowImages?: boolean;
+}
+
+const LANGUAGE_CLASS = /^language-[a-z0-9-]+$/i;
+
+// An href or src is either an http(s)/mailto URL or a same-document reference
+// starting with / or #. `/(?!/)` and not `/` alone, so a protocol-relative
+// `//evil.test` cannot pass itself off as an in-app path. Spelled out as an
+// allowlist rather than relaxed to DOMPurify's default, which is where a
+// bypass would creep back in.
+const SAFE_URI = /^(?:https?:|mailto:|#|\/(?!\/))/i;
+
+// DOMPurify strips these before its own URI check, so anything comparing a URI
+// by hand has to strip them too — `da&#9;ta:` is `data:` to the browser.
+const URI_WHITESPACE =
+  /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g;
+
+function isSafeURI(value: string): boolean {
+  return SAFE_URI.test(value.replace(URI_WHITESPACE, ""));
+}
+
+// Inline formatting and structure only. Anything that can execute, embed or
+// phone home (script, iframe, style, form, event handlers) is dropped rather
+// than escaped, because the source is user-authored text stored verbatim.
+//
+// svg, math, style, noscript and template are deliberately absent: they are the
+// namespace-confusion primitives every known mXSS mutation needs, and
+// highlightCodeBlocks below re-parses the sanitized output, so sanitizing is
+// not the last step. Do not add them without moving the highlighting pass
+// before the final sanitize.
+const ALLOWED_TAGS = [
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "a",
+  "ul",
+  "ol",
+  "li",
+  "strong",
+  "em",
+  "b",
+  "i",
+  "code",
+  "pre",
+  "blockquote",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  "br",
+  "hr",
+];
+
+const ALLOWED_ATTR = ["href", "title", "target", "rel", "class"];
+
+// Own instance rather than the shared default export: the hook below is
+// registered globally on whichever instance it is attached to, and other
+// callers sanitize their own content with different rules.
+const purify = createDOMPurify(window);
+
+/**
+ * Rewrites the body of each fenced code block whose language we can parse into
+ * class-tagged spans.
+ *
+ * Runs on already-sanitized HTML, and highlights the block's textContent rather
+ * than its markup, so the spans it introduces cannot carry anything the
+ * sanitizer just removed.
+ */
+function highlightCodeBlocks(html: string): string {
+  if (!html.includes("<code")) {
+    return html;
+  }
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const blocks = doc.querySelectorAll("pre > code[class]");
+
+  if (blocks.length === 0) {
+    return html;
+  }
+
+  blocks.forEach(block => {
+    const language = block.className
+      .replace(/^language-/i, "")
+      .toLowerCase() as Language;
+
+    const highlighted = highlightToHtml(block.textContent || "", language);
+
+    if (highlighted !== null) {
+      block.innerHTML = highlighted;
+    }
+  });
+
+  return doc.body.innerHTML;
+}
+
+purify.addHook("afterSanitizeAttributes", node => {
+  // ALLOWED_URI_REGEXP is not the last word on its own: DOMPurify carves out
+  // data: URIs for img and the other media tags regardless of it, which is how
+  // a `data:image/svg+xml,<svg onload=...>` source survives the config. Re-check
+  // both attributes here so the allowlist is actually the allowlist.
+  ["href", "src"].forEach(attr => {
+    const value = node.getAttribute?.(attr);
+
+    if (value !== null && value !== undefined && !isSafeURI(value)) {
+      node.removeAttribute(attr);
+    }
+  });
+
+  // Links off the app are authored by one team member and clicked by another,
+  // so they open in a new tab and never hand the opener over to the
+  // destination. In-app paths and anchors navigate in place.
+  if (node.tagName === "A" && node.hasAttribute("href")) {
+    if (/^https?:/i.test(node.getAttribute("href") || "")) {
+      node.setAttribute("target", "_blank");
+      node.setAttribute("rel", "noopener noreferrer nofollow");
+    }
+  }
+
+  // `class` is allowed only so fenced code blocks keep the language marker
+  // marked emits. Anything else is dropped rather than letting authored text
+  // borrow arbitrary styles from the app.
+  if (node.hasAttribute?.("class")) {
+    const className = node.getAttribute("class") || "";
+
+    if (LANGUAGE_CLASS.test(className)) {
+      node.setAttribute("class", className.trim());
+    } else {
+      node.removeAttribute("class");
+    }
+  }
+});
+
+export function toSafeHtml(
+  markdown: string,
+  { allowImages }: SafeHtmlOptions = {}
+): string {
+  const html = purify.sanitize(marked.parse(markdown || "") as string, {
+    ALLOWED_TAGS: allowImages ? [...ALLOWED_TAGS, "img"] : ALLOWED_TAGS,
+    ALLOWED_ATTR: allowImages ? [...ALLOWED_ATTR, "src", "alt"] : ALLOWED_ATTR,
+    ALLOW_DATA_ATTR: false,
+    // Backed up by the re-check in the hook above, which covers the data: URI
+    // exception this option does not.
+    ALLOWED_URI_REGEXP: SAFE_URI,
+  });
+
+  return highlightCodeBlocks(html);
+}
+
+/**
+ * Renders a markdown string as sanitized HTML, inheriting the surrounding
+ * typography so it reads as body text rather than raw HTML defaults.
+ */
+export default function Markdown({ children, allowImages, sx }: Props) {
+  const html = useMemo(
+    () => toSafeHtml(children, { allowImages }),
+    [children, allowImages]
+  );
+
+  if (!html) {
+    return null;
+  }
+
+  return (
+    <Typography
+      component="div"
+      data-testid="markdown"
+      dangerouslySetInnerHTML={{ __html: html }}
+      sx={{
+        wordBreak: "break-word",
+        "& > *:first-of-type": { mt: 0 },
+        "& > *:last-child": { mb: 0 },
+        "& p, & ul, & ol, & blockquote, & pre, & table": { my: 1 },
+        "& ul, & ol": { pl: 3 },
+        "& h1, & h2, & h3, & h4, & h5, & h6": {
+          my: 1,
+          fontSize: "inherit",
+          fontWeight: "bold",
+        },
+        "& a": { color: "text.primary" },
+        "& code": {
+          bgcolor: "container.transparent",
+          borderRadius: 1,
+          px: 0.5,
+        },
+        "& pre": {
+          bgcolor: "container.transparent",
+          borderRadius: 1,
+          p: 1,
+          overflowX: "auto",
+          "& code": { bgcolor: "transparent", px: 0 },
+          ...tokenStyles,
+        },
+        "& blockquote": {
+          borderLeft: "2px solid",
+          borderColor: "container.transparent",
+          pl: 1.5,
+          ml: 0,
+        },
+        "& table": { borderCollapse: "collapse" },
+        "& th, & td": {
+          border: "1px solid",
+          borderColor: "container.border",
+          px: 1,
+          py: 0.5,
+        },
+        ...sx,
+      }}
+    />
+  );
+}

--- a/src/ui/src/components/Markdown/index.ts
+++ b/src/ui/src/components/Markdown/index.ts
@@ -1,0 +1,1 @@
+export { default, toSafeHtml } from "./Markdown";

--- a/src/ui/src/layouts/TopMenu/UserButtons.tsx
+++ b/src/ui/src/layouts/TopMenu/UserButtons.tsx
@@ -1,6 +1,4 @@
 import React, { useContext, useEffect, useState } from "react";
-import DOMPurify from "dompurify";
-import { marked } from "marked";
 import { AuthContext } from "~/pages/auth/Auth.context";
 import api from "~/utils/api/Api";
 import { Notifications } from "@mui/icons-material";
@@ -8,23 +6,33 @@ import { useTheme } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import Typography from "@mui/material/Typography";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import UserAvatar from "~/components/UserAvatar";
+import Markdown from "~/components/Markdown";
 import SideBar from "~/components/SideBar";
 import Spinner from "~/components/Spinner";
 import UserMenu from "./UserMenu";
+
+// The changelog is authored relative to www.stormkit.io, so its links and
+// images are absolutized before rendering. Applied to the markdown source,
+// which covers both markdown syntax and any raw HTML embedded in it.
+function absolutize(markdown: string): string {
+  return markdown
+    .replace(/\]\(\//g, "](https://www.stormkit.io/")
+    .replace(/src="(\/[^"]+)"/g, 'src="https://www.stormkit.io$1"')
+    .replace(/href="(\/[^"]+)"/g, 'href="https://www.stormkit.io$1"');
+}
 
 const UserButtons: React.FC = () => {
   const theme = useTheme();
   const { user } = useContext(AuthContext);
   const [isNewsOpen, toggleNews] = useState(false);
   const [isUserMenuOpen, toggleUserMenu] = useState(false);
-  const [newsHtml, setNewsHtml] = useState("");
+  const [news, setNews] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    if (!isNewsOpen || newsHtml) {
+    if (!isNewsOpen || news) {
       return;
     }
 
@@ -33,47 +41,15 @@ const UserButtons: React.FC = () => {
     api
       .fetch<{ markdown: string }>("/changelog")
       .then(data => {
-        const raw = (marked.parse(data.markdown || "") as string)
-          .replace(/src="(\/[^"]+)"/g, 'src="https://www.stormkit.io$1"')
-          .replace(/href="(\/[^"]+)"/g, 'href="https://www.stormkit.io$1"');
-
-        const html = DOMPurify.sanitize(raw, {
-          ALLOWED_TAGS: [
-            "h1",
-            "h2",
-            "h3",
-            "h4",
-            "h5",
-            "h6",
-            "p",
-            "a",
-            "ul",
-            "ol",
-            "li",
-            "strong",
-            "em",
-            "b",
-            "i",
-            "code",
-            "pre",
-            "blockquote",
-            "img",
-            "br",
-            "hr",
-          ],
-          ALLOWED_ATTR: ["href", "src", "alt", "title"],
-          ALLOW_DATA_ATTR: false,
-        });
-
-        setNewsHtml(html);
+        setNews(absolutize(data.markdown || ""));
       })
       .catch(() => {
-        setNewsHtml("<p>Failed to load changelog.</p>");
+        setNews("Failed to load changelog.");
       })
       .finally(() => {
         setIsLoading(false);
       });
-  }, [isNewsOpen, newsHtml]);
+  }, [isNewsOpen, news]);
 
   if (!user) {
     return <></>;
@@ -140,10 +116,9 @@ const UserButtons: React.FC = () => {
               <Spinner />
             </Box>
           )}
-          {newsHtml && (
-            <Typography
-              component="div"
-              dangerouslySetInnerHTML={{ __html: newsHtml }}
+          {news && (
+            <Markdown
+              allowImages
               sx={{
                 "& h2": { mt: 2, mb: 1, fontSize: "1.1rem", fontWeight: 600 },
                 "& p": { mb: 1.5, lineHeight: 1.6 },
@@ -156,7 +131,9 @@ const UserButtons: React.FC = () => {
                 },
                 "& img": { maxWidth: "100%", height: "auto", display: "block" },
               }}
-            />
+            >
+              {news}
+            </Markdown>
           )}
         </Box>
       </SideBar>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.spec.tsx
@@ -105,6 +105,49 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/_components/Functi
     });
   });
 
+  it("should submit documentation and preview it as markdown", async () => {
+    await createWrapper();
+    await openDropdown();
+    await fireEvent.click(findOption("www.e.org")!);
+
+    const scope = mockActions.mockCreateFunctionTrigger({
+      appId: currentApp.id,
+      envId: currentEnv.id!,
+      status: false,
+      options: {
+        url: `https://www.e.org/test`,
+        method: "GET",
+        headers: {},
+        payload: "",
+      },
+      cron: "1 * * * *",
+      documentation: "Runs the **rollup**",
+    });
+
+    await userEvent.type(wrapper.getByLabelText("Cron"), "1 * * * *");
+    await userEvent.type(wrapper.getByLabelText(/trigger periodi/), "test");
+    await userEvent.type(
+      wrapper.getByLabelText("Documentation"),
+      "Runs the **rollup**"
+    );
+
+    await fireEvent.click(wrapper.getByText("Preview"));
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByTestId("documentation-preview").innerHTML
+      ).toContain("<strong>rollup</strong>");
+    });
+
+    await fireEvent.click(wrapper.getByText("Edit"));
+    await fireEvent.click(wrapper.getByText("Create"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(successHandler).toHaveBeenCalled();
+    });
+  });
+
   it("should create a new trigger", async () => {
     await createWrapper();
     await openDropdown();

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.tsx
@@ -14,6 +14,7 @@ import Link from "@mui/material/Link";
 import Modal from "~/components/Modal";
 import Form from "~/components/FormV2";
 import Card from "~/components/Card";
+import Markdown from "~/components/Markdown";
 import CardHeader from "~/components/CardHeader";
 import KeyValue from "~/components/FormV2/KeyValue";
 import CardFooter from "~/components/CardFooter";
@@ -54,6 +55,12 @@ export default function TriggerFunctionModal({
   const [showHeaders, setShowHeaders] = useState(Boolean(options?.headers));
   const [showPayload, setShowPayload] = useState(Boolean(options?.payload));
   const [codeContent, setCodeContent] = useState(options?.payload || "");
+  const [documentation, setDocumentation] = useState(
+    triggerFunction?.documentation || ""
+  );
+  // The editor and the preview swap in place, so the value is kept in state
+  // rather than read off the form on submit.
+  const [showPreview, setShowPreview] = useState(false);
 
   const defaultHeaders = useMemo(() => {
     return triggerFunction?.options?.headers || {};
@@ -85,6 +92,7 @@ export default function TriggerFunctionModal({
       envId: environment.id || "",
       cron,
       status,
+      documentation,
       options: {
         url: `https://${host}/${urlPath.replace(/^\/+/, "")}`,
         method: method as FunctionTriggerMethod,
@@ -176,6 +184,50 @@ export default function TriggerFunctionModal({
                 }
               />
             </Box>
+            <Box sx={{ mb: 4 }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  mb: 1,
+                }}
+              >
+                <Typography variant="h4">Documentation</Typography>
+                <Button
+                  type="button"
+                  variant="text"
+                  size="small"
+                  disabled={!documentation.trim()}
+                  onClick={() => setShowPreview(!showPreview)}
+                >
+                  {showPreview ? "Edit" : "Preview"}
+                </Button>
+              </Box>
+
+              {showPreview ? (
+                <Box
+                  data-testid="documentation-preview"
+                  sx={{ bgcolor: "container.paper", p: 1.75, minHeight: 120 }}
+                >
+                  <Markdown>{documentation}</Markdown>
+                </Box>
+              ) : (
+                <TextField
+                  name="documentation"
+                  variant="filled"
+                  multiline
+                  minRows={4}
+                  fullWidth
+                  placeholder="What this trigger does, and who to ping when it breaks."
+                  value={documentation}
+                  onChange={e => setDocumentation(e.target.value)}
+                  inputProps={{ "aria-label": "Documentation" }}
+                  helperText="Markdown supported. Shown with the trigger's run details, never sent with the request."
+                />
+              )}
+            </Box>
+
             <Box sx={{ bgcolor: "container.paper", p: 1.75, pt: 1, mb: 4 }}>
               <FormControlLabel
                 sx={{ pl: 0, ml: 0 }}

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.spec.tsx
@@ -155,10 +155,11 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.t
     await waitFor(() => {
       expect(invokeScope.isDone()).toBe(true);
       expect(wrapper.getByText("Log details")).toBeTruthy();
-      // The response body is pretty printed.
+      // The response body is pretty printed. Its text is split across
+      // highlighting spans, so it is matched on the block's text content.
       expect(
-        wrapper.getByText(`{\n  "status": "ok"\n}`, { normalizer: s => s })
-      ).toBeTruthy();
+        wrapper.getAllByTestId("code-block").at(1)?.textContent
+      ).toBe(`{\n  "status": "ok"\n}`);
     });
 
     // The past runs are only fetched once the user navigates back to them.
@@ -206,8 +207,8 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.t
     await waitFor(() => {
       expect(wrapper.getByText("Log details")).toBeTruthy();
       expect(
-        wrapper.getByText(`{\n  "status": "ok"\n}`, { normalizer: s => s })
-      ).toBeTruthy();
+        wrapper.getAllByTestId("code-block").at(1)?.textContent
+      ).toBe(`{\n  "status": "ok"\n}`);
     });
 
     fireEvent.click(wrapper.getByTestId("back-to-logs"));

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogDetails.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogDetails.spec.tsx
@@ -1,0 +1,36 @@
+import type { RenderResult } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { mockTriggerLog } from "~/testing/data/mock_function_triggers";
+import TriggerLogDetails from "./TriggerLogDetails";
+
+describe("~/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogDetails.tsx", () => {
+  let wrapper: RenderResult;
+
+  it("renders documentation as markdown below the response body", () => {
+    wrapper = render(
+      <TriggerLogDetails
+        log={mockTriggerLog()}
+        documentation={"Runs the **rollup**.\n\nPing #data if it fails."}
+      />
+    );
+
+    expect(wrapper.getByText("Documentation")).toBeTruthy();
+    expect(wrapper.getByTestId("markdown").innerHTML).toContain(
+      "<strong>rollup</strong>"
+    );
+
+    // The section is appended after the response body, not before it.
+    const html = wrapper.container.innerHTML;
+    expect(html.indexOf("Response body")).toBeLessThan(
+      html.indexOf("Documentation")
+    );
+  });
+
+  it("omits the section when the trigger has no documentation", () => {
+    wrapper = render(<TriggerLogDetails log={mockTriggerLog()} />);
+
+    expect(wrapper.queryByText("Documentation")).toBe(null);
+    expect(wrapper.queryByTestId("markdown")).toBe(null);
+  });
+});

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogDetails.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogDetails.tsx
@@ -1,32 +1,32 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Span from "~/components/Span";
+import Markdown from "~/components/Markdown";
+import CodeBlock from "~/components/CodeBlock";
 import { formatBody } from "./prettyPrint";
 import { statusColor } from "./statusColor";
 
 interface Props {
   log: TriggerLog;
+  documentation?: string;
 }
 
-const preStyles = {
+const sectionStyles = {
   bgcolor: "container.transparent",
   p: 2,
   maxWidth: "100%",
   overflow: "auto",
-  whiteSpace: "pre-wrap",
   wordBreak: "break-word",
 };
 
-export default function TriggerLogDetails({ log }: Props) {
+export default function TriggerLogDetails({ log, documentation }: Props) {
   return (
     <Box sx={{ fontSize: 12 }}>
       <Box sx={{ mb: 4 }}>
         <Typography variant="h3" sx={{ mb: 2 }}>
           Request payload
         </Typography>
-        <Box component="pre" sx={preStyles}>
-          {formatBody(log.request?.payload, "No payload")}
-        </Box>
+        <CodeBlock>{formatBody(log.request?.payload, "No payload")}</CodeBlock>
       </Box>
       <Box>
         <Typography
@@ -47,13 +47,23 @@ export default function TriggerLogDetails({ log }: Props) {
             {log.response?.code || "ERR"}
           </Span>
         </Typography>
-        <Box component="pre" sx={preStyles}>
+        <CodeBlock>
           {formatBody(
             log.response?.body || log.response?.error,
             "No response body"
           )}
-        </Box>
+        </CodeBlock>
       </Box>
+      {documentation && (
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h3" sx={{ mb: 2 }}>
+            Documentation
+          </Typography>
+          <Box sx={sectionStyles}>
+            <Markdown sx={{ fontSize: 12 }}>{documentation}</Markdown>
+          </Box>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogsDrawer.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/_components/TriggerLogsDrawer.tsx
@@ -80,7 +80,10 @@ export default function TriggerLogsDrawer({
               </Button>
             }
           />
-          <TriggerLogDetails log={selected} />
+          <TriggerLogDetails
+            log={selected}
+            documentation={trigger.documentation}
+          />
         </Card>
       ) : (
         <Card

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/actions.ts
@@ -92,6 +92,7 @@ export function createFunctionTrigger({
   cron,
   options,
   status,
+  documentation,
 }: CreateFunctionTriggerProps): Promise<FunctionTrigger> {
   if (appId === "" || envId === "") {
     return Promise.reject("AppId and EnvId cannot be empty.");
@@ -111,6 +112,7 @@ export function createFunctionTrigger({
     cron,
     status,
     options,
+    documentation,
   });
 }
 
@@ -121,6 +123,7 @@ interface UpdateFunctionTriggerProps {
   cron: string;
   status: boolean;
   options: FunctionTriggerOptions;
+  documentation?: string;
 }
 
 export const updateFunctionTrigger = ({
@@ -130,6 +133,7 @@ export const updateFunctionTrigger = ({
   cron,
   status,
   options,
+  documentation,
 }: UpdateFunctionTriggerProps): Promise<void> => {
   if (options.url.trim() === "") {
     return Promise.reject("Url cannot be empty.");
@@ -146,6 +150,7 @@ export const updateFunctionTrigger = ({
     status,
     cron,
     options,
+    documentation,
   });
 };
 
@@ -156,6 +161,7 @@ interface UpsertFunctionTriggerProps {
   status: boolean;
   cron: string;
   options: FunctionTriggerOptions;
+  documentation?: string;
 }
 
 export const upsertFunctionTrigger = ({
@@ -165,9 +171,18 @@ export const upsertFunctionTrigger = ({
   status,
   cron,
   options,
+  documentation,
 }: UpsertFunctionTriggerProps): Promise<void | FunctionTrigger> => {
   if (tfid) {
-    return updateFunctionTrigger({ tfid, status, cron, options, appId, envId });
+    return updateFunctionTrigger({
+      tfid,
+      status,
+      cron,
+      options,
+      documentation,
+      appId,
+      envId,
+    });
   }
 
   return createFunctionTrigger({
@@ -176,6 +191,7 @@ export const upsertFunctionTrigger = ({
     status,
     cron,
     options,
+    documentation,
   });
 };
 

--- a/src/ui/src/testing/nocks/nock_function_triggers.ts
+++ b/src/ui/src/testing/nocks/nock_function_triggers.ts
@@ -68,6 +68,7 @@ interface MockUpdateFunctionTriggerProps {
   status: boolean;
   cron: string;
   options: any;
+  documentation?: string;
 }
 
 export const mockUpdateFunctionTrigger = ({
@@ -77,6 +78,7 @@ export const mockUpdateFunctionTrigger = ({
   status,
   cron,
   options,
+  documentation = "",
 }: MockUpdateFunctionTriggerProps) => {
   return nock(endpoint)
     .patch(`/v1/trigger`, {
@@ -86,6 +88,7 @@ export const mockUpdateFunctionTrigger = ({
       status,
       cron,
       options,
+      documentation,
     })
     .reply(201, { ok: true });
 };
@@ -96,6 +99,7 @@ interface MockCreateFunctionTriggerProps {
   status: boolean;
   cron: string;
   options: any;
+  documentation?: string;
 }
 
 export const mockCreateFunctionTrigger = ({
@@ -104,6 +108,7 @@ export const mockCreateFunctionTrigger = ({
   status,
   cron,
   options,
+  documentation = "",
 }: MockCreateFunctionTriggerProps) => {
   return nock(endpoint)
     .post(`/v1/trigger`, {
@@ -112,6 +117,7 @@ export const mockCreateFunctionTrigger = ({
       status,
       cron,
       options,
+      documentation,
     })
     .reply(201, { ok: true });
 };

--- a/src/ui/src/types/function-triggers.d.ts
+++ b/src/ui/src/types/function-triggers.d.ts
@@ -15,6 +15,8 @@ declare interface FunctionTriggerOptions {
 declare interface FunctionTrigger {
   id?: string;
   cron: string;
+  /** Free-form markdown describing what the trigger is for. */
+  documentation?: string;
   status: boolean;
   options: FunctionTriggerOptions;
   nextRunAt?: number;

--- a/src/ui/src/utils/helpers/highlight.spec.tsx
+++ b/src/ui/src/utils/helpers/highlight.spec.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { detectLanguage, highlightToHtml } from "./highlight";
+
+describe("~/utils/helpers/highlight.ts", () => {
+  describe("detectLanguage", () => {
+    it("detects json objects and arrays", () => {
+      expect(detectLanguage('{"a":1}')).toBe("json");
+      expect(detectLanguage("[1, 2, 3]")).toBe("json");
+      expect(detectLanguage('\n  {"a":1}\n')).toBe("json");
+    });
+
+    it("detects html documents and fragments", () => {
+      expect(detectLanguage("<!DOCTYPE html>\n<html></html>")).toBe("html");
+      expect(detectLanguage("<div>hi</div>")).toBe("html");
+      expect(detectLanguage('<a href="/x">hi</a>')).toBe("html");
+    });
+
+    it("returns undefined for plain text and broken json", () => {
+      expect(detectLanguage("")).toBeUndefined();
+      expect(detectLanguage("   ")).toBeUndefined();
+      expect(detectLanguage("No payload")).toBeUndefined();
+      expect(detectLanguage("{not json")).toBeUndefined();
+      expect(detectLanguage("5 < 6 and 7 > 2")).toBeUndefined();
+    });
+  });
+
+  describe("highlightToHtml", () => {
+    it("returns null when the language is unknown", () => {
+      expect(highlightToHtml("print(1)", undefined)).toBe(null);
+    });
+
+    // The language comes from a fence's info string, so inherited keys must not
+    // resolve to a parser.
+    it("returns null for inherited object keys", () => {
+      const inherited = ["constructor", "toString", "valueOf", "__proto__"];
+
+      inherited.forEach(language => {
+        expect(highlightToHtml("x", language as never)).toBe(null);
+      });
+    });
+
+    it("tags json tokens", () => {
+      const html = highlightToHtml('{"a": 1, "b": true}', "json")!;
+
+      expect(html).toContain('<span class="tok-propertyName">&quot;a&quot;');
+      expect(html).toContain('<span class="tok-number">1</span>');
+      expect(html).toContain('<span class="tok-bool">true</span>');
+    });
+
+    it("tags html tokens and escapes the markup", () => {
+      const html = highlightToHtml('<a href="/x">hi</a>', "html")!;
+
+      expect(html).toContain('<span class="tok-typeName">a</span>');
+      expect(html).toContain('<span class="tok-propertyName">href</span>');
+      expect(html).toContain("&lt;");
+      expect(html).not.toContain('<a href="/x"');
+    });
+
+    it("escapes content that would otherwise become markup", () => {
+      const html = highlightToHtml(
+        '{"a": "<img src=x onerror=alert(1)>"}',
+        "json"
+      )!;
+
+      expect(html).not.toContain("<img");
+      expect(html).toContain("&lt;img");
+    });
+  });
+});

--- a/src/ui/src/utils/helpers/highlight.ts
+++ b/src/ui/src/utils/helpers/highlight.ts
@@ -1,0 +1,112 @@
+import type { Parser } from "@lezer/common";
+import { classHighlighter, highlightCode } from "@lezer/highlight";
+import { jsonLanguage } from "@codemirror/lang-json";
+import { htmlLanguage } from "@codemirror/lang-html";
+
+export type Language = "json" | "html";
+
+const parsers: Record<Language, Parser> = {
+  json: jsonLanguage.parser,
+  html: htmlLanguage.parser,
+};
+
+/**
+ * Token colors for highlighted output, keyed by the classes
+ * @lezer/highlight's classHighlighter emits.
+ *
+ * JSON keys and HTML attribute names both arrive as propertyName, and HTML tag
+ * names as typeName. Colors are palette entries so highlighting follows the
+ * active theme rather than assuming a dark background.
+ */
+export const tokenStyles = {
+  "& .tok-propertyName": { color: "info.main" },
+  "& .tok-string": { color: "success.main" },
+  "& .tok-number, & .tok-bool, & .tok-keyword, & .tok-atom": {
+    color: "warning.main",
+  },
+  "& .tok-typeName": { color: "error.main" },
+  "& .tok-punctuation, & .tok-operator": { color: "text.secondary" },
+  "& .tok-comment": { color: "text.secondary", fontStyle: "italic" },
+};
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Guesses the language of a request or response body, which arrives without a
+ * content type attached. Only the two languages we can highlight are detected;
+ * anything else is left to render as plain text.
+ */
+export function detectLanguage(code: string): Language | undefined {
+  const trimmed = code.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^[[{]/.test(trimmed)) {
+    try {
+      JSON.parse(trimmed);
+      return "json";
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (/^<(?:!doctype|\?xml|\/?[a-z][a-z0-9-]*)[\s>/]/i.test(trimmed)) {
+    return "html";
+  }
+
+  return undefined;
+}
+
+/**
+ * Renders code as class-tagged spans.
+ *
+ * Every span is built from the plain text passed in, with the text escaped, so
+ * the markup this produces never carries anything from the source beyond its
+ * characters. Returns null when the language is unknown, leaving the caller to
+ * render the text as is.
+ *
+ * The language reaches here from a fenced block's info string, so it is an
+ * arbitrary word rather than a `Language`: it is looked up as an own key, and
+ * parsing is guarded, because this runs during render and a throw here would
+ * take the page down.
+ */
+export function highlightToHtml(
+  code: string,
+  language?: Language
+): string | null {
+  if (!language || !Object.hasOwn(parsers, language)) {
+    return null;
+  }
+
+  const parser = parsers[language];
+
+  let html = "";
+
+  try {
+    highlightCode(
+      code,
+      parser.parse(code),
+      classHighlighter,
+      (text, classes) => {
+        html += classes
+          ? `<span class="${classes}">${escapeHtml(text)}</span>`
+          : escapeHtml(text);
+      },
+      () => {
+        html += "\n";
+      }
+    );
+  } catch {
+    return null;
+  }
+
+  return html;
+}


### PR DESCRIPTION
## What

Periodic triggers record *when* and *where* they fire, but not *why* they exist or what breaks when they stop. This adds a `documentation` field to triggers so that context lives next to the trigger itself.

## Schema

New migration `0026_2026-08-08.up.sql` adds a nullable `documentation text` column to `function_triggers`, plus the matching column in `structure.sql`.

A top-level column rather than a key inside `trigger_options`: the text documents the trigger, not the HTTP request that `Options` models, and keeping it top level leaves it searchable without digging through jsonb. Existing rows stay NULL and are normalized to an empty string via `COALESCE` on select, so they read as "undocumented" rather than failing the scan. Every select carries the column — including the scheduler's — so the column list and the scan stay identical on all three paths.

## Partial updates

`PATCH /v1/trigger` used to replace the trigger wholesale, so omitting an optional field cleared it. Adding a field that callers won't always send made that sharp enough to fix: every field on the request body is now a pointer, and only what the body carries is applied to the stored record. A caller changing the cron cannot destroy headers or documentation it never mentioned, and a field is cleared by sending its empty value explicitly.

Validation moved after the merge, so an update is checked against the record as it will be stored rather than against the partial body that produced it.

## Where it shows up

- **Trigger modal** — a multiline field with an Edit/Preview toggle.
- **Log details drawer** — rendered below Response body, in the same section container as the other two panes.
- **MCP** — `documentation` on `create_trigger` and `update_trigger`. Both schemas are `additionalProperties: false`, so the arg had to be declared explicitly. `update_trigger`'s required args drop to `envId` and `triggerId`, its description spells out that the update is partial, and `triggerBodyFromArgs` forwards only the arguments the caller actually supplied — filling in a zero value for an absent one would now clear the stored field.

## Markdown rendering

New `~/components/Markdown`, using `marked` and `dompurify` (both already dependencies):

- Allowlist of tags and attributes, so anything unnamed is dropped rather than escaped. No `script`, `iframe`, `style`, `form`, `input`, `svg` or `img`.
- `ALLOWED_URI_REGEXP` restricted to `https?:`/`mailto:`, so `javascript:` and `data:` URIs cannot reach an `href`.
- Links get `target="_blank"` and `rel="noopener noreferrer nofollow"`.
- `class` survives only when it matches `^language-[a-z0-9-]+$`, so authored text cannot borrow arbitrary app styles.
- Sanitizing happens on its **own** DOMPurify instance — `addHook` mutates whichever instance it is attached to globally, and `UserButtons.tsx` sanitizes the changelog with different rules on the shared one.

## Syntax highlighting

`json` and `html` are highlighted using the CodeMirror parsers already in the tree (`@codemirror/lang-json` / `lang-html` via `@lezer/highlight`) — no new highlighting library, and the same stack the payload editor already uses.

This applies to fenced code blocks in documentation **and** to the trigger log's Request payload and Response body, which previously rendered as flat text. Log bodies arrive with no content type, so `CodeBlock` sniffs the language: leading `{`/`[` that actually parses as JSON, or a leading tag/doctype. Anything else renders unchanged, so `No payload`, error strings and malformed JSON are left alone.

Highlighting runs **after** sanitizing and builds every span from escaped text, so it cannot reintroduce anything the sanitizer removed. An HTML response body renders as visible markup rather than becoming live elements.

Token colors map to palette entries, so highlighting follows light/dark instead of assuming a dark background.

## Tests

- **Go** — documentation round-trips via REST create, NULL reads back empty, oversized documentation is rejected, partial updates preserve unmentioned fields on both the REST and MCP paths, and MCP create → list → update carries it.
- **UI** — markdown sanitization (injected `<script>`/`onerror`/`svg onbegin` asserted not to execute when rendered, `javascript:`/`data:` URIs, dropped embed tags, class filtering), highlighting for both languages, language detection, the modal submit/preview flow, and the log details section.

Two existing assertions in `FunctionTriggers.spec.tsx` moved from `getByText` to matching on the code block's `textContent`: the pretty-printed JSON is now split across highlight spans. The rendered text is identical, only the element structure changed.

## Notes

- `@lezer/highlight` and `@lezer/common` were phantom dependencies — present transitively but undeclared, so a hoisting change could have broken the build. Both are now declared at their installed versions.
- Unrelated, but worth knowing: vitest's `include` is `**/*.spec.tsx`, which means `utils/helpers/providers.spec.ts`, `string.spec.js` and `instance.spec.js` have never been running. Left alone here.
- `AuthUsers.spec.tsx` is flaky on this branch and on a clean `main` alike (a different test in that file fails per run, and it passes in isolation). Not related to these changes.
