### PR TITLE
fix: serve the error page for unmatched paths

### DIFF
--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -134,6 +134,17 @@ func (r *RequestServer) finalize(res *shttp.Response) *shttp.Response {
 	return res
 }
 
+// isAPIPath reports whether a request path is routed to the API function. The
+// prefix defaults to /api: the column it comes from is only defaulted against
+// NULL, so an environment can still carry an empty one.
+func isAPIPath(requestPath, prefix string) bool {
+	if prefix == "" {
+		prefix = "/api"
+	}
+
+	return strings.HasPrefix(strings.ToLower(requestPath), strings.ToLower(prefix))
+}
+
 type FileMeta struct {
 	Name    string
 	Headers map[string]string
@@ -375,16 +386,22 @@ func (r *RequestServer) Static() *shttp.Response {
 func (r *RequestServer) Dynamic() *shttp.Response {
 	cnf := r.req.Host.Config
 	url := r.req.URL()
-	arn := utils.GetString(cnf.FunctionLocation, cnf.APILocation)
+
+	// The server function answers everything a static file did not; the API
+	// function answers only its own prefix. Stating it as one decision rather
+	// than a fallback plus a correction means a deployment with no server
+	// function cannot silently make the API function its catch-all: unmatched
+	// paths reach the deployment's own error page instead of costing an
+	// invocation and returning whatever the function runtime emits for an
+	// unknown route.
+	arn := cnf.FunctionLocation
+
+	if cnf.APILocation != "" && isAPIPath(url.Path, cnf.APIPathPrefix) {
+		arn = cnf.APILocation
+	}
 
 	if arn == "" {
 		return r.NotFound()
-	}
-
-	// If the path prefix is set and the request URL matches the prefix,
-	// we need to route the request to the API location instead.
-	if cnf.APILocation != "" && cnf.APIPathPrefix != "" && strings.HasPrefix(url.Path, cnf.APIPathPrefix) {
-		arn = cnf.APILocation
 	}
 
 	// When snippets are configured we want the origin to hand back uncompressed

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -953,6 +953,128 @@ func (s *HandlerForwardSuite) Test_404() {
 	s.Equal([]byte("Not found"), res.Data.([]byte))
 }
 
+// A deployment with API functions but no server function serves those
+// functions under their prefix and nothing else. Forwarding an unmatched path
+// to the API function costs an invocation and answers with whatever the
+// function runtime emits for an unknown route — typically a bodyless 404 —
+// instead of the deployment's own error page.
+func (s *HandlerForwardSuite) Test_UnmatchedPathDoesNotReachApiFunction() {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     "/404.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("Not found"),
+	}, nil)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:    types.ID(1),
+			AppID:           types.ID(25),
+			EnvID:           types.ID(100),
+			StorageLocation: "aws:my-bucket/my-key-prefix",
+			APILocation:     "aws:my-api-function",
+			APIPathPrefix:   "/api",
+			StaticFiles: appconf.StaticFileConfig{
+				"/404.html": {FileName: "/404.html"},
+			},
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/no-such-page"))
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Equal([]byte("Not found"), res.Data.([]byte))
+	s.mockClient.AssertNotCalled(s.T(), "Invoke")
+}
+
+// The prefix column is only defaulted against NULL, so an environment can
+// carry an empty one. That must not turn the API function back into a
+// catch-all for every unmatched path.
+func (s *HandlerForwardSuite) Test_EmptyApiPrefixDoesNotReachApiFunction() {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     "/404.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("Not found"),
+	}, nil)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:    types.ID(1),
+			AppID:           types.ID(25),
+			EnvID:           types.ID(100),
+			StorageLocation: "aws:my-bucket/my-key-prefix",
+			APILocation:     "aws:my-api-function",
+			APIPathPrefix:   "",
+			StaticFiles: appconf.StaticFileConfig{
+				"/404.html": {FileName: "/404.html"},
+			},
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/no-such-page"))
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.mockClient.AssertNotCalled(s.T(), "Invoke")
+}
+
+// A path under the prefix still reaches the API function, whatever its case.
+func (s *HandlerForwardSuite) Test_ApiPathReachesApiFunction() {
+	s.mockClient.On("Invoke", mock.Anything).Return(&integrations.InvokeResult{
+		StatusCode: http.StatusOK,
+		Body:       []byte(`{"ok":true}`),
+		Headers:    http.Header{"Content-Type": []string{"application/json"}},
+	}, nil)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:    types.ID(1),
+			AppID:           types.ID(25),
+			EnvID:           types.ID(100),
+			StorageLocation: "aws:my-bucket/my-key-prefix",
+			APILocation:     "aws:my-api-function",
+			APIPathPrefix:   "/api",
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/API/users"))
+
+	s.Equal(http.StatusOK, res.Status)
+}
+
+// A deployment with a server function keeps serving every unmatched path from
+// it — this change must not turn server-rendered apps into 404s.
+func (s *HandlerForwardSuite) Test_ServerFunctionHandlesUnmatchedPaths() {
+	s.mockClient.On("Invoke", mock.Anything).Return(&integrations.InvokeResult{
+		StatusCode: http.StatusOK,
+		Body:       []byte("<h1>Rendered</h1>"),
+		Headers:    http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+	}, nil)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			AppID:            types.ID(25),
+			EnvID:            types.ID(100),
+			StorageLocation:  "aws:my-bucket/my-key-prefix",
+			FunctionLocation: "aws:my-server-function",
+			APILocation:      "aws:my-api-function",
+			APIPathPrefix:    "/api",
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/some/ssr/route"))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("<h1>Rendered</h1>", string(res.Data.([]byte)))
+}
+
 func (s *HandlerForwardSuite) Test_404_CustomErrorFile() {
 	s.mockClient.On("GetFile", integrations.GetFileArgs{
 		Location:     "aws:my-bucket/my-key-prefix",


### PR DESCRIPTION
Part of the #459 breakdown. First of two in the hosting stack; the markdown negotiation PR is based on this branch.

## The bug

```
$ curl -sSD- https://www.stormkit.io/does-not-exist
HTTP/2 404
content-length: 0     <- even though the deployment ships a 404.html
```

`Dynamic()` resolved the function to invoke as `utils.GetString(cnf.FunctionLocation, cnf.APILocation)`. For a deployment with API functions but **no** server function — a static site with an `api/` folder, which is what www.stormkit.io is — that fallback quietly makes the API function the catch-all for every unmatched path. The request costs a Lambda invocation and answers with whatever the function runtime emits for an unknown route, instead of the deployment's own error page.

## The change

Stated as one decision rather than a fallback plus a correction:

```go
arn := cnf.FunctionLocation

if cnf.APILocation != "" && isAPIPath(url.Path, cnf.APIPathPrefix) {
    arn = cnf.APILocation
}

if arn == "" {
    return r.NotFound()
}
```

Two things fall out of it:

- **An empty prefix no longer disables the guard.** `coalesce(d.api_path_prefix, '/api')` in `appconf_store.go` defends against NULL but not `''`, so `isAPIPath` defaults the prefix at the point of use.
- **The prefix is matched case-insensitively**, so `/API/users` reaches the API function rather than 404ing.

## Blast radius

This changes behaviour for every deployment that has an API location and no server function. A deployment whose API function legitimately served paths outside its prefix (an Express app mounted at `/` with `apiPathPrefix` left at `/api`) would now get the 404 page instead. That is the intended semantic — the prefix is what routes to the API function — but it is the thing to weigh before merging.

Server-rendered deployments are unaffected: with a `FunctionLocation` set, every unmatched path still goes to it. There is a test for exactly that.

## Verification

`go build` / `go vet` clean. Four new tests in `HandlerForwardSuite` cover the 404 fallback, the empty prefix, case-insensitive prefix matching, and that a server function still handles unmatched paths. **They have not been executed** — the local Postgres test volume is out of disk space, which fails `databasetest` at package init. `go test ./src/ce/hosting/ -p 1` needs running before merge.
