### PR TITLE
fix: noindex llms.txt

### DIFF
--- a/src/www/_headers
+++ b/src/www/_headers
@@ -1,0 +1,5 @@
+# llms.txt is written for language models, not searchers. It was indexed and
+# drew 1,193 impressions at position 51 over 90 days with zero clicks, so it can
+# only ever produce a poor search result.
+/llms.txt
+  X-Robots-Tag: noindex


### PR DESCRIPTION
`llms.txt` is written for language models, not searchers, but it is indexed and
appears in search results at a very low average position with no clicks. A
machine-readable file surfacing as a search result can only ever be a poor one.

Adds a `_headers` file at the `www` app root serving `X-Robots-Tag: noindex` for
`/llms.txt`.

`robots.txt` deliberately keeps `Allow: /`. Blocking the URL there would stop
Google from crawling the file and therefore from ever seeing the noindex
directive, which is the usual way this fix gets applied and fails.

Scoped to the one file: `llms.txt` is the only non-HTML asset that appears in
Search Console at all.

## After deploy

`_headers` is resolved from the app root, which is `src/www` for this app - it
holds the `package.json` carrying `npm run build`, and `distFolder` is `./`
relative to it. Worth confirming rather than assuming:

```bash
curl -sI https://www.stormkit.io/llms.txt | grep -i x-robots-tag
```

If that comes back empty, the root is configured elsewhere and it is a one-field
change under Environment > Config > Headers > File Location.
