### PR TITLE
feat: point the 404 page at somewhere to go

### DIFF
--- a/src/www/public/sitemap.xml
+++ b/src/www/public/sitemap.xml
@@ -2,37 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.stormkit.io/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://www.stormkit.io/mcp</loc>
+    <lastmod>2026-08-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://www.stormkit.io/vs-netlify</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/vs-vercel</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/about-us</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/contact</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -80,13 +86,13 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/api/mailer</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/api/mcp</loc>
-    <lastmod>2026-08-08</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -188,13 +194,13 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/development/image-optimization</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/development/troubleshooting</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -212,7 +218,7 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/features/authentication</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -326,7 +332,7 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/self-hosting/getting-started</loc>
-    <lastmod>2026-03-17</lastmod>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -368,19 +374,19 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/docs/welcome/getting-started</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/enterprise</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/tutorials</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -392,7 +398,7 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/tutorials/how-to-deploy-your-self-hosted-strapi-instance</loc>
-    <lastmod>2025-12-12</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -416,19 +422,19 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/blog</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/blog/best-self-hosted-vercel-alternatives</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.stormkit.io/blog/case-study-elham</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -446,7 +452,7 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/blog/faq</loc>
-    <lastmod>2025-12-01</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -542,7 +548,7 @@
   </url>
   <url>
     <loc>https://www.stormkit.io/blog/vercel-data-residency-and-eu-alternatives</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/www/scripts/generate-sitemap.ts
+++ b/src/www/scripts/generate-sitemap.ts
@@ -15,6 +15,7 @@ const PRIORITY: [RegExp, string, string][] = [
   [/^\/$/, '1.0', 'weekly'],
   [/^\/vs-/, '0.9', 'monthly'],
   [/^\/(enterprise|about-us|contact)$/, '0.8', 'monthly'],
+  [/^\/mcp$/, '0.9', 'monthly'],
   [/^\/docs/, '0.8', 'weekly'],
   [/^\/tutorials/, '0.7', 'monthly'],
   [/^\/blog/, '0.6', 'weekly'],

--- a/src/www/scripts/prerender.ts
+++ b/src/www/scripts/prerender.ts
@@ -33,6 +33,12 @@ const routes: Prerender[] = [
   { route: '/vs-vercel' },
   { route: '/vs-netlify' },
   {
+    route: '/mcp',
+    title: 'Stormkit MCP Server',
+    description:
+      'Drive Stormkit from an agent: the Stormkit MCP server exposes deployments, environments, logs, domains, mailer and auth as tools, backed by the Stormkit REST API.',
+  },
+  {
     route: '/policies/terms',
     title: 'Terms of Service',
     description: 'Read terms of service before using Stormkit',

--- a/src/www/src/components/Error404/Error404.tsx
+++ b/src/www/src/components/Error404/Error404.tsx
@@ -1,9 +1,29 @@
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
+import Link from '@mui/material/Link'
 import Header from '~/components/Header'
 import Footer from '~/components/Footer'
 
-export default function Home() {
+// A dead URL is where both people and agents most need a way out, so the page
+// names the entry points explicitly instead of only apologising. The same list
+// is served as markdown from /404.md.
+const LINKS: { href: string; text: string; hint: string }[] = [
+  {
+    href: '/docs/welcome/getting-started',
+    text: 'Documentation',
+    hint: 'Guides and reference',
+  },
+  {
+    href: '/docs/api/authentication',
+    text: 'API documentation',
+    hint: 'Authenticate and call the REST API',
+  },
+  { href: '/mcp', text: 'MCP server', hint: 'Drive Stormkit from an agent' },
+  { href: '/sitemap.xml', text: 'Sitemap', hint: 'Every published page' },
+  { href: '/llms.txt', text: 'llms.txt', hint: 'What Stormkit is, in one file' },
+]
+
+export default function Error404() {
   return (
     <Box
       sx={{
@@ -34,9 +54,40 @@ export default function Home() {
           >
             4 oh 4
           </Typography>
-          <Typography variant="h4" sx={{ mt: 4 }}>
+          <Typography variant="h4" component="p" sx={{ mt: 4 }}>
             There is nothing under this link
           </Typography>
+          <Typography
+            variant="h2"
+            sx={{ mt: 6, mb: 2, fontSize: 16, fontWeight: 600 }}
+          >
+            Where to look next
+          </Typography>
+          <Box
+            component="ul"
+            sx={{
+              m: 0,
+              p: 0,
+              listStyle: 'none',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+            }}
+          >
+            {LINKS.map((link) => (
+              <Box component="li" key={link.href}>
+                <Link href={link.href} color="secondary" underline="hover">
+                  {link.text}
+                </Link>
+                <Typography
+                  component="span"
+                  sx={{ ml: 1, opacity: 0.6, fontSize: 14 }}
+                >
+                  {link.hint}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
         </Box>
       </Box>
       <Footer />


### PR DESCRIPTION
Part of the #459 breakdown. Independent of the other parts — this one can merge on its own.

Two small things, both about being findable:

**The 404 page** listed nothing. It now names where to go next — documentation, API documentation, the MCP server, the sitemap and llms.txt — as real links, in the page's existing style.

**`/mcp` was invisible to crawlers.** It is a route in the app, but it was never in `scripts/prerender.ts`, so it was never prerendered and never reached the sitemap. It now is, with its own title and description, at priority 0.9.

`sitemap.xml` is regenerated as a result — it gains the `/mcp` entry, and every `lastmod` moves to today because the generator stamps them at build time.

The OpenAPI link on the 404 page, and the `llms.txt` rewrite, are deliberately **not** here: they advertise resources other PRs in this series create, so they land in a final PR once those are live rather than pointing at 404s from here.
