### PR TITLE
refactor: use shttperr for validation errors

### DIFF
--- a/src/ce/api/app/buildconf/mailerhandlers/send.go
+++ b/src/ce/api/app/buildconf/mailerhandlers/send.go
@@ -5,16 +5,9 @@ import (
 	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttperr"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
-
-// SendValidationError is a user-facing validation failure on an outgoing
-// email. Handlers surface Message in the 400 response body.
-type SendValidationError struct {
-	Message string
-}
-
-func (e *SendValidationError) Error() string { return e.Message }
 
 // SendAndRecordParams carries the environment to send from and the message.
 type SendAndRecordParams struct {
@@ -30,16 +23,19 @@ type SendAndRecordParams struct {
 // is deliberate — it lets an app use the mailer log before an SMTP server is
 // configured — so callers that need to know delivery happened must consult the
 // returned flag rather than a nil error.
+//
+// On validation failure it returns a *shttperr.ValidationError, which
+// shttp.Error renders as a 400 with the field errors.
 func SendAndRecord(ctx context.Context, p SendAndRecordParams) (delivered bool, err error) {
 	env := p.Env
 	data := p.Data
 
 	if strings.TrimSpace(data.Body) == "" {
-		return false, &SendValidationError{Message: "Email body is a required field."}
+		return false, &shttperr.ValidationError{Errors: map[string]string{"body": "Email body is a required field."}}
 	}
 
 	if strings.TrimSpace(data.Subject) == "" {
-		return false, &SendValidationError{Message: "Subject is a required field."}
+		return false, &shttperr.ValidationError{Errors: map[string]string{"subject": "Subject is a required field."}}
 	}
 
 	from := data.From

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert.go
@@ -1,8 +1,6 @@
 package skauthhandlers
 
 import (
-	"errors"
-
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -37,13 +35,9 @@ func handlerAuthUpsert(req *app.RequestContext) *shttp.Response {
 		Data:  data,
 	})
 
+	// UpsertProvider reports a validation failure as a *shttperr.ValidationError,
+	// which shttp.Error renders as a 400 with the field errors.
 	if err != nil {
-		var verr *ProviderValidationError
-
-		if errors.As(err, &verr) {
-			return shttp.BadRequest(map[string]any{"error": verr.Message})
-		}
-
 		return shttp.Error(err)
 	}
 

--- a/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
+++ b/src/ce/api/app/skauth/skauthhandlers/handler_auth_upsert_test.go
@@ -143,51 +143,67 @@ func (s *HandlerAuthUpsertSuite) Test_Update() {
 }
 
 func (s *HandlerAuthUpsertSuite) Test_InvalidRequests() {
-	type payload = map[string]any
-
 	envWithoutSchema := s.MockEnv(s.app, map[string]any{
 		"Name": "env_without_schema",
 	})
 
-	payloads := map[string]payload{
-		"Schema configuration is not set for this environment. Please configure it first.": {
-			"envId": envWithoutSchema.ID,
+	cases := []struct {
+		field   string
+		message string
+		payload map[string]any
+	}{
+		{
+			field:   "schema",
+			message: "Schema configuration is not set for this environment. Please configure it first.",
+			payload: map[string]any{
+				"envId": envWithoutSchema.ID,
+			},
 		},
-		"Client ID is required": {
-			"envId":        s.env.ID,
-			"providerName": "google",
-			"clientSecret": "test",
-			"status":       true,
+		{
+			field:   "clientId",
+			message: "Client ID is required",
+			payload: map[string]any{
+				"envId":        s.env.ID,
+				"providerName": "google",
+				"clientSecret": "test",
+				"status":       true,
+			},
 		},
-		"Client Secret is required": {
-			"envId":        s.env.ID,
-			"providerName": "google",
-			"clientId":     "test-client-id",
-			"status":       true,
+		{
+			field:   "clientSecret",
+			message: "Client Secret is required",
+			payload: map[string]any{
+				"envId":        s.env.ID,
+				"providerName": "google",
+				"clientId":     "test-client-id",
+				"status":       true,
+			},
 		},
-		"Invalid provider": {
-			"envId":        s.env.ID,
-			"providerName": "invalid-provider",
-			"clientId":     "test-client-id",
-			"clientSecret": "test",
+		{
+			field:   "providerName",
+			message: "Invalid provider",
+			payload: map[string]any{
+				"envId":        s.env.ID,
+				"providerName": "invalid-provider",
+				"clientId":     "test-client-id",
+				"clientSecret": "test",
+			},
 		},
 	}
 
-	for msg, payload := range payloads {
-		{
-			response := shttptest.RequestWithHeaders(
-				shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
-				shttp.MethodPost,
-				"/skauth",
-				payload,
-				map[string]string{
-					"Authorization": usertest.Authorization(s.usr.ID),
-				},
-			)
+	for _, tc := range cases {
+		response := shttptest.RequestWithHeaders(
+			shttp.NewRouter().RegisterService(skauthhandlers.Services).Router().Handler(),
+			shttp.MethodPost,
+			"/skauth",
+			tc.payload,
+			map[string]string{
+				"Authorization": usertest.Authorization(s.usr.ID),
+			},
+		)
 
-			s.Equal(http.StatusBadRequest, response.Code)
-			s.JSONEq(fmt.Sprintf(`{ "error": "%s" }`, msg), response.String())
-		}
+		s.Equal(http.StatusBadRequest, response.Code)
+		s.JSONEq(fmt.Sprintf(`{ "errors": { "%s": "%s" } }`, tc.field, tc.message), response.String())
 	}
 }
 

--- a/src/ce/api/app/skauth/skauthhandlers/provider_upsert.go
+++ b/src/ce/api/app/skauth/skauthhandlers/provider_upsert.go
@@ -7,17 +7,10 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appcache"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttperr"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
-
-// ProviderValidationError is a user-facing validation failure on a provider
-// upsert. Handlers surface Message in the 400 response body.
-type ProviderValidationError struct {
-	Message string
-}
-
-func (e *ProviderValidationError) Error() string { return e.Message }
 
 // UpsertProviderParams carries everything UpsertProvider needs. Env is the
 // environment being configured; it is mutated when an auth config has to be
@@ -30,14 +23,13 @@ type UpsertProviderParams struct {
 
 // UpsertProvider validates and stores a single sign-in provider. It is shared
 // by the dashboard handler, the public API handler and the MCP tool. On
-// validation failure it returns a *ProviderValidationError.
+// validation failure it returns a *shttperr.ValidationError, which shttp.Error
+// renders as a 400 with the field errors.
 func UpsertProvider(ctx context.Context, p UpsertProviderParams) error {
 	env := p.Env
 
 	if env.SchemaConf == nil {
-		return &ProviderValidationError{
-			Message: "Schema configuration is not set for this environment. Please configure it first.",
-		}
+		return &shttperr.ValidationError{Errors: map[string]string{"schema": "Schema configuration is not set for this environment. Please configure it first."}}
 	}
 
 	if err := ensureAuthConf(ctx, env); err != nil {
@@ -136,7 +128,7 @@ func providerDataFor(p providerDataForParams) (skauth.ProviderData, error) {
 		}
 
 		if data.ProviderName == skauth.ProviderMagicLink && fromAddress == "" {
-			return skauth.ProviderData{}, &ProviderValidationError{Message: "From address is required"}
+			return skauth.ProviderData{}, &shttperr.ValidationError{Errors: map[string]string{"fromAddress": "From address is required"}}
 		}
 
 		return skauth.ProviderData{FromAddress: fromAddress}, nil
@@ -156,11 +148,11 @@ func providerDataFor(p providerDataForParams) (skauth.ProviderData, error) {
 	}
 
 	if data.ClientID == "" {
-		return skauth.ProviderData{}, &ProviderValidationError{Message: "Client ID is required"}
+		return skauth.ProviderData{}, &shttperr.ValidationError{Errors: map[string]string{"clientId": "Client ID is required"}}
 	}
 
 	if data.ClientSecret == "" {
-		return skauth.ProviderData{}, &ProviderValidationError{Message: "Client Secret is required"}
+		return skauth.ProviderData{}, &shttperr.ValidationError{Errors: map[string]string{"clientSecret": "Client Secret is required"}}
 	}
 
 	return skauth.ProviderData{
@@ -199,7 +191,7 @@ func saveProvider(ctx context.Context, p saveProviderParams) error {
 	}
 
 	if !provider.Supported() {
-		return &ProviderValidationError{Message: "Invalid provider"}
+		return &shttperr.ValidationError{Errors: map[string]string{"providerName": "Invalid provider"}}
 	}
 
 	return skauth.NewStore().SaveProvider(ctx, skauth.SaveProviderArgs{

--- a/src/ce/api/public/v1/handler_auth_provider_set.go
+++ b/src/ce/api/public/v1/handler_auth_provider_set.go
@@ -1,8 +1,6 @@
 package publicapiv1
 
 import (
-	"errors"
-
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/skauth/skauthhandlers"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
@@ -23,13 +21,9 @@ func handlerAuthProviderSet(req *RequestContext) *shttp.Response {
 		Data:  data,
 	})
 
+	// UpsertProvider reports a validation failure as a *shttperr.ValidationError,
+	// which shttp.Error renders as a 400 with the field errors.
 	if err != nil {
-		var verr *skauthhandlers.ProviderValidationError
-
-		if errors.As(err, &verr) {
-			return shttp.BadRequest(map[string]any{"error": verr.Message})
-		}
-
 		return shttp.Error(err)
 	}
 

--- a/src/ce/api/public/v1/handler_auth_provider_set_test.go
+++ b/src/ce/api/public/v1/handler_auth_provider_set_test.go
@@ -108,9 +108,9 @@ func (s *HandlerAuthProviderSetSuite) Test_Set_StoresProvider() {
 	s.Equal("client-secret", provider.Data.ClientSecret)
 }
 
-// Test_Set_ValidationErrorIsBadRequest covers the ProviderValidationError
-// branch: magiclink has no from address, so the upsert must be rejected with a
-// 400 carrying the message rather than a generic 500.
+// Test_Set_ValidationErrorIsBadRequest covers the validation branch: magiclink
+// has no from address, so the upsert must be rejected with a 400 carrying the
+// field error rather than a generic 500.
 func (s *HandlerAuthProviderSetSuite) Test_Set_ValidationErrorIsBadRequest() {
 	response := shttptest.RequestWithHeaders(
 		s.handler(),
@@ -124,7 +124,7 @@ func (s *HandlerAuthProviderSetSuite) Test_Set_ValidationErrorIsBadRequest() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.Contains(response.String(), "From address is required")
+	s.JSONEq(`{"errors":{"fromAddress":"From address is required"}}`, response.String())
 }
 
 func (s *HandlerAuthProviderSetSuite) Test_Set_IsAudited() {

--- a/src/ce/api/public/v1/handler_mail_send.go
+++ b/src/ce/api/public/v1/handler_mail_send.go
@@ -1,7 +1,6 @@
 package publicapiv1
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf/mailerhandlers"
@@ -22,16 +21,11 @@ func handlerMailSend(req *RequestContext) *shttp.Response {
 		Data: data,
 	})
 
+	// shttp.Error renders a validation failure as a 400 with the field errors,
+	// and anything else as a generic body logged with caller info. The SMTP
+	// host is caller-supplied, so echoing the raw send error would turn a
+	// failed send into a probe oracle for hosts reachable from the API.
 	if err != nil {
-		var verr *mailerhandlers.SendValidationError
-
-		if errors.As(err, &verr) {
-			return shttp.BadRequest(map[string]any{"error": verr.Message})
-		}
-
-		// shttp.Error logs with caller info and returns a generic body. The
-		// SMTP host is caller-supplied, so echoing the raw error would turn a
-		// failed send into a probe oracle for hosts reachable from the API.
 		return shttp.Error(err)
 	}
 

--- a/src/ce/api/public/v1/handler_mailer_test.go
+++ b/src/ce/api/public/v1/handler_mailer_test.go
@@ -231,7 +231,7 @@ func (s *HandlerMailerSuite) Test_Send_RequiresSubject() {
 	)
 
 	s.Equal(http.StatusBadRequest, response.Code)
-	s.Contains(response.String(), "Subject is a required field.")
+	s.JSONEq(`{"errors":{"subject":"Subject is a required field."}}`, response.String())
 }
 
 // Test_EmailsGet_OmitsBody is the guarantee that keeps magic-link tokens out of

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.spec.tsx
@@ -282,5 +282,17 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx", 
         ).toBeTruthy();
       });
     });
+
+    it("should display field validation errors on 400", async () => {
+      nock(apiDomain)
+        .post("/skauth")
+        .reply(400, { errors: { clientId: "Client ID is required" } });
+
+      fireEvent.click(wrapper.getByText("Save"));
+
+      await waitFor(() => {
+        expect(wrapper.getByText("Client ID is required")).toBeTruthy();
+      });
+    });
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/ProviderSettings.tsx
@@ -131,11 +131,9 @@ export default function ProviderSettings({
               setRefreshToken(Date.now());
               onClose();
             })
-            .catch(res => {
+            .catch(async (res: Response) => {
               if (res.status === 400) {
-                res.json().then(({ error }: { error: string }) => {
-                  setError(error);
-                });
+                setError((await Api.errors(res)).join(" "));
               } else {
                 setError(
                   "Something went wrong while saving provider settings.",


### PR DESCRIPTION
## What

Replaces the two bespoke validation error types — `mailerhandlers.SendValidationError` and `skauthhandlers.ProviderValidationError` — with the shared `*shttperr.ValidationError`.

`shttp.Error` already recognises that type and renders it as a `400` keyed by field, so the `errors.As` branch that each handler repeated is now dead weight. Three handlers lose it: the dashboard auth upsert, the public API auth provider set, and the public API mail send.

## Response shape change

These validation failures now return

```json
{ "errors": { "clientId": "Client ID is required" } }
```

instead of

```json
{ "error": "Client ID is required" }
```

Field keys: `schema`, `clientId`, `clientSecret`, `providerName`, `fromAddress`, `body`, `subject`.

## Dashboard

`ProviderSettings.tsx` destructured `{ error }` off the 400 body, so it would have silently shown nothing after this change. It now goes through `Api.errors`, the existing helper that already handles both shapes — the same path the mailer page uses. Added a spec covering a 400 with a field error.

The generic-error path (non-400) is unchanged, and `SendTestEmailModal` never read the body.

## Tests

- Go: the affected suites assert the new JSON shape; `handler_auth_upsert_test.go`'s invalid-request table moved from a message-keyed map to a slice of `{field, message, payload}` cases.
- UI: `ProviderSettings.spec.tsx` — 12 tests pass, including the new 400 case.