### PR TITLE
content: add eu data residency and on-premise articles

### DIFF
--- a/content/blog/best-self-hosted-vercel-alternatives.md
+++ b/content/blog/best-self-hosted-vercel-alternatives.md
@@ -4,6 +4,7 @@ description: An honest comparison of the open source platforms you can run on yo
 date: 2026-08-13
 author-name: Savas Vedova
 author-tw: @savasvedova
+author-img: https://pbs.twimg.com/profile_images/1993991074138779648/Up6HP-Jw_reasonably_small.jpg
 ---
 
 **Disclosure up front: we build Stormkit, one of the options below.** We have
@@ -129,7 +130,7 @@ analytics — is yours to assemble and operate. Stormkit ships those as part of
 the platform:
 
 - **[PostgreSQL](/docs/features/database)** attached to an environment, with migrations run on deploy
-- **[End-user authentication](/docs/self-hosting/authentication)** — email and password, magic links, Google and X OAuth, with session cookies handled for you
+- **[End-user authentication](/docs/features/authentication)** — email and password, magic links, Google and X OAuth, with session cookies handled for you
 - **[Transactional email](/docs/features/mailer)** through a built-in mailer
 - **[Periodic triggers](/docs/features/periodic-triggers)** for scheduled work, without a separate cron box
 - **[Server-side analytics](/docs/features/analytics)** that do not depend on client-side tracking

--- a/content/blog/vercel-data-residency-and-eu-alternatives.md
+++ b/content/blog/vercel-data-residency-and-eu-alternatives.md
@@ -1,0 +1,204 @@
+---
+title: Vercel data residency and the European alternatives in 2026
+description: What data residency on Vercel and Netlify actually covers, why picking an EU region is not the same as sovereignty, and the European and self-hosted options - Scaleway, OVHcloud, Clever Cloud, Hetzner and Stormkit - if you need the data to stay put.
+date: 2026-08-13
+author-name: Savas Vedova
+author-tw: @savasvedova
+author-img: https://pbs.twimg.com/profile_images/1993991074138779648/Up6HP-Jw_reasonably_small.jpg
+---
+
+**Disclosure up front: we build Stormkit, one of the options below.** This is the
+explainer we kept failing to find while answering procurement questionnaires, so
+it is written to be useful even if you finish it and stay where you are. It is
+also not legal advice — your DPO gets the final word, not a vendor blog.
+
+Most people arrive at this question from one of two directions. Either a customer
+has sent a security questionnaire asking where their data is processed, or
+someone in the company has read about the CLOUD Act and wants to know whether
+"our region is set to Frankfurt" is an answer. Those turn out to be different
+questions with different answers.
+
+## What "data residency" covers, and what it doesn't
+
+A deployment platform is not one thing in one place. It is at least five, and
+region settings usually govern only the first:
+
+- **Function execution** — where your server-side code runs. This is what a
+  region selector controls, and on Vercel or Netlify you can genuinely pin it to
+  an EU region — on Netlify that control is a paid-plan feature, so check what
+  your plan includes rather than assuming the dropdown is there.
+- **The CDN edge** — where responses are cached and served from. A global edge
+  network is the product; cached responses sit in points of presence worldwide
+  by design. Anything you cache leaves the region on purpose.
+- **Build infrastructure** — where your source is checked out and compiled. Your
+  repository, your environment variables and your build logs all pass through
+  it.
+- **Platform telemetry** — analytics, logs, traces, error reporting. Often a
+  different subsystem with different storage, and often not covered by the same
+  region control.
+- **The control plane** — accounts, teams, audit logs, billing. Almost always
+  centralised.
+
+When a questionnaire asks "where is our data processed", it means all five.
+When a region dropdown says `fra1`, it means the first.
+
+This is not a criticism of Vercel — the architecture is what makes the product
+fast, and both Vercel and Netlify document their sub-processors and offer a DPA.
+It is a mismatch between what the control does and what people assume it does.
+
+## Region is not the same as sovereignty
+
+Here is the part that surprises teams. Vercel and Netlify are US companies. Under
+the CLOUD Act, a US-headquartered provider can be compelled to produce data it
+controls regardless of which country the servers sit in. Choosing an EU region
+changes the physical location of the bytes. It does not change who can be served
+an order for them.
+
+For a large majority of businesses this is a theoretical concern and an EU region
+plus a signed DPA is a perfectly reasonable, defensible position. It stops being
+theoretical in a specific and recognisable set of cases:
+
+- Public sector procurement, especially German, French and Dutch, where
+  frameworks increasingly ask about provider jurisdiction rather than data
+  location
+- Healthcare and anything touching patient records
+- Financial services under DORA, where you owe regulators a concrete exit plan
+  for every critical provider
+- Defence, and any customer with their own defence customers
+- Contracts that name a specific country, not a region — "data stays in
+  Germany" is a stricter promise than "data stays in the EU"
+
+If you are in one of those, the honest chain of reasoning goes: EU region →
+EU-headquartered provider → your own infrastructure. Each step removes a
+category of exposure and adds work. Most teams need step one. Some need step
+two. A few genuinely need step three, and they usually already know it.
+
+One more thing worth getting right rather than assuming, because it is usually
+reported as more precarious than it is: transfers to US providers have relied on
+the EU–US Data Privacy Framework since 2023, and it is still standing. The
+General Court dismissed the first challenge to it in September 2025, holding
+that the redress mechanism and the limits on bulk collection were adequate. That
+ruling is under appeal at the Court of Justice, and separately the European Data
+Protection Board asked the Commission in mid-2026 to reassess whether recent US
+constitutional rulings on the independence of federal agencies undermine the
+commitments the framework rests on. So: valid today, contested, and not
+something to write into a compliance document without checking where the appeal
+has got to.
+
+## The European options
+
+| Provider | Country | Shape | Best for |
+| --- | --- | --- | --- |
+| [Clever Cloud](https://www.clever-cloud.com) | France | Managed PaaS | The closest thing to a European Vercel — you push, it deploys |
+| [Scaleway](https://www.scaleway.com) | France | Cloud provider | Containers, managed Postgres, object storage, serverless |
+| [OVHcloud](https://www.ovhcloud.com) | France | Cloud provider | The largest EU cloud; strong public-sector track record |
+| [Hetzner](https://www.hetzner.com) | Germany | VPS and bare metal | Cheapest capable servers in Europe, if you bring a platform |
+| [IONOS](https://www.ionos.com) | Germany | Cloud provider | German public-sector procurement |
+| [Exoscale](https://www.exoscale.com) | Switzerland | Cloud provider | Non-EU but adequacy-covered, when Switzerland is specified |
+| [Stormkit](https://www.stormkit.io) | Estonia | Self-hosted platform | Vercel's workflow on infrastructure you own, anywhere |
+
+The split matters. Clever Cloud is the only one there that replaces Vercel as a
+*product* — a managed PaaS run by a European company. The cloud providers replace
+the infrastructure underneath, and you still need something to turn a git push
+into a deployment. That is where a self-hosted platform comes in.
+
+### If Supabase is the thing you need a European answer for
+
+It comes up in the same conversation often enough to mention. Supabase is
+US-incorporated but offers EU regions and is open source, so the sovereignty
+answer is to self-host it on a European provider rather than to switch products.
+[Nhost](https://nhost.io) (Sweden) and a self-hosted
+[Appwrite](https://appwrite.io) are the alternatives if you would rather have an
+EU vendor than run it yourself.
+
+## Where Stormkit fits
+
+Stormkit's answer to this problem is that it is not a region setting — it is
+where you install it. The [self-hosted edition](/docs/self-hosting/getting-started)
+runs on your own servers, so all five of the layers above land wherever you put
+them: a Hetzner box in Nuremberg, a Scaleway instance in Paris, an OVHcloud
+tenancy, your own datacentre, or a private cloud VPC that never touches the
+public internet.
+
+```bash
+curl -sSL https://www.stormkit.io/install.sh | sh
+```
+
+The workflow survives the move — a deployment per push, a preview URL per
+branch, environments with their own variables and domains, automatic TLS. The
+part that matters for this particular question is the sub-processor list. A
+typical application answers to a database vendor, an auth vendor, an email
+vendor, a scheduler and an analytics provider, and every one of them is a row
+you document, assess, and assess again next year. Under Stormkit those are the
+platform: [PostgreSQL](/docs/features/database),
+[end-user authentication](/docs/features/authentication),
+[transactional email](/docs/features/mailer),
+[periodic triggers](/docs/features/periodic-triggers) and
+[server-side analytics](/docs/features/analytics), all running wherever you
+installed it. Shortening that list is frequently a bigger win in a compliance
+review than the hosting change that prompted it.
+
+Two honest caveats. **Stormkit Cloud is not the sovereign option** — it runs on
+AWS Lambda in the US, and if data location is your requirement then the
+self-hosted edition is the one to look at, not our managed service. And
+**self-hosting moves the obligation rather than removing it**: uptime, patching,
+backups and key management become yours. Stormkit automates a fair amount of
+that. It does not make it someone else's problem, and any vendor telling you
+otherwise is selling.
+
+**Pick it if** you need the deployment platform itself inside your jurisdiction
+or your own network, and you would rather not assemble a PaaS out of parts to get
+there.
+
+**Look elsewhere if** an EU region and a signed DPA already satisfy your
+requirement. In that case staying on Vercel or Netlify is genuinely the lower-risk
+choice, and this whole article is a problem you do not have.
+
+## Which one should you pick
+
+- **A customer questionnaire asked where data is processed** — set an EU region,
+  sign the DPA, document the sub-processors. Do not migrate.
+- **You want a European vendor without operating anything** — Clever Cloud.
+- **You want European infrastructure and will run the platform yourself** —
+  Hetzner, Scaleway or OVHcloud underneath, Stormkit or a container platform on
+  top.
+- **A contract names a specific country, or you are in defence, health or public
+  sector** — self-host, on infrastructure in that country.
+- **DORA exit planning** — self-hosting is the exit plan, because the software
+  keeps running if the vendor stops.
+
+## Frequently asked questions
+
+**Does Vercel offer data residency?**
+It offers region selection for function execution, a DPA, and documented
+sub-processors, with additional controls available on enterprise agreements.
+Check the current documentation for what your plan includes — the specifics move.
+The structural point stands regardless of plan: the edge network is global, and
+the company is subject to US jurisdiction.
+
+**Is choosing an EU region enough for GDPR?**
+Usually yes, for a normal business, alongside a DPA and a transfer mechanism.
+GDPR does not require EU-only processing. It requires a lawful basis for
+transfers and appropriate safeguards. Sovereignty requirements that go further
+than GDPR almost always come from a contract, a regulator or a procurement
+framework rather than from the regulation itself.
+
+**Is Vercel available on-premise?**
+Not as an install you run yourself. There is a private-beta bring-your-own-cloud
+option on AWS that puts the compute and data in your own account while Vercel
+keeps operating the control plane, which covers "our tenancy" but not "our
+building" and not an air gap. The [on-premise write-up](/blog/vercel-on-premise)
+covers the distinction and what it takes to get the same workflow inside your
+own network.
+
+**What about the edge network — can I turn it off?**
+You can reduce what is cached, but not being a global CDN defeats much of the
+point of the platform. If nothing may leave the region, you want an
+origin-in-region architecture rather than an edge-first one, which is an argument
+for a different shape of platform rather than a different setting on this one.
+
+**Does self-hosting make us compliant?**
+No. It removes a set of transfer and jurisdiction questions and hands you
+everything the provider was doing — patching, backups, access control, incident
+response. That is a better trade for some organisations and a worse one for
+others. It is never automatic.

--- a/content/blog/vercel-on-premise.md
+++ b/content/blog/vercel-on-premise.md
@@ -1,0 +1,186 @@
+---
+title: Vercel on-premise - what it takes to run the same workflow yourself
+description: Vercel's only self-managed option is a private-beta bring-your-own-cloud on AWS, so running deployments inside your own network means replacing it, not installing it.
+date: 2026-08-13
+author-name: Savas Vedova
+author-tw: @savasvedova
+author-img: https://pbs.twimg.com/profile_images/1993991074138779648/Up6HP-Jw_reasonably_small.jpg
+---
+
+**Disclosure up front: we build Stormkit, one of the options below.** The short
+answer to the question in the title is a fact rather than a pitch, so it goes
+first.
+
+**Vercel does not offer an on-premise edition you can install in your own
+datacentre.** What it offers instead is *bring your own cloud* on AWS:
+your compute, build artifacts and application data run inside your own AWS
+account and VPC, while Vercel continues to operate the control plane on top of
+them. At the time of writing that is a private beta, AWS only, and not something
+you can sign up for — you talk to their sales team. Netlify has no generally
+available self-managed edition either.
+
+That distinction is the whole article. Bring your own cloud answers "our account,
+our VPC, our security group". It does not answer "our building", it does not
+answer "no route to the public internet", and it does not answer "the platform
+keeps working if the vendor stops" — because the control plane is still theirs
+and still hosted. If your requirement is one of those three, or if you need
+something generally available today on a cloud other than AWS, you are not
+looking for a licence — you are looking for a replacement.
+
+That is a more tractable problem than it sounds, because the thing you actually
+depend on is a workflow, and the workflow is made of about six parts.
+
+## What "on-premise" means in practice
+
+Worth pinning down, because three quite different requirements arrive under the
+same word and they cost wildly different amounts of effort:
+
+- **Your own hardware** — a rack in your building, or a colocated cage. Rare
+  now, and usually driven by a contract or a regulator.
+- **Your own cloud tenancy** — a private VPC in AWS, Azure, GCP, OVHcloud or
+  Hetzner, where "on-premise" means "our account, our network, our security
+  group" rather than "our building". This is what most people mean, it is by
+  far the easiest of the three, and it is the one Vercel's bring-your-own-cloud
+  beta is aimed at.
+- **Air-gapped** — no route to the public internet at all. Genuinely hard, and
+  the section below is mostly about why.
+
+If you have not yet worked out which one you are being asked for, do that before
+choosing any tooling. The gap between the second and the third is larger than
+the gap between any two platforms you might pick.
+
+## What you are actually replacing
+
+Strip the marketing off and the Vercel workflow is:
+
+1. **A push triggers a build.** A webhook from GitHub, GitLab or Bitbucket, a
+   checkout, an install, a build command.
+2. **Every branch gets a URL.** Preview deployments are the feature people miss
+   most when they leave, and the one most self-hosted setups quietly drop.
+3. **Environments carry their own configuration.** Variables and domains per
+   environment, not a single `.env` on a server.
+4. **Something serves the result.** Static assets, SSR, API routes — with
+   sensible caching and no cold-start surprises.
+5. **TLS renews itself.** Nobody wants to be the person who forgot.
+6. **Rollback is one click.** The previous deployment is still there and going
+   back does not mean rebuilding.
+
+Everything else you might miss — a database, auth, cron, transactional email —
+sits alongside the platform rather than inside it. Whether they come with your
+replacement or become four more things to run is the main thing that separates
+the options.
+
+## The parts that get hard behind a firewall
+
+This is the section that tends to be missing from write-ups, and where projects
+lose their schedule.
+
+**Builds need the internet even when your application does not.** `npm install`
+reaches out to a registry. Docker pulls base images. A build platform inside an
+air-gapped network needs a package mirror — Verdaccio, Nexus or Artifactory —
+and a registry mirror, and someone to keep both current. This is usually the
+single largest piece of work, and it has nothing to do with which deployment
+platform you chose.
+
+**TLS is different inside a private network.** Automatic certificates normally
+work by proving control of a public domain over HTTP. With no inbound path from
+the internet, that fails, and the answer is to stop issuing certificates on the
+box: bring your own, from an internal CA with the root distributed to your
+machines, or issued out-of-band and installed. Whichever platform you pick, check
+that it accepts a certificate you supply per domain rather than assuming it can
+always fetch one. Decide this before installation, not after.
+
+**Git has to be reachable from the builder**, not just from developer laptops. A
+self-hosted GitLab or a network path to your provider.
+
+**Secrets probably already have an owner.** If Vault or a cloud secrets manager
+is the standard in your organisation, check how the platform expects to receive
+environment variables before you commit to it.
+
+**Build capacity becomes a resource you plan.** On a managed platform, ten
+people merging at once is someone else's problem. On one machine, it is a queue.
+Either size for the peak or push builds out to your existing CI.
+
+## Putting it back together
+
+The [self-hosted Vercel alternatives roundup](/blog/best-self-hosted-vercel-alternatives)
+compares the platforms in depth — Coolify, Dokploy, Dokku, CapRover, Kamal and
+Stormkit — and the choice there does not change much just because the network is
+private. The short version: container platforms if you are running a lot of
+software you did not write, an application platform if you are running a product
+you did.
+
+Where Stormkit is relevant to this particular question is that it installs onto
+machines you control and expects nothing from us at runtime:
+
+```bash
+curl -sSL https://www.stormkit.io/install.sh | sh
+```
+
+It ships as Docker images for `amd64` and `arm64`, installs via Docker Compose
+on a single machine or Docker Swarm across several, and is tested on Ubuntu,
+Debian, Fedora, Rocky Linux and macOS. Preview URLs per branch, environments
+with their own variables and domains, and one-click rollback all survive the move
+— which is the part people assume they are giving up. Builds run on the
+`workerserver` service by default, or you can hand them to
+[GitHub Actions](https://github.com/stormkit-io/runner) if you would rather your
+existing CI owned that. On the TLS question above, domains with no public inbound
+path take a [custom certificate](/docs/features/custom-certificates) you supply
+as PEM, per domain, instead of automatic issuance.
+
+The services that usually arrive as separate vendors are part of it:
+[PostgreSQL](/docs/features/database) attached to an environment with migrations
+on deploy, [end-user authentication](/docs/features/authentication),
+[transactional email](/docs/features/mailer),
+[periodic triggers](/docs/features/periodic-triggers),
+[persistent volumes](/docs/features/volumes) and
+[server-side analytics](/docs/features/analytics). In a private network that
+consolidation matters more than it does on the public internet, because every
+external service you remove is one less firewall exception to justify.
+
+**Pick it if** you want the Vercel workflow specifically — previews,
+environments, rollbacks — inside your own network, with the application services
+included.
+
+**Look elsewhere if** what you actually need is somewhere to run a lot of
+off-the-shelf containers. Coolify covers that better, and the
+[roundup](/blog/best-self-hosted-vercel-alternatives) explains why.
+
+If the driver is jurisdiction rather than network topology, the
+[data residency write-up](/blog/vercel-data-residency-and-eu-alternatives) is the
+more directly useful one — the answer there is often an EU region rather than a
+migration.
+
+## Frequently asked questions
+
+**Can I buy Vercel Enterprise and run it on our servers?**
+Not on your own servers. The closest thing is bring your own cloud, which places
+the compute and data in your AWS account while Vercel runs the control plane —
+private beta, AWS only, enterprise sales rather than self-serve. There is still
+no build of Vercel you install on hardware you own, and nothing that runs
+without a control plane operated by Vercel.
+
+**Is a private VPC good enough to count as on-premise?**
+For most auditors and most contracts, yes — the requirement is usually about
+control and network isolation rather than about owning the building. Check the
+actual wording you are being held to. "Our own infrastructure" and "our own
+premises" are different promises, and only one of them requires a rack.
+
+**Does Stormkit work fully air-gapped?**
+The platform installs and runs on machines with no inbound internet access. The
+harder question is builds, which need a package registry and a container
+registry — mirror both internally and you are in business. If you are planning a
+genuinely air-gapped deployment, [talk to us](/contact) first rather than
+discovering the gaps during a pilot.
+
+**What happens if the vendor disappears?**
+This is the underrated argument for self-hosting and the one regulators ask
+about directly under DORA. Software running on your machines keeps running. The
+Stormkit community edition is AGPL-3.0, so the source is available regardless of
+what happens to the company; some enterprise components are proprietary and ship
+in the published binaries.
+
+**How much machine do we need?**
+Less than people expect for serving, more than people expect for building. The
+serving side is comfortable on a small VPS. Builds are CPU and memory hungry in
+bursts — size for your worst simultaneous merge, or offload to CI.

--- a/src/www/public/sitemap.xml
+++ b/src/www/public/sitemap.xml
@@ -421,6 +421,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://www.stormkit.io/blog/best-self-hosted-vercel-alternatives</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://www.stormkit.io/blog/case-study-elham</loc>
     <lastmod>2025-12-01</lastmod>
     <changefreq>weekly</changefreq>
@@ -531,6 +537,18 @@
   <url>
     <loc>https://www.stormkit.io/blog/unlocking-dynamic-web-interactions-with-htmx</loc>
     <lastmod>2025-12-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/vercel-data-residency-and-eu-alternatives</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.stormkit.io/blog/vercel-on-premise</loc>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
Two articles targeting a query cluster around data residency, European
alternatives and on-premise deployment, where we already rank without a
dedicated page behind it. Volume is small; the case for writing anyway is that
these are commercial-intent queries currently answered only by the homepage.

## vercel-data-residency-and-eu-alternatives

Targets the residency and European-alternative queries. The argument is that a
region setting and sovereignty are different things: a platform is at least five
layers (function execution, CDN edge, build infrastructure, telemetry, control
plane), a region selector governs the first, and a questionnaire asks about all
five. Then the CLOUD Act point, and a table of EU providers separating the one
that replaces Vercel as a product (Clever Cloud) from the ones that replace the
infrastructure underneath.

It tells most readers not to migrate. An EU region plus a signed DPA is the
correct answer for a normal business, and the article says so before it makes a
case for anything else.

## vercel-on-premise

Separate intent from the alternatives roundup - "inside our network" rather than
"which platform" - so it is a separate page that links to the roundup rather
than competing with it. Opens with the fact that Vercel has no self-managed
edition, so this is a replacement rather than a licence. The substance is what
gets hard behind a firewall: builds need registry access even when the
application does not, the ACME HTTP challenge breaks with no inbound path, git
has to be reachable from the builder, and build capacity becomes a queue.

## Positioning

Sovereignty claims are kept on the self-hosted edition throughout. Both articles
state plainly that Stormkit Cloud runs on AWS Lambda in the US and is not the
sovereign option, and that self-hosting moves the compliance obligation rather
than removing it.

On air-gapped installs the FAQ claims only what is documented: the platform runs
without inbound internet access, builds need mirrored package and container
registries, and anyone planning one should get in touch first.

## Verification

- All internal links resolve and point at the right page. The end-user
  authentication links now go to \`/docs/features/authentication\` (Stormkit Auth)
  rather than \`/docs/self-hosting/authentication\` (admin and git-provider
  credentials); the same correction is applied to the already-published roundup.
- The TLS-behind-a-firewall section no longer implies DNS-01 is available on
  self-hosted installs - it is gated behind \`IsStormkitCloud()\` and Route53-only.
  Readers are pointed at custom certificates instead.
- \`npm run build:sitemap\` regenerated with both posts present. It also picked up
  \`best-self-hosted-vercel-alternatives\`, which was missing from the committed
  sitemap; that is included here.
- Install snippet and the platform/architecture claims match
  \`docs/self-hosting/1-getting-started.md\`.

## Please check before merging

Claims about competitors and about EU law that I could not verify from inside
the repo:

1. Vercel's current data-residency controls, and which plans gate them. The text hedges to "check the current documentation" rather than naming plans.
2. The status of the EU-US Data Privacy Framework. The article says it has been under legal challenge and tells readers to confirm before citing it.
3. That Vercel still offers no on-premise edition, and that Netlify has no generally available self-managed edition. The second article rests on the first.