### PR TITLE
feat: add mailer and auth provider mcp tools

### DIFF
--- a/docs/api/10-mcp.md
+++ b/docs/api/10-mcp.md
@@ -130,11 +130,72 @@ All tools return JSON. Errors are reported as MCP `isError` content while the tr
 | `list_teams`  | List teams the user belongs to.     |
 | `create_team` | Create a new team.                  |
 
+### Mailer
+
+| Tool                | Description                                                                       |
+| ------------------- | --------------------------------------------------------------------------------- |
+| `get_mailer_config` | Read the SMTP settings of an environment. The password is never returned.          |
+| `configure_mailer`  | Set the SMTP settings. Partial: only the fields you pass change, except that changing `smtpHost` or `username` also requires a new `password`. |
+| `send_test_email`   | Send an email through the configured SMTP server to verify the setup.              |
+| `list_emails`       | Return the last 100 emails recorded for an environment. No bodies; recipients masked.|
+
 ### Database integration (self-hosted only)
 
 | Tool                             | Description                                                      |
 | -------------------------------- | --------------------------------------------------------------- |
 | `enable_database_integration`    | Provision a Postgres schema for an environment.                 |
 | `configure_database_integration` | Toggle migrations and env-var injection for a provisioned schema.|
+
+### Authentication (self-hosted only)
+
+| Tool                      | Description                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| `get_auth_config`         | Read the Stormkit Auth configuration of an environment. Secrets are never returned. |
+| `configure_auth`          | Update session, allowed origins and OAuth-server settings. Partial update.          |
+| `configure_auth_provider` | Enable or update a single sign-in provider: `magiclink`, `email`, `google` or `x`. |
+
+## Secrets
+
+Values you send to the MCP server end up in the transcript of whatever agent
+called it, so Stormkit treats every secret it stores as **write-only**: SMTP
+passwords and OAuth client secrets are accepted on write, but these tools never
+echo them back. Reads render a placeholder (`****-****-****-****`) instead, and
+writing that placeholder back leaves the stored value untouched — so an agent
+can round-trip a configuration it is not allowed to see.
+
+Round-tripping stops at the point where it would move the credential. Changing
+`smtpHost` or `username` clears the stored password, so `configure_mailer`
+rejects such a call unless it carries a new one: a password the caller cannot
+read must not follow the configuration to another server or account.
+
+This is a property of these tools, not a containment boundary. An environment
+API key is a powerful credential in its own right: it can repoint `smtpHost` at
+a relay it controls (supplying its own password) and redirect an app's sign-in
+email, and `MAILER_URL` is injected into builds as
+`smtp://user:password@host`, readable from build output. Treat an env-scoped key
+as equivalent to the secrets of that environment, and scope keys accordingly.
+
+Message bodies are withheld for a related reason. The mailer log stores
+magic-link emails verbatim, so a body contains a sign-in link — single-use and
+valid for 15 minutes, but still worth keeping out of a transcript.
+`list_emails` returns sender, subject, timestamp and a masked recipient
+(`j***@example.com`), which is enough to confirm delivery without handing over
+the app's end-user mailing list. Full bodies and addresses remain visible in the
+dashboard, behind a session login.
+
+## Provisioning sign-in end to end
+
+Magic-link sign-in needs three pieces in place. Run them in this order:
+
+1. `enable_database_integration` — Stormkit Auth stores its users in the
+   environment's Postgres schema, and the provider tools refuse to run without
+   one.
+2. `configure_mailer` — magic links are delivered over SMTP. Without a mailer
+   the link is recorded but never sent.
+3. `configure_auth` and `configure_auth_provider` — turn auth on, then enable
+   the `magiclink` provider with a `fromAddress`.
+
+Call `send_test_email` at any point afterwards to confirm delivery works
+without going through a real sign-up.
 
 For the exact input parameters of each tool, call `tools/list` on your instance.

--- a/src/ce/api/app/skauth/skauthhandlers/provider_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/provider_upsert.go
@@ -129,6 +129,12 @@ func providerDataFor(p providerDataForParams) (skauth.ProviderData, error) {
 	case skauth.ProviderEmail, skauth.ProviderMagicLink:
 		fromAddress := strings.TrimSpace(data.FromAddress)
 
+		// An omitted from address keeps the stored one, so a caller that cannot
+		// read it back can still toggle the provider.
+		if fromAddress == "" && p.Existing != nil {
+			fromAddress = p.Existing.Data.FromAddress
+		}
+
 		if data.ProviderName == skauth.ProviderMagicLink && fromAddress == "" {
 			return skauth.ProviderData{}, &ProviderValidationError{Message: "From address is required"}
 		}
@@ -142,6 +148,11 @@ func providerDataFor(p providerDataForParams) (skauth.ProviderData, error) {
 		if p.Existing != nil && p.Existing.Data.ClientSecret != "" {
 			data.ClientSecret = p.Existing.Data.ClientSecret
 		}
+	}
+
+	// An omitted client ID keeps the stored one, for the same reason.
+	if data.ClientID == "" && p.Existing != nil {
+		data.ClientID = p.Existing.Data.ClientID
 	}
 
 	if data.ClientID == "" {

--- a/src/ce/api/public/v1/handler_mcp.go
+++ b/src/ce/api/public/v1/handler_mcp.go
@@ -198,6 +198,20 @@ func mcpDispatch(req *RequestContextMCP, id any, params *toolCallParams) *shttp.
 		}
 
 		resp = mcpConfigureAuth(req, id, params.Arguments)
+	case "get_mailer_config":
+		resp = mcpGetMailerConfig(req, params.Arguments)
+	case "configure_mailer":
+		resp = mcpConfigureMailer(req, id, params.Arguments)
+	case "list_emails":
+		resp = mcpListEmails(req, params.Arguments)
+	case "send_test_email":
+		resp = mcpSendTestEmail(req, id, params.Arguments)
+	case "configure_auth_provider":
+		if !authConfigEnabled() {
+			return jsonRPCError(id, rpcErrMethodUnknown, "unknown tool: "+params.Name)
+		}
+
+		resp = mcpConfigureAuthProvider(req, id, params.Arguments)
 	case "enable_database_integration":
 		if !databaseIntegrationEnabled() {
 			return jsonRPCError(id, rpcErrMethodUnknown, "unknown tool: "+params.Name)

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/smtp"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deployservice"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
@@ -69,6 +71,7 @@ func (s *HandlerMCPSuite) BeforeTest(suiteName, _ string) {
 
 func (s *HandlerMCPSuite) AfterTest(_, _ string) {
 	deployservice.MockDeployer = nil
+	buildconf.SendMailFunc = buildconf.SendMailWithDeadline
 	s.conn.CloseTx()
 }
 
@@ -312,7 +315,12 @@ func (s *HandlerMCPSuite) Test_ToolsList_ReturnsExpectedTools() {
 		"get_trigger_logs",
 		"list_teams",
 		"create_team",
+		"get_mailer_config",
+		"configure_mailer",
+		"list_emails",
+		"send_test_email",
 		"get_auth_config",
+		"configure_auth_provider",
 		"configure_auth",
 		"enable_database_integration",
 		"configure_database_integration",
@@ -343,6 +351,13 @@ func (s *HandlerMCPSuite) Test_ToolsList_HidesDatabaseToolsOnCloud() {
 	// The auth-config tools are gated the same way (self-hosted only).
 	s.NotContains(names, "get_auth_config")
 	s.NotContains(names, "configure_auth")
+	s.NotContains(names, "configure_auth_provider")
+	// The mailer tools are not gated -- mailer configuration ships in every
+	// edition, same as the /v1/mail endpoint.
+	s.Contains(names, "get_mailer_config")
+	s.Contains(names, "configure_mailer")
+	s.Contains(names, "list_emails")
+	s.Contains(names, "send_test_email")
 }
 
 func (s *HandlerMCPSuite) Test_EnableDatabaseIntegration_RejectedOnCloud() {
@@ -1435,4 +1450,542 @@ func (s *HandlerMCPSuite) Test_AuthTools_RejectedOnCloud() {
 
 func TestHandlerMCP(t *testing.T) {
 	suite.Run(t, &HandlerMCPSuite{})
+}
+
+// ---------------------------------------------------------------------------
+// Mailer tools
+// ---------------------------------------------------------------------------
+
+func (s *HandlerMCPSuite) Test_ConfigureMailer_Success() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_mailer", map[string]any{
+		"envId":    mockEnv.ID.String(),
+		"smtpHost": "smtp.gmail.com",
+		"smtpPort": "587",
+		"username": "noreply@acme.com",
+		"password": "super-secret",
+	}))
+
+	env := s.rpcOK(resp)
+	data := s.toolContent(env)
+	conf := data["config"].(map[string]any)
+
+	s.Equal("smtp.gmail.com", conf["host"])
+	s.Equal("587", conf["port"])
+	s.Equal("noreply@acme.com", conf["username"])
+	s.Equal(buildconf.PasswordPlaceholder, conf["password"],
+		"the password must never be echoed back into the agent transcript")
+
+	stored, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(stored.MailerConf)
+	s.Equal("super-secret", stored.MailerConf.Password)
+	s.Equal("smtp.gmail.com", stored.MailerConf.Host)
+}
+
+// Test_ConfigureMailer_IsPatch verifies that omitted fields — the password in
+// particular — keep their stored value. The port is patched rather than the
+// host because repointing the host deliberately drops the stored credential;
+// see Test_ConfigureMailer_HostChangeRequiresPassword.
+func (s *HandlerMCPSuite) Test_ConfigureMailer_IsPatch() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "noreply@acme.com",
+			Password: "original-pwd",
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_mailer", map[string]any{
+		"envId":    mockEnv.ID.String(),
+		"smtpPort": "2525",
+	}))
+
+	s.rpcOK(resp)
+
+	stored, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal("original-pwd", stored.MailerConf.Password, "password must survive a patch that omits it")
+	s.Equal("noreply@acme.com", stored.MailerConf.Username)
+	s.Equal("smtp.gmail.com", stored.MailerConf.Host)
+	s.Equal("2525", stored.MailerConf.Port)
+}
+
+// Test_ConfigureMailer_HostChangeRequiresPassword pins the credential-rebinding
+// guard on the MCP surface: an agent holding an environment key can never
+// repoint the relay while keeping a password it is not allowed to read, so the
+// tool must report the error rather than silently leaving the config untouched.
+func (s *HandlerMCPSuite) Test_ConfigureMailer_HostChangeRequiresPassword() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "noreply@acme.com",
+			Password: "original-pwd",
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_mailer", map[string]any{
+		"envId":    mockEnv.ID.String(),
+		"smtpHost": "smtp.attacker.tld",
+	}))
+
+	env := s.rpcOK(resp)
+	result := env["result"].(map[string]any)
+
+	s.True(result["isError"].(bool), "the agent must see the rejection")
+
+	errs := s.toolContent(env)["errors"].(map[string]any)
+	s.Equal("Password is a required field.", errs["password"])
+
+	stored, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal("smtp.gmail.com", stored.MailerConf.Host, "the relay must not move")
+	s.Equal("original-pwd", stored.MailerConf.Password)
+}
+
+func (s *HandlerMCPSuite) Test_ConfigureMailer_Invalid() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_mailer", map[string]any{
+		"envId":    mockEnv.ID.String(),
+		"username": "noreply@acme.com",
+	}))
+
+	env := s.rpcOK(resp)
+	result := env["result"].(map[string]any)
+	s.True(result["isError"].(bool))
+}
+
+func (s *HandlerMCPSuite) Test_GetMailerConfig_MasksPassword() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "noreply@acme.com",
+			Password: "super-secret",
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "get_mailer_config", map[string]any{
+		"envId": mockEnv.ID.String(),
+	}))
+
+	env := s.rpcOK(resp)
+	conf := s.toolContent(env)["config"].(map[string]any)
+
+	s.Equal("smtp.gmail.com", conf["host"])
+	s.Equal("noreply@acme.com", conf["username"])
+	s.Equal(buildconf.PasswordPlaceholder, conf["password"],
+		"the stored SMTP password must never reach the agent")
+}
+
+func (s *HandlerMCPSuite) Test_GetMailerConfig_Forbidden() {
+	usr := s.MockUser()
+	other := s.MockUser()
+	appl := s.MockApp(other)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "get_mailer_config", map[string]any{
+		"envId": mockEnv.ID.String(),
+	}))
+
+	env := s.rpcOK(resp)
+	result := env["result"].(map[string]any)
+	s.True(result["isError"].(bool))
+}
+
+func (s *HandlerMCPSuite) Test_SendTestEmail_NoMailerConfigured() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "send_test_email", map[string]any{
+		"envId":   mockEnv.ID.String(),
+		"to":      "someone@acme.com",
+		"subject": "Test",
+		"body":    "Hello",
+	}))
+
+	env := s.rpcOK(resp)
+	result := env["result"].(map[string]any)
+
+	s.True(result["isError"].(bool), "sending without a mailer must report an error, not a silent success")
+	s.Contains(result["content"].([]any)[0].(map[string]any)["text"], "configure_mailer")
+}
+
+func (s *HandlerMCPSuite) Test_SendTestEmail_Success() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "noreply@acme.com",
+			Password: "super-secret",
+		},
+	})
+	key := s.userKey(usr)
+
+	sent := struct {
+		addr string
+		from string
+		to   []string
+		msg  []byte
+	}{}
+
+	buildconf.SendMailFunc = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		sent.addr, sent.from, sent.to, sent.msg = addr, from, to, msg
+		return nil
+	}
+
+	resp := s.post(key.Value, mcpToolCall(1, "send_test_email", map[string]any{
+		"envId":   mockEnv.ID.String(),
+		"to":      "someone@acme.com",
+		"from":    "noreply@acme.com",
+		"subject": "Test",
+		"body":    "Hello",
+	}))
+
+	env := s.rpcOK(resp)
+	_, isError := env["result"].(map[string]any)["isError"]
+	s.False(isError)
+
+	s.Equal("smtp.gmail.com:587", sent.addr)
+	s.Equal("noreply@acme.com", sent.from)
+	s.Equal([]string{"someone@acme.com"}, sent.to)
+	s.Contains(string(sent.msg), "Hello")
+}
+
+// ---------------------------------------------------------------------------
+// Auth provider tool
+// ---------------------------------------------------------------------------
+
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_MagicLink() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			Host:              s.conn.Cfg.Host,
+			Port:              s.conn.Cfg.Port,
+			DBName:            s.conn.Cfg.DBName,
+			SchemaName:        s.conn.Cfg.Schema,
+			AppUserName:       s.conn.Cfg.User,
+			AppPassword:       s.conn.Cfg.Password,
+			MigrationPassword: s.conn.Cfg.Password,
+			MigrationUserName: s.conn.Cfg.User,
+			MigrationsEnabled: true,
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderMagicLink,
+		"fromAddress":  "Acme <noreply@acme.com>",
+		"status":       true,
+	}))
+
+	env := s.rpcOK(resp)
+	_, isError := env["result"].(map[string]any)["isError"]
+	s.False(isError)
+
+	provider, err := skauth.NewStore().Provider(context.Background(), mockEnv.ID, skauth.ProviderMagicLink)
+	s.Require().NoError(err)
+	s.Require().NotNil(provider)
+	s.True(provider.Status)
+	s.Equal("Acme <noreply@acme.com>", provider.Data.FromAddress)
+}
+
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_RequiresSchema() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderMagicLink,
+		"fromAddress":  "noreply@acme.com",
+		"status":       true,
+	}))
+
+	env := s.rpcOK(resp)
+	result := env["result"].(map[string]any)
+	s.True(result["isError"].(bool))
+}
+
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_RejectedOnCloud() {
+	config.SetIsStormkitCloud(true)
+	defer config.SetIsStormkitCloud(false)
+
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderMagicLink,
+	}))
+
+	errObj := s.rpcError(resp)
+	s.EqualValues(-32601, errObj["code"])
+}
+
+// Test_ListEmails_OmitsBody keeps live magic-link tokens out of an agent's
+// transcript: the mailer log stores those emails verbatim.
+func (s *HandlerMCPSuite) Test_ListEmails_OmitsBody() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	err := buildconf.MailerStore().InsertEmail(context.Background(), buildconf.Email{
+		EnvID:   mockEnv.ID,
+		To:      "someone@acme.com",
+		From:    "noreply@acme.com",
+		Subject: "Your magic link",
+		Body:    `<a href="https://app.example.com/_stormkit/auth/magic?token=live-token">link</a>`,
+	})
+
+	s.Require().NoError(err)
+
+	resp := s.post(key.Value, mcpToolCall(1, "list_emails", map[string]any{
+		"envId": mockEnv.ID.String(),
+	}))
+
+	env := s.rpcOK(resp)
+	emails := s.toolContent(env)["emails"].([]any)
+
+	s.Require().Len(emails, 1)
+
+	email := emails[0].(map[string]any)
+	s.Equal("Your magic link", email["subject"])
+	s.Equal("s***@acme.com", email["to"], "the recipient's local part must not reach an agent")
+	s.NotContains(email, "body")
+}
+
+// Test_ConfigureAuthProvider_AcceptsHyphenatedName pins the wire string an
+// agent actually sends. The canonical id is "magiclink"; the tool schema and
+// the docs previously advertised "magic-link", which fell through to the OAuth
+// branch and failed with "Client ID is required".
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_AcceptsHyphenatedName() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			Host:              s.conn.Cfg.Host,
+			Port:              s.conn.Cfg.Port,
+			DBName:            s.conn.Cfg.DBName,
+			SchemaName:        s.conn.Cfg.Schema,
+			AppUserName:       s.conn.Cfg.User,
+			AppPassword:       s.conn.Cfg.Password,
+			MigrationPassword: s.conn.Cfg.Password,
+			MigrationUserName: s.conn.Cfg.User,
+			MigrationsEnabled: true,
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": "magic-link",
+		"fromAddress":  "noreply@acme.com",
+		"status":       true,
+	}))
+
+	env := s.rpcOK(resp)
+	_, isError := env["result"].(map[string]any)["isError"]
+	s.False(isError, "the hyphenated spelling must resolve to the magiclink provider")
+
+	provider, err := skauth.NewStore().Provider(context.Background(), mockEnv.ID, skauth.ProviderMagicLink)
+	s.Require().NoError(err)
+	s.Require().NotNil(provider)
+	s.Equal("noreply@acme.com", provider.Data.FromAddress)
+}
+
+// Test_ConfigureAuthProvider_KeepsStatusWhenOmitted covers the patch semantics
+// the tool advertises: rotating a credential must not disable a live provider.
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_KeepsStatusWhenOmitted() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			Host:              s.conn.Cfg.Host,
+			Port:              s.conn.Cfg.Port,
+			DBName:            s.conn.Cfg.DBName,
+			SchemaName:        s.conn.Cfg.Schema,
+			AppUserName:       s.conn.Cfg.User,
+			AppPassword:       s.conn.Cfg.Password,
+			MigrationPassword: s.conn.Cfg.Password,
+			MigrationUserName: s.conn.Cfg.User,
+			MigrationsEnabled: true,
+		},
+	})
+	key := s.userKey(usr)
+
+	enable := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderGoogle,
+		"clientId":     "client-id",
+		"clientSecret": "client-secret",
+		"status":       true,
+	}))
+
+	s.rpcOK(enable)
+
+	// Rotate the client id without mentioning status.
+	rotate := s.post(key.Value, mcpToolCall(2, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderGoogle,
+		"clientId":     "rotated-id",
+	}))
+
+	s.rpcOK(rotate)
+
+	provider, err := skauth.NewStore().Provider(context.Background(), mockEnv.ID, skauth.ProviderGoogle)
+	s.Require().NoError(err)
+	s.Require().NotNil(provider)
+	s.True(provider.Status, "omitting status must not disable a live provider")
+	s.Equal("rotated-id", provider.Data.ClientID)
+	s.Equal("client-secret", provider.Data.ClientSecret, "omitted secret must be retained")
+}
+
+// Test_ConfigureAuthProvider_KeepsFromAddressWhenOmitted covers the same patch
+// semantics for the from address: nothing on the MCP surface can read it back,
+// so requiring it on every write would make a live magiclink provider
+// impossible to disable.
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_KeepsFromAddressWhenOmitted() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			Host:              s.conn.Cfg.Host,
+			Port:              s.conn.Cfg.Port,
+			DBName:            s.conn.Cfg.DBName,
+			SchemaName:        s.conn.Cfg.Schema,
+			AppUserName:       s.conn.Cfg.User,
+			AppPassword:       s.conn.Cfg.Password,
+			MigrationPassword: s.conn.Cfg.Password,
+			MigrationUserName: s.conn.Cfg.User,
+			MigrationsEnabled: true,
+		},
+	})
+	key := s.userKey(usr)
+
+	enable := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderMagicLink,
+		"fromAddress":  "Acme <noreply@acme.com>",
+		"status":       true,
+	}))
+
+	s.rpcOK(enable)
+
+	disable := s.post(key.Value, mcpToolCall(2, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderMagicLink,
+		"status":       false,
+	}))
+
+	env := s.rpcOK(disable)
+	_, isError := env["result"].(map[string]any)["isError"]
+	s.False(isError, "a live magiclink provider must be disableable without resending the address")
+
+	provider, err := skauth.NewStore().Provider(context.Background(), mockEnv.ID, skauth.ProviderMagicLink)
+	s.Require().NoError(err)
+	s.Require().NotNil(provider)
+	s.False(provider.Status)
+	s.Equal("Acme <noreply@acme.com>", provider.Data.FromAddress, "omitted from address must be retained")
+}
+
+// Test_ConfigureAuthProvider_CoercesQuotedStatus pins the fail-open direction
+// of a mistyped argument: a quoted boolean must still disable the provider,
+// because an ignored status silently keeps a live sign-in method enabled.
+func (s *HandlerMCPSuite) Test_ConfigureAuthProvider_CoercesQuotedStatus() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"SchemaConf": &buildconf.SchemaConf{
+			Host:              s.conn.Cfg.Host,
+			Port:              s.conn.Cfg.Port,
+			DBName:            s.conn.Cfg.DBName,
+			SchemaName:        s.conn.Cfg.Schema,
+			AppUserName:       s.conn.Cfg.User,
+			AppPassword:       s.conn.Cfg.Password,
+			MigrationPassword: s.conn.Cfg.Password,
+			MigrationUserName: s.conn.Cfg.User,
+			MigrationsEnabled: true,
+		},
+	})
+	key := s.userKey(usr)
+
+	enable := s.post(key.Value, mcpToolCall(1, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderEmail,
+		"status":       true,
+	}))
+
+	s.rpcOK(enable)
+
+	disable := s.post(key.Value, mcpToolCall(2, "configure_auth_provider", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"providerName": skauth.ProviderEmail,
+		"status":       "false",
+	}))
+
+	s.rpcOK(disable)
+
+	provider, err := skauth.NewStore().Provider(context.Background(), mockEnv.ID, skauth.ProviderEmail)
+	s.Require().NoError(err)
+	s.Require().NotNil(provider)
+	s.False(provider.Status, "a quoted boolean must not be dropped into keep-existing")
+}
+
+// Test_ConfigureMailer_CoercesNumericPort covers the same coercion for a
+// patch-style string field: a bare JSON number must not be dropped, or the tool
+// answers 200 with the port it failed to change.
+func (s *HandlerMCPSuite) Test_ConfigureMailer_CoercesNumericPort() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"MailerConf": &buildconf.MailerConf{
+			Host:     "smtp.gmail.com",
+			Port:     "587",
+			Username: "noreply@acme.com",
+			Password: "original-pwd",
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "configure_mailer", map[string]any{
+		"envId":    mockEnv.ID.String(),
+		"smtpPort": 2525,
+	}))
+
+	s.rpcOK(resp)
+
+	stored, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal("2525", stored.MailerConf.Port, "a numeric port must not be silently ignored")
 }

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/mailerhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/redirects"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
@@ -505,6 +507,62 @@ func mcpAllTools() []mcpToolDef {
 				"additionalProperties": false,
 			},
 		},
+		{
+			Name:        "get_mailer_config",
+			Description: "Return the SMTP configuration for an environment (host, port, username). The password is never returned; a placeholder marks that one is stored.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"envId": map[string]any{"type": "string", "description": "Environment ID to read the mailer configuration for."},
+				},
+				"required":             []string{"envId"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "configure_mailer",
+			Description: "Set the SMTP configuration used to send transactional email for an environment, including Stormkit Auth magic links. Only the fields you provide are changed; omitted fields keep their current value. Changing smtpHost or username clears the stored password, so such a call must carry a new one - the placeholder a read returns is not accepted. Host, username and password must all be set before email can be sent. The password is write-only and is never returned.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"envId":    map[string]any{"type": "string", "description": "Environment ID."},
+					"smtpHost": map[string]any{"type": "string", "description": "SMTP server hostname (e.g. smtp.gmail.com)."},
+					"smtpPort": map[string]any{"type": "string", "description": "SMTP server port. Defaults to 587 when empty."},
+					"username": map[string]any{"type": "string", "description": "SMTP username, usually the sending email address."},
+					"password": map[string]any{"type": "string", "description": "SMTP password. Write-only: omit it to keep the stored password, except when changing smtpHost or username, which requires a new one."},
+				},
+				"required":             []string{"envId"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "list_emails",
+			Description: "Return the last 100 emails recorded for an environment, newest first. Message bodies are never included and recipient addresses are masked (j***@example.com): the log stores magic-link emails verbatim and the full recipient list is the app's end-user mailing list. Use it to confirm an email was actually sent.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"envId": map[string]any{"type": "string", "description": "Environment ID to read the mailer log for."},
+				},
+				"required":             []string{"envId"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "send_test_email",
+			Description: "Send an email through the environment's configured SMTP server. Use it to verify a mailer configuration without going through a real sign-up. Fails when no mailer is configured for the environment.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"envId":   map[string]any{"type": "string", "description": "Environment ID to send the email from."},
+					"to":      map[string]any{"type": "string", "description": "Recipient address. Separate multiple recipients with a semicolon."},
+					"from":    map[string]any{"type": "string", "description": "Sender address. Defaults to the SMTP username when empty."},
+					"subject": map[string]any{"type": "string", "description": "Email subject."},
+					"body":    map[string]any{"type": "string", "description": "Email body. Rendered as HTML."},
+				},
+				"required":             []string{"envId", "to", "subject", "body"},
+				"additionalProperties": false,
+			},
+		},
 	}
 
 	if authConfigEnabled() {
@@ -518,6 +576,23 @@ func mcpAllTools() []mcpToolDef {
 						"envId": map[string]any{"type": "string", "description": "Environment ID to read the auth configuration for."},
 					},
 					"required":             []string{"envId"},
+					"additionalProperties": false,
+				},
+			},
+			mcpToolDef{
+				Name:        "configure_auth_provider",
+				Description: "Enable or update a single Stormkit Auth sign-in provider for an environment. Self-hosted only. Requires the database integration to be enabled first. Supported providers are magiclink, email, google and x. Use magiclink or email for email sign-in (magiclink needs fromAddress and a configured mailer); google and x need clientId and clientSecret. Client secrets are write-only and are never returned.",
+				InputSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"envId":        map[string]any{"type": "string", "description": "Environment ID."},
+						"providerName": map[string]any{"type": "string", "description": "Provider to configure.", "enum": []string{"magiclink", "email", "google", "x"}},
+						"status":       map[string]any{"type": "boolean", "description": "Whether the provider is enabled. Omit to keep the current value; a provider created for the first time defaults to enabled."},
+						"fromAddress":  map[string]any{"type": "string", "description": "Sender address for magic-link emails. Required for the magiclink provider. Omit it to keep the stored address."},
+						"clientId":     map[string]any{"type": "string", "description": "OAuth client ID. Required for OAuth providers. Omit it to keep the stored ID."},
+						"clientSecret": map[string]any{"type": "string", "description": "OAuth client secret. Write-only: omit it to keep the stored secret."},
+					},
+					"required":             []string{"envId", "providerName"},
 					"additionalProperties": false,
 				},
 			},
@@ -610,21 +685,52 @@ func intArg(args map[string]any, key string) int {
 
 // stringPtrArg returns a pointer to the string value at key, or nil when the
 // key is absent. Used by patch-style tools that must distinguish "leave
-// unchanged" (absent) from "set to empty" (present, "").
+// unchanged" (absent) from "set to empty" (present, ""). A model that sends a
+// bare number or boolean for a string field still means to set it, so those are
+// converted rather than dropped - silently ignoring them would report a
+// successful patch that changed nothing.
 func stringPtrArg(args map[string]any, key string) *string {
-	if v, ok := args[key].(string); ok {
-		return &v
+	var s string
+
+	switch v := args[key].(type) {
+	case string:
+		s = v
+	case float64:
+		s = strconv.FormatFloat(v, 'f', -1, 64)
+	case int:
+		s = strconv.Itoa(v)
+	case bool:
+		s = strconv.FormatBool(v)
+	default:
+		return nil
 	}
 
-	return nil
+	return &s
 }
 
+// boolPtrArg mirrors stringPtrArg for boolean fields. A quoted "true"/"false"
+// is accepted for the same reason, and matters more here: dropping it makes
+// resolveStatus keep the stored value, so a request to disable a provider would
+// answer ok while leaving it enabled.
 func boolPtrArg(args map[string]any, key string) *bool {
-	if v, ok := args[key].(bool); ok {
-		return &v
+	var b bool
+
+	switch v := args[key].(type) {
+	case bool:
+		b = v
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
+
+		if err != nil {
+			return nil
+		}
+
+		b = parsed
+	default:
+		return nil
 	}
 
-	return nil
+	return &b
 }
 
 func intPtrArg(args map[string]any, key string) *int {
@@ -1393,4 +1499,93 @@ func mcpConfigureAuth(req *RequestContextMCP, id any, args map[string]any) *shtt
 	}
 
 	return handlerAuthConfigSet(req.RequestContext)
+}
+
+func mcpGetMailerConfig(req *RequestContextMCP, args map[string]any) *shttp.Response {
+	if resp := req.withEnv(args); resp != nil {
+		return resp
+	}
+
+	return handlerMailerConfigGet(req.RequestContext)
+}
+
+func mcpConfigureMailer(req *RequestContextMCP, id any, args map[string]any) *shttp.Response {
+	if resp := req.withEnv(args); resp != nil {
+		return resp
+	}
+
+	// Build a patch from only the keys the caller supplied so unspecified
+	// settings keep their stored value (see ConfigUpdateRequest).
+	body := mailerhandlers.ConfigUpdateRequest{
+		SMTPHost: stringPtrArg(args, "smtpHost"),
+		SMTPPort: stringPtrArg(args, "smtpPort"),
+		Username: stringPtrArg(args, "username"),
+		Password: stringPtrArg(args, "password"),
+	}
+
+	if resp := req.setBody(id, body); resp != nil {
+		return resp
+	}
+
+	return handlerMailerConfigSet(req.RequestContext)
+}
+
+func mcpSendTestEmail(req *RequestContextMCP, id any, args map[string]any) *shttp.Response {
+	if resp := req.withEnv(args); resp != nil {
+		return resp
+	}
+
+	body := mailerhandlers.RequestData{
+		To:      stringArg(args, "to"),
+		From:    stringArg(args, "from"),
+		Subject: stringArg(args, "subject"),
+		Body:    stringArg(args, "body"),
+	}
+
+	if resp := req.setBody(id, body); resp != nil {
+		return resp
+	}
+
+	resp := handlerMailSend(req.RequestContext)
+
+	// The send succeeds and records the email even with no SMTP server
+	// configured. Verifying delivery is the whole point of this tool, so
+	// surface that as an error rather than a false positive.
+	if data, ok := resp.Data.(map[string]any); ok {
+		if delivered, found := data["delivered"].(bool); found && !delivered {
+			return shttp.BadRequest(map[string]any{
+				"errors": []string{"no mailer is configured for this environment; call configure_mailer first"},
+			})
+		}
+	}
+
+	return resp
+}
+
+func mcpConfigureAuthProvider(req *RequestContextMCP, id any, args map[string]any) *shttp.Response {
+	if resp := req.withEnv(args); resp != nil {
+		return resp
+	}
+
+	body := skauthhandlers.AuthUpsertRequest{
+		ProviderName: stringArg(args, "providerName"),
+		ClientID:     stringArg(args, "clientId"),
+		ClientSecret: stringArg(args, "clientSecret"),
+		FromAddress:  stringArg(args, "fromAddress"),
+		Status:       boolPtrArg(args, "status"),
+	}
+
+	if resp := req.setBody(id, body); resp != nil {
+		return resp
+	}
+
+	return handlerAuthProviderSet(req.RequestContext)
+}
+
+func mcpListEmails(req *RequestContextMCP, args map[string]any) *shttp.Response {
+	if resp := req.withEnv(args); resp != nil {
+		return resp
+	}
+
+	return handlerMailerEmailsGet(req.RequestContext)
 }


### PR DESCRIPTION
4 of 5 in a stack splitting #447. Based on #450. Closes #445.

Thin layer over the endpoints added in #450 — the MCP surface itself is only four files.

## Why

The MCP server could take an app most of the way from nothing to running — create it, configure the environment, attach domains, enable Stormkit Auth — then stopped at email. Magic-link sign-in needs an SMTP configuration and an enabled provider, and neither had a tool, so setup handed back to a human for a handful of fields and could not be reproduced across environments.

Adds five tools:

| Tool | Gating |
| --- | --- |
| `get_mailer_config`, `configure_mailer`, `send_test_email`, `list_emails` | ungated, matching how the mailer ships in every edition |
| `configure_auth_provider` | self-hosted, same gate as `configure_auth` |

`send_test_email` reports an error when the environment has no mailer, rather than the recorded-but-not-sent success the REST endpoint returns — verifying delivery is the entire point of the tool. It derives that from the `delivered` flag rather than duplicating the check.

## On the issue's premise

Two corrections came out of building this, both worth knowing:

The 404 described in #445 was **not** the missing mailer. `GET /_stormkit/auth/magic` 404s when `AuthConf` is nil, auth is disabled, or `env.SchemaConf == nil` — the missing DB schema is the likely cause. With no mailer the request succeeds and records the email without sending, which is deliberate and left alone.

Mailer tools alone would not have unblocked sign-in, which is why `configure_auth_provider` is in the stack: `configure_auth` explicitly does not manage providers, and the provider upsert was dashboard-only.

Also, `tlsMode` and `fromAddress` from the issue's suggested surface are not implemented, because neither exists: `MailerConf.Send` is always `smtp.SendMail` + `PlainAuth`, and the from address lives on the auth provider, not the mailer.

## Secrets

Write-only across the surface: passwords and client secrets are accepted on write, never returned, and writing back the placeholder a read produced leaves the stored value untouched.

The docs state the limits of that guarantee rather than overselling it — an environment API key can repoint `smtpHost` and read `MAILER_URL` out of a build, so it should be treated as equivalent to the secrets of its environment.