### PR TITLE
fix: evict service when process start fails

### DIFF
--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -298,7 +298,7 @@ func (pm *ProcessManager) Start(ctx context.Context, args *InvokeArgs, workDir s
 			return
 		}
 
-		service.cmd = sys.Command(ctx, sys.CommandOpts{
+		s.cmd = sys.Command(ctx, sys.CommandOpts{
 			String:      pm.BuildServerCommand(args.Command, workDir),
 			Dir:         workDir,
 			Env:         vars,
@@ -309,6 +309,13 @@ func (pm *ProcessManager) Start(ctx context.Context, args *InvokeArgs, workDir s
 
 		if err := s.cmd.Start(); err != nil {
 			pm.QueueLog(args, err.Error())
+			slog.Errorf("error while starting service, arn: %s, err: %s", s.arn, err.Error())
+
+			// Evict the service so that the next Invoke re-attempts the start.
+			// Without this the ARN stays registered with started=false and every
+			// subsequent request gets the warm-up interstitial forever.
+			s.Kill()
+
 			return
 		}
 

--- a/src/lib/integrations/client_process_manager_test.go
+++ b/src/lib/integrations/client_process_manager_test.go
@@ -413,6 +413,47 @@ func (s *ProcessManagerSuite) Test_Invoke_StaleProcess() {
 	s.Equal("Hello, https://example.org!\n", string(result.Body))
 }
 
+func (s *ProcessManagerSuite) Test_Invoke_FailedStart_EvictsService() {
+	arn := fmt.Sprintf("local:%s:failed_start", path.Join(s.tmpdir, "index.js"))
+
+	args := integrations.InvokeArgs{
+		URL:          &url.URL{},
+		ARN:          arn,
+		Method:       shttp.MethodGet,
+		Command:      "stormkit-binary-that-does-not-exist",
+		HostName:     "example.org",
+		CaptureLogs:  true,
+		DeploymentID: 1,
+	}
+
+	result, err := s.pm.Invoke(args, s.tmpdir)
+	s.NoError(err)
+	s.Require().NotNil(result)
+	s.Equal(http.StatusServiceUnavailable, result.StatusCode)
+
+	// The failed start must evict the service, otherwise every subsequent
+	// Invoke would keep returning the warm-up interstitial forever.
+	deadline := time.Now().Add(3 * time.Second)
+
+	for time.Now().Before(deadline) {
+		if s.pm.GetService(arn) == nil {
+			break
+		}
+
+		s.pm.Invoke(args, s.tmpdir)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	s.Nil(s.pm.GetService(arn), "expected the service to be evicted after a failed start")
+
+	// A subsequent invocation with a working command must be able to start.
+	args.Command = "node index.js"
+
+	result, err = s.invokeWithRetry(args, s.tmpdir)
+	s.NoError(err)
+	s.Equal("Hello, https://example.org!\n", string(result.Body))
+}
+
 func (s *ProcessManagerSuite) Test_BuildServerCommand_WithoutFlake() {
 	cmd := s.pm.BuildServerCommand("node index.js", s.tmpdir)
 	s.Equal("node index.js", cmd)


### PR DESCRIPTION
Fixes #427.

In `src/lib/integrations/client_process_manager.go`, if `s.cmd.Start()` failed the goroutine returned without evicting the service. `started` stayed `false` while the `*Service` remained registered in `pm.services`, and nothing ever retried the start — so every subsequent `Invoke` handed back the warm-up interstitial (a 503 since #426) forever, for the lifetime of the process.

## Changes

- Log the start failure and call `s.Kill()` in the error branch, so the ARN is removed from `pm.services` and the next `Invoke` re-attempts the start.
- Use `s.cmd` instead of `service.cmd` on the neighbouring line for consistency with the rest of the closure (same object).

## Test

`Test_Invoke_FailedStart_EvictsService` invokes with a nonexistent binary, asserts the 503, then asserts the service is evicted and that a follow-up invoke with a working command starts and serves normally. Verified it fails without the `s.Kill()` call.

Note: the goroutine can call `Kill()` before `Invoke` registers the service in `pm.services`, leaving a `killed=true` entry behind — the existing `service.killed` check at the top of `Invoke` already evicts and restarts in that case.