### PR TITLE
docs: rewrite readme around what stormkit does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,81 @@
-# Welcome
+# Stormkit
 
-[Stormkit](https://www.stormkit.io) is a hosting solution for seamless deployment and management of modern web applications.
+Deploy your app and get the pieces it needs — a Postgres database, end-user
+authentication, a transactional mailer, scheduled jobs and analytics — on
+infrastructure you own.
+
+```bash
+curl -sSL https://www.stormkit.io/install.sh | sh
+```
+
+That is a working Stormkit on your own server: git push to deploy, a preview URL
+per branch, custom domains with automatic TLS.
 
 ![Stormkit](./.github/assets/env-screen.png)
 
-## Cloud Edition
+## What you get
 
-For those who prefer a managed solution, Stormkit offers a Cloud Edition that can be accessed at [app.stormkit.io](app.stormkit.io). The Cloud Edition handles all the hosting, scaling, and maintenance tasks for you, allowing you to focus solely on building and improving your applications.
+| | |
+| --- | --- |
+| **Deployments** | Git push, UI, zip upload or API. A [preview URL per branch](https://www.stormkit.io/docs/deployments/auto-deployments), [environments](https://www.stormkit.io/docs/features/multiple-environments) with their own config, [status checks](https://www.stormkit.io/docs/deployments/status-checks) before publishing |
+| **Any language** | Runtimes come from [mise](https://mise.jdx.dev) — Node.js, Go, Python, Ruby and anything else it supports. System packages from a `flake.nix`. A [start command](https://www.stormkit.io/docs/deployments/application-runtime) runs a long-lived server in any language |
+| **Database** | [PostgreSQL](https://www.stormkit.io/docs/features/database) attached to an environment, with migrations run on deploy |
+| **Authentication** | [Stormkit Auth](https://www.stormkit.io/docs/features/authentication) for your end users — email and password, magic links, Google and X — with sessions handled for you |
+| **Email** | A [transactional mailer](https://www.stormkit.io/docs/features/mailer) wired to your SMTP provider |
+| **Scheduled jobs** | [Periodic triggers](https://www.stormkit.io/docs/features/periodic-triggers), without a separate cron box |
+| **Analytics** | [Server-side analytics](https://www.stormkit.io/docs/features/analytics) that do not depend on client-side tracking |
+| **Also** | [Volumes](https://www.stormkit.io/docs/features/volumes), [serverless API routes and SSR](https://www.stormkit.io/docs/features/writing-api), [redirects and rewrites](https://www.stormkit.io/docs/features/redirects-and-path-rewrites), [custom headers](https://www.stormkit.io/docs/features/custom-headers), [snippet injection](https://www.stormkit.io/docs/features/snippets), [Auth Wall](https://www.stormkit.io/docs/features/auth-wall), [teams and roles](https://www.stormkit.io/docs/features/teams-and-roles) |
 
-## Self-Hosted Edition
+## Let an agent run it
 
-The Self-Hosted Edition of Stormkit gives you the flexibility to host your own instance of Stormkit on your infrastructure. This version is ideal for organizations that require more control over their hosting environment, need to comply with specific regulatory requirements, or prefer to manage their own infrastructure.
+Stormkit exposes the whole platform over [MCP](https://www.stormkit.io/docs/api/mcp),
+so a coding agent can provision a server, deploy, publish and read the logs when
+something breaks — without you opening the dashboard.
 
-## Getting Started
+```bash
+curl -sSL https://www.stormkit.io/install.sh | sh -s -- --agent
+```
 
-To get started with the Self-Hosted Edition of Stormkit, you can choose to use either the provided binaries or Docker images.
+The `--agent` install is hands-off: give it an SSH key and it provisions the
+instance, creates the owner account and mints an MCP-ready API key.
 
-### Using docker containers
+Your app can be on the other side of that too. The
+[OAuth 2.1 server](https://www.stormkit.io/docs/features/oauth-server) turns an
+app you host into an authorization server, so MCP clients like Claude and
+ChatGPT connect to it as your end users rather than through a shared token.
 
-You can use Docker images to run the Self-Hosted Edition. The following images are available:
+## Cloud or self-hosted
 
-- ghcr.io/stormkit-io/workerserver:latest
-- ghcr.io/stormkit-io/hosting:latest
+[**Stormkit Cloud**](https://app.stormkit.io) is the managed option — deployments,
+previews, domains, mailer, triggers and analytics, with nothing to operate.
 
-## Additional services
+**Self-hosted** runs on your own infrastructure and is where the full platform
+lives: the database, Stormkit Auth, the OAuth 2.1 server and long-lived
+application runtimes are self-hosted only. Docker images:
 
-In addition to the Stormkit's microservices, a PostgreSQL database and a Redis Instance is also required for Stormkit to function properly.
+```
+ghcr.io/stormkit-io/workerserver:latest
+ghcr.io/stormkit-io/hosting:latest
+```
+
+A PostgreSQL database and a Redis instance are required alongside them.
+See the [self-hosting guide](https://www.stormkit.io/docs/self-hosting/getting-started).
+
+## Documentation
+
+[www.stormkit.io/docs](https://www.stormkit.io/docs) — or read it in this repo
+under [`docs/`](./docs).
+
+## License
+
+Open core. The Community Edition in [`src/ce/`](./src/ce) is AGPL-3.0. Enterprise
+Edition components in [`src/ee/`](./src/ee) are commercially licensed. See
+[LICENSE](./LICENSE).
+
+## Contributing
+
+Bug reports and pull requests are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md)
+and the local development setup below.
 
 ## Local Development
 


### PR DESCRIPTION
The README opened with "Welcome" and described Stormkit as "a hosting solution
for seamless deployment and management of modern web applications", then went
straight into Cloud Edition / Self-Hosted Edition / Docker image tags / local
development prerequisites.

Two problems with that. "Hosting solution" is the framing #441 just removed from
the docs and comparison pages, and it survived in the place most visitors read
first. And the first three sections are contributor-facing — someone deciding
whether to care got Docker image names before learning the product ships a
database, authentication, a mailer and scheduled jobs.

## What changed

Rewrote everything above `## Local Development`. Nothing below it is touched —
local dev, project structure, testing, mock generation and troubleshooting are
unchanged.

The new top:

- **One accurate line** on what Stormkit is, followed immediately by the install
  one-liner. It is the most demo-able thing we have and it was buried.
- **What you get** — a table of capabilities, each linked to its docs page:
  deployments, any-language runtimes, database, authentication, mailer,
  scheduled jobs, analytics, and the rest.
- **Let an agent run it** — the MCP surface, the `--agent` install, and the
  OAuth 2.1 server that lets an app hosted on Stormkit be the thing an agent
  connects *to*. This is the part nothing comparable offers and it was absent.
- **Cloud or self-hosted** — states plainly that the database, Stormkit Auth,
  the OAuth server and long-lived application runtimes are self-hosted only,
  rather than implying every feature is available everywhere.
- Documentation, license and contributing sections, which did not exist.

## Accuracy

Claims were checked against `docs/`, not written from marketing copy:

- "any language" is qualified by how it actually works — mise for runtimes,
  `flake.nix` for system packages, a start command for the server process.
- Self-hosted-only features verified in `docs/features/{database,authentication,
  oauth-server}.md` and `docs/deployments/application-runtime.md`.
- `--agent` verified against the published `install.sh` (`AGENT_MODE`,
  `--agent`, `setup_agent_env`).
- Install snippets use `sh`, matching the script's own header and the homepage.
- All 20 docs links and every referenced local path resolve.
