### PR TITLE
docs: clarify nix runtime scope and cloud-only functions

### DIFF
--- a/docs/deployments/10-application-runtime.md
+++ b/docs/deployments/10-application-runtime.md
@@ -13,6 +13,42 @@ This option is available only on **self-hosted** Stormkit instances.
 
 </section>
 
+## When to use it
+
+<section>
+
+On a self-hosted instance, the Application Runtime is the **recommended way to run
+backend code**. [Serverless functions](/docs/features/writing-api) are a Stormkit Cloud
+feature; self-hosted instances execute them by forking a short-lived `node` process per
+request, which is fine for parity and local development but not for production traffic.
+
+Reach for a Start command whenever your backend:
+
+- pays a cost per request it should pay once — booting a runtime, opening a connection,
+  loading a model or a large file into memory,
+- benefits from state that outlives a single request — connection pools, warm caches,
+  a headless browser you keep open,
+- needs system binaries from a [Nix flake](/docs/self-hosting/runtimes) at request time,
+  not only during the build.
+
+The process is reaped after 10 minutes without a request. Published environments are kept
+warm by the domain ping, so this is invisible in practice; preview deployments, which are
+not pinged, pay a cold start after an idle spell. Set `STORMKIT_MAX_IDLE` (in minutes) as
+an environment variable to widen the window.
+
+Requests reach your server through Stormkit's proxy, which applies
+`STORMKIT_HTTP_PROXY_TIMEOUT`
+([default 30 seconds](/docs/self-hosting/advanced-configuration)) to the time your server
+may take to start sending response headers. This is the only request deadline on a
+self-hosted instance — the 15 second function timeout is a Stormkit Cloud limit and does
+not apply here. Raise it, or set it to `0`, if a request legitimately needs longer.
+
+The runtime is not Go-specific — any process that listens on `PORT` works, including a
+Node/Express or Fastify server. Go is used in the examples below because compiling a
+binary is the most common case.
+
+</section>
+
 ## Go programs
 
 <section>

--- a/docs/features/13-periodic-triggers.md
+++ b/docs/features/13-periodic-triggers.md
@@ -92,6 +92,37 @@ available; host/system variables are never exposed to a trigger.
 
 Stormkit saves the request and response for each periodic task. You can view the last 25 logs for each trigger by expanding the dot menu `(...)` and clicking on the `Past triggers` menu item.
 
+## Long-running jobs
+
+<section>
+
+A trigger is an outgoing HTTP request that Stormkit makes on a schedule, and it waits for
+the response. How long the job may run depends on where you are running it.
+
+On **Stormkit Cloud**, a trigger pointed at a [serverless function](/docs/features/writing-api)
+is capped at the 15 second function timeout, and the worker making the request gives up
+after 30 seconds. A job that needs longer has to be started by the trigger rather than
+run inside it.
+
+On a **self-hosted instance** neither limit is fixed. Functions are not subject to the 15
+second cap at all, and the worker's own deadline —
+`STORMKIT_HTTP_PROXY_TIMEOUT`, [30 seconds by default](/docs/self-hosting/advanced-configuration)
+— can be raised, or set to `0` to remove it entirely. Point the trigger at a
+[Start command](/docs/deployments/application-runtime) server and the job can run for
+as long as you allow.
+
+The trade-off is that triggers due in the same sweep are executed one after another, so a
+slow trigger holds up the others behind it and none of their logs appear until the batch
+finishes. For jobs long enough that this matters — video processing, a large import —
+have the endpoint enqueue the work and return immediately, then let the same
+start-command server do the work outside the request.
+
+Either way, make the endpoint idempotent. When a trigger fails, Stormkit does not advance
+its next run time, so the trigger stays due and fires again on the following sweep — a
+job that times out while its work is still running will be started a second time.
+
+</section>
+
 ## Self Hosting
 
 <section>

--- a/docs/features/7-writing-api.md
+++ b/docs/features/7-writing-api.md
@@ -15,9 +15,24 @@ You can create node.js/typescript APIs using Stormkit.
 
 </section>
 
+## Serverless functions on self-hosted instances
+
+<div class="blog-alert">
+
+On Stormkit Cloud, functions run on managed function infrastructure (AWS Lambda). A
+self-hosted instance has none by default, so it forks a short-lived `node` process per
+invocation instead — fine for parity and local development, but not for production
+traffic.
+
+For a self-hosted backend, use a
+[**Start command**](/docs/deployments/application-runtime) and run a long-lived server.
+See [when to use it](/docs/deployments/application-runtime) for the trade-offs.
+
+</div>
+
 ## How it works
 
-> **Note: Function timeouts are set at 15 seconds. If you require a different timeout, please inform us, and we can adjust it to suit your workflow.**
+> **Note: On Stormkit Cloud, function timeouts are set at 15 seconds. If you require a different timeout, please inform us, and we can adjust it to suit your workflow. Work that legitimately runs longer — headless-browser rendering, video processing, large report generation — does not belong in a function. Self-hosted instances do not apply this limit, but a function still forks a fresh `node` process per request; run that kind of work behind a [Start command](/docs/deployments/application-runtime) server instead.**
 
 <section>
 

--- a/docs/self-hosting/5-runtimes.md
+++ b/docs/self-hosting/5-runtimes.md
@@ -76,7 +76,7 @@ The following files are recognized automatically:
 
 ## Nix Flakes
 
-If your repository contains a `flake.nix` file, Stormkit will automatically run `nix develop` during the **install runtimes** step to bootstrap the Nix development shell. The packages defined in the flake are then available for all subsequent build commands — no additional configuration required.
+If your repository contains a `flake.nix` file, Stormkit will automatically run `nix develop` during the **install runtimes** step to bootstrap the Nix development shell. The packages defined in the flake are then available for all subsequent build commands — no additional configuration required — and, as described under **Availability at runtime** below, to your deployed server as well.
 
 A typical `flake.nix` that provides `ffmpeg` and `imagemagick` during builds:
 
@@ -96,6 +96,59 @@ A typical `flake.nix` that provides `ffmpeg` and `imagemagick` during builds:
 ```
 
 `flake.nix` and `mise.toml` can coexist — mise handles language runtimes while the flake covers system-level tools.
+
+### Availability at runtime
+
+The flake is not a build-only feature. `flake.nix` and `flake.lock` are copied into
+the server artifact, and when your environment has a **Start command**, Stormkit wraps
+that command in `nix develop` before spawning the process. Your server therefore starts
+_inside_ the same shell your build commands ran in, so every package in the flake is on
+`PATH` — system binaries such as headless-browser dependencies can be launched from your
+application at request time, not only from build commands.
+
+This also explains why `/nix` has to be mounted on the `hosting` (serving) service and
+not only on the `workerserver` (builds, periodic jobs): the store has to be there when
+the app runs, too. Give each service its own volume rather than sharing one — see
+**Persisting the Nix Store** below.
+
+<div class="blog-alert">
+
+Two conditions apply:
+
+- **Auto install** must be enabled — the `nix develop` wrapper is skipped when it is off.
+- It applies to the [Application Runtime](/docs/deployments/application-runtime)
+  (**Start command**) only. [Serverless functions](/docs/features/writing-api) are
+  invoked as a plain `node` process with no Nix shell around them, so flake packages are
+  **not** on `PATH` there. If your code needs system binaries, run it behind a start
+  command.
+
+</div>
+
+The first request after a deployment may take a while, or briefly show a "dependencies
+are being installed" page, while Nix realises the shell. Subsequent requests reuse the
+warm store.
+
+A `flake.nix` providing headless Chromium to a start-command server:
+
+```javascript
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      packages = [ pkgs.playwright-driver.browsers pkgs.chromium ];
+
+      shellHook = ''
+        export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+        export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+      '';
+    };
+  };
+}
+```
 
 ## Mise Runtime Manager
 


### PR DESCRIPTION
Closes #423

## What

### 1. Nix flakes at runtime (#423)

The **Nix Flakes** section of `docs/self-hosting/5-runtimes.md` described flake packages as a build-time feature only. A new **Availability at runtime** subsection states that they persist to runtime — and, importantly, scopes *where*:

- **Application Runtime (Start command): yes.** `flake.nix` / `flake.lock` are copied into the server artifact (`runner/bundler.go` `copyNixFlake`) and the start command is wrapped in `nix develop` at spawn time (`integrations/client_process_manager.go` `BuildServerCommand`), so flake packages are on `PATH` at request time.
- **Serverless functions: no.** The filesystem client invokes a bare `node -e` process with no Nix shell (`integrations/client_filesystem.go`), so flake packages are *not* on `PATH`.
- Requires **Auto install** enabled — `hasNixFlake` returns false otherwise.

The issue assumed runtime availability was universal; it is not, and the doc now says which is which. Added a Playwright/Chromium `flake.nix` example for the runtime use case, and a note about the first-request "installing dependencies" page.

The section also notes that `/nix` must be mounted on the `hosting` service and not only on `workerserver`, and points at **Persisting the Nix Store** below it for the separate-volumes guidance — the two sections previously pulled in opposite directions.

### 2. Serverless functions on self-hosted instances

`docs/features/7-writing-api.md` gains a callout: on Stormkit Cloud, functions run on managed function infrastructure (AWS Lambda); a self-hosted instance has none by default and forks a short-lived `node` process per invocation — fine for parity and local development, not for production traffic. Self-hosted backends should use a **Start command** instead.

The callout is deliberately short and links out rather than restating the argument. `docs/deployments/10-application-runtime.md` **When to use it** is the canonical home for the trade-offs, so there is one place to edit when this behaviour changes.

### 3. Timeouts, scoped to the edition they apply to

Earlier drafts of this PR got the timeout story wrong twice: they claimed a start-command server has "no per-request timeout", and they stated the 15 second function timeout as if it were universal. It is not — it is the AWS Lambda timeout (`client_aws_lambda.go`), so it applies on Stormkit Cloud only. The self-hosted function path forks `node` with `context.Background()` and no deadline of its own (`client_filesystem.go`). Every mention in the docs is now scoped:

- Start-command traffic is proxied through `shttp.Proxy`, which applies `STORMKIT_HTTP_PROXY_TIMEOUT` (default 30s, `config.go:313`) to the time before the server sends response headers. Already documented in `docs/self-hosting/6-advanced-configuration.md`; now cross-referenced from the pages that need it.
- Periodic triggers carry a bound on their *own* outgoing request (`function_trigger_run.go` calls `.Do()` with no `.WithTimeout()`), so the endpoint's timeout is not the only one that applies. `docs/features/13-periodic-triggers.md` **Long-running jobs** now splits the two cases: on Cloud a trigger is capped and must *start* a long job rather than run it; self-hosted, neither limit is fixed and raising `STORMKIT_HTTP_PROXY_TIMEOUT` lets a trigger run against a start-command endpoint for as long as the operator allows.
- The same section notes the trade-off: all triggers due in one sweep are enqueued as a single task and run sequentially (`job_trigger_functions.go`), so a slow trigger delays the rest of its batch and their logs are withheld until it completes. Enqueue-and-return is offered as the alternative, not as the only option.
- That section also documents that a failed trigger does not advance `nextRunAt` (`job_trigger_functions.go` `continue`s past the update), so it re-fires on the following sweep — hence the endpoint must be idempotent.
- `docs/deployments/10-application-runtime.md` notes the 10-minute idle reap: published environments are kept warm by the domain ping, preview deployments are not and pay a cold start. `STORMKIT_MAX_IDLE` is now mentioned as the knob.

## Notes

Docs only — no code changes.

Two code-level issues surfaced while writing this and are **not** addressed here:

- #425 — the process-manager interstitials ("Service not yet started", "Installing dependencies") return `200` with a `Retry-After` header, so health checks and periodic triggers read them as success.
- `bundler.go` skips `copyNixFlake` on the `.stormkit/server` branch, and `distDirs` takes that branch before it checks `ServerCmd` — so a framework build combined with a start command gets no flake at runtime. The runtime doc's "copied into the server artifact" wording does not hold in that case.
