### PR TITLE
fix: correct frontend-only positioning

### DIFF
--- a/content/blog/case-study-elham.md
+++ b/content/blog/case-study-elham.md
@@ -1,6 +1,6 @@
 ---
 title: 'Case Study: Elham - a Leading Learning Platform'
-description: Discover how Elham, a leading learning platform, reduced deployment times from 24+ hours to 7 minutes, cut hosting costs, and scaled to handle millions of visitors per month with Stormkit’s self-hosted, compliant, and customizable frontend hosting solution.
+description: Discover how Elham, a leading learning platform, reduced deployment times from 24+ hours to 7 minutes, cut hosting costs, and scaled to handle millions of visitors per month with Stormkit’s self-hosted, compliant, and customizable hosting solution.
 date: 2024-09-03
 ---
 
@@ -9,7 +9,7 @@ date: 2024-09-03
 | **Customer**   | `Elham, a leading learning platform`                                                         |
 | **Industry**   | `Educaton and Training`                                                                      |
 | **Challenges** | `Slow deployment times, high costs, regulatory concerns, and lack of infrastructure control` |
-| **Solution**   | `Stormkit’s scalable, custom-tailored frontend hosting solution`                             |
+| **Solution**   | `Stormkit’s scalable, custom-tailored self-hosted deployment platform`                      |
 
 ### Results
 

--- a/content/blog/faq.md
+++ b/content/blog/faq.md
@@ -7,16 +7,18 @@ date: 2023-08-17
 <details>
 <summary>How Stormkit is different than Heroku?</summary>
 
-Stormkit stands out in its capability to host static websites, single-page applications (SPAs), and serverless functions. Its optimization for performance ensures a smooth journey for JavaScript developers. The platform offers a range of features, including dynamic injection of frontend code, instant rollbacks, customizable CDN storage, and trigger functions.
+Both are deployment platforms that take your code and run it. Stormkit hosts static sites, single-page apps, server-side rendered apps, serverless functions and long-running server processes, in any language — runtimes are provisioned with [mise](https://mise.jdx.dev), and system-level packages can come from a `flake.nix`. On top of deployment it ships a [PostgreSQL database](/docs/features/database), [end-user authentication](/docs/features/authentication), a [mailer](/docs/features/mailer), [periodic triggers](/docs/features/periodic-triggers) and [analytics](/docs/features/analytics), so you are not assembling those from separate vendors.
 
-Conversely, Heroku provides a broader application platform that accommodates diverse application types, including web apps, APIs, and beyond. It enables developers to deploy applications constructed with a variety of programming languages and frameworks.
+The bigger difference is that Stormkit can be [self-hosted](/docs/self-hosting/getting-started) on your own infrastructure, which is what most people are looking for when they compare the two.
 
 </details>
 
 <details>
 <summary>Can I run my Node.js applications on Stormkit?</summary>
 
-Not directly, Stormkit is optimized for serverless deployments and provides a serverless computing environment through its serverless functions feature, which allows you to deploy pieces of code that respond to HTTP requests. These functions are stateless and designed to be short-lived. You can use Nuxt.js functions or [use plain functions](/docs/features/writing-api) which has same interface as Node.js. If you are looking for long lived executions please contact with us. We can tailor our platform according your needs.
+Yes. On a [self-hosted instance](/docs/self-hosting/getting-started), set a **Start command** and Stormkit runs your server as a long-lived process — see [Application runtime](/docs/deployments/application-runtime). This is the recommended way to run backend code when self-hosting, and it is not limited to Node: a Go, Python or Ruby server works the same way.
+
+On Stormkit Cloud, backend code runs as [serverless functions](/docs/features/writing-api) — same interface as Node.js request handlers — which are stateless, short-lived and subject to a 15 second timeout. If you need long-lived processes, connection pools or a warm cache, self-host.
 
 </details>
 

--- a/docs/self-hosting/1-getting-started.md
+++ b/docs/self-hosting/1-getting-started.md
@@ -1,13 +1,13 @@
 ---
 title: "Self-Hosting with Stormkit: Deploy Web Apps with Full Control"
-description: Discover Stormkit, the self-hosted alternative to Vercel and Netlify. Deploy your frontend apps with full control over your infrastructure, offering powerful features like multiple environments, deployment previews, snippet injections, status checks and analytics.
+description: Discover Stormkit, the self-hosted alternative to Vercel and Netlify. Deploy web apps in any language with full control over your infrastructure, offering powerful features like multiple environments, deployment previews, snippet injections, status checks and analytics.
 ---
 
 # Self-Hosting
 
 <section>
 
-Stormkit is a deployment platform for frontend applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time.
+Stormkit is a deployment platform for web applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time. Your app can be written in any language — see [Runtime Management](/docs/self-hosting/runtimes) for how runtimes and system packages are provisioned.
 
 </section>
 

--- a/docs/welcome/1-getting-started.md
+++ b/docs/welcome/1-getting-started.md
@@ -1,12 +1,12 @@
 ---
 title: Getting started
-description: Stormkit is a deployment platform for jamstack applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time.
+description: Stormkit is a deployment platform for web applications in any language. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time.
 ---
 
 # Welcome
 
 <section>
-Stormkit is a deployment platform for frontend applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling, tls certificates, and helps saving valuable time.
+Stormkit is a deployment platform for web applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling, tls certificates, and helps saving valuable time. Builds can use any language runtime, and <a href="/docs/self-hosting/getting-started">self-hosted instances</a> additionally run long-lived server processes written in any language.
 </section>
 
 ## Getting Started

--- a/src/www/src/pages/about-us/AboutUs.tsx
+++ b/src/www/src/pages/about-us/AboutUs.tsx
@@ -58,7 +58,7 @@ export default function AboutUs() {
           At Stormkit, our mission is to simplify the job for developers,
           stripping away the complexity of deployment so you can focus on
           building your product. Our vision is to give you unmatched flexibility
-          and control, letting you deploy JavaScript apps — whether solo
+          and control, letting you deploy your apps — whether solo
           projects or enterprise-scale — on your own terms. I work closely with
           my users to understand their struggles and craft solutions that truly
           fit their needs. Seeing the satisfaction on their faces when Stormkit

--- a/src/www/src/pages/vs/netlify.tsx
+++ b/src/www/src/pages/vs/netlify.tsx
@@ -80,10 +80,11 @@ export default function Netlify() {
           <br /> great Netlify alternative
         </Typography>
         <Typography>
-          When it comes to hosting and deploying frontend applications, both{' '}
+          When it comes to hosting and deploying web applications, both{' '}
           <strong>Stormkit</strong> and <b>Netlify</b> are prominent platforms.
           While Netlify is well-known for its ease of use and cloud-based
-          hosting, Stormkit stands out by offering self-hosting capabilities,
+          hosting, Stormkit stands out by offering self-hosting capabilities and
+          a built-in database, authentication, mailer and scheduled jobs,
           giving developers more control over their infrastructure. In this
           guide, we'll compare the two platforms across key categories to help
           you determine which one best suits your needs.
@@ -91,7 +92,7 @@ export default function Netlify() {
         <Box
           component="img"
           src={StormkitToolImg}
-          alt="Stormkit - Self-Hosted Frontend Hosting platform"
+          alt="Stormkit - self-hosted deployment platform"
           sx={{
             mt: { xs: 4, lg: 8 },
             mb: { xs: 4, lg: 8 },

--- a/src/www/src/pages/vs/vercel.tsx
+++ b/src/www/src/pages/vs/vercel.tsx
@@ -80,9 +80,10 @@ export default function Vercel() {
         </Typography>
         <Typography>
           Stormkit is an intuitive, scalable, and cost-effective self-hostable
-          platform for frontend applications. It comes with built-in features
-          like deployment previews, analytics, snippet injections, multiple
-          environments and more.
+          deployment platform for web applications in any language. It comes
+          with built-in features like deployment previews, a PostgreSQL
+          database, end-user authentication, a mailer, scheduled jobs,
+          analytics, snippet injections, multiple environments and more.
         </Typography>
         <Typography sx={{ mt: 2 }}>
           Vercel, on the other hand, is a fully-managed cloud provider in the
@@ -92,7 +93,7 @@ export default function Vercel() {
         <Box
           component="img"
           src={StormkitToolImg}
-          alt="Stormkit - Self-Hosted Frontend Hosting platform"
+          alt="Stormkit - self-hosted deployment platform"
           sx={{
             mt: { xs: 4, lg: 8 },
             mb: { xs: 4, lg: 8 },
@@ -201,7 +202,7 @@ export default function Vercel() {
         <Subtitle id="flexibility">2. Deployment Flexibility</Subtitle>
         <Typography component="ul" sx={{ mt: 2 }}>
           <Typography component="li">
-            When self-hosting Stormkit, developers can deploy their frontend
+            When self-hosting Stormkit, developers can deploy their
             applications in multiple ways, whether via GitHub Actions, custom
             servers, or other CI/CD platforms. This approach empowers teams by
             allowing them to choose the best solution that fits their
@@ -278,8 +279,8 @@ export default function Vercel() {
         <Subtitle id="conclusion">Conclusion</Subtitle>
         <Typography component="ul" sx={{ mt: 2 }}>
           <Typography component="li">
-            Both Stormkit and Vercel offer powerful solutions for frontend
-            hosting, but they cater to different needs: Stormkit is best for
+            Both Stormkit and Vercel offer powerful solutions for deploying
+            web applications, but they cater to different needs: Stormkit is best for
             developers and teams who value flexibility, control, and
             customizability. Its self-hostable nature makes it ideal for
             projects with specific infrastructure requirements, such as


### PR DESCRIPTION
Stormkit was described as a platform for **frontend / JavaScript / jamstack**
applications in the docs, the website and two blog posts. That is not accurate —
runtimes are provisioned with mise (Node.js, Go, Python, Ruby, ...), system
packages can come from a `flake.nix`, and a **Start command** runs a long-lived
server process in any language on self-hosted instances.

The wrong framing had spread: it is also what the `stormkit` Claude skill told
agents, which is how it ended up in an external directory submission.

### Changed

| File | Was | Now |
| --- | --- | --- |
| `docs/welcome/1-getting-started.md` | "platform for **jamstack** applications" (meta description), "platform for **frontend** applications" | "web applications in any language" / "web applications", with a pointer to self-hosting for long-lived processes |
| `docs/self-hosting/1-getting-started.md` | "Deploy your **frontend apps**" (meta description), "platform for **frontend** applications" | "web apps in any language", plus a link to Runtime Management |
| `src/www/src/pages/vs/vercel.tsx` | "platform for **frontend** applications", "solutions for **frontend hosting**", alt text "Self-Hosted **Frontend Hosting** platform" | "deployment platform for web applications in any language", now also naming the database, auth, mailer, scheduled jobs and analytics |
| `src/www/src/pages/vs/netlify.tsx` | "hosting and deploying **frontend** applications", same alt text | "hosting and deploying web applications", plus the built-in database/auth/mailer/jobs |
| `src/www/src/pages/about-us/AboutUs.tsx` | "deploy **JavaScript apps**" | "deploy your apps" |
| `content/blog/case-study-elham.md` | "**frontend hosting** solution" ×2 | "hosting solution" / "self-hosted deployment platform" |
| `content/blog/faq.md` | Heroku answer conceded that Heroku "enables developers to deploy applications constructed with a variety of programming languages" while Stormkit was for "JavaScript developers" | rewritten: any language, plus the built-in database/auth/mailer/jobs and self-hosting |
| `content/blog/faq.md` | **"Can I run my Node.js applications on Stormkit?" — "Not directly… please contact with us"** | rewritten: yes, via a Start command on self-hosted; Cloud runs serverless functions with a 15s timeout |

The two `getting-started` meta descriptions are what Google shows for the docs,
and "jamstack" is the worst available word for a product competing on being more
than static hosting — those two lines are the highest-impact part of this diff.

### Accuracy note

The Application Runtime (Start command) is **self-hosted only**; Stormkit Cloud
runs backend code as Node serverless functions. The copy distinguishes the two
rather than claiming any-language support everywhere.

### Testing

Copy-only changes inside existing JSX text nodes and markdown. `npx tsc --noEmit`
reports two `tsconfig.json` option errors, confirmed identical on a clean tree
(a tsc/tsconfig version mismatch under npx), so unrelated to this change.
