### PR TITLE
fix: correct docs metadata and broken links

### DIFF
--- a/content/blog/faq.md
+++ b/content/blog/faq.md
@@ -26,7 +26,7 @@ On Stormkit Cloud, backend code runs as [serverless functions](/docs/features/wr
 
 <summary>Is it possible to establish a database connection using Stormkit?</summary>
 
-Certainly! Explore our [detailed blog post](/blog/monitoring-app-using-stormkit-and-supabase) as an example, demonstrating the integration with Supabase, a PostgreSQL database. By injecting database credentials as environment variables into backend functions, you can seamlessly establish a connection.
+Certainly! Stormkit can provision a [PostgreSQL database](/docs/features/database) for your environment and run migrations on deployment. You can also connect to an external database by injecting its credentials as environment variables into your backend functions.
 
 </details>
 

--- a/docs/development/1-image-optimization.md
+++ b/docs/development/1-image-optimization.md
@@ -1,3 +1,8 @@
+---
+title: Image Optimization Setup
+description: Enable Stormkit's opt-in image optimization: the system dependencies it needs, how to turn it on, and how to verify it is running.
+---
+
 # Image Optimization
 
 Stormkit includes optional image optimization capabilities that can resize and optimize images on-the-fly. This feature is **opt-in** and requires additional system dependencies.

--- a/docs/development/2-troubleshooting.md
+++ b/docs/development/2-troubleshooting.md
@@ -1,3 +1,8 @@
+---
+title: Development Troubleshooting
+description: Fixes for common problems when running Stormkit locally, including mise, Go toolchain and image optimization setup errors.
+---
+
 # Troubleshooting
 
 <details>
@@ -32,7 +37,7 @@ For other shells, replace `zsh` with your shell (e.g., `bash`, `fish`). See [mis
 Image optimization is disabled by default on local environments to avoid
 requiring additional dependencies.
 
-See [docs/image-optimization.md](docs/image-optimization.md) for more details on enabling and using image optimization.
+See [Image Optimization Setup](/docs/development/image-optimization) for more details on enabling and using image optimization.
 
 </details>
 

--- a/src/www/src/helpers/markdown.test.ts
+++ b/src/www/src/helpers/markdown.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseAttributes } from './markdown'
+
+const frontMatter = (...lines: string[]) =>
+  ['---', ...lines, '---', '', '# Heading', ''].join('\n')
+
+describe('parseAttributes', () => {
+  it('reads unquoted values', () => {
+    const attrs = parseAttributes(frontMatter('title: Database'))
+    assert.equal(attrs.title, 'Database')
+  })
+
+  it('strips the single quotes that make a colon valid YAML', () => {
+    const attrs = parseAttributes(
+      frontMatter("title: 'Strapi Hosting: How to Self-Host Strapi CMS'")
+    )
+    assert.equal(attrs.title, 'Strapi Hosting: How to Self-Host Strapi CMS')
+  })
+
+  it('strips double quotes the same way', () => {
+    const attrs = parseAttributes(
+      frontMatter('title: "Self-Hosting: Deploy Web Apps with Full Control"')
+    )
+    assert.equal(attrs.title, 'Self-Hosting: Deploy Web Apps with Full Control')
+  })
+
+  it('keeps apostrophes inside the value', () => {
+    const attrs = parseAttributes(
+      frontMatter("description: Improve your website's performance")
+    )
+    assert.equal(attrs.description, "Improve your website's performance")
+  })
+
+  it('keeps a quote that is not a matching pair', () => {
+    assert.equal(parseAttributes(frontMatter("title: 'Half quoted")).title, "'Half quoted")
+    assert.equal(parseAttributes(frontMatter('title: Half quoted"')).title, 'Half quoted"')
+    assert.equal(parseAttributes(frontMatter('title: \'Mixed"')).title, '\'Mixed"')
+  })
+
+  it('handles a lone quote character as the value', () => {
+    assert.equal(parseAttributes(frontMatter("title: '")).title, "'")
+  })
+
+  it('returns no attributes when the document has no front matter', () => {
+    assert.deepEqual(parseAttributes('# Image Optimization\n\nSome text.\n'), {})
+  })
+
+  it('overrides the category when one is passed', () => {
+    const attrs = parseAttributes(frontMatter('title: Database'), 'features')
+    assert.equal(attrs.category, 'features')
+  })
+})

--- a/src/www/src/helpers/markdown.ts
+++ b/src/www/src/helpers/markdown.ts
@@ -28,6 +28,11 @@ export interface Attributes {
   search?: string // Whether to include as a resource in the search modal or not
 }
 
+// Front matter values may be wrapped in quotes so that a value containing a
+// colon stays valid YAML. The quotes are delimiters, not part of the value.
+const unquote = (value: string): string =>
+  /^(['"]).*\1$/s.test(value) ? value.slice(1, -1) : value
+
 export const parseAttributes = (
   content: string,
   category?: string
@@ -49,7 +54,7 @@ export const parseAttributes = (
             .replace(/-[a-z]/, (m) =>
               m.toUpperCase().replace('-', '')
             ) as keyof Attributes
-        ] = value.join(':').trim()
+        ] = unquote(value.join(':').trim())
       })
   }
 

--- a/src/www/src/pages/blog/_ssr.ts
+++ b/src/www/src/pages/blog/_ssr.ts
@@ -35,9 +35,8 @@ export const fetchData: FetchDataFunc = async ({ title }: Params) => {
       search,
     } = attrs
 
-    const titleNormalized = (
+    const titleNormalized =
       title || toTitleCase(fileName.split('--')[0].replace(/-/g, ' '))
-    ).replaceAll("'", '')
 
     if (fileName === slug) {
       active = true
@@ -68,6 +67,20 @@ export const fetchData: FetchDataFunc = async ({ title }: Params) => {
     const date2 = n2.date || ''
     return date1 < date2 ? 1 : date1 > date2 ? -1 : 0
   })
+
+  // The index route shares this loader with /blog/:title and has no title to
+  // match against, so it would otherwise inherit the home page metadata.
+  if (!slug) {
+    return {
+      head: {
+        title: 'Blog',
+        description:
+          'Product updates, engineering write-ups and guides on deploying, self-hosting and running web applications with Stormkit.',
+        type: 'website',
+      },
+      context: { navigation },
+    }
+  }
 
   if (!foundFile || !files[foundFile.fileName]) {
     return { head: {}, context: { navigation } }

--- a/src/www/src/pages/tutorials/_ssr.ts
+++ b/src/www/src/pages/tutorials/_ssr.ts
@@ -37,6 +37,21 @@ export const fetchData: FetchDataFunc = async ({ slug }: Params) => {
     })
   }
 
+  // The index route shares this loader with /tutorials/:slug, and has no slug
+  // to match against. It gets its own listing metadata rather than the
+  // not-found copy meant for an unknown slug.
+  if (!slug) {
+    return {
+      head: {
+        title: 'Tutorials',
+        description:
+          'Step-by-step guides for deploying and self-hosting web apps, APIs and databases on Stormkit.',
+        type: 'website',
+      },
+      context: { navigation, content: '' },
+    }
+  }
+
   if (!articleContent) {
     articleContent = 'Tutorial is not found.'
   }


### PR DESCRIPTION
Several pages were serving the home page's title and description, or copy meant for a missing document.

### Front matter quotes leaked into `<title>`

`parseAttributes` splits each line on `:` and never stripped the quotes that make a value containing a colon valid YAML, so these rendered with a trailing quote:

- `Strapi Hosting: How to Self-Host Strapi CMS on Your Own Server' - Stormkit`
- `Self-Hosting with Stormkit: Deploy Web Apps with Full Control" - Stormkit`

The blog listing worked around it by deleting every apostrophe from the title, which also mangled legitimate ones — `What's New?` rendered as `Whats New?`. Quote stripping now happens in the parser and the workaround is gone.

### Index routes inherited detail-route metadata

`/tutorials` and `/blog` share a loader with their detail route and have no slug to match against, so `/tutorials` served `<title>Tutorial is not found - Stormkit</title>` and `/blog` fell through to the home page title. Both are in the sitemap. Each index now returns its own title and description; an unknown slug still gets the not-found copy.

### Docs pages without front matter

`docs/development/1-image-optimization.md` and `2-troubleshooting.md` had no front matter, so both inherited the home page title and description. Added.

### Broken links

- `docs/development/2-troubleshooting.md` linked to `docs/image-optimization.md` relative to its own path, resolving to `/docs/development/docs/image-optimization.md` (404). Now `/docs/development/image-optimization`.
- `content/blog/faq.md` linked to `/blog/monitoring-app-using-stormkit-and-supabase`, which no longer exists. Rewritten to point at the database docs.

### Testing

Added `src/www/src/helpers/markdown.test.ts` covering quoted and unquoted values, apostrophes inside a value, unmatched quotes, and documents with no front matter. Full suite passes (14/14).

Verified the rendered output against a dev server:

| Path | Before | After |
| --- | --- | --- |
| `/tutorials` | `Tutorial is not found` | `Tutorials` |
| `/blog` | `Self-Hosted Vercel and Netlify Alternative` | `Blog` |
| `/docs/development/troubleshooting` | `Self-Hosted Vercel and Netlify Alternative` | `Development Troubleshooting` |
| `/docs/development/image-optimization` | `Self-Hosted Vercel and Netlify Alternative` | `Image Optimization Setup` |
| `/docs/self-hosting/getting-started` | `…with Full Control"` | `…with Full Control` |
| `/tutorials/how-to-deploy-…-strapi-instance` | `…on Your Own Server'` | `…on Your Own Server` |

Both previously broken link targets return 200, `/blog` still lists all 26 posts with apostrophes intact, and an unknown slug still renders the not-found title.