### PR TITLE
fix: return 503 for warm-up interstitials

### DIFF
--- a/src/ce/api/app/functiontrigger/function_trigger_model.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_model.go
@@ -101,6 +101,25 @@ type TriggerLog struct {
 	CreatedAt utils.Unix `json:"createdAt"`
 }
 
+// ResponseCode returns the status the trigger's target responded with, or 0 if
+// the request never produced a response. The value is an int when the log was
+// just built in-process and a float64 after a JSON round-trip out of the
+// database.
+func (l TriggerLog) ResponseCode() int {
+	if l.Response == nil {
+		return 0
+	}
+
+	switch code := l.Response["code"].(type) {
+	case int:
+		return code
+	case float64:
+		return int(code)
+	}
+
+	return 0
+}
+
 // Masked returns a copy of the log with the request header values blanked so a
 // trigger's secret headers are never returned to a client. The request map is
 // copied shallowly except for the rebuilt headers entry, leaving the original

--- a/src/ce/api/app/functiontrigger/function_trigger_model_test.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_model_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -55,6 +56,17 @@ func (s *TriggerFunctionModelSuite) Test_FetchingStringHeadersFromDB() {
 	s.NoError(err)
 	s.NotNil(tf)
 	s.Equal(tf.Options.Headers.String(), "name:joe;surname:doe")
+}
+
+func (s *TriggerFunctionModelSuite) Test_ResponseCode() {
+	s.Equal(0, functiontrigger.TriggerLog{}.ResponseCode())
+	s.Equal(0, functiontrigger.TriggerLog{Response: utils.Map{"error": "boom"}}.ResponseCode())
+
+	// Freshly built in-process.
+	s.Equal(503, functiontrigger.TriggerLog{Response: utils.Map{"code": 503}}.ResponseCode())
+
+	// After a JSON round-trip out of the database.
+	s.Equal(503, functiontrigger.TriggerLog{Response: utils.Map{"code": float64(503)}}.ResponseCode())
 }
 
 func TestHandlerTrigger(t *testing.T) {

--- a/src/ce/api/app/functiontrigger/function_trigger_run.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_run.go
@@ -1,10 +1,29 @@
 package functiontrigger
 
 import (
+	"io"
+
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
+
+// maxLoggedBodySize bounds how much of a target's response is kept in the log
+// row. The target is an arbitrary user-supplied host and an unavailable one
+// produces several rows per tick, so an uncapped body is a storage amplifier.
+const maxLoggedBodySize = 64 * 1024
+
+// loggedBody reads at most maxLoggedBodySize of the response body, marking the
+// value when the target sent more than that.
+func loggedBody(res *shttp.HTTPResponse) string {
+	body, _ := io.ReadAll(io.LimitReader(res.Body, maxLoggedBodySize+1))
+
+	if len(body) > maxLoggedBodySize {
+		return string(body[:maxLoggedBodySize]) + "... (truncated)"
+	}
+
+	return string(body)
+}
 
 type RunParams struct {
 	TriggerID types.ID
@@ -34,7 +53,7 @@ func Run(p RunParams) (TriggerLog, error) {
 	if res != nil {
 		response = map[string]any{
 			"code": res.StatusCode,
-			"body": res.String(),
+			"body": loggedBody(res),
 		}
 	} else if err != nil {
 		response = map[string]any{

--- a/src/ce/api/app/functiontrigger/function_trigger_run_test.go
+++ b/src/ce/api/app/functiontrigger/function_trigger_run_test.go
@@ -1,0 +1,66 @@
+package functiontrigger_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/functiontrigger"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type TriggerFunctionRunSuite struct {
+	suite.Suite
+	mockRequest *mocks.RequestInterface
+}
+
+func (s *TriggerFunctionRunSuite) BeforeTest(_, _ string) {
+	s.mockRequest = &mocks.RequestInterface{}
+	shttp.DefaultRequest = s.mockRequest
+}
+
+func (s *TriggerFunctionRunSuite) AfterTest(_, _ string) {
+	shttp.DefaultRequest = nil
+}
+
+func (s *TriggerFunctionRunSuite) run(body string) functiontrigger.TriggerLog {
+	s.mockRequest.On("URL", "https://example.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", shttp.MethodGet).Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	log, err := functiontrigger.Run(functiontrigger.RunParams{URL: "https://example.org"})
+	s.NoError(err)
+
+	return log
+}
+
+func (s *TriggerFunctionRunSuite) Test_Run_KeepsSmallBodyIntact() {
+	log := s.run("hello")
+
+	s.Equal("hello", log.Response["body"])
+}
+
+// A trigger's target is an arbitrary user-supplied host and an unavailable one
+// produces several log rows per tick, so the stored body must be bounded.
+func (s *TriggerFunctionRunSuite) Test_Run_TruncatesLargeBody() {
+	log := s.run(strings.Repeat("a", 128*1024))
+
+	body, ok := log.Response["body"].(string)
+	s.Require().True(ok)
+	s.Equal(strings.Repeat("a", 64*1024)+"... (truncated)", body)
+}
+
+func TestTriggerFunctionRunSuite(t *testing.T) {
+	suite.Run(t, &TriggerFunctionRunSuite{})
+}

--- a/src/ce/workerserver/job_trigger_functions.go
+++ b/src/ce/workerserver/job_trigger_functions.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"time"
 
 	"github.com/adhocore/gronx"
@@ -116,6 +117,14 @@ func HandleFunctionTrigger(ctx context.Context, t *asynq.Task) error {
 
 		if err != nil {
 			slog.Errorf("trigger function request failed %v", err)
+			continue
+		}
+
+		// A 503 means the target never got to run the job — it was warming up
+		// or otherwise unavailable. Leave nextRunAt untouched so the next sweep
+		// picks the trigger up again instead of skipping to the following tick.
+		if log.ResponseCode() == http.StatusServiceUnavailable {
+			slog.Errorf("trigger function %d unavailable, will retry on the next sweep", tf.ID)
 			continue
 		}
 

--- a/src/ce/workerserver/job_trigger_functions.go
+++ b/src/ce/workerserver/job_trigger_functions.go
@@ -17,13 +17,21 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
+// triggerRetryWindow is how long a trigger stays due after a run that never
+// happened. The sweep runs every minute, so this is roughly five attempts.
+const triggerRetryWindow = 5 * time.Minute
+
 type FunctionTriggerMessage struct {
-	ID        types.ID      `json:"id,string"`
-	Payload   []byte        `json:"payload"`
-	Headers   shttp.Headers `json:"headers"`
-	Method    string        `json:"method"`
-	URL       string        `json:"url"`
-	NextRunAt utils.Unix    `json:"nextRunAt"`
+	ID      types.ID      `json:"id,string"`
+	Payload []byte        `json:"payload"`
+	Headers shttp.Headers `json:"headers"`
+	Method  string        `json:"method"`
+	URL     string        `json:"url"`
+	// NextRunAt is the tick this run advances the trigger to once it succeeds.
+	NextRunAt utils.Unix `json:"nextRunAt"`
+	// ScheduledAt is the overdue tick this run was fired for. It bounds how long
+	// a failing trigger is allowed to stay due.
+	ScheduledAt utils.Unix `json:"scheduledAt"`
 }
 
 // InvokeDueFunctionTriggers fetches function triggers from the database that are due date. Matching
@@ -71,12 +79,13 @@ func InvokeDueFunctionTriggers(ctx context.Context) error {
 		}
 
 		messages = append(messages, FunctionTriggerMessage{
-			URL:       opts.URL,
-			Payload:   opts.Payload,
-			Headers:   opts.Headers,
-			Method:    opts.Method,
-			ID:        tf.ID,
-			NextRunAt: utils.UnixFrom(nextRunAt),
+			URL:         opts.URL,
+			Payload:     opts.Payload,
+			Headers:     opts.Headers,
+			Method:      opts.Method,
+			ID:          tf.ID,
+			NextRunAt:   utils.UnixFrom(nextRunAt),
+			ScheduledAt: tf.NextRunAt,
 		})
 	}
 
@@ -115,17 +124,16 @@ func HandleFunctionTrigger(ctx context.Context, t *asynq.Task) error {
 
 		logs = append(logs, log)
 
-		if err != nil {
-			slog.Errorf("trigger function request failed %v", err)
-			continue
-		}
+		// The run never happened — the target was unreachable or still warming up.
+		// Stay due for a short grace window so a cold start is picked up by the next
+		// sweep, then fall through to the regular tick so one dead target cannot
+		// re-fire every minute forever.
+		if err != nil || log.ResponseCode() == http.StatusServiceUnavailable {
+			slog.Infof("trigger function %d did not run: %v", tf.ID, err)
 
-		// A 503 means the target never got to run the job — it was warming up
-		// or otherwise unavailable. Leave nextRunAt untouched so the next sweep
-		// picks the trigger up again instead of skipping to the following tick.
-		if log.ResponseCode() == http.StatusServiceUnavailable {
-			slog.Errorf("trigger function %d unavailable, will retry on the next sweep", tf.ID)
-			continue
+			if time.Since(tf.ScheduledAt.Time) < triggerRetryWindow {
+				continue
+			}
 		}
 
 		updates[tf.ID] = tf.NextRunAt

--- a/src/ce/workerserver/job_trigger_functions.go
+++ b/src/ce/workerserver/job_trigger_functions.go
@@ -129,9 +129,18 @@ func HandleFunctionTrigger(ctx context.Context, t *asynq.Task) error {
 		// sweep, then fall through to the regular tick so one dead target cannot
 		// re-fire every minute forever.
 		if err != nil || log.ResponseCode() == http.StatusServiceUnavailable {
-			slog.Infof("trigger function %d did not run: %v", tf.ID, err)
+			retrying := time.Since(tf.ScheduledAt.Time) < triggerRetryWindow
 
-			if time.Since(tf.ScheduledAt.Time) < triggerRetryWindow {
+			// A warming target is expected and sweeps once a minute, so it stays at
+			// info; a transport failure is a genuine trigger error and keeps its
+			// error level so log-based alerting still sees it.
+			if err != nil {
+				slog.Errorf("trigger function %d request failed, retrying: %t: %v", tf.ID, retrying, err)
+			} else {
+				slog.Infof("trigger function %d did not run, target responded with %d, retrying: %t", tf.ID, log.ResponseCode(), retrying)
+			}
+
+			if retrying {
 				continue
 			}
 		}

--- a/src/ce/workerserver/job_trigger_functions_test.go
+++ b/src/ce/workerserver/job_trigger_functions_test.go
@@ -95,12 +95,13 @@ func (s *JobTriggerFunctionsSuite) generateMockMessage() []byte {
 		s.NoError(err)
 
 		messages = append(messages, jobs.FunctionTriggerMessage{
-			ID:        tf.ID,
-			URL:       tf.Options.URL,
-			Payload:   tf.Options.Payload,
-			Headers:   tf.Options.Headers,
-			Method:    tf.Options.Method,
-			NextRunAt: utils.UnixFrom(nextRunAt),
+			ID:          tf.ID,
+			URL:         tf.Options.URL,
+			Payload:     tf.Options.Payload,
+			Headers:     tf.Options.Headers,
+			Method:      tf.Options.Method,
+			NextRunAt:   utils.UnixFrom(nextRunAt),
+			ScheduledAt: tf.NextRunAt,
 		})
 	}
 
@@ -199,7 +200,7 @@ func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_Unavailable_KeepsN
 
 	for _, m := range messages {
 		tf, err := store.ByID(ctx, m.ID)
-		s.NoError(err)
+		s.Require().NoError(err)
 		before[m.ID] = tf.NextRunAt.Unix()
 	}
 
@@ -232,12 +233,105 @@ func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_Unavailable_KeepsN
 	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
 
 	ran, err := store.ByID(ctx, messages[0].ID)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(messages[0].NextRunAt.Unix(), ran.NextRunAt.Unix(), "a trigger that ran should advance to its next tick")
 
 	skipped, err := store.ByID(ctx, messages[1].ID)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(before[messages[1].ID], skipped.NextRunAt.Unix(), "a trigger that got a 503 should stay due for the next sweep")
+}
+
+// The first message is scheduled ten minutes ago, past the retry window; the
+// second two minutes ago, still inside it.
+func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_Unavailable_BeyondRetryWindow() {
+	payload := s.generateMockMessage()
+	task := asynq.NewTask("", payload)
+
+	messages := []jobs.FunctionTriggerMessage{}
+	s.NoError(json.Unmarshal(payload, &messages))
+	s.Require().Len(messages, 2)
+
+	store := functiontrigger.NewStore()
+	ctx := context.Background()
+
+	stale, err := store.ByID(ctx, messages[1].ID)
+	s.Require().NoError(err)
+	staleNextRunAt := stale.NextRunAt.Unix()
+
+	// Long overdue target, still unavailable — give up and wait for the next tick.
+	s.mockRequest.On("URL", "https://example-1.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "application/json"})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	// Recently overdue target, still within the window — stays due.
+	s.mockRequest.On("URL", "https://example-2.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "PATCH").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "text/html"})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte("Hello World!")).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
+
+	gaveUp, err := store.ByID(ctx, messages[0].ID)
+	s.Require().NoError(err)
+	s.Equal(messages[0].NextRunAt.Unix(), gaveUp.NextRunAt.Unix(), "a 503 past the retry window should advance to the next tick")
+
+	retrying, err := store.ByID(ctx, messages[1].ID)
+	s.Require().NoError(err)
+	s.Equal(staleNextRunAt, retrying.NextRunAt.Unix(), "a 503 within the retry window should stay due")
+}
+
+func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_TransportError_IsBounded() {
+	payload := s.generateMockMessage()
+	task := asynq.NewTask("", payload)
+
+	messages := []jobs.FunctionTriggerMessage{}
+	s.NoError(json.Unmarshal(payload, &messages))
+	s.Require().Len(messages, 2)
+
+	store := functiontrigger.NewStore()
+	ctx := context.Background()
+
+	stale, err := store.ByID(ctx, messages[1].ID)
+	s.Require().NoError(err)
+	staleNextRunAt := stale.NextRunAt.Unix()
+
+	// Both targets are unreachable; only the long overdue one gives up.
+	s.mockRequest.On("URL", "https://example-1.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "application/json"})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(nil, errors.New("connection refused")).Once()
+
+	s.mockRequest.On("URL", "https://example-2.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "PATCH").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "text/html"})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte("Hello World!")).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(nil, errors.New("connection refused")).Once()
+
+	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
+
+	gaveUp, err := store.ByID(ctx, messages[0].ID)
+	s.Require().NoError(err)
+	s.Equal(messages[0].NextRunAt.Unix(), gaveUp.NextRunAt.Unix(), "a transport error past the retry window should advance to the next tick")
+
+	retrying, err := store.ByID(ctx, messages[1].ID)
+	s.Require().NoError(err)
+	s.Equal(staleNextRunAt, retrying.NextRunAt.Unix(), "a transport error within the retry window should stay due")
 }
 
 func TestJobTriggerFunctionSuite(t *testing.T) {

--- a/src/ce/workerserver/job_trigger_functions_test.go
+++ b/src/ce/workerserver/job_trigger_functions_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/tasks"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stormkit-io/stormkit-io/src/mocks"
 	"github.com/stretchr/testify/mock"
@@ -181,6 +182,62 @@ func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_PartialFailure() {
 
 	// We only assert no panic/error; deeper DB assertions can be added if store getters are available.
 	// Ensures code handles mixed success/failure gracefully.
+}
+
+func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_Unavailable_KeepsNextRunAt() {
+	payload := s.generateMockMessage()
+	task := asynq.NewTask("", payload)
+
+	messages := []jobs.FunctionTriggerMessage{}
+	s.NoError(json.Unmarshal(payload, &messages))
+	s.Require().Len(messages, 2)
+
+	store := functiontrigger.NewStore()
+	ctx := context.Background()
+
+	before := map[types.ID]int64{}
+
+	for _, m := range messages {
+		tf, err := store.ByID(ctx, m.ID)
+		s.NoError(err)
+		before[m.ID] = tf.NextRunAt.Unix()
+	}
+
+	// First target is up and runs the job.
+	s.mockRequest.On("URL", "https://example-1.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "application/json"})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok-1")),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	// Second target is still warming up and never runs the job.
+	s.mockRequest.On("URL", "https://example-2.org").Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", "PATCH").Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "text/html"})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", []byte("Hello World!")).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
+			Header:     make(http.Header),
+		},
+	}, nil).Once()
+
+	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
+
+	ran, err := store.ByID(ctx, messages[0].ID)
+	s.NoError(err)
+	s.Equal(messages[0].NextRunAt.Unix(), ran.NextRunAt.Unix(), "a trigger that ran should advance to its next tick")
+
+	skipped, err := store.ByID(ctx, messages[1].ID)
+	s.NoError(err)
+	s.Equal(before[messages[1].ID], skipped.NextRunAt.Unix(), "a trigger that got a 503 should stay due for the next sweep")
 }
 
 func TestJobTriggerFunctionSuite(t *testing.T) {

--- a/src/ce/workerserver/job_trigger_functions_test.go
+++ b/src/ce/workerserver/job_trigger_functions_test.go
@@ -185,153 +185,131 @@ func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_PartialFailure() {
 	// Ensures code handles mixed success/failure gracefully.
 }
 
-func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_Unavailable_KeepsNextRunAt() {
-	payload := s.generateMockMessage()
-	task := asynq.NewTask("", payload)
+type expectTargetParams struct {
+	URL         string
+	Method      string
+	ContentType string
+	Payload     []byte
+	Response    *shttp.HTTPResponse
+	Err         error
+}
 
-	messages := []jobs.FunctionTriggerMessage{}
-	s.NoError(json.Unmarshal(payload, &messages))
-	s.Require().Len(messages, 2)
+// expectTarget wires the request mock for one of generateMockMessage's targets.
+func (s *JobTriggerFunctionsSuite) expectTarget(p expectTargetParams) {
+	s.mockRequest.On("URL", p.URL).Return(s.mockRequest).Once()
+	s.mockRequest.On("Method", p.Method).Return(s.mockRequest).Once()
+	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": p.ContentType})).Return(s.mockRequest).Once()
+	s.mockRequest.On("Payload", p.Payload).Return(s.mockRequest).Once()
+	s.mockRequest.On("Do").Return(p.Response, p.Err).Once()
+}
 
-	store := functiontrigger.NewStore()
-	ctx := context.Background()
-
-	before := map[types.ID]int64{}
-
-	for _, m := range messages {
-		tf, err := store.ByID(ctx, m.ID)
-		s.Require().NoError(err)
-		before[m.ID] = tf.NextRunAt.Unix()
+func unavailableResponse() *shttp.HTTPResponse {
+	return &shttp.HTTPResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
+			Header:     make(http.Header),
+		},
 	}
+}
 
-	// First target is up and runs the job.
-	s.mockRequest.On("URL", "https://example-1.org").Return(s.mockRequest).Once()
-	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
-	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "application/json"})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
-	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
+func okResponse() *shttp.HTTPResponse {
+	return &shttp.HTTPResponse{
 		Response: &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("ok-1")),
+			Body:       io.NopCloser(strings.NewReader("ok")),
 			Header:     make(http.Header),
 		},
-	}, nil).Once()
-
-	// Second target is still warming up and never runs the job.
-	s.mockRequest.On("URL", "https://example-2.org").Return(s.mockRequest).Once()
-	s.mockRequest.On("Method", "PATCH").Return(s.mockRequest).Once()
-	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "text/html"})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", []byte("Hello World!")).Return(s.mockRequest).Once()
-	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
-		Response: &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
-			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
-			Header:     make(http.Header),
-		},
-	}, nil).Once()
-
-	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
-
-	ran, err := store.ByID(ctx, messages[0].ID)
-	s.Require().NoError(err)
-	s.Equal(messages[0].NextRunAt.Unix(), ran.NextRunAt.Unix(), "a trigger that ran should advance to its next tick")
-
-	skipped, err := store.ByID(ctx, messages[1].ID)
-	s.Require().NoError(err)
-	s.Equal(before[messages[1].ID], skipped.NextRunAt.Unix(), "a trigger that got a 503 should stay due for the next sweep")
+	}
 }
 
-// The first message is scheduled ten minutes ago, past the retry window; the
-// second two minutes ago, still inside it.
-func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_Unavailable_BeyondRetryWindow() {
-	payload := s.generateMockMessage()
-	task := asynq.NewTask("", payload)
+// Test_HandleFunctionTrigger_RetryWindow covers what a run that never happened
+// does to nextRunAt. The fixture's first trigger is ten minutes overdue, past
+// the five minute retry window, and the second two minutes, still inside it, so
+// every case asserts both the "give up" and the "stay due" side of the bound.
+func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_RetryWindow() {
+	type target struct {
+		response *shttp.HTTPResponse
+		err      error
+		advances bool
+	}
 
-	messages := []jobs.FunctionTriggerMessage{}
-	s.NoError(json.Unmarshal(payload, &messages))
-	s.Require().Len(messages, 2)
-
-	store := functiontrigger.NewStore()
-	ctx := context.Background()
-
-	stale, err := store.ByID(ctx, messages[1].ID)
-	s.Require().NoError(err)
-	staleNextRunAt := stale.NextRunAt.Unix()
-
-	// Long overdue target, still unavailable — give up and wait for the next tick.
-	s.mockRequest.On("URL", "https://example-1.org").Return(s.mockRequest).Once()
-	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
-	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "application/json"})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
-	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
-		Response: &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
-			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
-			Header:     make(http.Header),
+	cases := []struct {
+		name   string
+		first  target
+		second target
+	}{
+		{
+			name:   "a 503 stays due while a sibling that ran advances",
+			first:  target{response: okResponse(), advances: true},
+			second: target{response: unavailableResponse()},
 		},
-	}, nil).Once()
-
-	// Recently overdue target, still within the window — stays due.
-	s.mockRequest.On("URL", "https://example-2.org").Return(s.mockRequest).Once()
-	s.mockRequest.On("Method", "PATCH").Return(s.mockRequest).Once()
-	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "text/html"})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", []byte("Hello World!")).Return(s.mockRequest).Once()
-	s.mockRequest.On("Do").Return(&shttp.HTTPResponse{
-		Response: &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
-			Body:       io.NopCloser(strings.NewReader("Service not yet started, retry in a bit.")),
-			Header:     make(http.Header),
+		{
+			name:   "a 503 past the window advances, one inside it stays due",
+			first:  target{response: unavailableResponse(), advances: true},
+			second: target{response: unavailableResponse()},
 		},
-	}, nil).Once()
+		{
+			name:   "a transport error is bounded by the same window",
+			first:  target{err: errors.New("connection refused"), advances: true},
+			second: target{err: errors.New("connection refused")},
+		},
+	}
 
-	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			s.mockRequest = &mocks.RequestInterface{}
+			shttp.DefaultRequest = s.mockRequest
 
-	gaveUp, err := store.ByID(ctx, messages[0].ID)
-	s.Require().NoError(err)
-	s.Equal(messages[0].NextRunAt.Unix(), gaveUp.NextRunAt.Unix(), "a 503 past the retry window should advance to the next tick")
+			payload := s.generateMockMessage()
+			task := asynq.NewTask("", payload)
 
-	retrying, err := store.ByID(ctx, messages[1].ID)
-	s.Require().NoError(err)
-	s.Equal(staleNextRunAt, retrying.NextRunAt.Unix(), "a 503 within the retry window should stay due")
-}
+			messages := []jobs.FunctionTriggerMessage{}
+			s.NoError(json.Unmarshal(payload, &messages))
+			s.Require().Len(messages, 2)
 
-func (s *JobTriggerFunctionsSuite) Test_HandleFunctionTrigger_TransportError_IsBounded() {
-	payload := s.generateMockMessage()
-	task := asynq.NewTask("", payload)
+			store := functiontrigger.NewStore()
+			ctx := context.Background()
 
-	messages := []jobs.FunctionTriggerMessage{}
-	s.NoError(json.Unmarshal(payload, &messages))
-	s.Require().Len(messages, 2)
+			before := map[types.ID]int64{}
 
-	store := functiontrigger.NewStore()
-	ctx := context.Background()
+			for _, m := range messages {
+				tf, err := store.ByID(ctx, m.ID)
+				s.Require().NoError(err)
+				before[m.ID] = tf.NextRunAt.Unix()
+			}
 
-	stale, err := store.ByID(ctx, messages[1].ID)
-	s.Require().NoError(err)
-	staleNextRunAt := stale.NextRunAt.Unix()
+			s.expectTarget(expectTargetParams{
+				URL:         "https://example-1.org",
+				Method:      "GET",
+				ContentType: "application/json",
+				Response:    c.first.response,
+				Err:         c.first.err,
+			})
 
-	// Both targets are unreachable; only the long overdue one gives up.
-	s.mockRequest.On("URL", "https://example-1.org").Return(s.mockRequest).Once()
-	s.mockRequest.On("Method", "GET").Return(s.mockRequest).Once()
-	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "application/json"})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", []byte(nil)).Return(s.mockRequest).Once()
-	s.mockRequest.On("Do").Return(nil, errors.New("connection refused")).Once()
+			s.expectTarget(expectTargetParams{
+				URL:         "https://example-2.org",
+				Method:      "PATCH",
+				ContentType: "text/html",
+				Payload:     []byte("Hello World!"),
+				Response:    c.second.response,
+				Err:         c.second.err,
+			})
 
-	s.mockRequest.On("URL", "https://example-2.org").Return(s.mockRequest).Once()
-	s.mockRequest.On("Method", "PATCH").Return(s.mockRequest).Once()
-	s.mockRequest.On("Headers", shttp.HeadersFromMap(map[string]string{"content-type": "text/html"})).Return(s.mockRequest).Once()
-	s.mockRequest.On("Payload", []byte("Hello World!")).Return(s.mockRequest).Once()
-	s.mockRequest.On("Do").Return(nil, errors.New("connection refused")).Once()
+			s.NoError(jobs.HandleFunctionTrigger(ctx, task))
 
-	s.NoError(jobs.HandleFunctionTrigger(ctx, task))
+			for i, want := range []bool{c.first.advances, c.second.advances} {
+				tf, err := store.ByID(ctx, messages[i].ID)
+				s.Require().NoError(err)
 
-	gaveUp, err := store.ByID(ctx, messages[0].ID)
-	s.Require().NoError(err)
-	s.Equal(messages[0].NextRunAt.Unix(), gaveUp.NextRunAt.Unix(), "a transport error past the retry window should advance to the next tick")
-
-	retrying, err := store.ByID(ctx, messages[1].ID)
-	s.Require().NoError(err)
-	s.Equal(staleNextRunAt, retrying.NextRunAt.Unix(), "a transport error within the retry window should stay due")
+				if want {
+					s.Equal(messages[i].NextRunAt.Unix(), tf.NextRunAt.Unix(), "expected the trigger to advance to its next tick")
+				} else {
+					s.Equal(before[messages[i].ID], tf.NextRunAt.Unix(), "expected the trigger to stay due for the next sweep")
+				}
+			}
+		})
+	}
 }
 
 func TestJobTriggerFunctionSuite(t *testing.T) {

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -447,7 +447,7 @@ func (pm *ProcessManager) Invoke(args InvokeArgs, workDir string) (*InvokeResult
 		})
 
 		return &InvokeResult{
-			StatusCode: http.StatusOK,
+			StatusCode: http.StatusServiceUnavailable,
 			Headers: http.Header{
 				"Retry-After":  []string{"1"},
 				"Content-Type": []string{"text/html"},
@@ -468,7 +468,7 @@ func (pm *ProcessManager) Invoke(args InvokeArgs, workDir string) (*InvokeResult
 		})
 
 		return &InvokeResult{
-			StatusCode: http.StatusOK,
+			StatusCode: http.StatusServiceUnavailable,
 			Headers: http.Header{
 				"Retry-After":  []string{"5"},
 				"Content-Type": []string{"text/html"},

--- a/src/lib/integrations/client_process_manager_test.go
+++ b/src/lib/integrations/client_process_manager_test.go
@@ -193,6 +193,26 @@ func (s *ProcessManagerSuite) Test_Invoke_WithServerCmd() {
 	s.Equal("Hello, https://example.org!\n", string(result.Body))
 }
 
+func (s *ProcessManagerSuite) Test_Invoke_WarmingUp_ReturnsServiceUnavailable() {
+	fileName := path.Join(s.tmpdir, "index.js")
+
+	result, err := s.pm.Invoke(integrations.InvokeArgs{
+		URL:          &url.URL{},
+		ARN:          fmt.Sprintf("local:%s:warming_up", fileName),
+		Method:       shttp.MethodGet,
+		Command:      "node index.js",
+		HostName:     "example.org",
+		CaptureLogs:  true,
+		DeploymentID: 1,
+	}, s.tmpdir)
+
+	s.NoError(err)
+	s.Require().NotNil(result)
+	s.Equal("1", result.Headers.Get("Retry-After"), "expected the warming-up interstitial")
+	s.Equal(http.StatusServiceUnavailable, result.StatusCode)
+	s.Contains(string(result.Body), "Service not yet started")
+}
+
 func (s *ProcessManagerSuite) Test_CustomPortHandling_Published() {
 	args := &integrations.InvokeArgs{
 		URL:          &url.URL{},


### PR DESCRIPTION
Closes #425.

## What changed

**1. The interstitials return 503** (`client_process_manager.go`)

Both "service is warming up" pages now return `503 Service Unavailable` instead
of `200 OK`, matching the `Retry-After` header they already send. Browsers still
render the body and honour the `<meta http-equiv="refresh">`, so nothing changes
for a human visitor.

**2. Triggers that did not run stay due for a bounded grace window** (`job_trigger_functions.go`)

While implementing #425 it turned out the status change on its own does *not*
fix the periodic-trigger half of the issue, contrary to what the issue assumed.
`HandleFunctionTrigger` skips the `nextRunAt` update only when `err != nil`, and
`functiontrigger.Run` returns a non-nil error only on transport failures —
`shttp`'s `Do()` returns a nil error for every HTTP status, 5xx included. So a
trigger firing at a warming service would still have recorded a successful run
and still advanced `nextRunAt`; only the logged `"code"` would have changed.

So this PR also makes `HandleFunctionTrigger` leave `nextRunAt` untouched when
the run never happened — a transport error or a 503 response. New
`TriggerLog.ResponseCode()` reads the status back out of the log (handling both
the in-process `int` and the post-JSON-round-trip `float64`).

That retry is **bounded**. `nextRunAt` is the only scheduling state and the
sweep runs every minute, so leaving it in the past unconditionally would re-fire
a persistently dead target every 60 seconds forever — 1440x/day for a daily
trigger, one `function_trigger_logs` row each, against an arbitrary user-supplied
host that may legitimately be shedding load. Instead the queued message now
carries `ScheduledAt`, the overdue `nextRunAt` the run was fired for, and the
trigger stays due only while that is within `triggerRetryWindow` (5 minutes,
roughly five attempts). Past the window it advances to the regular tick and
waits for its own cron. The same bound covers both failure paths, since
connection-refused is the same storm in a different encoding.

Scoped deliberately to 503 rather than all 5xx: an app returning its own 500 has
run, and should not be re-fired until it recovers.

Logged at `Infof`, not `Errorf` — a warming-up target is expected, and at
once-per-minute an error-level line drowns genuine trigger failures.

## Other effects of the status change

- **Uptime checks** — fixed, as the issue intends. `PingDomains` already treats
  non-2xx as a failure, retries once after 3s, and records the real status, so a
  domain serving an interstitial no longer pings as healthy.
- **Analytics** — warm-up hits currently land in the `200` bucket and inflate the
  visitor/referrer/country aggregates. At 503 they fall into no bucket at all
  (aggregation only buckets 200/304 and 404), so they drop out of the aggregates
  while remaining in the raw `analytics` table. That reads as a correction, but
  flagging it since it will show as a small dip on apps that cold-start often.
- **Prometheus** — these requests move from the `200` series into `5xx`, which
  will affect any error-rate alert built on that metric.

## Tests

- `Test_Invoke_WarmingUp_ReturnsServiceUnavailable` — asserts the interstitial's
  status, `Retry-After` and body.
- `Test_HandleFunctionTrigger_Unavailable_KeepsNextRunAt` — a 503 inside the
  grace window stays due while a sibling that ran advances.
- `Test_HandleFunctionTrigger_Unavailable_BeyondRetryWindow` — a 503 past the
  window advances to the next tick; one inside it still stays due.
- `Test_HandleFunctionTrigger_TransportError_IsBounded` — same bound for a
  connection failure.
- `Test_ResponseCode` — int, float64, missing and nil cases.

Verified the two window tests fail if the grace-window check is reverted.
`go build ./src/...` clean; `functiontrigger`, `workerserver`, `public/v1` and
`lib/integrations` packages all pass.

## Follow-ups (not in this PR)

- #427 — a failed `cmd.Start()` leaves the service registered but never started,
  so the warm-up 503 becomes permanent.
- #428 — `function_trigger_logs` has no retention job and no cap on the stored
  response body.
