### PR TITLE
fix: seo quick wins from search console data

### DIFF
--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -7,6 +7,9 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#000000" />
+    <!-- The console is an authenticated app; keep it out of search results so it
+         does not compete with the marketing site for Stormkit queries. -->
+    <meta name="robots" content="noindex, nofollow" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/www/package.json
+++ b/src/www/package.json
@@ -11,12 +11,14 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/vite-server.ts",
-    "build": "npm run build:docs && npm run build:spa && npm run build:ssr && npm run build:ssg && rm -rf .stormkit/server && npm run build:api",
+    "build": "npm run build:sitemap && npm run build:docs && npm run build:spa && npm run build:ssr && npm run build:ssg && rm -rf .stormkit/server && npm run build:api",
     "build:docs": "DOCS=true tsx ./src/vite-server.ts",
     "build:spa": "rm -rf .stormkit && vite build -c vite.config.ts",
     "build:ssg": "SSG=true tsx ./src/vite-server.ts",
     "build:ssr": "vite build -c vite.config.ssr.ts",
-    "build:api": "rm -rf .stormkit/api && tsx vite.config.api.ts"
+    "build:api": "rm -rf .stormkit/api && tsx vite.config.api.ts",
+    "build:sitemap": "tsx ./scripts/generate-sitemap.ts",
+    "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/www/public/sitemap.xml
+++ b/src/www/public/sitemap.xml
@@ -2,302 +2,560 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.stormkit.io/</loc>
-    <lastmod>2024-09-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/vs-vercel</loc>
-    <lastmod>2024-09-26</lastmod>
+    <loc>https://www.stormkit.io/vs-netlify</loc>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/vs-netlify</loc>
-    <lastmod>2024-09-26</lastmod>
+    <loc>https://www.stormkit.io/vs-vercel</loc>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/about-us</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/contact</loc>
-    <lastmod>2025-03-19</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.2</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/blog</loc>
-    <lastmod>2024-09-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/blog/hosting-hundreds-of-websites</loc>
-    <lastmod>2025-05-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/blog/critical-middleware-bypass-vulnerability-in-nextjs-cve-2025-29927</loc>
-    <lastmod>2025-03-24</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/blog/hunting-zombie-processes-in-go-and-docker</loc>
-    <lastmod>2025-04-16</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/blog/what-we-built-feb-apr-2026</loc>
-    <lastmod>2026-05-03</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/welcome/getting-started</loc>
-    <lastmod>2024-09-20</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/self-hosting/getting-started</loc>
-    <lastmod>2025-05-18</lastmod>
+    <loc>https://www.stormkit.io/docs</loc>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/self-hosting/authentication</loc>
-    <lastmod>2025-05-20</lastmod>
+    <loc>https://www.stormkit.io/docs/api/access-logs</loc>
+    <lastmod>2026-08-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/self-hosting/custom-images</loc>
-    <lastmod>2025-07-11</lastmod>
+    <loc>https://www.stormkit.io/docs/api/apps</loc>
+    <lastmod>2026-04-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/welcome/contributing</loc>
-    <lastmod>2024-09-24</lastmod>
+    <loc>https://www.stormkit.io/docs/api/authentication</loc>
+    <lastmod>2026-03-07</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/welcome/contact-us</loc>
-    <lastmod>2024-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://www.stormkit.io/docs/api/database</loc>
+    <lastmod>2026-05-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/deployments/introduction</loc>
-    <lastmod>2024-05-13</lastmod>
+    <loc>https://www.stormkit.io/docs/api/deployments</loc>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/deployments/configuration</loc>
-    <lastmod>2024-05-16</lastmod>
+    <loc>https://www.stormkit.io/docs/api/domains</loc>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/environments</loc>
+    <lastmod>2026-08-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/mailer</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/mcp</loc>
+    <lastmod>2026-08-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/redirects</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/snippets</loc>
+    <lastmod>2026-03-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/teams</loc>
+    <lastmod>2026-06-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/triggers</loc>
+    <lastmod>2026-08-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/api/volumes</loc>
+    <lastmod>2026-03-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/deployments/application-runtime</loc>
-    <lastmod>2024-05-11</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2026-08-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/deployments/auto-deployments</loc>
-    <lastmod>2024-12-26</lastmod>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/deployments/outbound-webhooks</loc>
-    <lastmod>2025-09-06</lastmod>
+    <loc>https://www.stormkit.io/docs/deployments/configuration</loc>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/deployments/system-variables</loc>
-    <lastmod>2024-09-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/deployments/system-variables</loc>
-    <lastmod>2024-09-05</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/deployments/how-do-we-deploy</loc>
-    <lastmod>2024-09-05</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/deployments/introduction</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/deployments/outbound-webhooks</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/deployments/priority-deployments</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/deployments/status-checks</loc>
-    <lastmod>2024-09-20</lastmod>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/deployments/system-variables</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/deployments/troubleshooting</loc>
+    <lastmod>2026-08-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/deployments/zip-file-deployments</loc>
-    <lastmod>2025-05-08</lastmod>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/development/image-optimization</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/development/troubleshooting</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/features/analytics</loc>
-    <lastmod>2024-09-05</lastmod>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/features/auth-wall</loc>
-    <lastmod>2025-04-24</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/authentication</loc>
+    <lastmod>2026-08-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/features/custom-certificates</loc>
-    <lastmod>2024-08-16</lastmod>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/features/custom-headers</loc>
-    <lastmod>2025-09-06</lastmod>
+    <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/features/mailer</loc>
-    <lastmod>2024-11-04</lastmod>
+    <loc>https://www.stormkit.io/docs/features/database</loc>
+    <lastmod>2025-12-25</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/multiple-environments</loc>
-    <lastmod>2024-08-12</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/redirects-and-path-rewrites</loc>
-    <lastmod>2024-08-20</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/snippets</loc>
-    <lastmod>2024-02-23</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/teams-and-roles</loc>
-    <lastmod>2023-11-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/periodic-triggers</loc>
-    <lastmod>2024-12-26</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/volumes</loc>
-    <lastmod>2024-11-04</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://www.stormkit.io/docs/features/writing-api</loc>
-    <lastmod>2024-09-25</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/features/image-optimization</loc>
-    <lastmod>2025-03-06</lastmod>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/mailer</loc>
+    <lastmod>2026-02-18</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/multiple-environments</loc>
+    <lastmod>2025-12-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/oauth-server</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/periodic-triggers</loc>
+    <lastmod>2026-08-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/redirects-and-path-rewrites</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/snippets</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/teams-and-roles</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/volumes</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/features/writing-api</loc>
+    <lastmod>2026-08-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/migrations/vercel</loc>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/other/personal-access-token</loc>
-    <lastmod>2024-05-13</lastmod>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/other/troubleshooting</loc>
-    <lastmod>2024-05-13</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/advanced-configuration</loc>
+    <lastmod>2026-04-24</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/api/authentication</loc>
-    <lastmod>2024-09-05</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/authentication</loc>
+    <lastmod>2025-12-02</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/api/domains</loc>
-    <lastmod>2024-11-05</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/custom-images</loc>
+    <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/api/redirects</loc>
-    <lastmod>2024-05-21</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/getting-started</loc>
+    <lastmod>2026-03-17</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/api/redirects</loc>
-    <lastmod>2024-05-21</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/managing-users</loc>
+    <lastmod>2025-12-03</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/api/snippets</loc>
-    <lastmod>2024-08-16</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/monitoring</loc>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/api/environments</loc>
-    <lastmod>2025-02-12</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/runtimes</loc>
+    <lastmod>2026-08-10</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/docs/migrations/vercel</loc>
-    <lastmod>2025-05-20</lastmod>
+    <loc>https://www.stormkit.io/docs/self-hosting/system-configuration</loc>
+    <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/tutorials/how-to-deploy-your-self-hosted-strapi-instance</loc>
-    <lastmod>2025-04-22</lastmod>
+    <loc>https://www.stormkit.io/docs/welcome/contact-us</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/welcome/contributing</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/docs/welcome/getting-started</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/enterprise</loc>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.stormkit.io/tutorials/how-to-self-host-stormkit-on-hetzner-cloud</loc>
-    <lastmod>2025-04-24</lastmod>
+    <loc>https://www.stormkit.io/tutorials</loc>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/tutorials/how-to-deploy-your-self-hosted-remix-app</loc>
-    <lastmod>2025-04-24</lastmod>
+    <lastmod>2025-12-12</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/tutorials/how-to-deploy-your-self-hosted-strapi-instance</loc>
+    <lastmod>2025-12-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/tutorials/how-to-run-automated-e2-e-tests-with-stormkit-and-browserless</loc>
+    <lastmod>2025-12-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/tutorials/how-to-self-host-stormkit-on-hetzner-cloud</loc>
+    <lastmod>2025-12-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/tutorials/setting-up-stormkit-with-cloudflare-tunnels</loc>
+    <lastmod>2025-12-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/case-study-elham</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/critical-middleware-bypass-vulnerability-in-nextjs-cve-2025-29927</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/factory-pattern-for-go-tests</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/faq</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/free-trial-discontinuation-announcement</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/getting-started-with-vitejs</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/guide-to-understanding-choosing-right-analytic-tools-for-your-website</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/hosting-hundreds-of-websites</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/how-ai-helping-us-catch-phishing-websites</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/how-to-create-content-site</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/how-to-deploy-docusarous</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/how-to-deploy-gatsby</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/how-to-deploy-vitepress</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/how-we-migrated-from-aws-to-hetzner-without-downtime</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/hunting-zombie-processes-in-go-and-docker</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/migrating-your-app-from-webpack-to-vite</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/postgresql-with-golang-crafting-insert-queries</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/site-search-with-react-and-minisearch</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/unlocking-dynamic-web-interactions-with-htmx</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/what-we-built-feb-apr-2026</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/whats-new</loc>
+    <lastmod>2026-07-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/why-we-are-dropping-support-for-next-js</loc>
+    <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/why-we-are-migrating-from-semver-to-calver</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
 </urlset>

--- a/src/www/redirects.json
+++ b/src/www/redirects.json
@@ -3,7 +3,7 @@
     "from": "stormkit.io",
     "to": "www.stormkit.io",
     "assets": true,
-    "status": 302
+    "status": 301
   },
   {
     "from": "/docs/welcome/self-hosting",

--- a/src/www/scripts/generate-sitemap.ts
+++ b/src/www/scripts/generate-sitemap.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { glob } from 'glob'
+import routes from './prerender'
+
+const ORIGIN = 'https://www.stormkit.io'
+
+// Routes that should stay out of search results. Legal pages and the 404 carry
+// no search value and dilute the sitemap.
+const EXCLUDE = new Set(['/404', '/policies/terms', '/policies/privacy'])
+
+// Priority by section, highest first. Anything unlisted falls back to 0.5.
+const PRIORITY: [RegExp, string, string][] = [
+  [/^\/$/, '1.0', 'weekly'],
+  [/^\/vs-/, '0.9', 'monthly'],
+  [/^\/(enterprise|about-us|contact)$/, '0.8', 'monthly'],
+  [/^\/docs/, '0.8', 'weekly'],
+  [/^\/tutorials/, '0.7', 'monthly'],
+  [/^\/blog/, '0.6', 'weekly'],
+]
+
+interface Entry {
+  loc: string
+  lastmod: string
+  changefreq: string
+  priority: string
+}
+
+const ROOT = path.resolve(import.meta.dirname, '../../../')
+const TODAY = new Date().toISOString().slice(0, 10)
+
+// Markdown routes drop the numeric ordering prefix from their filename
+// (docs/self-hosting/5-runtimes.md -> /docs/self-hosting/runtimes), so the route
+// alone cannot be turned back into a path. Walk the same globs prerender.ts uses
+// and index the files by the route they produce.
+function markdownByRoute(): Map<string, string> {
+  const files = [
+    ...glob.sync(path.resolve(ROOT, 'docs/**/*.md')),
+    ...glob.sync(path.resolve(ROOT, 'content/blog/*.md')),
+    ...glob.sync(path.resolve(ROOT, 'content/tutorials/**/*.md')),
+  ]
+
+  return new Map(
+    files.map((file) => [
+      file
+        .replace(ROOT, '')
+        .replace(/^\/content/, '')
+        .replace('.md', '')
+        .replace(/\/[\d]+-/, '/'),
+      file,
+    ])
+  )
+}
+
+const MARKDOWN = markdownByRoute()
+
+// lastMod prefers the file's last commit date so the sitemap reflects real
+// edits. A shallow clone has no history to read, so fall back to mtime and then
+// to today rather than failing the build.
+function lastMod(route: string): string {
+  const file = MARKDOWN.get(route)
+
+  if (!file) {
+    return TODAY
+  }
+
+  try {
+    const out = execFileSync('git', ['log', '-1', '--format=%cs', '--', file], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(out)) {
+      return out
+    }
+  } catch {
+    // git unavailable or no history for this path
+  }
+
+  return fs.statSync(file).mtime.toISOString().slice(0, 10)
+}
+
+function entryFor(route: string): Entry {
+  const match = PRIORITY.find(([re]) => re.test(route))
+
+  return {
+    loc: route === '/' ? `${ORIGIN}/` : `${ORIGIN}${route}`,
+    lastmod: lastMod(route),
+    changefreq: match ? match[2] : 'monthly',
+    priority: match ? match[1] : '0.5',
+  }
+}
+
+export function generateSitemap(): string {
+  const seen = new Set<string>()
+  const entries: Entry[] = []
+
+  for (const { route } of routes) {
+    if (EXCLUDE.has(route) || seen.has(route)) {
+      continue
+    }
+
+    seen.add(route)
+    entries.push(entryFor(route))
+  }
+
+  entries.sort((a, b) => Number(b.priority) - Number(a.priority) || a.loc.localeCompare(b.loc))
+
+  const body = entries
+    .map(
+      (e) =>
+        `  <url>\n` +
+        `    <loc>${e.loc}</loc>\n` +
+        `    <lastmod>${e.lastmod}</lastmod>\n` +
+        `    <changefreq>${e.changefreq}</changefreq>\n` +
+        `    <priority>${e.priority}</priority>\n` +
+        `  </url>`
+    )
+    .join('\n')
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `${body}\n` +
+    `</urlset>\n`
+  )
+}
+
+const dist = path.resolve(import.meta.dirname, '../public/sitemap.xml')
+fs.writeFileSync(dist, generateSitemap(), 'utf-8')
+console.info(`✅ sitemap.xml written with ${routes.length} candidate routes`)

--- a/src/www/src/entry-server.tsx
+++ b/src/www/src/entry-server.tsx
@@ -7,6 +7,7 @@ import http from 'node:http'
 import { fileURLToPath } from 'node:url'
 import serverless from '@stormkit/serverless'
 import createRoutes from './routes'
+import { canonicalUrl } from './helpers/seo'
 import Context from './context'
 import App from './App'
 import createEmotionCache from './emotion-cache'
@@ -72,6 +73,7 @@ export const render: RenderFunction = async (url, seo) => {
   const emotionCss = constructStyleTagsFromChunks(emotionChunks)
 
   const title = tags.title.replace(/^["']|["']$/g, '')
+  const canonical = canonicalUrl(url, tags.domain?.url)
 
   return {
     status: 200,
@@ -81,9 +83,10 @@ export const render: RenderFunction = async (url, seo) => {
       `<meta charset="utf-8" />`,
       `<meta name="viewport" content="width=device-width, initial-scale=1" />`,
       `<meta name="description" content="${tags.description}" />`,
+      `<link rel="canonical" href="${canonical}" />`,
       `<meta property="og:title" content="${title}" />`,
       `<meta property="og:type" content="${tags.type}" />`,
-      `<meta property="og:url" content="${tags.domain?.url}" />`,
+      `<meta property="og:url" content="${canonical}" />`,
       `<meta property="og:description" content="${tags.description}" />`,
       `<meta property="og:image" content="${tags.domain?.url}/stormkit-og-image.png" />`,
       `<meta name="twitter:card" content="${tags.twitter!.card}" />`,
@@ -99,7 +102,7 @@ export const render: RenderFunction = async (url, seo) => {
         tags.twitter!.imageWidth
       }"/>`,
       `<meta name="twitter:image:height" content="${
-        tags.twitter!.imageWidth
+        tags.twitter!.imageHeight
       }"/>`,
       `<link rel="apple-touch-icon" href="/stormkit-logo.png"/>`,
       `<link rel="icon" type="image/svg+xml" href="/stormkit-logo.png" />`,
@@ -120,7 +123,7 @@ export const handler = serverless(
     const html = fs.readFileSync(path.join(dir, './index.html'), 'utf-8')
 
     const { status, content, head } = await render(
-      req.url?.split(/\?#/)[0] || '/'
+      req.url?.split(/[?#]/)[0] || '/'
     )
 
     res.writeHead(status, 'OK', { 'Content-Type': 'text/html; charset=utf-8' })

--- a/src/www/src/helpers/seo.test.ts
+++ b/src/www/src/helpers/seo.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { canonicalUrl, DEFAULT_ORIGIN } from './seo'
+
+describe('canonicalUrl', () => {
+  it('returns the origin with a trailing slash for the root', () => {
+    assert.equal(canonicalUrl('/'), `${DEFAULT_ORIGIN}/`)
+  })
+
+  it('keeps a normal path as-is', () => {
+    assert.equal(canonicalUrl('/vs-netlify'), `${DEFAULT_ORIGIN}/vs-netlify`)
+  })
+
+  it('drops the trailing slash so /page and /page/ do not split signals', () => {
+    assert.equal(canonicalUrl('/blog/'), `${DEFAULT_ORIGIN}/blog`)
+    assert.equal(canonicalUrl('/blog///'), `${DEFAULT_ORIGIN}/blog`)
+  })
+
+  it('strips query strings and fragments', () => {
+    assert.equal(canonicalUrl('/blog?ref=hn'), `${DEFAULT_ORIGIN}/blog`)
+    assert.equal(canonicalUrl('/blog#top'), `${DEFAULT_ORIGIN}/blog`)
+    assert.equal(canonicalUrl('/blog?a=1#top'), `${DEFAULT_ORIGIN}/blog`)
+  })
+
+  it('falls back to the root for an empty pathname', () => {
+    assert.equal(canonicalUrl(''), `${DEFAULT_ORIGIN}/`)
+  })
+
+  it('honours an explicit origin and never doubles the slash', () => {
+    assert.equal(canonicalUrl('/docs', 'https://example.com'), 'https://example.com/docs')
+    assert.equal(canonicalUrl('/docs', 'https://example.com/'), 'https://example.com/docs')
+  })
+})

--- a/src/www/src/helpers/seo.ts
+++ b/src/www/src/helpers/seo.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_ORIGIN = 'https://www.stormkit.io'
+
+/**
+ * canonicalUrl builds the absolute, canonical form of a page: the www origin, no
+ * query string or fragment, and no trailing slash except on the root. Without
+ * this, search engines treat /page, /page/, and /page?ref=x as three separate
+ * URLs and split the ranking signals between them.
+ */
+export function canonicalUrl(pathname: string, origin?: string): string {
+  const base = (origin || DEFAULT_ORIGIN).replace(/\/+$/, '')
+  const clean = (pathname || '/').split(/[?#]/)[0].replace(/\/+$/, '')
+
+  return clean === '' ? `${base}/` : `${base}${clean}`
+}

--- a/src/www/src/pages/vs/netlify.tsx
+++ b/src/www/src/pages/vs/netlify.tsx
@@ -9,9 +9,9 @@ import { useScrollToHash } from '~/helpers/scroll'
 export const fetchData: FetchDataFunc = async () => {
   return {
     head: {
-      title: 'What makes Stormkit a great Netlify alternative?',
+      title: 'Stormkit vs Netlify: self-hosted, no per-seat pricing',
       description:
-        'Stormkit is a fully-featured, powerful, and self-hostable alternative to Netlify.',
+        'A side-by-side comparison of Stormkit and Netlify: self-hosting on your own servers, predictable pricing without per-seat fees, deployment previews, and full control over your build pipeline.',
     },
     context: {},
   }

--- a/src/www/src/pages/vs/vercel.tsx
+++ b/src/www/src/pages/vs/vercel.tsx
@@ -9,9 +9,9 @@ import { useScrollToHash } from '~/helpers/scroll'
 export const fetchData: FetchDataFunc = async () => {
   return {
     head: {
-      title: 'What makes Stormkit a great Vercel alternative?',
+      title: 'Stormkit vs Vercel: self-hosted, no per-seat pricing',
       description:
-        'Stormkit is a fully-featured, powerful, and self-hostable alternative to Vercel.Discover Stormkit, a self-hostable Vercel alternative with powerful features like deployment previews, custom configurations, and transparent pricing for your web applications.',
+        'A side-by-side comparison of Stormkit and Vercel: self-hosting on your own infrastructure, transparent pricing without per-seat fees, deployment previews, and no vendor lock-in.',
     },
     context: {},
   }


### PR DESCRIPTION
Four fixes driven by a review of Search Console data for `sc-domain:stormkit.io`, ranked by the clicks each should recover.

## 1. Comparison page titles

The clearest gap in the data: `/vs-netlify` and `/vs-vercel` both earn impressions but convert far below what their ranking should return. Both titles were questions with no answer in them and nothing to distinguish Stormkit:

```
- What makes Stormkit a great Netlify alternative?
+ Stormkit vs Netlify: self-hosted, no per-seat pricing
```

The Vercel description was also 290 characters with a missing space (`to Vercel.Discover`), so the snippet truncated mid-sentence.

## 2. Canonical URLs, and a 301 for www

`entry-server.tsx` built the whole head — title, description, og:*, twitter:* — with **no `rel=canonical`**, and `og:url` pointed at the domain root on every page. Search Console already reports `stormkit.io/` and `www.stormkit.io/` as separate pages. The www redirect in `redirects.json` was a **302**, which does not consolidate ranking signals; it is now 301.

## 3. Generated sitemap

`public/sitemap.xml` was hand-written: 50 URLs covering **4 of 23 blog posts**, `lastmod` dates from 2024. Several posts that already rank were missing from it entirely.

It is now generated from the same route list `prerender.ts` feeds the static build, so the sitemap and the prerendered pages cannot drift. `lastmod` comes from each file's last commit date, falling back to mtime in a shallow clone.

```
93 URLs — 23 blog posts, 56 docs pages, 5 tutorials   (was 50 / 4 / 38)
```

Runs as `build:sitemap`, ordered **before** `build:spa` since that step wipes `.stormkit` and copies `public/`.

## 4. noindex on the console

`app.stormkit.io` was indexable (`<title>Stormkit - Console</title>`, no robots meta) and appearing in search results, competing with the marketing site for Stormkit queries.

## Two defects found in the same files

- `req.url?.split(/\?#/)` splits on the literal sequence `?#`, so query strings were **never** stripped from the rendered path. Now `/[?#]/`. This matters directly for canonicalisation.
- `twitter:image:height` emitted `imageWidth`, reporting the OG image as 1200×1200 instead of 1200×628.

## Tests

The `www` package had no test harness — `jest.config.js` is a stale Vue-era config with zero tests — so rather than bolt one on, `canonicalUrl` lives in `helpers/seo.ts` with tests under `node:test`, wired to `npm test` in `src/www`.

## Scope

These recover clicks the site has already earned the rankings for. They do not fix what is underneath: non-brand search is a small fraction of organic traffic compared with brand queries. That is a content coverage problem, not a technical one.
