### PR TITLE
feat: return structured json errors from the api

### DIFF
--- a/docs/api/1-authentication.md
+++ b/docs/api/1-authentication.md
@@ -63,3 +63,28 @@ curl -X GET \
      -H 'Content-Type: application/json' \
      'https://api.stormkit.io/v1/redirects?appId=48961&envId=58181'
 ```
+
+## Error responses
+
+Every failing call answers with JSON:
+
+```json
+{
+  "error": "The API key is missing, invalid, or does not grant access to this resource.",
+  "code": "forbidden",
+  "docs": "https://www.stormkit.io/docs/api/authentication"
+}
+```
+
+| Field    | Description                                                                       |
+| -------- | --------------------------------------------------------------------------------- |
+| `error`  | Human-readable description of what went wrong.                                    |
+| `code`   | Stable, machine-readable identifier — branch on this, not on the message.         |
+| `docs`   | Present on authentication failures: the page explaining how to resolve them.      |
+| `errors` | Present on validation failures: a message per rejected field, keyed by field name. |
+
+Common codes: `forbidden` (missing, invalid or too narrowly scoped key),
+`unauthorized` (no credentials at all), `not-found` (the addressed resource does
+not exist or is not visible to the key), `unknown-endpoint` (no such path — check
+the OpenAPI document), `method-not-allowed` (wrong HTTP method for the path).
+

--- a/src/ce/api/public/v1/request_context.go
+++ b/src/ce/api/public/v1/request_context.go
@@ -170,7 +170,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			uid := user.UIDFromBearer(token)
 
 			if uid == 0 {
-				return shttp.Forbidden()
+				return shttp.ForbiddenAPIKey()
 			}
 
 			usr, err := user.NewStore().UserByID(uid)
@@ -180,7 +180,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if usr == nil {
-				return shttp.Forbidden()
+				return shttp.ForbiddenAPIKey()
 			}
 
 			request.User = usr
@@ -198,7 +198,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 
 			// This is an invalid key. A key needs to have either an app ID, user ID or team ID.
 			if key == nil || (key.UserID == 0 && key.AppID == 0 && key.TeamID == 0) {
-				return shttp.Forbidden()
+				return shttp.ForbiddenAPIKey()
 			}
 
 			request.Token = key
@@ -207,7 +207,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 		switch options.MinimumScope {
 		case apikey.SCOPE_USER:
 			if request.Token.UserID == 0 {
-				return shttp.Forbidden()
+				return shttp.ForbiddenAPIKey()
 			}
 		case apikey.SCOPE_TEAM:
 			request.TeamID = request.Token.TeamID
@@ -221,7 +221,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 				isMember := team.NewStore().IsMember(req.Context(), request.Token.UserID, request.TeamID)
 
 				if !isMember {
-					return shttp.Forbidden()
+					return shttp.ForbiddenAPIKey()
 				}
 			}
 		case apikey.SCOPE_APP:
@@ -232,7 +232,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if appID == 0 {
-				return shttp.NotFound()
+				return shttp.NotFoundJSON("No application was addressed. Pass 'appId', or use an app-scoped API key.")
 			}
 
 			app, err := app.NewStore().AppByID(req.Context(), appID)
@@ -242,7 +242,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if app == nil {
-				return shttp.NotFound()
+				return shttp.NotFoundJSON("The application does not exist.")
 			}
 
 			request.App = app
@@ -252,13 +252,13 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			if request.Token.AppID == 0 {
 				if request.Token.TeamID != 0 {
 					if app.TeamID != request.Token.TeamID {
-						return shttp.Forbidden()
+						return shttp.ForbiddenAPIKey()
 					}
 				} else if request.Token.UserID != 0 {
 					isMember := team.NewStore().IsMember(req.Context(), request.Token.UserID, app.TeamID)
 
 					if !isMember {
-						return shttp.Forbidden()
+						return shttp.ForbiddenAPIKey()
 					}
 				}
 			}
@@ -276,7 +276,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if env == nil {
-				return shttp.NotFound()
+				return shttp.NotFoundJSON("The environment does not exist. Pass a valid 'envId', or use an environment-scoped API key.")
 			}
 
 			app, err := app.NewStore().AppByID(req.Context(), env.AppID)
@@ -286,7 +286,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if app == nil {
-				return shttp.NotFound()
+				return shttp.NotFoundJSON("The application owning this environment does not exist.")
 			}
 
 			request.Env = env
@@ -296,10 +296,10 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			// Validate membership if the key is not already tied to an environment.
 			if request.Token.EnvID == 0 {
 				if request.Token.AppID != 0 && request.Token.AppID != env.AppID {
-					return shttp.Forbidden()
+					return shttp.ForbiddenAPIKey()
 				} else if request.Token.TeamID != 0 {
 					if app.TeamID != request.Token.TeamID {
-						return shttp.Forbidden()
+						return shttp.ForbiddenAPIKey()
 					}
 
 					request.App = app
@@ -308,7 +308,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 					isMember := buildconf.NewStore().IsMember(req.Context(), env.ID, request.Token.UserID)
 
 					if !isMember {
-						return shttp.Forbidden()
+						return shttp.ForbiddenAPIKey()
 					}
 				}
 			}

--- a/src/ce/api/public/v1/request_context_mcp.go
+++ b/src/ce/api/public/v1/request_context_mcp.go
@@ -52,7 +52,7 @@ func (req *RequestContextMCP) withEnv(args map[string]any) *shttp.Response {
 	}
 
 	if !buildconf.NewStore().IsMember(req.Context(), env.ID, req.Token.UserID) {
-		return shttp.Forbidden()
+		return shttp.ForbiddenAPIKey()
 	}
 
 	req.Env = env
@@ -83,7 +83,7 @@ func (req *RequestContextMCP) withApp(args map[string]any) *shttp.Response {
 	}
 
 	if !team.NewStore().IsMember(req.Context(), req.Token.UserID, myApp.TeamID) {
-		return shttp.Forbidden()
+		return shttp.ForbiddenAPIKey()
 	}
 
 	req.App = myApp
@@ -121,7 +121,7 @@ func (req *RequestContextMCP) withTeamID(args map[string]any) *shttp.Response {
 	}
 
 	if !team.NewStore().IsMember(req.Context(), req.Token.UserID, teamID) {
-		return shttp.Forbidden()
+		return shttp.ForbiddenAPIKey()
 	}
 
 	req.TeamID = teamID

--- a/src/ce/api/router/router.go
+++ b/src/ce/api/router/router.go
@@ -30,6 +30,7 @@ import (
 
 func Get() *shttp.Router {
 	r := shttp.NewRouter()
+	r.WithJSONErrors()
 	r.RegisterMiddleware(WithCors)
 	r.RegisterMiddleware(WithTimeout)
 

--- a/src/lib/shttp/response.go
+++ b/src/lib/shttp/response.go
@@ -60,11 +60,65 @@ func (r *Response) String() string {
 	return string(data)
 }
 
+// DocsAuthenticationURL documents how to obtain and send an API key. It is
+// attached to authentication errors so that a client — human or agent — can
+// resolve the failure without searching for the docs first.
+const DocsAuthenticationURL = "https://www.stormkit.io/docs/api/authentication"
+
+// APIErrorBody is the structured payload returned by failing API calls. Agents
+// cannot parse an HTML error page or an empty body, so every error carries a
+// human-readable message plus a stable machine-readable code.
+type APIErrorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+	Docs  string `json:"docs,omitempty"`
+}
+
+// APIErrorParams are the arguments of APIError.
+type APIErrorParams struct {
+	Status  int
+	Code    string
+	Message string
+	Docs    string
+}
+
+// APIError returns a response carrying a structured JSON error body.
+func APIError(p APIErrorParams) *Response {
+	return &Response{
+		Status: p.Status,
+		Data: APIErrorBody{
+			Error: p.Message,
+			Code:  p.Code,
+			Docs:  p.Docs,
+		},
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+}
+
 // NotFound returns a not found response.
 func NotFound() *Response {
 	return &Response{
 		Status: http.StatusNotFound,
 	}
+}
+
+// NotFoundJSON returns a 404 with a structured JSON body. Use it on API
+// endpoints; NotFound stays bodyless for the hosting layer, which serves the
+// deployment's own 404 page instead.
+func NotFoundJSON(message ...string) *Response {
+	msg := "The requested resource was not found."
+
+	if len(message) > 0 && message[0] != "" {
+		msg = message[0]
+	}
+
+	return APIError(APIErrorParams{
+		Status:  http.StatusNotFound,
+		Code:    "not-found",
+		Message: msg,
+	})
 }
 
 // BadRequest returns a bad request response.
@@ -126,22 +180,43 @@ func NoContent() *Response {
 	}
 }
 
-// NotAllowed returns a 401 response with user data set to false.
+// NotAllowed returns a 401 response with user data set to false. The ok/user
+// flags are kept for the dashboard, which branches on them; the error/code
+// fields are what non-browser clients read. Most callers authenticate a session
+// or a webhook, so the message names no particular credential.
 func NotAllowed() *Response {
 	return &Response{
 		Status: http.StatusUnauthorized,
-		Data: map[string]bool{
-			"ok":   false,
-			"user": false,
+		Data: map[string]any{
+			"ok":    false,
+			"user":  false,
+			"error": "Authentication is required.",
+			"code":  "unauthorized",
 		},
 	}
 }
 
-// Forbidden returns a 403 response with empty data.
+// Forbidden returns a 403 with a structured JSON body. The message is
+// deliberately neutral: this helper also answers end users of a customer's app
+// and signed-in dashboard users, neither of whom holds an API key. Paths where
+// the credential really is an API key say so themselves — see ForbiddenAPIKey.
 func Forbidden() *Response {
-	return &Response{
-		Status: http.StatusForbidden,
-	}
+	return APIError(APIErrorParams{
+		Status:  http.StatusForbidden,
+		Code:    "forbidden",
+		Message: "You do not have access to this resource.",
+	})
+}
+
+// ForbiddenAPIKey returns a 403 for a request authenticated with a Stormkit API
+// key, naming the credential and where to read about it.
+func ForbiddenAPIKey() *Response {
+	return APIError(APIErrorParams{
+		Status:  http.StatusForbidden,
+		Code:    "forbidden",
+		Message: "The API key is missing, invalid, or does not grant access to this resource.",
+		Docs:    DocsAuthenticationURL,
+	})
 }
 
 // Gone returns a 410 response with empty data.

--- a/src/lib/shttp/router.go
+++ b/src/lib/shttp/router.go
@@ -1,6 +1,7 @@
 package shttp
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -37,6 +38,37 @@ func (r *Router) RegisterMiddleware(handler func(h http.Handler) http.Handler) {
 	} else {
 		r.handler = handler(r.mux)
 	}
+}
+
+// WithJSONErrors makes unmatched routes answer with the same structured JSON
+// body as the handlers do. Without it gorilla/mux falls back to net/http, which
+// writes "404 page not found" as text/plain — unparseable for an API client.
+func (r *Router) WithJSONErrors() *Router {
+	r.mux.NotFoundHandler = jsonErrorHandler(APIErrorParams{
+		Status:  http.StatusNotFound,
+		Code:    "unknown-endpoint",
+		Message: "This endpoint does not exist. See the API documentation for the available endpoints.",
+		Docs:    DocsAuthenticationURL,
+	})
+
+	r.mux.MethodNotAllowedHandler = jsonErrorHandler(APIErrorParams{
+		Status:  http.StatusMethodNotAllowed,
+		Code:    "method-not-allowed",
+		Message: "This endpoint does not accept the used HTTP method. See the API documentation for the accepted methods.",
+		Docs:    DocsAuthenticationURL,
+	})
+
+	return r
+}
+
+func jsonErrorHandler(p APIErrorParams) http.Handler {
+	body, _ := json.Marshal(APIErrorBody{Error: p.Message, Code: p.Code, Docs: p.Docs})
+
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(p.Status)
+		_, _ = w.Write(body)
+	})
 }
 
 // WithContext enables the context handler.

--- a/src/lib/shttp/router_json_errors_test.go
+++ b/src/lib/shttp/router_json_errors_test.go
@@ -1,0 +1,135 @@
+package shttp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
+	"github.com/stretchr/testify/suite"
+)
+
+// RouterJSONErrorsSuite covers the responses an API client gets when it asks
+// for something that is not there. An agent cannot act on "404 page not found"
+// written as text/plain, so unmatched routes answer with the same JSON shape as
+// the handlers.
+type RouterJSONErrorsSuite struct {
+	suite.Suite
+}
+
+func (s *RouterJSONErrorsSuite) handler() http.Handler {
+	router := shttp.NewRouter()
+	router.WithJSONErrors()
+
+	router.NewService().
+		NewEndpoint("/v1/ping").
+		Handler(shttp.MethodGet, "", func(*shttp.RequestContext) *shttp.Response {
+			return shttp.OK()
+		})
+
+	return router.Handler()
+}
+
+func (s *RouterJSONErrorsSuite) errorBody(body []byte) shttp.APIErrorBody {
+	var parsed shttp.APIErrorBody
+	s.Require().NoError(json.Unmarshal(body, &parsed))
+
+	return parsed
+}
+
+func (s *RouterJSONErrorsSuite) Test_UnknownEndpoint() {
+	res := shttptest.Request(s.handler(), shttp.MethodGet, "/v1/nope", nil)
+
+	s.Equal(http.StatusNotFound, res.Code)
+	s.Equal("application/json", res.Header().Get("Content-Type"))
+
+	body := s.errorBody(res.Body.Bytes())
+	s.Equal("unknown-endpoint", body.Code)
+	s.NotEmpty(body.Error)
+}
+
+func (s *RouterJSONErrorsSuite) Test_MethodNotAllowed() {
+	res := shttptest.Request(s.handler(), shttp.MethodDelete, "/v1/ping", nil)
+
+	s.Equal(http.StatusMethodNotAllowed, res.Code)
+	s.Equal("application/json", res.Header().Get("Content-Type"))
+
+	body := s.errorBody(res.Body.Bytes())
+	s.Equal("method-not-allowed", body.Code)
+	s.NotEmpty(body.Error)
+}
+
+func (s *RouterJSONErrorsSuite) Test_KnownEndpointIsUnaffected() {
+	res := shttptest.Request(s.handler(), shttp.MethodGet, "/v1/ping", nil)
+
+	s.Equal(http.StatusOK, res.Code)
+}
+
+// Forbidden answers API-key callers, end users of a customer's app and
+// signed-in dashboard users alike, so it carries a body without naming a
+// credential none of them may hold.
+func (s *RouterJSONErrorsSuite) Test_ForbiddenCarriesAJsonBody() {
+	res := shttp.Forbidden()
+
+	body, ok := res.Data.(shttp.APIErrorBody)
+
+	s.Require().True(ok)
+	s.Equal(http.StatusForbidden, res.Status)
+	s.Equal("forbidden", body.Code)
+	s.NotEmpty(body.Error)
+	s.NotContains(body.Error, "API key")
+	s.Empty(body.Docs)
+}
+
+// The API-key variant is the one that may name the credential.
+func (s *RouterJSONErrorsSuite) Test_ForbiddenAPIKeyNamesTheCredential() {
+	body, ok := shttp.ForbiddenAPIKey().Data.(shttp.APIErrorBody)
+
+	s.Require().True(ok)
+	s.Equal("forbidden", body.Code)
+	s.Contains(body.Error, "API key")
+	s.Equal(shttp.DocsAuthenticationURL, body.Docs)
+}
+
+// NotAllowed answers admin logins and webhook callbacks, so it must not tell
+// the caller to send an API key.
+func (s *RouterJSONErrorsSuite) Test_NotAllowedDoesNotNameACredential() {
+	data, ok := shttp.NotAllowed().Data.(map[string]any)
+
+	s.Require().True(ok)
+	s.Equal(false, data["user"])
+	s.Equal("unauthorized", data["code"])
+	s.NotContains(data["error"].(string), "API key")
+}
+
+func (s *RouterJSONErrorsSuite) Test_NotFoundJSON() {
+	res := shttp.NotFoundJSON("The environment does not exist.")
+
+	body, ok := res.Data.(shttp.APIErrorBody)
+
+	s.Require().True(ok)
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Equal("not-found", body.Code)
+	s.Equal("The environment does not exist.", body.Error)
+}
+
+func (s *RouterJSONErrorsSuite) Test_NotFoundJSON_DefaultMessage() {
+	body, ok := shttp.NotFoundJSON().Data.(shttp.APIErrorBody)
+
+	s.Require().True(ok)
+	s.NotEmpty(body.Error)
+}
+
+// The hosting layer serves the deployment's own 404 page, so the bodyless
+// NotFound it relies on must stay bodyless.
+func (s *RouterJSONErrorsSuite) Test_NotFoundStaysBodyless() {
+	res := shttp.NotFound()
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Nil(res.Data)
+}
+
+func TestRouterJSONErrorsSuite(t *testing.T) {
+	suite.Run(t, new(RouterJSONErrorsSuite))
+}


### PR DESCRIPTION
Part of the #459 breakdown. First of two in the API stack; the OpenAPI spec PR is based on this branch.

## The problem

```
$ curl -sSD- https://api.stormkit.io/v1/apps
HTTP/2 403
content-type: application/json
content-length: 0          <- nothing to parse

$ curl -s https://api.stormkit.io/v1/nonexistent
404 page not found         <- text/plain, from net/http
```

## The change

Every failure now carries a structured body:

```json
{
  "error": "The API key is missing, invalid, or does not grant access to this resource.",
  "code": "forbidden",
  "docs": "https://www.stormkit.io/docs/api/authentication"
}
```

- `error` — human-readable
- `code` — stable, machine-readable; branch on this, not on the message
- `docs` — present where the credential is an API key
- `errors` — field-level validation messages, unchanged from before

Unknown paths (`unknown-endpoint`) and wrong methods (`method-not-allowed`) answer in the same shape, via a new `Router.WithJSONErrors()` installed on the API router only.

## Why the shared helpers stay neutral

`Forbidden()` has 35 callers and `NotAllowed()` 24. Most are **not** API-key paths — `skauth_magic.go` answers an end user of a *customer's* app on the customer's own domain, and `handler_admin_login.go` answers someone who mistyped their admin password. Telling either to check their Stormkit API key would be wrong, so the shared helpers say only what is true, and `ForbiddenAPIKey()` carries the key-specific wording on the ~13 call sites in `request_context.go` / `request_context_mcp.go` where a key really is being validated.

`shttp.NotFound()` is deliberately left bodyless — the hosting layer depends on it to serve a deployment's own 404 page rather than a JSON blob.

## Notes

- The 404/405 messages point at "the API documentation"; the follow-up PR in this stack changes them to name `/v1/openapi.json` once that endpoint exists.
- The dashboard is unaffected: `Api.ts handle403` branches on `json?.user === false`, and `NotAllowed()` keeps its `ok`/`user` flags.

## Verification

`go test ./src/lib/shttp/` passes, including a new suite covering the JSON 404/405, the neutral wording, and that `NotFound()` stays bodyless.
