### PR TITLE
fix: stop returning the smtp password

### DIFF
--- a/src/ce/api/app/app_shttp.go
+++ b/src/ce/api/app/app_shttp.go
@@ -150,11 +150,15 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 
 			request.EnvID = envID
 
-			// Then let's fetch the app
-			if appID != 0 {
-				request.App, err = NewStore().AppByID(req.Context(), appID)
-			} else if envID != 0 {
+			// Then let's fetch the app. The environment is authoritative when
+			// one is given: an app- or team-level key carries an appID while
+			// envID may come from the caller, so resolving from appID would
+			// run the ownership checks below against the wrong app. An envID
+			// that resolves to no app does not exist.
+			if envID != 0 {
 				request.App, err = NewStore().AppByEnvID(req.Context(), envID)
+			} else if appID != 0 {
+				request.App, err = NewStore().AppByID(req.Context(), appID)
 			}
 
 			if err != nil {
@@ -203,12 +207,19 @@ func WithApp(handler func(*RequestContext) *shttp.Response, opts ...*Opts) shttp
 
 		var err error
 
-		if appID != 0 {
-			app.App, err = store.AppByID(req.Context(), appID)
-		} else if envID != 0 {
+		if appID == 0 && envID == 0 {
+			return shttp.Error(ErrMissingOrInvalidAppID)
+		}
+
+		// The environment is authoritative when one is given: envID and appID
+		// arrive independently, so resolving from appID would check membership
+		// against the caller's own app while the handler acts on the
+		// environment another tenant owns. An envID that resolves to no app
+		// does not exist, which the nil check below reports as a 404.
+		if envID != 0 {
 			app.App, err = store.AppByEnvID(req.Context(), envID)
 		} else {
-			return shttp.Error(ErrMissingOrInvalidAppID)
+			app.App, err = store.AppByID(req.Context(), appID)
 		}
 
 		if err != nil || app.App == nil {

--- a/src/ce/api/app/app_shttp_test.go
+++ b/src/ce/api/app/app_shttp_test.go
@@ -132,6 +132,7 @@ func (s *AppSHTTPSuite) Test_WithAPIKey_Success_EnvID() {
 func (s *AppSHTTPSuite) Test_WithAPIKey_UserAuth() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
 
 	fn := app.WithAPIKey(func(rc *app.RequestContext) *shttp.Response {
 		return &shttp.Response{
@@ -143,7 +144,7 @@ func (s *AppSHTTPSuite) Test_WithAPIKey_UserAuth() {
 		}
 	})
 
-	jsonData := fmt.Sprintf(`{"appId":"%s","envId":"1"}`, appl.ID.String())
+	jsonData := fmt.Sprintf(`{"appId":"%s","envId":"%s"}`, appl.ID.String(), env.ID.String())
 
 	res := fn(&shttp.RequestContext{
 		Request: &http.Request{
@@ -156,7 +157,7 @@ func (s *AppSHTTPSuite) Test_WithAPIKey_UserAuth() {
 
 	s.Equal(http.StatusOK, res.Status)
 	s.Equal(appl.ID.String(), (res.Data.(map[string]string))["appId"])
-	s.Equal("1", (res.Data.(map[string]string))["envId"])
+	s.Equal(env.ID.String(), (res.Data.(map[string]string))["envId"])
 }
 
 func (s *AppSHTTPSuite) Test_WithAPIKey_APIKeyInvalid() {
@@ -428,6 +429,39 @@ func (s *AppSHTTPSuite) Test_WithApp_WithEnvID() {
 	s.Equal(http.StatusOK, res.Status)
 	s.Equal(appl.ID.String(), (res.Data.(map[string]string))["appId"])
 	s.Equal(env.ID.String(), (res.Data.(map[string]string))["envId"])
+}
+
+// Test_WithApp_EnvBelongsToAnotherApp guards a cross-tenant IDOR: appId and
+// envId arrive independently, so pairing an app the caller owns with someone
+// else's envId used to pass the membership check and hand the handler the
+// victim's environment.
+func (s *AppSHTTPSuite) Test_WithApp_EnvBelongsToAnotherApp() {
+	usr := s.MockUser()
+	attacker := s.MockApp(usr)
+
+	victim := s.MockApp(s.MockUser())
+	victimEnv := s.MockEnv(victim)
+
+	fn := app.WithApp(func(rc *app.RequestContext) *shttp.Response {
+		return &shttp.Response{Status: http.StatusOK}
+	})
+
+	jsonData := fmt.Sprintf(
+		`{"appId":"%s","envId":"%s"}`,
+		attacker.ID.String(),
+		victimEnv.ID.String(),
+	)
+
+	res := fn(&shttp.RequestContext{
+		Request: &http.Request{
+			Body: io.NopCloser(strings.NewReader(jsonData)),
+			Header: http.Header{
+				"Authorization": []string{usertest.Authorization(usr.ID)},
+			},
+		},
+	})
+
+	s.Equal(http.StatusNotFound, res.Status)
 }
 
 func (s *AppSHTTPSuite) Test_WithApp_RequireEnv_Missing() {

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -319,7 +319,7 @@ func (env Env) JSON() map[string]any {
 	}
 
 	if env.MailerConf != nil {
-		m["mailer"] = env.MailerConf
+		m["mailer"] = env.MailerConf.JSON()
 	}
 
 	if len(env.Published) > 0 {

--- a/src/ce/api/app/buildconf/env_model_test.go
+++ b/src/ce/api/app/buildconf/env_model_test.go
@@ -1,6 +1,7 @@
 package buildconf_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -76,6 +77,33 @@ func (s *EnvModelSuite) Test_JSON_MasksEnvVars() {
 
 	// The original Env keeps the real values for internal use.
 	s.Equal("shh", env.Data.Vars["SECRET"])
+}
+
+// Test_JSON_MasksMailerPassword guards the wide surface: every environment
+// serialization (dashboard env GET, public API env list, the list_environments
+// MCP tool) goes through Env.JSON, so the SMTP credential must not be in it.
+func (s *EnvModelSuite) Test_JSON_MasksMailerPassword() {
+	env := buildconf.Env{
+		Name: "production",
+		MailerConf: &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "test",
+			Password: "super-secret",
+		},
+	}
+
+	mailer := env.JSON()["mailer"].(map[string]any)
+
+	s.Equal(buildconf.PasswordPlaceholder, mailer["password"])
+	s.Equal("smtp.gmail.com", mailer["host"])
+
+	serialized, err := json.Marshal(env)
+	s.NoError(err)
+	s.NotContains(string(serialized), "super-secret")
+
+	// The original Env keeps the real value for internal use.
+	s.Equal("super-secret", env.MailerConf.Password)
 }
 
 func TestEnvModelSuite(t *testing.T) {

--- a/src/ce/api/app/buildconf/mailer_model.go
+++ b/src/ce/api/app/buildconf/mailer_model.go
@@ -22,6 +22,12 @@ type SendEmailParams struct {
 	Body    string
 }
 
+// PasswordPlaceholder stands in for the stored SMTP password whenever a mailer
+// configuration is rendered for a client. Writing it back leaves the stored
+// password untouched, so a client can round-trip a configuration without ever
+// handling the real secret.
+const PasswordPlaceholder = "****-****-****-****"
+
 type MailerConf struct {
 	EnvID    types.ID `json:"-"`
 	Host     string   `json:"host"`
@@ -30,12 +36,46 @@ type MailerConf struct {
 	Password string   `json:"password"`
 }
 
-// Bytes uses the json marshaler to return the byte representation.
+// Bytes uses the json marshaler to return the byte representation. It marshals
+// a storage type that sheds MarshalJSON, so persistence keeps writing the
+// encrypted credential rather than the placeholder rendered for clients.
 func (mc *MailerConf) Bytes() ([]byte, error) {
-	cnf := *mc
+	type mailerConfStorage MailerConf
+
+	cnf := mailerConfStorage(*mc)
 	cnf.Username = utils.EncryptToString(cnf.Username)
 	cnf.Password = utils.EncryptToString(cnf.Password)
+
 	return json.Marshal(cnf)
+}
+
+// MarshalJSON implements json.Marshaler by delegating to JSON, so masking is
+// the default: a MailerConf placed in a response cannot serialize the password
+// even if the caller forgets to call JSON explicitly.
+func (mc *MailerConf) MarshalJSON() ([]byte, error) {
+	return json.Marshal(mc.JSON())
+}
+
+// JSON renders the configuration for API responses. The password is never
+// included; the placeholder marks that one is stored. Every client-facing
+// serialization goes through here so the credential cannot escape by accident.
+func (mc *MailerConf) JSON() map[string]any {
+	if mc == nil {
+		return nil
+	}
+
+	password := ""
+
+	if mc.Password != "" {
+		password = PasswordPlaceholder
+	}
+
+	return map[string]any{
+		"host":     mc.Host,
+		"port":     mc.Port,
+		"username": mc.Username,
+		"password": password,
+	}
 }
 
 // String returns a connection string.

--- a/src/ce/api/app/buildconf/mailer_model_test.go
+++ b/src/ce/api/app/buildconf/mailer_model_test.go
@@ -1,6 +1,7 @@
 package buildconf_test
 
 import (
+	"encoding/json"
 	"net/smtp"
 	"testing"
 
@@ -14,6 +15,43 @@ type MailerModelSuite struct {
 
 func (s *MailerModelSuite) AfterTest(_, _ string) {
 	buildconf.SendMailFunc = smtp.SendMail
+}
+
+// Test_MarshalJSON_MasksPassword makes masking the default rather than a
+// convention: a MailerConf placed in a response cannot leak the credential
+// even when the caller never calls JSON.
+func (s *MailerModelSuite) Test_MarshalJSON_MasksPassword() {
+	mailer := &buildconf.MailerConf{
+		Host:     "smtp.gmail.com",
+		Port:     "587",
+		Username: "test-user",
+		Password: "super-secret",
+	}
+
+	serialized, err := json.Marshal(map[string]any{"config": mailer})
+	s.NoError(err)
+	s.NotContains(string(serialized), "super-secret")
+	s.Contains(string(serialized), buildconf.PasswordPlaceholder)
+}
+
+// Test_Bytes_KeepsRealPassword pins the other half: persistence must keep
+// writing the encrypted credential, not the placeholder MarshalJSON renders.
+func (s *MailerModelSuite) Test_Bytes_KeepsRealPassword() {
+	mailer := &buildconf.MailerConf{
+		Host:     "smtp.gmail.com",
+		Port:     "587",
+		Username: "test-user",
+		Password: "super-secret",
+	}
+
+	b, err := mailer.Bytes()
+	s.NoError(err)
+	s.NotContains(string(b), buildconf.PasswordPlaceholder)
+
+	restored := &buildconf.MailerConf{}
+	s.NoError(json.Unmarshal(b, restored))
+	s.Equal("super-secret", restored.Password)
+	s.Equal("test-user", restored.Username)
 }
 
 func (s *MailerModelSuite) Test_String_DefaultPort() {

--- a/src/ce/api/app/buildconf/mailerhandlers/config.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/config.go
@@ -1,0 +1,85 @@
+package mailerhandlers
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttperr"
+)
+
+// ConfigUpdateRequest patches the mailer configuration of an environment. Nil
+// fields keep their stored value, which lets the dashboard, the public API and
+// the MCP tool share one payload shape.
+type ConfigUpdateRequest struct {
+	Username *string `json:"username"`
+	Password *string `json:"password"`
+	SMTPHost *string `json:"smtpHost"`
+	SMTPPort *string `json:"smtpPort"`
+}
+
+// ApplyConfigUpdate validates data and merges its provided fields into conf in
+// place. It performs no I/O so it can be shared by the dashboard handler, the
+// public API handler and the MCP tool. On validation failure it returns a
+// *shttperr.ValidationError, which shttp.Error renders as a 400.
+//
+// An omitted, empty or placeholder password keeps the stored one: the password
+// is write-only across every surface, so clients that never see it can still
+// submit the rest of the form.
+//
+// Retaining it is only safe while the credential keeps pointing at the same
+// account, so changing the host or the username drops the stored password.
+// Otherwise a caller who is never allowed to read it could repoint the config
+// at a server it controls and have Send hand the credential over.
+func ApplyConfigUpdate(conf *buildconf.MailerConf, data ConfigUpdateRequest) error {
+	previousHost := conf.Host
+	previousUsername := conf.Username
+
+	if data.SMTPHost != nil {
+		conf.Host = strings.TrimSpace(*data.SMTPHost)
+	}
+
+	if data.Username != nil {
+		conf.Username = strings.TrimSpace(*data.Username)
+	}
+
+	if conf.Host != previousHost || conf.Username != previousUsername {
+		conf.Password = ""
+	}
+
+	if data.Password != nil && *data.Password != "" && *data.Password != buildconf.PasswordPlaceholder {
+		conf.Password = *data.Password
+	}
+
+	if data.SMTPPort != nil {
+		conf.Port = strings.TrimSpace(*data.SMTPPort)
+	}
+
+	errors := map[string]string{}
+
+	if conf.Host == "" {
+		errors["host"] = "SMTP Host is a required field."
+	}
+
+	if conf.Username == "" {
+		errors["username"] = "Username is a required field."
+	}
+
+	if conf.Password == "" {
+		errors["password"] = "Password is a required field."
+	}
+
+	if conf.Port != "" {
+		port, err := strconv.Atoi(conf.Port)
+
+		if err != nil || port < 1 || port > 65535 {
+			errors["port"] = "SMTP Port must be a number between 1 and 65535."
+		}
+	}
+
+	if len(errors) > 0 {
+		return &shttperr.ValidationError{Errors: errors}
+	}
+
+	return nil
+}

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail.go
@@ -44,9 +44,17 @@ func HandlerMail(req *app.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
+	// WithApp only asserts that an envId was provided, not that it exists, and
+	// the store returns (nil, nil) for an unknown id.
+	if env == nil {
+		return shttp.NotFound()
+	}
+
 	config := env.MailerConf
 	from := data.From
 
+	// An environment with no SMTP configuration records the email without
+	// sending it - see Test_NoConfig_StoresEmail.
 	if config != nil {
 		from = utils.GetString(data.From, config.Username)
 

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mail_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mail_test.go
@@ -126,6 +126,31 @@ func (s *MailerSuite) Test_NoConfig_StoresEmail() {
 	s.Equal("Welcome to my world!", emails[0].Body)
 }
 
+// Test_UnknownEnvID guards a nil dereference: WithApp only asserts that an
+// envId was provided, and the store returns (nil, nil) for an unknown id.
+func (s *MailerSuite) Test_UnknownEnvID() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/mailer",
+		map[string]any{
+			"appId":   app.ID.String(),
+			"envId":   "999999999",
+			"to":      "joe@stormkit.io",
+			"subject": "Hello",
+			"body":    "Welcome to my world!",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
 func TestMailerSuite(t *testing.T) {
 	suite.Run(t, &MailerSuite{})
 }

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
 
+// HandlerMailerConfigGet returns the SMTP configuration for the environment.
+// The password is never included — see MailerConf.JSON.
 func HandlerMailerConfigGet(req *app.RequestContext) *shttp.Response {
 	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), req.EnvID)
 
@@ -15,21 +17,12 @@ func HandlerMailerConfigGet(req *app.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
-	response := map[string]any{
-		"config": nil,
-	}
-
-	if env.MailerConf != nil {
-		response["config"] = map[string]any{
-			"host":     env.MailerConf.Host,
-			"port":     env.MailerConf.Port,
-			"username": env.MailerConf.Username,
-			"password": env.MailerConf.Password,
-		}
+	if env == nil {
+		return shttp.NotFound()
 	}
 
 	return &shttp.Response{
 		Status: http.StatusOK,
-		Data:   response,
+		Data:   map[string]any{"config": env.MailerConf.JSON()},
 	}
 }

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_get_test.go
@@ -58,13 +58,80 @@ func (s *HandlerMailerConfigGetSuite) Test_Success() {
 		"config": { 
 			"host": "smtp.gmail.com",
 			"port": "587",
-			"password": "testpwd",
+			"password": "****-****-****-****",
 			"username": "test"
 		}
 	}`
 
 	s.Equal(http.StatusOK, response.Code)
 	s.JSONEq(expected, response.String())
+}
+
+// Test_MasksPassword is the guarantee the MCP tools rely on: the stored SMTP
+// password never leaves the server, so an agent that can read the config
+// cannot exfiltrate the credential.
+func (s *HandlerMailerConfigGetSuite) Test_MasksPassword() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Username: "test",
+			Password: "super-secret",
+		},
+	})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/mailer/config?appId=%d&envId=%d", app.ID, env.ID),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	body := response.String()
+
+	s.Equal(http.StatusOK, response.Code)
+	s.NotContains(body, "super-secret")
+	s.Contains(body, buildconf.PasswordPlaceholder)
+}
+
+func (s *HandlerMailerConfigGetSuite) Test_NoConfig() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, nil)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/mailer/config?appId=%d&envId=%d", app.ID, env.ID),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.JSONEq(`{"config": null}`, response.String())
+}
+
+func (s *HandlerMailerConfigGetSuite) Test_UnknownEnvID() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/mailer/config?appId=%d&envId=999999999", app.ID),
+		nil,
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func TestHandlerMailerConfigGetSuite(t *testing.T) {

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set.go
@@ -8,58 +8,38 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
 
-type ConfigRequestData struct {
-	Username    string `json:"username"`
-	Password    string `json:"password"`
-	SMTPHost    string `json:"smtpHost"`
-	SMTPPort    string `json:"smtpPort"`
-	FromAddress string `json:"fromAddress"`
-}
-
-func validateConfig(data ConfigRequestData) map[string]string {
-	errors := map[string]string{}
-
-	if data.Username == "" {
-		errors["username"] = "Username is a required field."
-	}
-
-	if data.Password == "" {
-		errors["password"] = "Password is a required field."
-	}
-
-	if data.SMTPHost == "" {
-		errors["host"] = "SMTP Host is a required field."
-	}
-
-	if len(errors) == 0 {
-		return nil
-	}
-
-	return errors
-}
-
+// HandlerMailerConfigSet patches the SMTP configuration for the environment.
+// Only the fields present in the request body are changed; the rest keep their
+// stored values. The response never echoes the password back.
 func HandlerMailerConfigSet(req *app.RequestContext) *shttp.Response {
-	data := ConfigRequestData{}
+	data := ConfigUpdateRequest{}
 
 	if err := req.Post(&data); err != nil {
 		return shttp.Error(err)
 	}
 
-	if err := validateConfig(data); err != nil {
-		return &shttp.Response{
-			Status: http.StatusBadRequest,
-			Data: map[string]any{
-				"errors": err,
-			},
-		}
+	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), req.EnvID)
+
+	if err != nil {
+		return shttp.Error(err)
 	}
 
-	config := &buildconf.MailerConf{
-		Host:     data.SMTPHost,
-		Port:     data.SMTPPort,
-		Username: data.Username,
-		Password: data.Password,
-		EnvID:    req.EnvID,
+	// WithApp only asserts that an envId was provided, not that it exists, and
+	// the store returns (nil, nil) for an unknown id.
+	if env == nil {
+		return shttp.NotFound()
+	}
+
+	config := env.MailerConf
+
+	if config == nil {
+		config = &buildconf.MailerConf{}
+	}
+
+	config.EnvID = req.EnvID
+
+	if err := ApplyConfigUpdate(config, data); err != nil {
+		return shttp.Error(err)
 	}
 
 	if err := buildconf.MailerStore().UpsertConfig(req.Context(), config); err != nil {
@@ -68,8 +48,6 @@ func HandlerMailerConfigSet(req *app.RequestContext) *shttp.Response {
 
 	return &shttp.Response{
 		Status: http.StatusOK,
-		Data: map[string]any{
-			"config": config,
-		},
+		Data:   map[string]any{"config": config.JSON()},
 	}
 }

--- a/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set_test.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/handler_mailer_config_set_test.go
@@ -97,6 +97,162 @@ func (s *HandlerMailerConfigSetSuite) Test_BadRequest() {
 	s.JSONEq(expected, response.String())
 }
 
+// Test_KeepsPasswordWhenOmitted covers the round-trip a masked client makes:
+// it reads the config, gets the placeholder, and posts it straight back.
+func (s *HandlerMailerConfigSetSuite) Test_KeepsPasswordWhenOmitted() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "test-user",
+			Password: "original-pwd",
+		},
+	})
+
+	for _, password := range []string{"", buildconf.PasswordPlaceholder} {
+		response := shttptest.RequestWithHeaders(
+			shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+			shttp.MethodPost,
+			"/mailer/config",
+			map[string]string{
+				"appId":    app.ID.String(),
+				"envId":    env.ID.String(),
+				"smtpHost": "smtp.gmail.com",
+				"password": password,
+			},
+			map[string]string{
+				"Authorization": usertest.Authorization(usr.ID),
+			},
+		)
+
+		s.Equal(http.StatusOK, response.Code)
+
+		envUpdated, err := buildconf.NewStore().EnvironmentByID(context.Background(), env.ID)
+		s.NoError(err)
+		s.Equal("original-pwd", envUpdated.MailerConf.Password)
+		s.Equal("smtp.gmail.com", envUpdated.MailerConf.Host)
+		s.Equal("test-user", envUpdated.MailerConf.Username)
+	}
+}
+
+// Test_ClearsPasswordWhenHostChanges closes the exfiltration path the masking
+// would otherwise leave open: repointing the config at a server the caller
+// controls while the stored credential is retained makes the next send hand
+// that credential over.
+func (s *HandlerMailerConfigSetSuite) Test_ClearsPasswordWhenHostChanges() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "test-user",
+			Password: "original-pwd",
+		},
+	})
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/mailer/config",
+		map[string]string{
+			"appId":    app.ID.String(),
+			"envId":    env.ID.String(),
+			"smtpHost": "smtp.attacker.tld",
+			"password": buildconf.PasswordPlaceholder,
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "Password is a required field.")
+
+	envUpdated, err := buildconf.NewStore().EnvironmentByID(context.Background(), env.ID)
+	s.NoError(err)
+	s.Equal("smtp.gmail.com", envUpdated.MailerConf.Host)
+	s.Equal("original-pwd", envUpdated.MailerConf.Password)
+}
+
+func (s *HandlerMailerConfigSetSuite) Test_NeverEchoesPassword() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/mailer/config",
+		map[string]string{
+			"appId":    app.ID.String(),
+			"envId":    env.ID.String(),
+			"smtpHost": "smtp.gmail.com",
+			"username": "test-user",
+			"password": "super-secret",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+	s.NotContains(response.String(), "super-secret")
+}
+
+func (s *HandlerMailerConfigSetSuite) Test_InvalidPort() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+	env := s.MockEnv(app)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/mailer/config",
+		map[string]string{
+			"appId":    app.ID.String(),
+			"envId":    env.ID.String(),
+			"smtpHost": "smtp.gmail.com",
+			"smtpPort": "not-a-port",
+			"username": "test-user",
+			"password": "test-pwd",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusBadRequest, response.Code)
+	s.Contains(response.String(), "SMTP Port must be a number")
+}
+
+// Test_UnknownEnvID guards a nil dereference: WithApp only asserts that an
+// envId was provided, and the store returns (nil, nil) for an unknown id.
+func (s *HandlerMailerConfigSetSuite) Test_UnknownEnvID() {
+	usr := s.MockUser()
+	app := s.MockApp(usr)
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(mailerhandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		"/mailer/config",
+		map[string]string{
+			"appId":    app.ID.String(),
+			"envId":    "999999999",
+			"smtpHost": "smtp.gmail.com",
+			"username": "test-user",
+			"password": "test-pwd",
+		},
+		map[string]string{
+			"Authorization": usertest.Authorization(usr.ID),
+		},
+	)
+
+	s.Equal(http.StatusNotFound, response.Code)
+}
+
 func TestHandlerMailerConfigSetSuite(t *testing.T) {
 	suite.Run(t, &HandlerMailerConfigSetSuite{})
 }

--- a/src/ce/api/app/deploy/deployhandlers/handler_publish_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_publish_test.go
@@ -175,6 +175,7 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest() {
 func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
 	usr := s.MockUser()
 	app := s.MockApp(usr)
+	env := s.MockEnv(app)
 
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(deployhandlers.Services).Router().Handler(),
@@ -182,7 +183,7 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
 		"/app/deployments/publish",
 		map[string]any{
 			"appId": app.ID.String(),
-			"envId": app.ID.String(),
+			"envId": env.ID.String(),
 			"publish": []map[string]any{
 				{"percentage": 70, "deploymentId": app.ID.String()},
 			},

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -161,6 +161,10 @@ func (d *Deployment) includeMailerVars(mailer *buildconf.MailerConf) {
 		d.BuildConfig = &buildconf.BuildConf{}
 	}
 
+	if d.BuildConfig.Vars == nil {
+		d.BuildConfig.Vars = make(map[string]string)
+	}
+
 	if d.BuildConfig.Vars["MAILER_URL"] == "" {
 		d.BuildConfig.Vars["MAILER_URL"] = mailer.String()
 	}

--- a/src/ce/api/app/deploy/deployment_model_test.go
+++ b/src/ce/api/app/deploy/deployment_model_test.go
@@ -299,6 +299,34 @@ func (s *DeploymentModelSuite) Test_PopulateFromEnv_SchemaDoNotInjectEnvVars() {
 	s.Empty(dep.BuildConfig.Vars["DATABASE_URL"])
 }
 
+// Test_PopulateFromEnv_MailerOnlyWithNoVars guards a nil-map assignment:
+// includeSchemaVars allocates BuildConf.Vars, so an environment with a mailer
+// but no database integration and no build vars is the only path that reaches
+// includeMailerVars with a nil map.
+func (s *DeploymentModelSuite) Test_PopulateFromEnv_MailerOnlyWithNoVars() {
+	dep := &deploy.Deployment{}
+	env := &buildconf.Env{
+		ID:     16,
+		Name:   "production",
+		Branch: "main",
+		Data:   &buildconf.BuildConf{},
+		MailerConf: &buildconf.MailerConf{
+			Username: "test-user",
+			Password: "test-pwd",
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+		},
+	}
+
+	s.Nil(env.Data.Vars)
+
+	s.NotPanics(func() {
+		dep.PopulateFromEnv(env)
+	})
+
+	s.Equal("smtp://test-user:test-pwd@smtp.gmail.com:587", dep.BuildConfig.Vars["MAILER_URL"])
+}
+
 func (s *DeploymentModelSuite) Test_PopulateFromEnv() {
 	dep := &deploy.Deployment{}
 	env := &buildconf.Env{

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
@@ -114,6 +114,60 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
     expect(fetchScope.isDone()).toBe(true);
   });
 
+  it("should surface server validation errors on save", async () => {
+    createWrapper({});
+
+    const scope = mockSetMailerConfig({
+      appId: currentApp.id,
+      envId: currentEnv.id,
+      username: "joe@example.org",
+      password: "",
+      smtpHost: "smtp.example.org",
+      smtpPort: "",
+      status: 400,
+      // @ts-ignore - error shape, not the success shape
+      response: { errors: { password: "Password is a required field." } },
+    });
+
+    await waitFor(() => {
+      expect(fetchScope.isDone()).toBe(true);
+      expect(wrapper.getByLabelText("SMTP Host")).toBeTruthy();
+    });
+
+    await userEvent.type(wrapper.getByLabelText("SMTP Host"), "smtp.example.org");
+    await userEvent.type(wrapper.getByLabelText("Username"), "joe@example.org");
+
+    fireEvent.click(wrapper.getByText("Save"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByText("Password is a required field.")).toBeTruthy();
+    });
+  });
+
+  it("should not prefill the password field", async () => {
+    createWrapper({
+      config: {
+        host: "smtp.example.org",
+        port: "587",
+        username: "joe@example.org",
+        // What the API returns in place of the stored password.
+        password: "****-****-****-****",
+      },
+    });
+
+    await waitFor(() => {
+      expect(wrapper.getByDisplayValue("smtp.example.org")).toBeTruthy();
+    });
+
+    expect(wrapper.getByLabelText("Password").getAttribute("value")).toBe("");
+    expect(
+      wrapper.getByText(
+        "A password is stored. Leave this empty to keep it — changing the host or username requires re-entering it.",
+      ),
+    ).toBeTruthy();
+  });
+
   it("should send a test email", async () => {
     createWrapper({
       config: {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx
@@ -35,10 +35,6 @@ export default function TabMailer() {
       string
     >;
 
-    if (data["username"] === "") {
-      return setFormError("Username is a required field");
-    }
-
     setFormError(undefined);
     setSuccess(undefined);
 
@@ -47,6 +43,12 @@ export default function TabMailer() {
       .then(() => {
         setSuccess("Mailer configuration saved successfully.");
         setRefreshToken(Date.now());
+      })
+      .catch(async (res: Response) => {
+        // The API rejects a first-time save with no password, which is easy to
+        // hit now that the field is never prefilled - show what it objected to
+        // rather than leaving the form looking inert.
+        setFormError((await api.errors(res)).join(" "));
       });
   };
 
@@ -184,7 +186,12 @@ export default function TabMailer() {
           label="Password"
           name="password"
           fullWidth
-          defaultValue={config?.password || ""}
+          defaultValue=""
+          helperText={
+            config?.password
+              ? "A password is stored. Leave this empty to keep it — changing the host or username requires re-entering it."
+              : undefined
+          }
           variant="filled"
           autoComplete="off"
         />

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/actions.ts
@@ -5,6 +5,7 @@ interface MailerConfig {
   host: string;
   port: string;
   username: string;
+  // Never the real password: a placeholder marking that one is stored.
   password: string;
 }
 


### PR DESCRIPTION
1 of 5 in a stack splitting #447. Reviewable and mergeable on its own — this is a live leak in the current dashboard API and does not depend on the rest.

## The leak

`/mailer/config` returned the stored SMTP password in cleartext on read, and echoed it straight back on write:

- `HandlerMailerConfigGet` put `env.MailerConf.Password` in the response
- `HandlerMailerConfigSet` responded with `{"config": config}`, and `MailerConf`'s tag is `json:"password"`

Anyone who could read the config could take the credential. That matters more than it looks: the SMTP account sends the app's magic-link emails.

## The fix

Both now render `****-****-****-****`. Writing the placeholder back — or omitting the field — keeps the stored password, so a client can round-trip a configuration it is never allowed to see.

That also makes the endpoint a patch rather than a full replace: only the fields present in the body change. Validation and rendering move into `ApplyConfigUpdate` and `MailerConf.JSON` so there is one place where the password can or cannot escape, which the later PRs in this stack reuse.

Masking is now the default rather than a convention: `MailerConf` gains a `MarshalJSON` that delegates to `JSON`, so the credential cannot be serialized by a caller that forgets to mask. `Bytes` marshals a separate storage type, keeping persistence on the real encrypted value.

Retaining the password across a patch is only safe while it keeps pointing at the same account, so **changing the host or the username drops it**. Otherwise a caller who may never read the password could repoint the config at a server it controls and have `Send` hand the credential over — masking the read alone would have been a one-request detour, not a control.

## Access control and crash fixes found alongside

- **Cross-tenant IDOR.** `WithApp` and `WithAPIKey` resolved the app from `appId` and checked team membership against it, while `envId` arrived independently and was never validated. Pairing an app you own with another tenant's `envId` passed authorization and handed the handler the victim's environment — combined with the patch semantics above, enough to repoint someone else's SMTP config. Both paths now resolve the app from the environment when one is given, so membership is checked against the environment's real owner and a mismatched `appId` buys nothing. An `envId` that resolves to no app does not exist and is reported as a 404 rather than falling through to the app named by `appId`.
- **`HandlerMail` nil dereference** for an unknown `envId` — the same crash the config handlers guard against, and reachable through the public API.
- **`includeMailerVars` nil-map panic** on deploy for an environment with a mailer, no database integration and no build variables. Its sibling `includeSchemaVars` already had the guard.

## Dashboard

The password field is no longer prefilled, and the form now surfaces the server's validation errors. These are related: not prefilling makes an empty-password rejection the common first-run path, and the save had no `.catch` at all, so the form silently did nothing.

## Cleanup

`ConfigValidationError` is replaced by the existing `shttperr.ValidationError`, which `shttp.Error` already renders in the same wire shape.

## Tests

`Test_MasksPassword` replaces an assertion that checked for the opposite — that test is what proves the leak was real. Plus coverage for the placeholder round-trip, empty-password retention, no-echo-on-write, port validation, password clearing on host change, `MarshalJSON` masking with the `Bytes` round-trip still storing the real value, the cross-tenant `envId` rejection, the `HandlerMail` unknown-env 404, and the mailer-only deploy path. The IDOR and deploy-panic tests were each confirmed to fail without their fix.

