### PR TITLE
content: rewrite strapi tutorial for hosting intent

### DIFF
--- a/content/tutorials/how-to-deploy-your-self-hosted-strapi-instance.md
+++ b/content/tutorials/how-to-deploy-your-self-hosted-strapi-instance.md
@@ -1,11 +1,15 @@
 ---
-title: How to Deploy Your Self-Hosted Strapi CMS
-description: Learn to deploy self-hosted Strapi CMS on Stormkit with this step-by-step guide, covering project setup, GitHub integration and environment configuration.
+title: 'Strapi Hosting: How to Self-Host Strapi CMS on Your Own Server'
+description: Where to host Strapi, what it needs to run, and a step-by-step guide to deploying a self-hosted Strapi CMS on your own infrastructure with persistent uploads and a database that survives redeploys.
 date: 2025-05-01
 category: deployment guides
 ---
 
-Deploy a Strapi CMS instance on your server with this step-by-step guide.
+Strapi is self-hosted by design: there is no free tier you can push to and forget.
+You bring a server, and you decide where it lives, what it costs, and who can
+reach the data. This guide covers both halves of that — what Strapi actually
+needs from a host, and then a complete walkthrough of deploying it on your own
+infrastructure with Stormkit.
 
 <div class="img-wrapper">
 
@@ -13,13 +17,76 @@ Deploy a Strapi CMS instance on your server with this step-by-step guide.
 
 </div>
 
-## Prerequisites
+## Your Strapi hosting options
 
-Before diving in, review [Strapi's documentation](https://docs.strapi.io/cms/deployment) for hardware requirements. Stormkit suggests at least 4GB RAM, 2 vCPUs, and 20GB storage for optimal performance.
+Strapi is a Node.js application with a database and an uploads directory. That
+rules out static hosts and most frontend platforms, and leaves three routes:
+
+**Strapi Cloud** — the managed service from Strapi's own team. Least work,
+priced per project, and your content sits on their infrastructure.
+
+**A plain VPS** — Hetzner, DigitalOcean, Scaleway, or a machine you already own.
+Cheapest in euros, most expensive in time: you are responsible for Node
+versions, process supervision, TLS certificates, backups and redeploys.
+
+**A self-hosted platform on your own server** — the middle path, and what this
+guide covers. You still own the machine and the data, but deployments, TLS,
+environment variables and persistent storage are handled for you. Stormkit's
+self-hosted edition does this; so do other open-source platforms.
+
+There is no meaningful "free Strapi hosting". Strapi holds a database and serves
+an admin panel, so it needs a machine that stays running. The honest floor is a
+small VPS, which is usually a few euros a month.
+
+## What Strapi needs from a host
+
+Check [Strapi's deployment documentation](https://docs.strapi.io/cms/deployment)
+for the authoritative requirements. In practice, plan for:
+
+| Resource | Recommended |
+| --- | --- |
+| RAM | 4 GB |
+| CPU | 2 vCPUs |
+| Storage | 20 GB |
+
+The admin panel is rebuilt on deploy, which is the memory-hungry part — a 1 GB
+instance will typically survive serving traffic but fall over during a build.
+
+Two things matter more than the specs, because they are what break a Strapi
+deployment that looked fine on day one:
+
+**The database has to outlive the deployment.** Strapi defaults to SQLite at
+`.tmp/data.db`. If that file is missing at build time, Strapi regenerates it,
+and every piece of content is gone. The file has to live on a volume that
+survives redeploys.
+
+**Uploads have to outlive the deployment too.** Strapi writes to
+`public/uploads`, a path inside the project directory. Without intervention,
+every deploy ships a fresh empty folder and your media library breaks.
+
+Both are solved below.
+
+### A note on data residency
+
+Because Strapi is self-hosted, the answer to "can I host Strapi in the UK, or
+Germany, or anywhere specific?" is simply: pick a server there. This is one of
+the few genuine advantages of self-hosting a CMS over a managed one — the
+hosting region is your decision rather than a plan feature, which matters if you
+have GDPR or contractual obligations about where content is stored.
+
+## Prerequisites
 
 - A GitHub account
 - A [self-hosted Stormkit instance](/tutorials/how-to-self-host-stormkit-on-hetzner-cloud) for deployment
 - Basic knowledge of Git and terminal commands
+
+<div class="blog-alert">
+
+Strapi is a long-running Node.js server, so it needs the Application Runtime.
+That means a self-hosted Stormkit instance — this particular walkthrough does not
+apply to Stormkit Cloud.
+
+</div>
 
 ## 1. Create a Strapi Project
 
@@ -103,15 +170,9 @@ git push -u origin HEAD
 
 ## 4. Deploy on Stormkit
 
-<div class="blog-alert">
-
-Note: Strapi is a Node.js project and for now it works only on self-hosted Stormkit instances.
-
-</div>
-
 ### Importing the project
 
-- Log in to your Stormkit account at [app.stormkit.io](https://app.stormkit.io).
+- Log in to your Stormkit instance.
 - Click to `Create new app` > `Import from GitHub`
 - Choose your Strapi project and click `Import`
 
@@ -156,3 +217,33 @@ Next, we need to setup the environment variables.
 ## 5. Verify the Deployment
 
 Once you went through all the steps mentioned above, go ahead and `Deploy` your Strapi application. When the deployment is complete click on the `Preview` button to access your Strapi instance.
+
+Redeploy once more before you trust it. The first deployment proves the build
+works; the second proves your content and uploads survived it, which is the part
+that actually distinguishes a working Strapi host from a broken one.
+
+## Frequently asked questions
+
+**Can I host Strapi for free?**
+Not realistically. Strapi runs a persistent Node.js process and a database, so
+it needs a machine that stays up. Free tiers that sleep on idle will lose SQLite
+data and make the admin panel unusable. Budget for a small VPS.
+
+**How much does it cost to host Strapi yourself?**
+The server is the cost. A VPS meeting the 4 GB / 2 vCPU recommendation is
+typically in the €5–15 per month range, and one server can host several projects
+alongside Strapi.
+
+**SQLite or PostgreSQL?**
+SQLite is fine for a single instance with modest content, and it is what this
+guide uses. Move to PostgreSQL when you need more than one instance, want
+managed backups, or your content outgrows a single file.
+
+**Why does my Strapi content disappear after a deploy?**
+Almost always the two paths above: SQLite regenerated at `.tmp/data.db` because
+the old file was not found, or `public/uploads` shipped empty with the new
+build. Both need to point at persistent storage.
+
+**Can I move from Strapi Cloud to self-hosted?**
+Yes. Strapi is the same software in both places — export your data, point the
+new instance at it, and repoint your DNS.


### PR DESCRIPTION
Closes the on-site half of stormkit-io/growth#3.

## The diagnosis

This page attracts hosting-intent traffic but converts almost none of it, because
it sits well outside the first page for the hosting queries.

The tell is that it ranks better for `strapi self hosted` than for
`strapi hosting` — Google understands the page as "how to self-host Strapi",
which is what it is, and not as a hosting resource, which is what most of the
demand is asking for.

The page never answers what a hosting searcher asks first: *where can I run this,
what does it need, what does it cost.* It opens at `npx create-strapi@latest`.

## What changed

Added ahead of the existing walkthrough:

- **Your Strapi hosting options** — three honest routes: Strapi Cloud, a plain VPS, a self-hosted platform. Strapi Cloud is named as the least-work option, because pretending otherwise fools nobody and Google least of all.
- **What Strapi needs from a host** — the resource table, plus the two failure modes that actually break Strapi deployments: SQLite regenerating at `.tmp/data.db`, and `public/uploads` shipping empty. Both were buried mid-tutorial; they are the reason someone is searching in the first place.
- **A data-residency note** — the UK-qualified variants are a meaningful share of the demand, and "pick a server there" is a genuine self-hosting advantage rather than a plan feature.
- **An FAQ** — free hosting, cost, SQLite vs PostgreSQL, disappearing content, migrating off Strapi Cloud. These mirror the People Also Ask box on these queries.

**Every technical step, code block, diff and screenshot is unchanged.** 792 → 1504 words.

## One bug fixed along the way

The page told readers to *"Log in to your Stormkit account at app.stormkit.io"* while also stating Strapi only runs on self-hosted instances. Following it as written could not work. The Cloud caveat now appears once, up front, in the prerequisites.

## Expectation

Realistically this moves the page onto the first page for `strapi hosting`, not
to #1 — the top of that SERP is Strapi's own docs and Strapi Cloud. Re-measure
with growth#7.