### PR TITLE
feat: add trigger description

### DIFF
--- a/docs/api/11-triggers.md
+++ b/docs/api/11-triggers.md
@@ -39,6 +39,7 @@ interface Request {
   envId?: string // Required when the API key is not environment-scoped.
   cron: string // Cron expression, evaluated in UTC.
   status: boolean // Whether the trigger is active.
+  description?: string // One-line summary shown in listings. Max 200 chars, single line.
   documentation?: string // Markdown notes describing the trigger. Max 64KB.
   options: {
     method: string // GET, POST, HEAD, PATCH or DELETE.
@@ -63,6 +64,7 @@ curl -X POST \
      -d '{
        "cron": "*/5 * * * *",
        "status": true,
+       "description": "Nightly rollup",
        "documentation": "Nightly rollup. Ping #data if it fails.",
        "options": {
          "method": "POST",
@@ -79,6 +81,7 @@ curl -X POST \
     "id": "18914",
     "envId": "1500",
     "cron": "*/5 * * * *",
+    "description": "Nightly rollup",
     "documentation": "Nightly rollup. Ping #data if it fails.",
     "status": true,
     "nextRunAt": 1712418330,
@@ -98,8 +101,11 @@ curl -X POST \
 Validation errors return `400` with a map of field errors, e.g.
 `{ "cron": "Invalid cron format" }` or `{ "url": "Invalid URL" }`.
 
-`documentation` is free-form markdown shown in the Stormkit UI next to the
-trigger. It is never sent with the request and never affects execution.
+`description` is a one-line summary shown next to the trigger in listings —
+"Autofill weekly newsletter" against a URL ending in `/api/cron/newsletter-autofill`.
+`documentation` is free-form markdown: the longer runbook explaining how the
+trigger is used and what breaks if it stops. Neither is sent with the request or
+affects execution.
 
 </details>
 
@@ -127,6 +133,7 @@ interface Request {
   envId?: string // Required when the API key is not environment-scoped.
   cron?: string
   status?: boolean
+  description?: string
   documentation?: string
   options?: {
     method?: string
@@ -282,6 +289,7 @@ curl -X GET \
       "id": "18914",
       "envId": "1500",
       "cron": "*/5 * * * *",
+      "description": "Nightly rollup",
       "documentation": "Nightly rollup. Ping #data if it fails.",
       "status": true,
       "nextRunAt": 1712418330,
@@ -357,6 +365,7 @@ interface Trigger {
   id: string
   envId: string
   cron: string
+  description: string // One-line summary. Empty when unset.
   documentation: string // Markdown notes. Empty when undocumented.
   status: boolean
   nextRunAt: number // Unix timestamp of the next scheduled run.
@@ -391,6 +400,7 @@ interface TriggerLog {
 | id            | The unique id of the trigger.                                               |
 | envId         | The environment the trigger belongs to.                                     |
 | cron          | The cron expression, evaluated in UTC.                                       |
+| description   | One-line summary shown next to the trigger in listings. Max 200 chars.      |
 | documentation | Markdown notes describing the trigger, shown in the UI. Max 64KB.           |
 | status        | Whether the trigger is active. Inactive triggers are not scheduled.         |
 | nextRunAt     | Unix timestamp of the next scheduled run. `0` when the trigger is inactive. |

--- a/docs/features/13-periodic-triggers.md
+++ b/docs/features/13-periodic-triggers.md
@@ -26,6 +26,20 @@ This will call the specified endpoint with the configured cron periodicity. The 
 
 </section>
 
+## Description
+
+<section>
+
+A list of triggers is a list of cron expressions and URLs, which says nothing
+about intent. The **Description** field holds a one-line summary shown next to
+the trigger — "Autofill weekly newsletter" against a URL ending in
+`/api/cron/newsletter-autofill` — so a list of them stays scannable.
+
+Keep it to a single line of at most 200 characters. For anything longer, use
+**Documentation** below.
+
+</section>
+
 ## Documentation
 
 <section>
@@ -40,9 +54,9 @@ It is shown alongside the trigger's run details (expand the dot menu `(...)` >
 the trigger is for and who to contact. The text is never sent with the request
 and never affects execution.
 
-Documentation can also be set through the [API](/docs/api/triggers) and the MCP
-`create_trigger` / `update_trigger` tools, which is a convenient way to have an
-agent write up a trigger it just created.
+Description and documentation can also be set through the
+[API](/docs/api/triggers) and the MCP `create_trigger` / `update_trigger` tools,
+which is a convenient way to have an agent write up a trigger it just created.
 
 </section>
 

--- a/src/ce/api/app/functiontrigger/function_trigger_description_test.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_description_test.go
@@ -1,0 +1,123 @@
+package functiontrigger_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type TriggerDescriptionSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *TriggerDescriptionSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+}
+
+func (s *TriggerDescriptionSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+// Rows written before the column existed read as an empty description rather
+// than failing the scan.
+func (s *TriggerDescriptionSuite) Test_ExistingTriggersHaveNoDescription() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+	tid := types.ID(0)
+
+	err := s.conn.QueryRow(`
+		INSERT INTO
+			function_triggers (env_id, trigger_status, trigger_options, cron)
+		VALUES
+			($1, true, $2, '* * * * *')
+		RETURNING
+			trigger_id;
+	`, env.ID, []byte(`{"url": "https://example.com"}`)).Scan(&tid)
+
+	s.Require().NoError(err)
+
+	tf, err := functiontrigger.NewStore().ByID(context.Background(), tid)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(tf)
+	s.Empty(tf.Description)
+}
+
+func (s *TriggerDescriptionSuite) Test_DescriptionRoundTrips() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+	store := functiontrigger.NewStore()
+
+	record := &functiontrigger.FunctionTrigger{
+		EnvID:       env.ID,
+		Cron:        "* * * * *",
+		Description: "Autofill weekly newsletter",
+		Status:      true,
+		Options:     functiontrigger.Options{URL: "https://example.com/api/cron"},
+	}
+
+	s.Require().NoError(store.Insert(context.Background(), record))
+
+	stored, err := store.ByID(context.Background(), record.ID)
+
+	s.Require().NoError(err)
+	s.Equal("Autofill weekly newsletter", stored.Description)
+
+	stored.Description = "Autofill the newsletter draft"
+
+	s.Require().NoError(store.Update(context.Background(), stored))
+
+	updated, err := store.ByID(context.Background(), record.ID)
+
+	s.Require().NoError(err)
+	s.Equal("Autofill the newsletter draft", updated.Description)
+}
+
+// The scheduler reads its own column list, so a field the display paths return
+// must reach the batch that actually fires the trigger too.
+func (s *TriggerDescriptionSuite) Test_DueTriggersCarryDescription() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+	tid := types.ID(0)
+
+	err := s.conn.QueryRow(`
+		INSERT INTO
+			function_triggers (env_id, trigger_status, trigger_options, cron, next_run_at, description)
+		VALUES
+			($1, true, $2, '* * * * *', timezone('utc', now()) - interval '1 hour', 'Nightly rollup')
+		RETURNING
+			trigger_id;
+	`, env.ID, []byte(`{"url": "https://example.com"}`)).Scan(&tid)
+
+	s.Require().NoError(err)
+
+	due, err := functiontrigger.NewStore().DueTriggers(context.Background())
+
+	s.Require().NoError(err)
+	s.Require().NotEmpty(due)
+
+	for _, tf := range due {
+		if tf.ID == tid {
+			s.Equal("Nightly rollup", tf.Description)
+			return
+		}
+	}
+
+	s.Fail("the due trigger was not returned")
+}
+
+func TestTriggerDescription(t *testing.T) {
+	suite.Run(t, &TriggerDescriptionSuite{})
+}

--- a/src/ce/api/app/functiontrigger/function_trigger_model.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_model.go
@@ -40,6 +40,9 @@ type FunctionTrigger struct {
 	ID    types.ID `json:"id,string"`
 	EnvID types.ID `json:"envId,string"`
 	Cron  string   `json:"cron"`
+	// Description is a one-line summary shown next to the trigger in listings.
+	// Documentation is the long-form runbook; this is the label.
+	Description string `json:"description,omitempty"`
 	// Documentation is free-form markdown describing what the trigger is for.
 	// Rendered by the UI, never interpreted when the trigger runs.
 	Documentation string     `json:"documentation,omitempty"`
@@ -77,6 +80,7 @@ func (t *FunctionTrigger) ToMap() map[string]any {
 		"id":            t.ID.String(),
 		"envId":         t.EnvID.String(),
 		"cron":          t.Cron,
+		"description":   t.Description,
 		"documentation": t.Documentation,
 		"status":        t.Status,
 		"nextRunAt":     t.NextRunAt.Unix(),

--- a/src/ce/api/app/functiontrigger/function_trigger_store.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_store.go
@@ -27,7 +27,7 @@ var stmts = struct {
 		SELECT
 			trigger_id, env_id, cron, trigger_options,
 			trigger_status, created_at, next_run_at, updated_at,
-			COALESCE(documentation, '')
+			COALESCE(documentation, ''), COALESCE(description, '')
         FROM
 			function_triggers
 		WHERE
@@ -55,9 +55,9 @@ var stmts = struct {
 	`,
 	insertTrigger: `
 		INSERT INTO function_triggers
-		    (env_id, cron, next_run_at, trigger_options, trigger_status, documentation)
+		    (env_id, cron, next_run_at, trigger_options, trigger_status, documentation, description)
 		VALUES
-			($1, $2, $3, $4, $5, $6)
+			($1, $2, $3, $4, $5, $6, $7)
     	RETURNING
 			trigger_id;
 	`,
@@ -70,9 +70,10 @@ var stmts = struct {
 			trigger_status = $3,
 			next_run_at = $4,
 			documentation = $5,
+			description = $6,
 			updated_at = timezone('utc', now())
 		WHERE
-			trigger_id = $6;
+			trigger_id = $7;
 	`,
 	updateNextRunAt: `
 		UPDATE
@@ -203,6 +204,7 @@ func (s *Store) Insert(ctx context.Context, ft *FunctionTrigger) error {
 		opts,
 		ft.Status,
 		ft.Documentation,
+		ft.Description,
 	)
 
 	if err != nil {
@@ -256,7 +258,18 @@ func (s *Store) Update(ctx context.Context, ft *FunctionTrigger) error {
 		ft.NextRunAt = utils.Unix{Valid: false}
 	}
 
-	_, err = s.Exec(ctx, stmts.updateTrigger, ft.Cron, opts, ft.Status, ft.NextRunAt, ft.Documentation, ft.ID)
+	_, err = s.Exec(
+		ctx,
+		stmts.updateTrigger,
+		ft.Cron,
+		opts,
+		ft.Status,
+		ft.NextRunAt,
+		ft.Documentation,
+		ft.Description,
+		ft.ID,
+	)
+
 	return err
 }
 
@@ -333,6 +346,7 @@ func (s *Store) selectRows(ctx context.Context, query string, args ...any) ([]*F
 			&tmp.ID, &tmp.EnvID, &tmp.Cron,
 			&tmp.Options, &tmp.Status, &tmp.CreatedAt,
 			&tmp.NextRunAt, &tmp.UpdatedAt, &tmp.Documentation,
+			&tmp.Description,
 		)
 
 		if err != nil {

--- a/src/ce/api/public/v1/handler_function_trigger_create.go
+++ b/src/ce/api/public/v1/handler_function_trigger_create.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode"
 
 	"github.com/adhocore/gronx"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
@@ -20,6 +21,7 @@ import (
 type functionTriggerRequest struct {
 	ID            types.ID `json:"id,string"`
 	Cron          *string  `json:"cron"`
+	Description   *string  `json:"description"`
 	Documentation *string  `json:"documentation"`
 	Status        *bool    `json:"status"`
 	Options       *struct {
@@ -35,6 +37,12 @@ type functionTriggerRequest struct {
 func (r *functionTriggerRequest) applyTo(ft *functiontrigger.FunctionTrigger) {
 	if r.Cron != nil {
 		ft.Cron = *r.Cron
+	}
+
+	// A whitespace-only description would otherwise render as a blank line
+	// under the trigger's URL in the listing.
+	if r.Description != nil {
+		ft.Description = strings.TrimSpace(*r.Description)
 	}
 
 	if r.Documentation != nil {
@@ -72,6 +80,29 @@ func (r *functionTriggerRequest) applyTo(ft *functiontrigger.FunctionTrigger) {
 // accident.
 const maxDocumentationLength = 64 * 1024
 
+// maxDescriptionLength keeps the description a label rather than a second
+// documentation field: it is rendered inline next to the trigger in listings,
+// where anything longer stops being scannable.
+const maxDescriptionLength = 200
+
+// hasDisplayControlRune reports whether s carries a rune that changes how the
+// rest of the string renders rather than adding a glyph of its own. The
+// description is shown inline next to the trigger's URL and returned verbatim
+// to MCP clients, so a bidi override or an escape sequence could misrepresent
+// which endpoint a trigger calls.
+func hasDisplayControlRune(s string) bool {
+	for _, r := range s {
+		if unicode.IsControl(r) ||
+			unicode.Is(unicode.Cf, r) ||
+			unicode.Is(unicode.Zl, r) ||
+			unicode.Is(unicode.Zp, r) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // validateFunctionTrigger checks the trigger as it will be stored, so that an
 // update is validated against the merged record rather than the partial body
 // that produced it.
@@ -86,6 +117,16 @@ func validateFunctionTrigger(ft *functiontrigger.FunctionTrigger) map[string]str
 		errors["documentation"] = fmt.Sprintf(
 			"Documentation cannot exceed %d characters", maxDocumentationLength,
 		)
+	}
+
+	if len(ft.Description) > maxDescriptionLength {
+		errors["description"] = fmt.Sprintf(
+			"Description cannot exceed %d characters", maxDescriptionLength,
+		)
+	} else if strings.ContainsAny(ft.Description, "\r\n") {
+		errors["description"] = "Description must be a single line"
+	} else if hasDisplayControlRune(ft.Description) {
+		errors["description"] = "Description must not contain control characters"
 	}
 
 	parsedURL, err := url.Parse(ft.Options.URL)

--- a/src/ce/api/public/v1/handler_function_trigger_description_test.go
+++ b/src/ce/api/public/v1/handler_function_trigger_description_test.go
@@ -1,0 +1,119 @@
+package publicapiv1_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/user/usertest"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+)
+
+type HandlerFunctionTriggerDescriptionSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *HandlerFunctionTriggerDescriptionSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+	admin.SetMockLicense()
+}
+
+func (s *HandlerFunctionTriggerDescriptionSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+	admin.ResetMockLicense()
+}
+
+func (s *HandlerFunctionTriggerDescriptionSuite) create(env *factory.MockEnv, body map[string]any) shttptest.Response {
+	body["appId"] = env.AppID.String()
+	body["envId"] = env.ID.String()
+
+	return shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(publicapiv1.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/v1/trigger",
+		body,
+		map[string]string{
+			"Authorization": usertest.Authorization(env.GetApp().UserID),
+		},
+	)
+}
+
+func (s *HandlerFunctionTriggerDescriptionSuite) Test_Success_Description() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := s.create(env, map[string]any{
+		"cron":        "*/1 * * * *",
+		"status":      true,
+		"description": "Autofill weekly newsletter",
+		"options": map[string]any{
+			"method": "GET",
+			"url":    "https://test.com/api/cron",
+		},
+	})
+
+	s.Equal(http.StatusCreated, response.Code)
+
+	tfs, err := functiontrigger.NewStore().List(context.Background(), env.ID)
+
+	s.Require().NoError(err)
+	s.Require().Len(tfs, 1)
+	s.Equal("Autofill weekly newsletter", tfs[0].Description)
+}
+
+// The description is rendered inline in listings, so it is bounded and kept to
+// a single line rather than becoming a second documentation field.
+func (s *HandlerFunctionTriggerDescriptionSuite) Test_Fail_DescriptionTooLong() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := s.create(env, map[string]any{
+		"cron":        "*/1 * * * *",
+		"status":      true,
+		"description": strings.Repeat("a", 201),
+		"options": map[string]any{
+			"method": "GET",
+			"url":    "https://test.com/api/cron",
+		},
+	})
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "description")
+}
+
+func (s *HandlerFunctionTriggerDescriptionSuite) Test_Fail_DescriptionMultiline() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := s.create(env, map[string]any{
+		"cron":        "*/1 * * * *",
+		"status":      true,
+		"description": "Autofill weekly newsletter\nand mail it",
+		"options": map[string]any{
+			"method": "GET",
+			"url":    "https://test.com/api/cron",
+		},
+	})
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "description")
+}
+
+func TestHandlerFunctionTriggerDescription(t *testing.T) {
+	suite.Run(t, &HandlerFunctionTriggerDescriptionSuite{})
+}

--- a/src/ce/api/public/v1/handler_function_triggers_get_test.go
+++ b/src/ce/api/public/v1/handler_function_triggers_get_test.go
@@ -64,6 +64,7 @@ func (s *HandlerTriggerFunctionGetSuite) Test_Success() {
 			"id": "1",
 			"envId": "1",
 			"cron": "*/1 * * * *",
+			"description": "",
 			"documentation": "",
 			"nextRunAt": 1712418330,
 			"options": {

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -412,6 +412,7 @@ func mcpAllTools() []mcpToolDef {
 					"envId":         map[string]any{"type": "string", "description": "Environment ID to attach the trigger to."},
 					"cron":          map[string]any{"type": "string", "description": "Cron expression, evaluated in UTC, e.g. '*/5 * * * *'."},
 					"status":        map[string]any{"type": "boolean", "description": "Whether the trigger is active. Inactive triggers are not scheduled."},
+					"description":   map[string]any{"type": "string", "description": "One-line summary of what the trigger does, e.g. 'Autofill weekly newsletter'. Shown next to the trigger in listings. Max 200 characters, single line."},
 					"documentation": map[string]any{"type": "string", "description": "Markdown notes describing what the trigger is for. Displayed in the UI only; never affects execution."},
 					"method":        map[string]any{"type": "string", "description": "HTTP method: GET, POST, HEAD, PATCH or DELETE. Defaults to GET."},
 					"url":           map[string]any{"type": "string", "description": "http/https URL to call."},
@@ -432,6 +433,7 @@ func mcpAllTools() []mcpToolDef {
 					"triggerId":     map[string]any{"type": "string", "description": "ID of the trigger to update (from list_triggers or create_trigger)."},
 					"cron":          map[string]any{"type": "string", "description": "Cron expression, evaluated in UTC."},
 					"status":        map[string]any{"type": "boolean", "description": "Whether the trigger is active."},
+					"description":   map[string]any{"type": "string", "description": "One-line summary of what the trigger does, e.g. 'Autofill weekly newsletter'. Shown next to the trigger in listings. Max 200 characters, single line."},
 					"documentation": map[string]any{"type": "string", "description": "Markdown notes describing what the trigger is for. Displayed in the UI only; never affects execution."},
 					"method":        map[string]any{"type": "string", "description": "HTTP method: GET, POST, HEAD, PATCH or DELETE."},
 					"url":           map[string]any{"type": "string", "description": "http/https URL to call."},
@@ -1166,7 +1168,7 @@ func triggerBodyFromArgs(args map[string]any) map[string]any {
 
 	body := map[string]any{}
 
-	for _, key := range []string{"cron", "status", "documentation"} {
+	for _, key := range []string{"cron", "status", "description", "documentation"} {
 		if v, ok := args[key]; ok {
 			body[key] = v
 		}

--- a/src/lib/factory/trigger_function.go
+++ b/src/lib/factory/trigger_function.go
@@ -23,9 +23,9 @@ func (tf MockFunctionTrigger) Insert(conn databasetest.TestDB) error {
 
 	insertQuery := `
 		INSERT INTO skitapi.function_triggers
-			(env_id, cron, next_run_at, trigger_options, trigger_status, updated_at, created_at, documentation)
+			(env_id, cron, next_run_at, trigger_options, trigger_status, updated_at, created_at, documentation, description)
 		VALUES
-			($1, $2, $3, $4, $5, $6, $7, $8)
+			($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		RETURNING
 			trigger_id;
 	`
@@ -39,6 +39,7 @@ func (tf MockFunctionTrigger) Insert(conn databasetest.TestDB) error {
 		tf.UpdatedAt,
 		tf.CreatedAt,
 		tf.Documentation,
+		tf.Description,
 	).Scan(&tf.ID)
 }
 

--- a/src/migrations/0027_2026-08-09.up.sql
+++ b/src/migrations/0027_2026-08-09.up.sql
@@ -1,0 +1,11 @@
+-- A one-line summary of what a trigger does, shown next to it in listings.
+--
+-- Distinct from documentation: that column is the team-facing runbook (markdown,
+-- how to use the trigger, what breaks if it stops), while this is the label that
+-- makes a list of triggers scannable when the cron expression and URL alone say
+-- nothing about intent — "Autofill weekly newsletter" against a URL ending in
+-- /api/cron/newsletter-autofill.
+--
+-- Nullable with no default, so existing triggers read as "no description"
+-- rather than carrying an empty string.
+ALTER TABLE function_triggers ADD COLUMN IF NOT EXISTS description text;

--- a/src/migrations/structure.sql
+++ b/src/migrations/structure.sql
@@ -703,7 +703,8 @@ CREATE TABLE skitapi.function_triggers (
     next_run_at timestamp without time zone,
     created_at timestamp without time zone DEFAULT (now() AT TIME ZONE 'UTC'::text) NOT NULL,
     updated_at timestamp without time zone,
-    documentation text
+    documentation text,
+    description text
 );
 
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.spec.tsx
@@ -148,6 +148,39 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/_components/Functi
     });
   });
 
+  it("should submit a one-line description", async () => {
+    await createWrapper();
+    await openDropdown();
+    await fireEvent.click(findOption("www.e.org")!);
+
+    const scope = mockActions.mockCreateFunctionTrigger({
+      appId: currentApp.id,
+      envId: currentEnv.id!,
+      status: false,
+      options: {
+        url: `https://www.e.org/test`,
+        method: "GET",
+        headers: {},
+        payload: "",
+      },
+      cron: "1 * * * *",
+      description: "Autofill weekly newsletter",
+    });
+
+    await userEvent.type(wrapper.getByLabelText("Cron"), "1 * * * *");
+    await userEvent.type(wrapper.getByLabelText(/trigger periodi/), "test");
+    await userEvent.type(
+      wrapper.getByLabelText("Description"),
+      "Autofill weekly newsletter"
+    );
+    await fireEvent.click(wrapper.getByText("Create"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(successHandler).toHaveBeenCalled();
+    });
+  });
+
   it("should create a new trigger", async () => {
     await createWrapper();
     await openDropdown();

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggerModal.tsx
@@ -81,7 +81,7 @@ export default function TriggerFunctionModal({
       string
     >;
 
-    const { urlPath = "", cron, method } = values;
+    const { urlPath = "", cron, method, description } = values;
 
     setLoading(true);
     setError(null);
@@ -92,6 +92,7 @@ export default function TriggerFunctionModal({
       envId: environment.id || "",
       cron,
       status,
+      description,
       documentation,
       options: {
         url: `https://${host}/${urlPath.replace(/^\/+/, "")}`,
@@ -104,14 +105,34 @@ export default function TriggerFunctionModal({
         closeModal();
         onSuccess();
       })
-      .catch((e: string | Error) => {
+      .catch((e: unknown) => {
         if (typeof e === "string") {
           setError(e);
-        } else if (typeof e === "object") {
-          setError("Cron is invalid. Example expected format: 5 4 * * *");
-        } else {
-          setError("Something went wrong while saving periodic trigger");
+          return;
         }
+
+        // The api layer rejects with the raw Response. Validation failures
+        // carry a field -> message map, which is more useful than a guess at
+        // which field the server disliked.
+        if (e instanceof Response) {
+          e.json()
+            .then((errors: Record<string, string>) => {
+              const messages = Object.values(errors || {});
+
+              setError(
+                messages.length
+                  ? messages.join(" ")
+                  : "Something went wrong while saving periodic trigger"
+              );
+            })
+            .catch(() => {
+              setError("Something went wrong while saving periodic trigger");
+            });
+
+          return;
+        }
+
+        setError("Something went wrong while saving periodic trigger");
       })
       .finally(() => {
         setLoading(false);
@@ -156,6 +177,23 @@ export default function TriggerFunctionModal({
                   "aria-label": "URL to trigger periodically",
                 }}
                 InputLabelProps={{ shrink: true }}
+                fullWidth
+              />
+            </Box>
+
+            <Box sx={{ mb: 4 }}>
+              <TextField
+                name="description"
+                variant="filled"
+                label="Description"
+                placeholder="Autofill weekly newsletter"
+                defaultValue={triggerFunction?.description || ""}
+                inputProps={{
+                  "aria-label": "Description",
+                  maxLength: 200,
+                }}
+                InputLabelProps={{ shrink: true }}
+                helperText="One line explaining what this trigger does, shown next to it in the list."
                 fullWidth
               />
             </Box>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.spec.tsx
@@ -86,6 +86,33 @@ describe("~/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.t
     });
   });
 
+  it("shows the description when set", async () => {
+    createWrapper({
+      triggers: [
+        {
+          ...mockFunctionTriggers()[0],
+          description: "Autofill weekly newsletter",
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByText("Autofill weekly newsletter")).toBeTruthy();
+    });
+  });
+
+  // The description is optional, so a trigger without one must not render an
+  // empty line in its place.
+  it("omits the description line by default", async () => {
+    createWrapper();
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.queryByTestId("trigger-description")).toBeNull();
+    });
+  });
+
   it("should handle deleting function trigger", async () => {
     createWrapper();
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/FunctionTriggers.tsx
@@ -4,6 +4,7 @@ import EditIcon from "@mui/icons-material/ModeEdit";
 import PlayIcon from "@mui/icons-material/PlayArrow";
 import TimeIcon from "@mui/icons-material/AccessTime";
 import CircleIcon from "@mui/icons-material/Circle";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import Chip from "@mui/material/Chip";
@@ -201,23 +202,37 @@ export default function FunctionTriggers() {
               label={f.options.method}
               sx={{ fontSize: 10, mr: 2, minWidth: "60px" }}
             />
-            <Tooltip title="See past triggers">
-              <Typography
-                component="span"
-                color="text.secondary"
-                noWrap
-                data-testid="trigger-url"
-                onClick={() => openDrawer(f)}
-                sx={{
-                  mr: 2,
-                  flex: 1,
-                  cursor: "pointer",
-                  "&:hover": { textDecoration: "underline" },
-                }}
-              >
-                {f.options.url}
-              </Typography>
-            </Tooltip>
+            <Box
+              component="span"
+              sx={{ display: "block", flex: 1, mr: 2, minWidth: 0 }}
+            >
+              <Tooltip title="See past triggers">
+                <Typography
+                  component="span"
+                  color="text.secondary"
+                  noWrap
+                  data-testid="trigger-url"
+                  onClick={() => openDrawer(f)}
+                  sx={{
+                    display: "block",
+                    cursor: "pointer",
+                    "&:hover": { textDecoration: "underline" },
+                  }}
+                >
+                  {f.options.url}
+                </Typography>
+              </Tooltip>
+              {f.description && (
+                <Typography
+                  component="span"
+                  noWrap
+                  data-testid="trigger-description"
+                  sx={{ display: "block", fontSize: 12, opacity: 0.6 }}
+                >
+                  {f.description}
+                </Typography>
+              )}
+            </Box>
             <Span sx={{ display: "inline-flex", alignItems: "center" }}>
               <Tooltip
                 title={

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/function-triggers/actions.ts
@@ -93,6 +93,7 @@ export function createFunctionTrigger({
   options,
   status,
   documentation,
+  description,
 }: CreateFunctionTriggerProps): Promise<FunctionTrigger> {
   if (appId === "" || envId === "") {
     return Promise.reject("AppId and EnvId cannot be empty.");
@@ -113,6 +114,7 @@ export function createFunctionTrigger({
     status,
     options,
     documentation,
+    description,
   });
 }
 
@@ -124,6 +126,7 @@ interface UpdateFunctionTriggerProps {
   status: boolean;
   options: FunctionTriggerOptions;
   documentation?: string;
+  description?: string;
 }
 
 export const updateFunctionTrigger = ({
@@ -134,6 +137,7 @@ export const updateFunctionTrigger = ({
   status,
   options,
   documentation,
+  description,
 }: UpdateFunctionTriggerProps): Promise<void> => {
   if (options.url.trim() === "") {
     return Promise.reject("Url cannot be empty.");
@@ -151,6 +155,7 @@ export const updateFunctionTrigger = ({
     cron,
     options,
     documentation,
+    description,
   });
 };
 
@@ -162,6 +167,7 @@ interface UpsertFunctionTriggerProps {
   cron: string;
   options: FunctionTriggerOptions;
   documentation?: string;
+  description?: string;
 }
 
 export const upsertFunctionTrigger = ({
@@ -172,6 +178,7 @@ export const upsertFunctionTrigger = ({
   cron,
   options,
   documentation,
+  description,
 }: UpsertFunctionTriggerProps): Promise<void | FunctionTrigger> => {
   if (tfid) {
     return updateFunctionTrigger({
@@ -180,6 +187,7 @@ export const upsertFunctionTrigger = ({
       cron,
       options,
       documentation,
+      description,
       appId,
       envId,
     });
@@ -192,6 +200,7 @@ export const upsertFunctionTrigger = ({
     cron,
     options,
     documentation,
+    description,
   });
 };
 

--- a/src/ui/src/testing/nocks/nock_function_triggers.ts
+++ b/src/ui/src/testing/nocks/nock_function_triggers.ts
@@ -69,6 +69,7 @@ interface MockUpdateFunctionTriggerProps {
   cron: string;
   options: any;
   documentation?: string;
+  description?: string;
 }
 
 export const mockUpdateFunctionTrigger = ({
@@ -79,6 +80,7 @@ export const mockUpdateFunctionTrigger = ({
   cron,
   options,
   documentation = "",
+  description = "",
 }: MockUpdateFunctionTriggerProps) => {
   return nock(endpoint)
     .patch(`/v1/trigger`, {
@@ -89,6 +91,7 @@ export const mockUpdateFunctionTrigger = ({
       cron,
       options,
       documentation,
+      description,
     })
     .reply(201, { ok: true });
 };
@@ -100,6 +103,7 @@ interface MockCreateFunctionTriggerProps {
   cron: string;
   options: any;
   documentation?: string;
+  description?: string;
 }
 
 export const mockCreateFunctionTrigger = ({
@@ -109,6 +113,7 @@ export const mockCreateFunctionTrigger = ({
   cron,
   options,
   documentation = "",
+  description = "",
 }: MockCreateFunctionTriggerProps) => {
   return nock(endpoint)
     .post(`/v1/trigger`, {
@@ -118,6 +123,7 @@ export const mockCreateFunctionTrigger = ({
       cron,
       options,
       documentation,
+      description,
     })
     .reply(201, { ok: true });
 };

--- a/src/ui/src/types/function-triggers.d.ts
+++ b/src/ui/src/types/function-triggers.d.ts
@@ -15,6 +15,8 @@ declare interface FunctionTriggerOptions {
 declare interface FunctionTrigger {
   id?: string;
   cron: string;
+  /** One-line summary shown next to the trigger in listings. */
+  description?: string;
   /** Free-form markdown describing what the trigger is for. */
   documentation?: string;
   status: boolean;


### PR DESCRIPTION
Adds a one-line `description` field to periodic triggers.

## Description

A one-line summary shown next to the trigger in listings — "Autofill weekly newsletter" against a URL ending in `/api/cron/newsletter-autofill`. Capped at 200 characters and a single line.

This is deliberately distinct from `documentation`: that field is the long-form, team-facing runbook, and it is too long to render inline. A list of triggers is otherwise a list of cron expressions and URLs, which says nothing about what any of them are for.

## Surface

`description` is exposed on the REST API (partial-update semantics preserved), the `create_trigger` / `update_trigger` MCP tools, and the trigger modal. The list shows it under the URL.

The column is nullable with no default, so triggers that predate it read as "no description" rather than carrying an empty string.

## Tests

- Store: round-trip, `NULL` reads for rows predating the column, scheduler column parity
- Handlers: length and single-line rules, successful create
- UI: description submission and list rendering

Full Go suite green (`-p 1`). UI trigger suites green.

## Docs

`docs/features/13-periodic-triggers.md` gains a Description section; `docs/api/11-triggers.md` covers the field and its validation rules.