### PR TITLE
fix: merge env vars in mcp update_environment

### DIFF
--- a/docs/api/10-mcp.md
+++ b/docs/api/10-mcp.md
@@ -101,7 +101,7 @@ All tools return JSON. Errors are reported as MCP `isError` content while the tr
 | `create_app`         | Connect a git repository as a new Stormkit app.                  |
 | `list_apps`          | List apps the API key can access.                                |
 | `create_environment` | Create an environment for an app.                                |
-| `update_environment` | Update an environment's build config. `envVars` merges into the existing variables — pass `replaceEnvVars` to overwrite the whole set, `unsetEnvVars` to remove keys. Returns the resulting variable names. |
+| `update_environment` | Update an environment's build config. `envVars` merges into the existing variables — keys not passed keep their value, a key set to an empty string is removed. Returns the resulting variable names. |
 | `list_environments`  | List environments for an app (env-var values masked).            |
 
 ### Domains

--- a/docs/api/10-mcp.md
+++ b/docs/api/10-mcp.md
@@ -101,7 +101,7 @@ All tools return JSON. Errors are reported as MCP `isError` content while the tr
 | `create_app`         | Connect a git repository as a new Stormkit app.                  |
 | `list_apps`          | List apps the API key can access.                                |
 | `create_environment` | Create an environment for an app.                                |
-| `update_environment` | Update an environment's build config.                            |
+| `update_environment` | Update an environment's build config. `envVars` merges into the existing variables — pass `replaceEnvVars` to overwrite the whole set, `unsetEnvVars` to remove keys. Returns the resulting variable names. |
 | `list_environments`  | List environments for an app (env-var values masked).            |
 
 ### Domains

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -37,7 +37,7 @@ type EnvUpdateRequest struct {
 	ServerCmd          *string                 `json:"serverCmd,omitempty"`
 	StatusChecks       []buildconf.StatusCheck `json:"statusChecks,omitempty"`
 	PriorityPattern    *string                 `json:"priorityPattern,omitempty"`
-	EnvVars            map[string]string       `json:"envVars,omitempty"`
+	EnvVars            *map[string]string      `json:"envVars,omitempty"`
 	CacheDirs          *[]string               `json:"cacheDirs,omitempty"`
 }
 
@@ -164,7 +164,7 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 	}
 
 	if data.EnvVars != nil {
-		env.Data.Vars = data.EnvVars
+		env.Data.Vars = *data.EnvVars
 	}
 
 	if data.CacheDirs != nil {

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -935,7 +935,7 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_WithEnvVars() {
 
 // Test_UpdateEnvironment_EnvVars_Merge verifies that envVars merges into the
 // existing set. Values cannot be read back, so a caller cannot reconstruct the
-// keys a replace would drop.
+// keys a wholesale replace would drop.
 func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Merge() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
@@ -955,16 +955,36 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Merge() {
 	s.Equal(map[string]string{"NODE_ENV": "production", "API_KEY": "secret"}, updated.Data.Vars)
 }
 
-func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Replace() {
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Overwrite() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
 	mockEnv := s.MockEnv(appl)
 	key := s.userKey(usr)
 
 	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
-		"envId":          mockEnv.ID.String(),
-		"envVars":        map[string]any{"API_KEY": "secret"},
-		"replaceEnvVars": true,
+		"envId":   mockEnv.ID.String(),
+		"envVars": map[string]any{"NODE_ENV": "staging"},
+	}))
+
+	data := s.toolContent(s.rpcOK(resp))
+	s.Equal([]any{"NODE_ENV"}, data["envVars"])
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"NODE_ENV": "staging"}, updated.Data.Vars)
+}
+
+// Test_UpdateEnvironment_EnvVars_EmptyValueUnsets verifies that an empty value
+// removes the key, the only way to drop a variable through the tool.
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_EmptyValueUnsets() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":   mockEnv.ID.String(),
+		"envVars": map[string]any{"API_KEY": "secret", "NODE_ENV": ""},
 	}))
 
 	data := s.toolContent(s.rpcOK(resp))
@@ -975,36 +995,15 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Replace() {
 	s.Equal(map[string]string{"API_KEY": "secret"}, updated.Data.Vars)
 }
 
-func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Unset() {
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_UnsetLastKey() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
 	mockEnv := s.MockEnv(appl)
 	key := s.userKey(usr)
 
 	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
-		"envId":        mockEnv.ID.String(),
-		"envVars":      map[string]any{"API_KEY": "secret"},
-		"unsetEnvVars": []any{"NODE_ENV"},
-	}))
-
-	data := s.toolContent(s.rpcOK(resp))
-	s.Equal([]any{"API_KEY"}, data["envVars"])
-
-	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
-	s.Require().NoError(err)
-	s.Equal(map[string]string{"API_KEY": "secret"}, updated.Data.Vars)
-}
-
-func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_ClearAll() {
-	usr := s.MockUser()
-	appl := s.MockApp(usr)
-	mockEnv := s.MockEnv(appl)
-	key := s.userKey(usr)
-
-	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
-		"envId":          mockEnv.ID.String(),
-		"envVars":        map[string]any{},
-		"replaceEnvVars": true,
+		"envId":   mockEnv.ID.String(),
+		"envVars": map[string]any{"NODE_ENV": ""},
 	}))
 
 	data := s.toolContent(s.rpcOK(resp))
@@ -1013,25 +1012,6 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_ClearAll() {
 	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
 	s.Require().NoError(err)
 	s.Empty(updated.Data.Vars)
-}
-
-func (s *HandlerMCPSuite) Test_UpdateEnvironment_ReplaceEnvVars_RequiresEnvVars() {
-	usr := s.MockUser()
-	appl := s.MockApp(usr)
-	mockEnv := s.MockEnv(appl)
-	key := s.userKey(usr)
-
-	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
-		"envId":          mockEnv.ID.String(),
-		"replaceEnvVars": true,
-	}))
-
-	result := s.rpcOK(resp)["result"].(map[string]any)
-	s.True(result["isError"].(bool))
-
-	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
-	s.Require().NoError(err)
-	s.Equal(map[string]string{"NODE_ENV": "production"}, updated.Data.Vars)
 }
 
 func (s *HandlerMCPSuite) Test_UpdateEnvironment_WithoutEnvVars_LeavesVarsUntouched() {

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -933,6 +933,125 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_WithEnvVars() {
 	s.True(ok)
 }
 
+// Test_UpdateEnvironment_EnvVars_Merge verifies that envVars merges into the
+// existing set. Values cannot be read back, so a caller cannot reconstruct the
+// keys a replace would drop.
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Merge() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":   mockEnv.ID.String(),
+		"envVars": map[string]any{"API_KEY": "secret"},
+	}))
+
+	data := s.toolContent(s.rpcOK(resp))
+	s.Equal([]any{"API_KEY", "NODE_ENV"}, data["envVars"])
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"NODE_ENV": "production", "API_KEY": "secret"}, updated.Data.Vars)
+}
+
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Replace() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":          mockEnv.ID.String(),
+		"envVars":        map[string]any{"API_KEY": "secret"},
+		"replaceEnvVars": true,
+	}))
+
+	data := s.toolContent(s.rpcOK(resp))
+	s.Equal([]any{"API_KEY"}, data["envVars"])
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"API_KEY": "secret"}, updated.Data.Vars)
+}
+
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_Unset() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":        mockEnv.ID.String(),
+		"envVars":      map[string]any{"API_KEY": "secret"},
+		"unsetEnvVars": []any{"NODE_ENV"},
+	}))
+
+	data := s.toolContent(s.rpcOK(resp))
+	s.Equal([]any{"API_KEY"}, data["envVars"])
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"API_KEY": "secret"}, updated.Data.Vars)
+}
+
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_EnvVars_ClearAll() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":          mockEnv.ID.String(),
+		"envVars":        map[string]any{},
+		"replaceEnvVars": true,
+	}))
+
+	data := s.toolContent(s.rpcOK(resp))
+	s.Empty(data["envVars"])
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Empty(updated.Data.Vars)
+}
+
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_ReplaceEnvVars_RequiresEnvVars() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":          mockEnv.ID.String(),
+		"replaceEnvVars": true,
+	}))
+
+	result := s.rpcOK(resp)["result"].(map[string]any)
+	s.True(result["isError"].(bool))
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"NODE_ENV": "production"}, updated.Data.Vars)
+}
+
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_WithoutEnvVars_LeavesVarsUntouched() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":  mockEnv.ID.String(),
+		"branch": "develop",
+	}))
+
+	s.rpcOK(resp)
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+	s.Require().NoError(err)
+	s.Equal(map[string]string{"NODE_ENV": "production"}, updated.Data.Vars)
+}
+
 // Test_UpdateEnvironment_PartialUpdate_BooleanFieldsNotZeroed verifies that updating
 // a single non-boolean field (e.g. branch) does not zero out pre-existing boolean
 // fields (e.g. AutoDeploy) that were not included in the update payload.

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -314,9 +314,7 @@ func mcpAllTools() []mcpToolDef {
 					"redirectsFile":      map[string]any{"type": "string", "description": "Path to a redirects file (relative to repo root)."},
 					"previewLinks":       map[string]any{"type": "boolean", "description": "Generate preview links for each deployment."},
 					"priorityPattern":    map[string]any{"type": "string", "description": "Regex matched against the commit message of auto-deploys; matching deployments are automatically routed to the priority queue. Leave empty to disable."},
-					"envVars":            map[string]any{"type": "object", "description": "Environment variables to set or update. Merged into the existing set: keys not listed here keep their current value. Pass replaceEnvVars to overwrite the whole set instead.", "additionalProperties": map[string]any{"type": "string"}},
-					"replaceEnvVars":     map[string]any{"type": "boolean", "description": "Replace the entire variable set with envVars instead of merging, dropping every key not listed. Values cannot be read back through the API, so anything dropped is unrecoverable. Requires envVars."},
-					"unsetEnvVars":       map[string]any{"type": "array", "description": "Environment variable names to remove.", "items": map[string]any{"type": "string"}},
+					"envVars":            map[string]any{"type": "object", "description": "Environment variables to set or update. Merged into the existing set: keys not listed here keep their current value, and a key set to an empty string is removed.", "additionalProperties": map[string]any{"type": "string"}},
 					"redirects": map[string]any{
 						"type":        "array",
 						"description": "Redirect / rewrite rules.",
@@ -1071,13 +1069,7 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	setBool("autoPublish", &update.AutoPublish)
 	setBool("previewLinks", &update.PreviewLinks)
 
-	vars, resp := mergeEnvVarsArg(req.Env.Data.Vars, args)
-
-	if resp != nil {
-		return resp
-	}
-
-	update.EnvVars = vars
+	update.EnvVars = mergeEnvVarsArg(req.Env.Data.Vars, args)
 
 	if r := parseRedirectsArg(args); r != nil {
 		update.Redirects = &r
@@ -1097,53 +1089,42 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 		return resp
 	}
 
-	// Report the resulting key set: values cannot be read back, so this is the
-	// caller's only way to see which variables the environment ends up with.
+	// Report the resulting key set so a caller sees straight away which
+	// variables the environment ended up with.
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Data:   map[string]any{"ok": true, "envVars": sortedKeys(req.Env.Data.Vars)},
 	}
 }
 
-// mergeEnvVarsArg resolves the env-var arguments of update_environment into the
-// final variable set, or nil when the caller did not touch them. Values are
-// masked everywhere they are read back, so a caller cannot reconstruct what a
-// replace would destroy: the default is a merge, and dropping keys has to be
-// asked for explicitly through unsetEnvVars or replaceEnvVars.
-func mergeEnvVarsArg(current map[string]string, args map[string]any) (*map[string]string, *shttp.Response) {
+// mergeEnvVarsArg merges the envVars argument of update_environment into the
+// environment's current variables, or returns nil when the caller did not pass
+// any. Values are masked everywhere they are read back, so a caller cannot
+// reconstruct what a wholesale replace would destroy — keys not listed keep
+// their value, and an empty value removes the key.
+func mergeEnvVarsArg(current map[string]string, args map[string]any) *map[string]string {
 	given := stringMapArg(args, "envVars")
-	unset, hasUnset := stringArrayArg(args, "unsetEnvVars")
-	replace := boolArg(args, "replaceEnvVars")
 
 	if given == nil {
-		if replace {
-			return nil, shttp.BadRequest(map[string]any{
-				"errors": []string{"replaceEnvVars requires envVars; pass an empty object to clear every variable"},
-			})
-		}
-
-		if !hasUnset {
-			return nil, nil
-		}
+		return nil
 	}
 
 	out := make(map[string]string, len(current)+len(given))
 
-	if !replace {
-		for k, v := range current {
-			out[k] = v
-		}
-	}
-
-	for k, v := range given {
+	for k, v := range current {
 		out[k] = v
 	}
 
-	for _, k := range unset {
-		delete(out, k)
+	for k, v := range given {
+		if v == "" {
+			delete(out, k)
+			continue
+		}
+
+		out[k] = v
 	}
 
-	return &out, nil
+	return &out
 }
 
 func sortedKeys(m map[string]string) []string {

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -3,6 +3,7 @@ package publicapiv1
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
@@ -313,7 +314,9 @@ func mcpAllTools() []mcpToolDef {
 					"redirectsFile":      map[string]any{"type": "string", "description": "Path to a redirects file (relative to repo root)."},
 					"previewLinks":       map[string]any{"type": "boolean", "description": "Generate preview links for each deployment."},
 					"priorityPattern":    map[string]any{"type": "string", "description": "Regex matched against the commit message of auto-deploys; matching deployments are automatically routed to the priority queue. Leave empty to disable."},
-					"envVars":            map[string]any{"type": "object", "description": "Environment variables to set or update.", "additionalProperties": map[string]any{"type": "string"}},
+					"envVars":            map[string]any{"type": "object", "description": "Environment variables to set or update. Merged into the existing set: keys not listed here keep their current value. Pass replaceEnvVars to overwrite the whole set instead.", "additionalProperties": map[string]any{"type": "string"}},
+					"replaceEnvVars":     map[string]any{"type": "boolean", "description": "Replace the entire variable set with envVars instead of merging, dropping every key not listed. Values cannot be read back through the API, so anything dropped is unrecoverable. Requires envVars."},
+					"unsetEnvVars":       map[string]any{"type": "array", "description": "Environment variable names to remove.", "items": map[string]any{"type": "string"}},
 					"redirects": map[string]any{
 						"type":        "array",
 						"description": "Redirect / rewrite rules.",
@@ -1068,9 +1071,13 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	setBool("autoPublish", &update.AutoPublish)
 	setBool("previewLinks", &update.PreviewLinks)
 
-	if m := stringMapArg(args, "envVars"); m != nil {
-		update.EnvVars = m
+	vars, resp := mergeEnvVarsArg(req.Env.Data.Vars, args)
+
+	if resp != nil {
+		return resp
 	}
+
+	update.EnvVars = vars
 
 	if r := parseRedirectsArg(args); r != nil {
 		update.Redirects = &r
@@ -1082,13 +1089,73 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 		update.CacheDirs = &dirs
 	}
 
-	resp := req.setBody(id, update)
-
-	if resp != nil {
+	if resp := req.setBody(id, update); resp != nil {
 		return resp
 	}
 
-	return handlerEnvUpdate(req.RequestContext)
+	if resp := handlerEnvUpdate(req.RequestContext); resp.Status >= 400 {
+		return resp
+	}
+
+	// Report the resulting key set: values cannot be read back, so this is the
+	// caller's only way to see which variables the environment ends up with.
+	return &shttp.Response{
+		Status: http.StatusOK,
+		Data:   map[string]any{"ok": true, "envVars": sortedKeys(req.Env.Data.Vars)},
+	}
+}
+
+// mergeEnvVarsArg resolves the env-var arguments of update_environment into the
+// final variable set, or nil when the caller did not touch them. Values are
+// masked everywhere they are read back, so a caller cannot reconstruct what a
+// replace would destroy: the default is a merge, and dropping keys has to be
+// asked for explicitly through unsetEnvVars or replaceEnvVars.
+func mergeEnvVarsArg(current map[string]string, args map[string]any) (*map[string]string, *shttp.Response) {
+	given := stringMapArg(args, "envVars")
+	unset, hasUnset := stringArrayArg(args, "unsetEnvVars")
+	replace := boolArg(args, "replaceEnvVars")
+
+	if given == nil {
+		if replace {
+			return nil, shttp.BadRequest(map[string]any{
+				"errors": []string{"replaceEnvVars requires envVars; pass an empty object to clear every variable"},
+			})
+		}
+
+		if !hasUnset {
+			return nil, nil
+		}
+	}
+
+	out := make(map[string]string, len(current)+len(given))
+
+	if !replace {
+		for k, v := range current {
+			out[k] = v
+		}
+	}
+
+	for k, v := range given {
+		out[k] = v
+	}
+
+	for _, k := range unset {
+		delete(out, k)
+	}
+
+	return &out, nil
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
 }
 
 func mcpListDomains(req *RequestContextMCP, args map[string]any) *shttp.Response {


### PR DESCRIPTION
Closes #452.

`update_environment` described `envVars` as *"Environment variables to set or update"* but replaced the whole map — every key not passed was silently dropped. Env-var values are masked everywhere they can be read back, so a caller cannot read-modify-write around it: what gets dropped is unrecoverable.

## Changes

- `envVars` now **merges** into the environment's current variables. Keys not listed keep their value.
- A key given an **empty value is removed**, which is the only way to drop a variable through the tool.
- The tool returns the resulting key set (`{"ok": true, "envVars": [...]}`), so a caller sees immediately which variables the environment ended up with.
- Tool description updated to state the semantics, plus the MCP docs page.

The REST endpoint keeps replace semantics — the UI submits the full set and can reveal values through the admin-gated pull endpoint. `EnvUpdateRequest.EnvVars` became a `*map[string]string` so the MCP layer can send a merged set that ends up empty (a plain map with `omitempty` was dropped from the payload).

Known trade-off: a deliberately blank value (`KEY=""`) is not expressible over MCP, since blank means "remove". Setting one stays a REST/UI operation.

## Tests

Five cases in `HandlerMCPSuite` cover merge, overwrite, unset via empty value, unsetting the last key, and an update that omits `envVars` entirely. `TestHandlerMCP` and `TestHandlerEnvUpdate` pass.