### PR TITLE
refactor: share skauth config and provider logic

### DIFF
--- a/src/ce/api/app/skauth/skauthhandlers/auth_config_json.go
+++ b/src/ce/api/app/skauth/skauthhandlers/auth_config_json.go
@@ -1,0 +1,47 @@
+package skauthhandlers
+
+import (
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+)
+
+// AuthConfigJSON renders the non-secret Stormkit Auth configuration fields.
+// The signing secret and provider client secrets are never included.
+func AuthConfigJSON(conf *buildconf.SKAuthConf) map[string]any {
+	out := map[string]any{
+		"status":             false,
+		"successUrl":         "",
+		"tokenTtl":           0,
+		"allowedOrigins":     []string{},
+		"oauthServerEnabled": false,
+		"oauthResourcePath":  "",
+		"oauthAllowLoopback": false,
+		"cookieDomain":       "",
+		"loginUrl":           "",
+	}
+
+	if conf == nil {
+		return out
+	}
+
+	out["status"] = conf.Status
+	out["successUrl"] = conf.SuccessURL
+	out["tokenTtl"] = conf.TTL
+	out["cookieDomain"] = conf.CookieDomain
+	out["loginUrl"] = conf.LoginURL
+
+	if conf.AllowedOrigins != nil {
+		out["allowedOrigins"] = conf.AllowedOrigins
+	}
+
+	// Report the effective value the runtime honours, not the stored flag:
+	// the OAuth server is inert while Stormkit Auth itself is off, so a raw
+	// flag would show the toggle on for an endpoint that rejects every request.
+	out["oauthServerEnabled"] = conf.OAuthServerEnabled()
+
+	if conf.OAuthServer != nil {
+		out["oauthResourcePath"] = conf.OAuthServer.ResourcePath
+		out["oauthAllowLoopback"] = conf.OAuthServer.AllowLoopback
+	}
+
+	return out
+}

--- a/src/ce/api/app/skauth/skauthhandlers/auth_config_json_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/auth_config_json_test.go
@@ -1,0 +1,39 @@
+package skauthhandlers_test
+
+import (
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
+	"github.com/stretchr/testify/suite"
+)
+
+type AuthConfigJSONSuite struct {
+	suite.Suite
+}
+
+// Test_OAuthServerEnabled_RequiresAuthStatus pins the effective-value contract:
+// the OAuth server is inert while Stormkit Auth is off, so the rendered flag
+// must not claim otherwise.
+func (s *AuthConfigJSONSuite) Test_OAuthServerEnabled_RequiresAuthStatus() {
+	conf := &buildconf.SKAuthConf{
+		Status:      false,
+		OAuthServer: &buildconf.OAuthServerConf{Enabled: true},
+	}
+
+	s.Equal(false, skauthhandlers.AuthConfigJSON(conf)["oauthServerEnabled"])
+
+	conf.Status = true
+	s.Equal(true, skauthhandlers.AuthConfigJSON(conf)["oauthServerEnabled"])
+}
+
+func (s *AuthConfigJSONSuite) Test_NilConf() {
+	out := skauthhandlers.AuthConfigJSON(nil)
+
+	s.Equal(false, out["status"])
+	s.Equal(false, out["oauthServerEnabled"])
+}
+
+func TestAuthConfigJSONSuite(t *testing.T) {
+	suite.Run(t, &AuthConfigJSONSuite{})
+}

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
@@ -1,15 +1,11 @@
 package skauthhandlers
 
 import (
-	"fmt"
-	"strings"
+	"errors"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
 type AuthUpsertRequest struct {
@@ -17,148 +13,37 @@ type AuthUpsertRequest struct {
 	ClientID     string `json:"clientId"`
 	ClientSecret string `json:"clientSecret"`
 	FromAddress  string `json:"fromAddress"`
-	Status       bool   `json:"status"`
+	Status       *bool  `json:"status"`
 }
 
-// handlerAuthUpsert handles the upsert of an authentication provider configuration.
-// It delegates to a provider-specific helper based on the provider name.
+// handlerAuthUpsert handles the upsert of an authentication provider
+// configuration for the dashboard.
 func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
-	data := &AuthUpsertRequest{}
+	data := AuthUpsertRequest{}
 
-	if err := req.Post(data); err != nil {
+	if err := req.Post(&data); err != nil {
 		return shttp.Error(err)
 	}
 
-	ctx := req.Context()
-	envStore := buildconf.NewStore()
-	env, err := envStore.EnvironmentByID(ctx, req.EnvID)
+	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), req.EnvID)
 
 	if err != nil {
 		return shttp.Error(err)
 	}
 
-	if env.SchemaConf == nil {
-		return shttp.BadRequest(map[string]any{
-			"error": "Schema configuration is not set for this environment. Please configure it first.",
-		})
-	}
-
-	// Let's create an auth conf on the fly, with default settings
-	if env.AuthConf == nil {
-		env.AuthConf = &buildconf.SKAuthConf{
-			TTL:        7 * 24 * 60,
-			SuccessURL: "/",
-			Secret:     utils.RandomToken(128),
-			Status:     true,
-		}
-
-		if err := envStore.SaveAuthConf(req.Context(), req.EnvID, env.AuthConf); err != nil {
-			return shttp.Error(err, fmt.Sprintf("error while saving auth config: %s, envId: %s", err.Error(), req.EnvID.String()))
-		}
-
-		if err := appcache.Service().Reset(req.EnvID); err != nil {
-			return shttp.Error(err)
-		}
-	}
-
-	data.ProviderName = strings.TrimSpace(strings.ToLower(data.ProviderName))
-
-	switch data.ProviderName {
-	case skauth.ProviderEmail, skauth.ProviderMagicLink:
-		return handleEmailProvider(req, data, env)
-	default:
-		return handleOAuthProvider(req, data, env)
-	}
-}
-
-// handleOAuthProvider validates OAuth-specific fields (clientId, clientSecret) and saves
-// the provider configuration.
-func handleOAuthProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env) *shttp.Response {
-	ctx := req.Context()
-
-	// If updating an existing provider and client secret is not provided, retain the existing secret.
-	if data.ClientSecret == "" || data.ClientSecret == ClientSecretPlaceholder {
-		existingProvider, err := skauth.NewStore().Provider(ctx, req.EnvID, data.ProviderName)
-
-		if err != nil {
-			return shttp.Error(err)
-		}
-
-		if existingProvider != nil && existingProvider.Data.ClientSecret != "" {
-			data.ClientSecret = existingProvider.Data.ClientSecret
-		}
-	}
-
-	if data.ClientID == "" {
-		return shttp.BadRequest(map[string]any{
-			"error": "Client ID is required",
-		})
-	}
-
-	if data.ClientSecret == "" {
-		return shttp.BadRequest(map[string]any{
-			"error": "Client Secret is required",
-		})
-	}
-
-	return saveProvider(req, data, env, skauth.ProviderData{
-		ClientID:     data.ClientID,
-		ClientSecret: data.ClientSecret,
-	})
-}
-
-// handleEmailProvider saves the email/password provider configuration.
-// Email providers do not require OAuth credentials.
-func handleEmailProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env) *shttp.Response {
-	fromAddress := strings.TrimSpace(data.FromAddress)
-
-	if data.ProviderName == skauth.ProviderMagicLink && fromAddress == "" {
-		return shttp.BadRequest(map[string]any{
-			"error": "From address is required",
-		})
-	}
-
-	return saveProvider(req, data, env, skauth.ProviderData{
-		FromAddress: fromAddress,
-	})
-}
-
-// saveProvider creates the auth table (idempotent) and upserts the provider record.
-func saveProvider(req *app.RequestContext, data *AuthUpsertRequest, env *buildconf.Env, providerData skauth.ProviderData) *shttp.Response {
-	ctx := req.Context()
-
-	migrationStore, err := env.SchemaConf.Store(buildconf.SchemaAccessTypeMigrations)
-
-	if err != nil {
-		return shttp.Error(err)
-	}
-
-	defer migrationStore.Close()
-
-	// This is idempotent - if the table already exists, no error is returned.
-	if err := migrationStore.CreateAuthTable(ctx); err != nil {
-		return shttp.Error(err)
-	}
-
-	provider := &skauth.Provider{
-		Name:   data.ProviderName,
-		Status: data.Status,
-		Data:   providerData,
-	}
-
-	if !provider.Supported() {
-		return shttp.BadRequest(map[string]any{
-			"error": "Invalid provider",
-		})
-	}
-
-	err = skauth.NewStore().SaveProvider(ctx, skauth.SaveProviderArgs{
-		EnvID:    req.EnvID,
-		AppID:    req.App.ID,
-		Provider: provider,
+	err = UpsertProvider(req.Context(), UpsertProviderParams{
+		Env:   env,
+		AppID: req.App.ID,
+		Data:  data,
 	})
 
 	if err != nil {
+		var verr *ProviderValidationError
+
+		if errors.As(err, &verr) {
+			return shttp.BadRequest(map[string]any{"error": verr.Message})
+		}
+
 		return shttp.Error(err)
 	}
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auths.go
@@ -5,11 +5,8 @@ import (
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
-	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 )
-
-const ClientSecretPlaceholder = "****-****-****-****"
 
 func handlerAuths(req *app.RequestContext) *shttp.Response {
 	env, err := buildconf.NewStore().EnvironmentByID(req.Context(), req.EnvID)
@@ -18,70 +15,11 @@ func handlerAuths(req *app.RequestContext) *shttp.Response {
 		return shttp.Error(err, fmt.Sprintf("error while fetching environment for skauth: %s, envId: %s", err.Error(), req.EnvID.String()))
 	}
 
-	providers, err := skauth.NewStore().Providers(req.Context(), skauth.ProvidersArgs{
-		EnvID: req.EnvID,
-	})
+	data, err := ProvidersJSON(req.Context(), env)
 
 	if err != nil {
 		return shttp.Error(err)
 	}
 
-	returnValue := map[string]map[string]any{}
-
-	for _, p := range providers {
-		returnValue[p.Name] = map[string]any{
-			"status":   p.Status,
-			"clientId": p.Data.ClientID,
-		}
-
-		if p.Data.ClientSecret != "" {
-			returnValue[p.Name]["clientSecret"] = ClientSecretPlaceholder
-		}
-
-		if p.Data.FromAddress != "" {
-			returnValue[p.Name]["fromAddress"] = p.Data.FromAddress
-		}
-	}
-
-	successURL := ""
-	ttl := 0
-	allowedOrigins := []string{}
-	oauthServerEnabled := false
-	oauthResourcePath := ""
-	oauthAllowLoopback := false
-	cookieDomain := ""
-	loginURL := ""
-
-	if env.AuthConf != nil {
-		successURL = env.AuthConf.SuccessURL
-		ttl = env.AuthConf.TTL
-		oauthServerEnabled = env.AuthConf.OAuthServerEnabled()
-		cookieDomain = env.AuthConf.CookieDomain
-		loginURL = env.AuthConf.LoginURL
-
-		if env.AuthConf.AllowedOrigins != nil {
-			allowedOrigins = env.AuthConf.AllowedOrigins
-		}
-
-		if env.AuthConf.OAuthServer != nil {
-			oauthResourcePath = env.AuthConf.OAuthServer.ResourcePath
-			oauthAllowLoopback = env.AuthConf.OAuthServer.AllowLoopback
-		}
-	}
-
-	return &shttp.Response{
-		Data: map[string]any{
-			"providers":          returnValue,
-			"successUrl":         successURL,
-			"tokenTtl":           ttl,
-			"allowedOrigins":     allowedOrigins,
-			"oauthServerEnabled": oauthServerEnabled,
-			"oauthResourcePath":  oauthResourcePath,
-			"oauthAllowLoopback": oauthAllowLoopback,
-			"cookieDomain":       cookieDomain,
-			"loginUrl":           loginURL,
-			"redirectUrl":        skauth.RedirectURL(),
-			"authUrl":            skauth.AuthURL(),
-		},
-	}
+	return &shttp.Response{Data: data}
 }

--- a/src/ce/api/app/skauth/skauthhandlers/provider_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/provider_upsert.go
@@ -1,0 +1,199 @@
+package skauthhandlers
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+// ProviderValidationError is a user-facing validation failure on a provider
+// upsert. Handlers surface Message in the 400 response body.
+type ProviderValidationError struct {
+	Message string
+}
+
+func (e *ProviderValidationError) Error() string { return e.Message }
+
+// UpsertProviderParams carries everything UpsertProvider needs. Env is the
+// environment being configured; it is mutated when an auth config has to be
+// created on the fly.
+type UpsertProviderParams struct {
+	Env   *buildconf.Env
+	AppID types.ID
+	Data  AuthUpsertRequest
+}
+
+// UpsertProvider validates and stores a single sign-in provider. It is shared
+// by the dashboard handler, the public API handler and the MCP tool. On
+// validation failure it returns a *ProviderValidationError.
+func UpsertProvider(ctx context.Context, p UpsertProviderParams) error {
+	env := p.Env
+
+	if env.SchemaConf == nil {
+		return &ProviderValidationError{
+			Message: "Schema configuration is not set for this environment. Please configure it first.",
+		}
+	}
+
+	if err := ensureAuthConf(ctx, env); err != nil {
+		return err
+	}
+
+	data := p.Data
+	data.ProviderName = normalizeProviderName(data.ProviderName)
+
+	existing, err := skauth.NewStore().Provider(ctx, env.ID, data.ProviderName)
+
+	if err != nil {
+		return err
+	}
+
+	providerData, err := providerDataFor(providerDataForParams{Data: data, Existing: existing})
+
+	if err != nil {
+		return err
+	}
+
+	return saveProvider(ctx, saveProviderParams{
+		Env:    env,
+		AppID:  p.AppID,
+		Name:   data.ProviderName,
+		Status: resolveStatus(data.Status, existing),
+		Data:   providerData,
+	})
+}
+
+// resolveStatus applies patch semantics to the enabled flag: an omitted status
+// keeps whatever the provider already had, so a caller rotating a client
+// secret cannot disable a live provider by not mentioning it. A provider being
+// created for the first time defaults to enabled.
+func resolveStatus(supplied *bool, existing *skauth.Provider) bool {
+	if supplied != nil {
+		return *supplied
+	}
+
+	if existing != nil {
+		return existing.Status
+	}
+
+	return true
+}
+
+// normalizeProviderName maps what a caller typed onto the canonical provider
+// id. Separators are stripped so the natural spellings of "magic-link" and
+// "magic_link" both reach skauth.ProviderMagicLink ("magiclink").
+func normalizeProviderName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+
+	return strings.NewReplacer("-", "", "_", "", " ", "").Replace(name)
+}
+
+// ensureAuthConf creates a default auth configuration when the environment has
+// none, so that enabling a provider is enough to get a working sign-in.
+func ensureAuthConf(ctx context.Context, env *buildconf.Env) error {
+	if env.AuthConf != nil {
+		return nil
+	}
+
+	env.AuthConf = &buildconf.SKAuthConf{
+		TTL:        7 * 24 * 60,
+		SuccessURL: "/",
+		Secret:     utils.RandomToken(128),
+		Status:     true,
+	}
+
+	if err := buildconf.NewStore().SaveAuthConf(ctx, env.ID, env.AuthConf); err != nil {
+		return err
+	}
+
+	return appcache.Service().Reset(env.ID)
+}
+
+type providerDataForParams struct {
+	Data     AuthUpsertRequest
+	Existing *skauth.Provider
+}
+
+// providerDataFor validates the provider-specific fields and returns the data
+// to store. Email providers carry a from address; everything else is OAuth and
+// needs a client ID and secret.
+func providerDataFor(p providerDataForParams) (skauth.ProviderData, error) {
+	data := p.Data
+
+	switch data.ProviderName {
+	case skauth.ProviderEmail, skauth.ProviderMagicLink:
+		fromAddress := strings.TrimSpace(data.FromAddress)
+
+		if data.ProviderName == skauth.ProviderMagicLink && fromAddress == "" {
+			return skauth.ProviderData{}, &ProviderValidationError{Message: "From address is required"}
+		}
+
+		return skauth.ProviderData{FromAddress: fromAddress}, nil
+	}
+
+	// An omitted or placeholder secret keeps the stored one, so a client that
+	// never sees the secret can still toggle the provider.
+	if data.ClientSecret == "" || data.ClientSecret == ClientSecretPlaceholder {
+		if p.Existing != nil && p.Existing.Data.ClientSecret != "" {
+			data.ClientSecret = p.Existing.Data.ClientSecret
+		}
+	}
+
+	if data.ClientID == "" {
+		return skauth.ProviderData{}, &ProviderValidationError{Message: "Client ID is required"}
+	}
+
+	if data.ClientSecret == "" {
+		return skauth.ProviderData{}, &ProviderValidationError{Message: "Client Secret is required"}
+	}
+
+	return skauth.ProviderData{
+		ClientID:     data.ClientID,
+		ClientSecret: data.ClientSecret,
+	}, nil
+}
+
+type saveProviderParams struct {
+	Env    *buildconf.Env
+	AppID  types.ID
+	Name   string
+	Status bool
+	Data   skauth.ProviderData
+}
+
+// saveProvider creates the auth table (idempotent) and upserts the provider.
+func saveProvider(ctx context.Context, p saveProviderParams) error {
+	migrationStore, err := p.Env.SchemaConf.Store(buildconf.SchemaAccessTypeMigrations)
+
+	if err != nil {
+		return err
+	}
+
+	defer migrationStore.Close()
+
+	// This is idempotent - if the table already exists, no error is returned.
+	if err := migrationStore.CreateAuthTable(ctx); err != nil {
+		return err
+	}
+
+	provider := &skauth.Provider{
+		Name:   p.Name,
+		Status: p.Status,
+		Data:   p.Data,
+	}
+
+	if !provider.Supported() {
+		return &ProviderValidationError{Message: "Invalid provider"}
+	}
+
+	return skauth.NewStore().SaveProvider(ctx, skauth.SaveProviderArgs{
+		EnvID:    p.Env.ID,
+		AppID:    p.AppID,
+		Provider: provider,
+	})
+}

--- a/src/ce/api/app/skauth/skauthhandlers/providers_json.go
+++ b/src/ce/api/app/skauth/skauthhandlers/providers_json.go
@@ -1,0 +1,45 @@
+package skauthhandlers
+
+import (
+	"context"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
+)
+
+const ClientSecretPlaceholder = "****-****-****-****"
+
+// ProvidersJSON renders the environment's sign-in providers together with its
+// auth configuration. Client secrets are replaced with ClientSecretPlaceholder
+// so the real value never leaves the server.
+func ProvidersJSON(ctx context.Context, env *buildconf.Env) (map[string]any, error) {
+	providers, err := skauth.NewStore().Providers(ctx, skauth.ProvidersArgs{EnvID: env.ID})
+
+	if err != nil {
+		return nil, err
+	}
+
+	rendered := map[string]map[string]any{}
+
+	for _, p := range providers {
+		rendered[p.Name] = map[string]any{
+			"status":   p.Status,
+			"clientId": p.Data.ClientID,
+		}
+
+		if p.Data.ClientSecret != "" {
+			rendered[p.Name]["clientSecret"] = ClientSecretPlaceholder
+		}
+
+		if p.Data.FromAddress != "" {
+			rendered[p.Name]["fromAddress"] = p.Data.FromAddress
+		}
+	}
+
+	out := AuthConfigJSON(env.AuthConf)
+	out["providers"] = rendered
+	out["redirectUrl"] = skauth.RedirectURL()
+	out["authUrl"] = skauth.AuthURL()
+
+	return out, nil
+}

--- a/src/ce/api/public/v1/handler_auth_config.go
+++ b/src/ce/api/public/v1/handler_auth_config.go
@@ -25,7 +25,7 @@ func authConfigEnabled() bool {
 func handlerAuthConfigGet(req *RequestContext) *shttp.Response {
 	return &shttp.Response{
 		Status: http.StatusOK,
-		Data:   authConfigJSON(req.Env.AuthConf),
+		Data:   skauthhandlers.AuthConfigJSON(req.Env.AuthConf),
 	}
 }
 
@@ -69,43 +69,6 @@ func handlerAuthConfigSet(req *RequestContext) *shttp.Response {
 
 	return &shttp.Response{
 		Status: http.StatusOK,
-		Data:   authConfigJSON(env.AuthConf),
+		Data:   skauthhandlers.AuthConfigJSON(env.AuthConf),
 	}
-}
-
-// authConfigJSON renders the non-secret Stormkit Auth configuration fields.
-func authConfigJSON(conf *buildconf.SKAuthConf) map[string]any {
-	out := map[string]any{
-		"status":             false,
-		"successUrl":         "",
-		"tokenTtl":           0,
-		"allowedOrigins":     []string{},
-		"oauthServerEnabled": false,
-		"oauthResourcePath":  "",
-		"oauthAllowLoopback": false,
-		"cookieDomain":       "",
-		"loginUrl":           "",
-	}
-
-	if conf == nil {
-		return out
-	}
-
-	out["status"] = conf.Status
-	out["successUrl"] = conf.SuccessURL
-	out["tokenTtl"] = conf.TTL
-	out["cookieDomain"] = conf.CookieDomain
-	out["loginUrl"] = conf.LoginURL
-
-	if conf.AllowedOrigins != nil {
-		out["allowedOrigins"] = conf.AllowedOrigins
-	}
-
-	if conf.OAuthServer != nil {
-		out["oauthServerEnabled"] = conf.OAuthServer.Enabled
-		out["oauthResourcePath"] = conf.OAuthServer.ResourcePath
-		out["oauthAllowLoopback"] = conf.OAuthServer.AllowLoopback
-	}
-
-	return out
 }


### PR DESCRIPTION
2 of 5 in a stack splitting #447. Based on #448.

Mostly a refactor, with two behaviour changes called out below.

## Why

The provider upsert and the auth-config rendering each existed once, inside a dashboard handler, so nothing else could reuse them without copying. The public API added in the next PR needs both.

- `UpsertProvider` holds the validate → bootstrap → persist sequence previously spread across `handlerAuthUpsert`, `handleOAuthProvider`, `handleEmailProvider` and `saveProvider`
- `ProvidersJSON` renders the provider list with client secrets masked
- `AuthConfigJSON` moves out of `publicapiv1` — where the dashboard could not reach it — into `skauthhandlers`, where both surfaces can

The handlers keep their behaviour and shrink to request plumbing. `handler_auths.go` loses ~60 lines that were a hand-rolled copy of the config renderer.

## Behaviour changes

**`oauthServerEnabled` now reports the effective value.** It was `conf.OAuthServer.Enabled`; it is now `OAuthServerEnabled()`, which also requires `AuthConf.Status`. The OAuth server is inert while Stormkit Auth is off, so the raw flag showed the dashboard toggle ON for an endpoint that rejects every request. The dashboard already used the stricter form — this makes `/v1/auth/config` agree with it rather than the other way round.

Side effect: `GET /skauth/providers` gains a `status` key, since it now composes the shared renderer. Additive; the dashboard and tests decode into structs.

**Provider `status` becomes a pointer.** An omitted status keeps whatever the provider had. Previously a caller rotating a client secret without restating `status` would write `false` and disable sign-in for every end user of the app. A provider created for the first time defaults to enabled.