### PR TITLE
chore: prune old function trigger logs

### DIFF
--- a/src/ce/workerserver/job_analytics_retention.go
+++ b/src/ce/workerserver/job_analytics_retention.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	defaultAnalyticsRetentionDays = 180
-	analyticsRetentionBatchSize   = 10000
-	analyticsRetentionMaxBatches  = 1000
+	retentionBatchSize            = 10000
+	retentionMaxBatches           = 1000
 )
 
 // RemoveOldAnalytics deletes raw analytics and custom-event rows older than the
@@ -51,13 +51,13 @@ func RemoveOldAnalytics(ctx context.Context) error {
 // batchDeleteOldRows repeatedly invokes a batched delete until a batch comes
 // back smaller than the batch size (i.e. the backlog is drained) or the per-run
 // cap is reached, returning the total number of rows deleted.
-func batchDeleteOldRows(ctx context.Context, days int, del func(context.Context, RemoveOldAnalyticsParams) (int64, error)) (int64, error) {
+func batchDeleteOldRows(ctx context.Context, days int, del func(context.Context, RemoveOldRowsParams) (int64, error)) (int64, error) {
 	var total int64
 
-	for range analyticsRetentionMaxBatches {
-		deleted, err := del(ctx, RemoveOldAnalyticsParams{
+	for range retentionMaxBatches {
+		deleted, err := del(ctx, RemoveOldRowsParams{
 			RetentionDays: days,
-			BatchSize:     analyticsRetentionBatchSize,
+			BatchSize:     retentionBatchSize,
 		})
 
 		if err != nil {
@@ -66,7 +66,7 @@ func batchDeleteOldRows(ctx context.Context, days int, del func(context.Context,
 
 		total += deleted
 
-		if deleted < analyticsRetentionBatchSize {
+		if deleted < retentionBatchSize {
 			break
 		}
 	}

--- a/src/ce/workerserver/job_analytics_retention_test.go
+++ b/src/ce/workerserver/job_analytics_retention_test.go
@@ -84,7 +84,7 @@ func (s *JobAnalyticsRetentionSuite) countAnalytics() int {
 func (s *JobAnalyticsRetentionSuite) Test_RemoveOldAnalytics_DeletesOnlyOldRows() {
 	s.Equal(4, s.countAnalytics())
 
-	deleted, err := jobs.NewStore().RemoveOldAnalytics(context.Background(), jobs.RemoveOldAnalyticsParams{
+	deleted, err := jobs.NewStore().RemoveOldAnalytics(context.Background(), jobs.RemoveOldRowsParams{
 		RetentionDays: 180,
 		BatchSize:     10000,
 	})
@@ -95,7 +95,7 @@ func (s *JobAnalyticsRetentionSuite) Test_RemoveOldAnalytics_DeletesOnlyOldRows(
 }
 
 func (s *JobAnalyticsRetentionSuite) Test_RemoveOldAnalytics_NoOpWhenNothingExpired() {
-	deleted, err := jobs.NewStore().RemoveOldAnalytics(context.Background(), jobs.RemoveOldAnalyticsParams{
+	deleted, err := jobs.NewStore().RemoveOldAnalytics(context.Background(), jobs.RemoveOldRowsParams{
 		RetentionDays: 365,
 		BatchSize:     10000,
 	})

--- a/src/ce/workerserver/job_logs.go
+++ b/src/ce/workerserver/job_logs.go
@@ -2,9 +2,41 @@ package jobs
 
 import (
 	"context"
+	"os"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
-// RemoveOldLogs removes logs older than 30 days.
+const defaultTriggerLogsRetentionDays = 30
+
+// RemoveOldLogs removes application logs and function trigger logs older than
+// 30 days. The trigger log window can be overridden with
+// STORMKIT_TRIGGER_LOGS_RETENTION_DAYS.
 func RemoveOldLogs(ctx context.Context) error {
-	return NewStore().RemoveOldLogs(ctx)
+	store := NewStore()
+
+	if err := store.RemoveOldLogs(ctx); err != nil {
+		slog.Errorf("could not remove old app logs: %s", err.Error())
+		return err
+	}
+
+	days := utils.StringToInt(os.Getenv("STORMKIT_TRIGGER_LOGS_RETENTION_DAYS"))
+
+	if days <= 0 {
+		days = defaultTriggerLogsRetentionDays
+	}
+
+	removed, err := batchDeleteOldRows(ctx, days, store.RemoveOldTriggerLogs)
+
+	if err != nil {
+		slog.Errorf("could not remove old trigger logs: %s", err.Error())
+		return err
+	}
+
+	if removed > 0 {
+		slog.Infof("removed %d trigger log records (retention=%d days)", removed, days)
+	}
+
+	return nil
 }

--- a/src/ce/workerserver/job_trigger_logs_retention_test.go
+++ b/src/ce/workerserver/job_trigger_logs_retention_test.go
@@ -1,0 +1,88 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+
+	jobs "github.com/stormkit-io/stormkit-io/src/ce/workerserver"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/factory"
+	"github.com/stretchr/testify/suite"
+)
+
+type JobTriggerLogsRetentionSuite struct {
+	suite.Suite
+	*factory.Factory
+
+	conn databasetest.TestDB
+}
+
+func (s *JobTriggerLogsRetentionSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	s.Factory = factory.New(s.conn)
+
+	app := s.MockApp(nil)
+	env := s.MockEnv(app)
+	trigger := s.MockTriggerFunction(env)
+
+	// Two rows older than the 30-day default, two within the window.
+	ages := []string{"45 days", "31 days", "10 days", "1 day"}
+
+	for _, age := range ages {
+		_, err := s.conn.Exec(`
+			INSERT INTO skitapi.function_trigger_logs
+				(trigger_id, request, response, created_at)
+			VALUES
+				($1, '{}'::jsonb, '{}'::jsonb, timezone('utc', now()) - $2::interval);
+		`, trigger.ID, age)
+
+		s.NoError(err)
+	}
+}
+
+func (s *JobTriggerLogsRetentionSuite) AfterTest(_, _ string) {
+	s.conn.CloseTx()
+}
+
+func (s *JobTriggerLogsRetentionSuite) countLogs() int {
+	var count int
+	s.NoError(s.conn.QueryRow(`SELECT count(*) FROM skitapi.function_trigger_logs`).Scan(&count))
+	return count
+}
+
+func (s *JobTriggerLogsRetentionSuite) Test_RemoveOldTriggerLogs_DeletesOnlyOldRows() {
+	s.Equal(4, s.countLogs())
+
+	deleted, err := jobs.NewStore().RemoveOldTriggerLogs(context.Background(), jobs.RemoveOldRowsParams{
+		RetentionDays: 30,
+		BatchSize:     10000,
+	})
+
+	s.NoError(err)
+	s.Equal(int64(2), deleted)
+	s.Equal(2, s.countLogs())
+}
+
+func (s *JobTriggerLogsRetentionSuite) Test_RemoveOldTriggerLogs_NoOpWhenNothingExpired() {
+	deleted, err := jobs.NewStore().RemoveOldTriggerLogs(context.Background(), jobs.RemoveOldRowsParams{
+		RetentionDays: 365,
+		BatchSize:     10000,
+	})
+
+	s.NoError(err)
+	s.Equal(int64(0), deleted)
+	s.Equal(4, s.countLogs())
+}
+
+func (s *JobTriggerLogsRetentionSuite) Test_RemoveOldLogs_JobHonorsEnvWindow() {
+	s.T().Setenv("STORMKIT_TRIGGER_LOGS_RETENTION_DAYS", "5")
+
+	s.NoError(jobs.RemoveOldLogs(context.Background()))
+
+	// Only the 1-day-old row survives a 5-day window.
+	s.Equal(1, s.countLogs())
+}
+
+func TestJobTriggerLogsRetentionSuite(t *testing.T) {
+	suite.Run(t, &JobTriggerLogsRetentionSuite{})
+}

--- a/src/ce/workerserver/ws_statements.go
+++ b/src/ce/workerserver/ws_statements.go
@@ -16,6 +16,7 @@ type statement struct {
 	selectTimedOutDeployments       string
 	selectOldOrDeletedDeployments   string
 	removeOldLogs                   string
+	removeOldTriggerLogs            string
 	removeOldAnalytics              string
 	removeOldAnalyticsEvents        string
 	syncAnalyticsVisitors           string
@@ -48,6 +49,15 @@ var stmt = &statement{
        WHERE
          to_timestamp(timestamp)::date < now() - interval '30 days'
 	`, tableLogs),
+	removeOldTriggerLogs: `
+		DELETE FROM function_trigger_logs
+		WHERE ctid IN (
+			SELECT ctid
+			FROM function_trigger_logs
+			WHERE created_at < timezone('utc', now()) - make_interval(days => $1)
+			LIMIT $2
+		)
+	`,
 	removeOldAnalytics: `
 		DELETE FROM analytics
 		WHERE ctid IN (

--- a/src/ce/workerserver/ws_store.go
+++ b/src/ce/workerserver/ws_store.go
@@ -36,16 +36,16 @@ func (s *Store) RemoveOldLogs(ctx context.Context) error {
 	return err
 }
 
-// RemoveOldAnalyticsParams configures a single batched deletion of raw
-// analytics rows older than the retention window.
-type RemoveOldAnalyticsParams struct {
+// RemoveOldRowsParams configures a single batched deletion of rows older than
+// the retention window.
+type RemoveOldRowsParams struct {
 	RetentionDays int
 	BatchSize     int
 }
 
 // RemoveOldAnalytics deletes up to BatchSize raw analytics rows older than
 // RetentionDays and returns the number of rows removed.
-func (s *Store) RemoveOldAnalytics(ctx context.Context, p RemoveOldAnalyticsParams) (int64, error) {
+func (s *Store) RemoveOldAnalytics(ctx context.Context, p RemoveOldRowsParams) (int64, error) {
 	res, err := s.Exec(ctx, stmt.removeOldAnalytics, p.RetentionDays, p.BatchSize)
 
 	if err != nil {
@@ -57,8 +57,20 @@ func (s *Store) RemoveOldAnalytics(ctx context.Context, p RemoveOldAnalyticsPara
 
 // RemoveOldAnalyticsEvents deletes up to BatchSize raw custom-event rows older
 // than RetentionDays and returns the number of rows removed.
-func (s *Store) RemoveOldAnalyticsEvents(ctx context.Context, p RemoveOldAnalyticsParams) (int64, error) {
+func (s *Store) RemoveOldAnalyticsEvents(ctx context.Context, p RemoveOldRowsParams) (int64, error) {
 	res, err := s.Exec(ctx, stmt.removeOldAnalyticsEvents, p.RetentionDays, p.BatchSize)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return res.RowsAffected()
+}
+
+// RemoveOldTriggerLogs deletes up to BatchSize function trigger log rows older
+// than RetentionDays and returns the number of rows removed.
+func (s *Store) RemoveOldTriggerLogs(ctx context.Context, p RemoveOldRowsParams) (int64, error) {
+	res, err := s.Exec(ctx, stmt.removeOldTriggerLogs, p.RetentionDays, p.BatchSize)
 
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Closes #428.

`function_trigger_logs` had no retention — `RemoveOldLogs` only targeted `app_logs`, so rows accumulated for the lifetime of a trigger (a per-minute trigger writes ~43k rows a month).

## Changes

- New `removeOldTriggerLogs` statement + `Store.RemoveOldTriggerLogs`, deleting rows older than the retention window in batches (same `ctid`-based pattern as analytics retention) so the first run on a large backlog doesn't hold a long lock.
- `RemoveOldLogs` now prunes `function_trigger_logs` too, defaulting to 30 days (matching `app_logs`) and overridable with `STORMKIT_TRIGGER_LOGS_RETENTION_DAYS`.
- Renamed `RemoveOldAnalyticsParams` → `RemoveOldRowsParams` and the batch constants, since the helper is now shared by both retention paths.

## Notes

The issue's second point — capping the stored response body — already landed in #426 (`maxLoggedBodySize`, 64 KiB with a truncation marker), so nothing was needed there.

## Tests

`go test -p 1 ./src/ce/workerserver/...` passes; new suite covers old-rows-only deletion, the no-op case, and the env-var window through the job.