### PR TITLE
feat: serve markdown representations of pages

### DIFF
--- a/docs/deployments/6-how-do-we-deploy.md
+++ b/docs/deployments/6-how-do-we-deploy.md
@@ -73,6 +73,39 @@ In this case, the `serverless` wrapper is omitted because the API function has i
 
 All files under the `.stormkit/public` (or the configured output folder) will be deployed to our S3 bucket and served by our Load Balancer as static files.
 
+### Error pages
+
+A request that matches no static file and no function is answered with your
+deployment's error page: the file configured as `errorFile`, or `404.html`,
+`500.html` or `error.html` when none is configured. The status code is always a
+real `404` — never a `200` carrying your app shell.
+
+### Markdown representations
+
+Set `markdown: true` on the environment and Stormkit serves any `.md` file in
+your output as a second representation of the page next to it.
+`/docs/getting-started.md` published alongside `/docs/getting-started.html`
+means:
+
+- `GET /docs/getting-started` with `Accept: text/markdown` answers with the
+  markdown, as `text/markdown; charset=utf-8`.
+- The same URL with a browser's `Accept` still answers with the HTML, and so
+  does a client that accepts neither — negotiation only ever adds a
+  representation, it never refuses a request that used to succeed.
+- `q` values are honoured, so `Accept: text/html;q=0.9, text/markdown;q=0.5`
+  still gets HTML.
+- Every answer carries `Vary: Accept`, so a CDN caches the two variants
+  separately instead of serving one to the wrong client, and both share the
+  page's cache policy.
+
+The homepage negotiates through `index.md`, and error pages through `404.md` or
+`error.md`. This is what [acceptmarkdown.com](https://acceptmarkdown.com)
+describes, and it is how an agent reads your documentation without scraping the
+rendered page.
+
+The setting defaults to off: a build that copies its markdown sources into the
+output keeps serving exactly what it served before until you turn it on.
+
 ## Example
 
 Check out and build our [React Starter Template](https://github.com/stormkit-io/monorepo-template-react) to see an example of the `.stormkit` subfolder.

--- a/src/ce/api/app/appconf/appconf_model.go
+++ b/src/ce/api/app/appconf/appconf_model.go
@@ -22,6 +22,7 @@ type Config struct {
 	BillingUserID    types.ID              `json:"billingUserId,string,omitempty"`
 	Domains          []string              `json:"domains"`
 	ErrorFile        string                `json:"errorFile,omitempty"`
+	Markdown         bool                  `json:"markdown,omitempty"`
 	StorageLocation  string                `json:"storageLocation,omitempty"`
 	FunctionLocation string                `json:"functionLocation,omitempty"`
 	APIPathPrefix    string                `json:"apiPathPrefix"`

--- a/src/ce/api/app/appconf/appconf_store.go
+++ b/src/ce/api/app/appconf/appconf_store.go
@@ -367,6 +367,7 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 			cnf.Redirects = data.Redirects
 			cnf.ServerCmd = data.ServerCmd
 			cnf.ErrorFile = data.ErrorFile
+			cnf.Markdown = data.Markdown.ValueOrZero()
 			cnf.EnvVariables = data.InterpolatedVars(
 				buildconf.InterpolatedVarsOpts{
 					DeploymentID: cnf.DeploymentID.String(),

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -361,6 +361,7 @@ type BuildConf struct {
 	APIPathPrefix   string               `json:"apiPathPrefix,omitempty"`   // Path prefix in the URL that will be used to call api functions, default: /api
 	RedirectsFile   string               `json:"redirectsFile,omitempty"`   // Path to the redirects file.
 	ErrorFile       string               `json:"errorFile,omitempty"`       // When specified, we'll load this file instead of the default 404.html or error.html
+	Markdown        null.Bool            `json:"markdown,omitempty"`        // Serve the .md twin of a page to clients that send Accept: text/markdown. Off unless enabled.
 	Headers         string               `json:"headers,omitempty"`         // Custom headers set from the UI.
 	HeadersFile     string               `json:"headersFile,omitempty"`     // Path to the headers file. The path is relative to working dir.
 	DistFolder      string               `json:"distFolder,omitempty"`      // DistFolder is the client dist folder.

--- a/src/ce/hosting/content_negotiation.go
+++ b/src/ce/hosting/content_negotiation.go
@@ -1,0 +1,141 @@
+package hosting
+
+import (
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+)
+
+// MarkdownContentType is what a markdown representation is served as. RFC 7763
+// registers text/markdown; the charset removes any doubt about the encoding.
+const MarkdownContentType = "text/markdown; charset=utf-8"
+
+// acceptedType is one entry of a parsed Accept header.
+type acceptedType struct {
+	mime    string
+	quality float64
+}
+
+// acceptPreference is a parsed Accept header, answering the only three
+// questions the static handler asks of it.
+type acceptPreference struct {
+	types []acceptedType
+	// empty is true when the request carried no usable Accept header at all, in
+	// which case RFC 9110 says everything is acceptable.
+	empty bool
+}
+
+// parseAccept parses an Accept header into its media types and q-values.
+// Malformed entries are skipped rather than failing the request: a browser with
+// a broken header must still get its page.
+func parseAccept(header string) acceptPreference {
+	pref := acceptPreference{empty: true}
+
+	for _, part := range strings.Split(header, ",") {
+		fields := strings.Split(strings.TrimSpace(part), ";")
+		mime := strings.ToLower(strings.TrimSpace(fields[0]))
+
+		if mime == "" {
+			continue
+		}
+
+		entry := acceptedType{mime: mime, quality: 1}
+
+		for _, param := range fields[1:] {
+			key, value, found := strings.Cut(strings.TrimSpace(param), "=")
+
+			if !found || strings.ToLower(strings.TrimSpace(key)) != "q" {
+				continue
+			}
+
+			if q, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+				entry.quality = q
+			}
+		}
+
+		pref.empty = false
+		pref.types = append(pref.types, entry)
+	}
+
+	return pref
+}
+
+// qualityFor returns the q-value the client assigned to a media type, honouring
+// the `type/*` and `*/*` wildcards. It returns 0 when the type is not accepted.
+func (p acceptPreference) qualityFor(mime string) float64 {
+	if p.empty {
+		return 1
+	}
+
+	family, _, _ := strings.Cut(mime, "/")
+	best := 0.0
+
+	for _, entry := range p.types {
+		switch entry.mime {
+		case mime, family + "/*", "*/*":
+			if entry.quality > best {
+				best = entry.quality
+			}
+		}
+	}
+
+	return best
+}
+
+// prefersMarkdown reports whether the client would rather have markdown than
+// HTML. A tie goes to HTML, so a browser sending `*/*` keeps its page.
+func (p acceptPreference) prefersMarkdown() bool {
+	markdown := p.qualityFor("text/markdown")
+
+	return markdown > 0 && markdown > p.qualityFor("text/html")
+}
+
+// markdownTwinParams are the arguments of markdownTwin.
+type markdownTwinParams struct {
+	RequestPath string
+	Files       appconf.StaticFileConfig
+}
+
+// markdownTwin returns the deployment file holding the markdown representation
+// of a request path, or an empty string when the deployment ships none.
+//
+// Only files the build actually published are considered, so content
+// negotiation can never invent a URL: /docs/foo is negotiable exactly when the
+// deployment contains /docs/foo.md (or /docs/foo/index.md).
+func markdownTwin(p markdownTwinParams) string {
+	clean := strings.ToLower(p.RequestPath)
+	ext := path.Ext(clean)
+
+	// Assets carry an extension of their own and can never have a twin. They are
+	// the bulk of the requests a deployment serves, so they leave before this
+	// function allocates anything.
+	if ext != "" && ext != ".md" && ext != ".html" {
+		return ""
+	}
+
+	trimmed := strings.TrimSuffix(clean, "/")
+	candidates := []string{}
+
+	switch ext {
+	case ".md":
+		candidates = append(candidates, clean)
+	case ".html":
+		candidates = append(candidates, strings.TrimSuffix(clean, ".html")+".md")
+	default:
+		if trimmed != "" {
+			candidates = append(candidates, trimmed+".md")
+		}
+
+		candidates = append(candidates, path.Join(clean, "index.md"))
+	}
+
+	for _, candidate := range candidates {
+		if p.Files[candidate] != nil {
+			return candidate
+		}
+	}
+
+	return ""
+}

--- a/src/ce/hosting/content_negotiation_test.go
+++ b/src/ce/hosting/content_negotiation_test.go
@@ -1,0 +1,349 @@
+package hosting_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
+	"github.com/stormkit-io/stormkit-io/src/lib/pool"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+// ContentNegotiationSuite covers acceptmarkdown.com compliance: a page that
+// ships a markdown twin is served as markdown to clients that ask for it, HTML
+// to everyone else, and both answers carry Vary: Accept so a cache cannot mix
+// the two up.
+type ContentNegotiationSuite struct {
+	suite.Suite
+
+	mockClient *mocks.ClientInterface
+	tmpDir     string
+}
+
+func (s *ContentNegotiationSuite) SetupSuite() {
+	tmpDir, err := os.MkdirTemp("", "tmp-test-content-negotiation-")
+	s.Require().NoError(err)
+
+	s.tmpDir = tmpDir
+}
+
+func (s *ContentNegotiationSuite) TearDownSuite() {
+	_ = os.RemoveAll(s.tmpDir)
+}
+
+func (s *ContentNegotiationSuite) BeforeTest(_, _ string) {
+	rediscache.Client().Del(context.Background(), "content-negotiation")
+
+	hosting.WaitArtifacts()
+	hosting.ResetBatcher(pool.New(
+		pool.WithSize(1000),
+		pool.WithFlushInterval(time.Hour),
+		pool.WithFlusher(pool.FlusherFunc(func(items []any) {})),
+	))
+
+	s.mockClient = &mocks.ClientInterface{}
+	integrations.SetDefaultClient(s.mockClient)
+}
+
+func (s *ContentNegotiationSuite) AfterTest(_, _ string) {
+	hosting.WaitArtifacts()
+}
+
+// host returns a deployment that publishes /docs.html plus its markdown twin.
+func (s *ContentNegotiationSuite) host() *hosting.Host {
+	return &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:    types.ID(1),
+			AppID:           types.ID(25),
+			EnvID:           types.ID(100),
+			StorageLocation: "aws:my-bucket/my-key-prefix",
+			Markdown:        true,
+			StaticFiles: appconf.StaticFileConfig{
+				"/docs.html": {
+					FileName: "/docs.html",
+					Headers:  map[string]string{"content-type": "text/html; charset=utf-8"},
+				},
+				"/docs.md": {
+					FileName: "/docs.md",
+					Headers:  map[string]string{"content-type": "text/markdown; charset=utf-8"},
+				},
+				"/pricing.html": {
+					FileName: "/pricing.html",
+					Headers:  map[string]string{"content-type": "text/html; charset=utf-8"},
+				},
+			},
+		},
+	}
+}
+
+func (s *ContentNegotiationSuite) mockFile(fileName, content string) {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     fileName,
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content:     []byte(content),
+		ContentType: "text/html; charset=utf-8",
+	}, nil)
+}
+
+func (s *ContentNegotiationSuite) request(host *hosting.Host, path, accept string) *shttp.Response {
+	headers := make(http.Header)
+
+	if accept != "" {
+		headers.Set("Accept", accept)
+	}
+
+	req := &hosting.RequestContext{
+		Host: host,
+		RequestContext: shttp.NewRequestContext(&http.Request{
+			Header: headers,
+			URL:    &url.URL{Host: host.Name, Path: path, RawPath: path},
+		}),
+	}
+
+	req.OriginalPath = path
+
+	return hosting.HandlerForward(req)
+}
+
+func (s *ContentNegotiationSuite) Test_ServesMarkdownWhenRequested() {
+	s.mockFile("/docs.md", "# Docs\n")
+
+	res := s.request(s.host(), "/docs", "text/markdown")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
+	s.Equal("Accept", res.Headers.Get("Vary"))
+	s.Equal("# Docs\n", string(res.Data.([]byte)))
+}
+
+// Both representations of a URL must expire together. Classifying the markdown
+// twin by its own content type would file it under the asset policy and leave a
+// corrected page stale for a day.
+func (s *ContentNegotiationSuite) Test_MarkdownSharesThePageCachePolicy() {
+	s.mockFile("/docs.md", "# Docs\n")
+
+	res := s.request(s.host(), "/docs", "text/markdown")
+
+	s.Equal("no-cache, must-revalidate", res.Headers.Get("Cache-Control"))
+}
+
+func (s *ContentNegotiationSuite) Test_ServesHtmlToBrowsers() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	res := s.request(s.host(), "/docs", "text/html,application/xhtml+xml,*/*;q=0.8")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+	s.Equal("Accept", res.Headers.Get("Vary"))
+}
+
+// A wildcard-only Accept must not flip the page to markdown: `*/*` is what
+// curl and most crawlers send, and they expect the HTML representation.
+func (s *ContentNegotiationSuite) Test_WildcardKeepsHtml() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	res := s.request(s.host(), "/docs", "*/*")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+}
+
+func (s *ContentNegotiationSuite) Test_NoAcceptHeaderKeepsHtml() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	res := s.request(s.host(), "/docs", "")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+}
+
+// q-values decide which representation wins when the client accepts both.
+func (s *ContentNegotiationSuite) Test_HonoursQValues() {
+	s.mockFile("/docs.md", "# Docs\n")
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	markdownPreferred := s.request(s.host(), "/docs", "text/html;q=0.5, text/markdown;q=0.9")
+	s.Equal("text/markdown; charset=utf-8", markdownPreferred.Headers.Get("Content-Type"))
+
+	htmlPreferred := s.request(s.host(), "/docs", "text/html;q=0.9, text/markdown;q=0.5")
+	s.True(strings.HasPrefix(htmlPreferred.Headers.Get("Content-Type"), "text/html"))
+}
+
+// Explicitly requesting the .md URL serves markdown regardless of Accept.
+func (s *ContentNegotiationSuite) Test_DirectMarkdownUrl() {
+	s.mockFile("/docs.md", "# Docs\n")
+
+	res := s.request(s.host(), "/docs.md", "text/markdown")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
+}
+
+// A page without a markdown twin is not negotiable, so nothing about its
+// response changes — no Vary, no 406.
+func (s *ContentNegotiationSuite) Test_PageWithoutTwinIsUnchanged() {
+	s.mockFile("/pricing.html", "<h1>Pricing</h1>")
+
+	res := s.request(s.host(), "/pricing", "text/markdown")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+	s.Empty(res.Headers.Get("Vary"))
+}
+
+// Negotiation never refuses a request. A client that accepts neither
+// representation gets the HTML it would have got before the page became
+// negotiable — uptime probes and JSON-only fetch wrappers keep working.
+func (s *ContentNegotiationSuite) Test_UnsupportedAcceptStillServesHtml() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	for _, accept := range []string{"application/pdf", "application/json", "text/plain"} {
+		res := s.request(s.host(), "/docs", accept)
+
+		s.Equal(http.StatusOK, res.Status, "Accept: %s", accept)
+		s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"), "Accept: %s", accept)
+		s.Equal("Accept", res.Headers.Get("Vary"), "Accept: %s", accept)
+	}
+}
+
+// The 404 has a markdown representation too, so an agent that hits a dead URL
+// can read where to go next.
+func (s *ContentNegotiationSuite) Test_MarkdownNotFound() {
+	host := s.host()
+	host.Config.StaticFiles["/404.html"] = &appconf.StaticFile{FileName: "/404.html"}
+	host.Config.StaticFiles["/404.md"] = &appconf.StaticFile{FileName: "/404.md"}
+
+	s.mockFile("/404.md", "# Not found\n\nSee /sitemap.xml\n")
+
+	res := s.request(host, "/no-such-page", "text/markdown")
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
+	s.Equal("Accept", res.Headers.Get("Vary"))
+	s.Contains(string(res.Data.([]byte)), "Not found")
+}
+
+func (s *ContentNegotiationSuite) Test_HtmlNotFoundStillWins() {
+	host := s.host()
+	host.Config.StaticFiles["/404.html"] = &appconf.StaticFile{FileName: "/404.html"}
+	host.Config.StaticFiles["/404.md"] = &appconf.StaticFile{FileName: "/404.md"}
+
+	s.mockFile("/404.html", "<h1>Not found</h1>")
+
+	res := s.request(host, "/no-such-page", "text/html")
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+	s.Equal("Accept", res.Headers.Get("Vary"))
+}
+
+// Negotiation is opt-in: a build that merely happens to publish .md files keeps
+// serving exactly what it served before.
+func (s *ContentNegotiationSuite) Test_DisabledByDefault() {
+	host := s.host()
+	host.Config.Markdown = false
+
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	res := s.request(host, "/docs", "text/markdown")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+	s.Empty(res.Headers.Get("Vary"))
+}
+
+// The HTML representation is not always a static file. When it is server
+// rendered the response still has to carry Vary, or a cache keyed on the URL
+// alone hands that HTML to the next client asking for markdown.
+func (s *ContentNegotiationSuite) Test_VaryOnServerRenderedVariant() {
+	host := s.host()
+	host.Config.FunctionLocation = "aws:my-server-function"
+
+	delete(host.Config.StaticFiles, "/docs.html")
+
+	s.mockClient.On("Invoke", mock.Anything).Return(&integrations.InvokeResult{
+		StatusCode: http.StatusOK,
+		Body:       []byte("<h1>Docs</h1>"),
+		Headers:    http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+	}, nil)
+
+	res := s.request(host, "/docs", "text/html")
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("Accept", res.Headers.Get("Vary"))
+}
+
+// A deployment shipping only a markdown error page still answers browsers with
+// the built-in 404 — which must carry Vary just the same.
+func (s *ContentNegotiationSuite) Test_VaryOnBuiltInNotFound() {
+	host := s.host()
+	host.Config.StaticFiles["/404.md"] = &appconf.StaticFile{FileName: "/404.md"}
+
+	res := s.request(host, "/no-such-page", "text/html")
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Equal("Accept", res.Headers.Get("Vary"))
+}
+
+// A deployment that already varies on something keeps that token.
+func (s *ContentNegotiationSuite) Test_VaryPreservesExistingTokens() {
+	host := s.host()
+	host.Config.StaticFiles["/docs.md"].Headers = map[string]string{
+		"content-type": "text/markdown; charset=utf-8",
+		"vary":         "Accept-Encoding",
+	}
+
+	s.mockFile("/docs.md", "# Docs\n")
+
+	res := s.request(host, "/docs", "text/markdown")
+
+	s.Equal("Accept-Encoding, Accept", res.Headers.Get("Vary"))
+}
+
+// A SPA points errorFile at its app shell, whose markdown twin is the homepage.
+// That must never become the body of a 404.
+func (s *ContentNegotiationSuite) Test_MarkdownNotFoundIgnoresConfiguredErrorFile() {
+	host := s.host()
+	host.Config.ErrorFile = "/index.html"
+	host.Config.StaticFiles["/index.html"] = &appconf.StaticFile{FileName: "/index.html"}
+	host.Config.StaticFiles["/index.md"] = &appconf.StaticFile{FileName: "/index.md"}
+
+	s.mockFile("/index.html", "<div id=root></div>")
+
+	res := s.request(host, "/no-such-page", "text/markdown")
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.False(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/markdown"),
+		"the homepage markdown must not be served as the 404 body")
+}
+
+func (s *ContentNegotiationSuite) Test_MarkdownNotFoundAcceptsFiveHundred() {
+	host := s.host()
+	host.Config.StaticFiles["/500.md"] = &appconf.StaticFile{FileName: "/500.md"}
+
+	s.mockFile("/500.md", "# Error\n")
+
+	res := s.request(host, "/no-such-page", "text/markdown")
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
+}
+
+func TestContentNegotiationSuite(t *testing.T) {
+	suite.Run(t, new(ContentNegotiationSuite))
+}

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -123,6 +123,13 @@ func (r *RequestServer) finalize(res *shttp.Response) *shttp.Response {
 	res = injectSnippets(r.req, res)
 	res = injectOAuthChallenge(r.req, res)
 
+	// Vary is stamped here, and not in the individual handlers, because every
+	// exit path has to carry it: the static twin, the server-rendered HTML, the
+	// deployment's 404 and the built-in one are all representations of a
+	// negotiable URL. It runs after injectHeaders so a custom header rule cannot
+	// drop the one header that keeps a cache from serving markdown to a browser.
+	res = r.applyVary(res)
+
 	if r.req.Host.Config.IsEnterprise {
 		contentType := strings.ToLower(res.Headers.Get("Content-Type"))
 
@@ -132,6 +139,46 @@ func (r *RequestServer) finalize(res *shttp.Response) *shttp.Response {
 	}
 
 	return res
+}
+
+// applyVary stamps Vary: Accept on a response for a URL that has more than one
+// representation, preserving any tokens the deployment already asked for.
+func (r *RequestServer) applyVary(res *shttp.Response) *shttp.Response {
+	if res == nil || !r.varyAccept {
+		return res
+	}
+
+	if res.Headers == nil {
+		res.Headers = http.Header{}
+	}
+
+	for _, token := range strings.Split(res.Headers.Get("Vary"), ",") {
+		if strings.EqualFold(strings.TrimSpace(token), "Accept") {
+			return res
+		}
+	}
+
+	if existing := res.Headers.Get("Vary"); existing != "" {
+		res.Headers.Set("Vary", existing+", Accept")
+	} else {
+		res.Headers.Set("Vary", "Accept")
+	}
+
+	return res
+}
+
+// markdownTwin returns the deployment file holding the markdown representation
+// of the requested path, or an empty string when the deployment does not
+// negotiate or ships no twin.
+func (r *RequestServer) markdownTwin() string {
+	if !r.req.Host.Config.Markdown {
+		return ""
+	}
+
+	return markdownTwin(markdownTwinParams{
+		RequestPath: r.req.URL().Path,
+		Files:       r.req.Host.Config.StaticFiles,
+	})
 }
 
 // isAPIPath reports whether a request path is routed to the API function. The
@@ -160,6 +207,12 @@ type RequestServer struct {
 	logs      []integrations.Log
 	record    *analytics.Record
 	fnInvoked bool
+	// markdown is true when the response serves the markdown representation of
+	// a negotiable page.
+	markdown bool
+	// varyAccept is true when the requested URL has more than one
+	// representation, so caches must key on the Accept header.
+	varyAccept bool
 }
 
 func NewRequestServer(req *RequestContext) *RequestServer {
@@ -301,7 +354,39 @@ func (r *RequestServer) FileMeta() *FileMeta {
 }
 
 func (r *RequestServer) Handle() *shttp.Response {
-	if r.fileMeta = r.FileMeta(); r.fileMeta != nil {
+	r.fileMeta = r.FileMeta()
+
+	// Markdown negotiation runs before anything is served: a deployment that
+	// ships a .md twin of a page offers two representations of the same URL, and
+	// which one the client gets depends on its Accept header.
+	//
+	// It is opt-in. A build that happens to copy its markdown sources into the
+	// output must keep serving exactly what it served before, so a deployment
+	// only negotiates once it asks to.
+	if twin := r.markdownTwin(); twin != "" {
+		accept := parseAccept(r.req.Header.Get("Accept"))
+
+		// Negotiation only ever adds a representation. A client that accepts
+		// neither type still gets the HTML it would have got before, because
+		// refusing a request that used to succeed is a worse answer than serving
+		// the page.
+		//
+		// Vary is set on both representations, not only the markdown one:
+		// without it a cache that stored the HTML variant would hand it to the
+		// next agent asking for markdown, and the other way round.
+		r.varyAccept = true
+
+		if accept.prefersMarkdown() {
+			file := r.req.Host.Config.StaticFiles[twin]
+
+			r.fileMeta = &FileMeta{Name: file.FileName, Headers: file.Headers}
+			r.markdown = true
+
+			return r.Static()
+		}
+	}
+
+	if r.fileMeta != nil {
 		return r.Static()
 	}
 
@@ -344,8 +429,16 @@ func (r *RequestServer) Static() *shttp.Response {
 		notModified = headers.Get("ETag") == noneMatchHeader
 	}
 
+	if r.markdown {
+		headers.Set("Content-Type", MarkdownContentType)
+	}
+
 	if headers.Get("Cache-Control") == "" {
-		if strings.HasPrefix(headers.Get("Content-Type"), "text/html") {
+		// A markdown twin stands in for the page at the same URL, so it takes the
+		// page's revalidation policy and not the asset one. Without this it is
+		// classified by its own content type, and one representation of a URL
+		// outlives the other by a day.
+		if r.markdown || strings.HasPrefix(headers.Get("Content-Type"), "text/html") {
 			headers.Add("Cache-Control", "no-cache, must-revalidate")
 		} else {
 			headers.Add("Cache-Control", "public, max-age=86400")
@@ -555,6 +648,18 @@ func (r *RequestServer) NotFound() *shttp.Response {
 	cnf := r.req.Host.Config
 	customNotFound := ErrorFile(cnf)
 
+	// A deployment can ship a markdown error page next to the HTML one. Serving
+	// it lets an agent that hit a dead URL read where to go next instead of
+	// parsing a rendered page.
+	if markdownNotFound := MarkdownErrorFile(cnf); cnf.Markdown && markdownNotFound != nil {
+		r.varyAccept = true
+
+		if parseAccept(r.req.Header.Get("Accept")).prefersMarkdown() {
+			customNotFound = markdownNotFound
+			r.markdown = true
+		}
+	}
+
 	if customNotFound == nil {
 		return r.NotFoundBuiltIn()
 	}
@@ -571,6 +676,10 @@ func (r *RequestServer) NotFound() *shttp.Response {
 
 	headers := shttp.HeadersFromMap(customNotFound.Headers)
 	headers.Set("Content-Type", file.ContentType)
+
+	if r.markdown {
+		headers.Set("Content-Type", MarkdownContentType)
+	}
 
 	r.res = &shttp.Response{
 		Status:  http.StatusNotFound,
@@ -987,6 +1096,23 @@ func ErrorFile(cnf *appconf.Config) *appconf.StaticFile {
 		}
 
 		if file := cnf.StaticFiles[v]; file != nil {
+			return file
+		}
+	}
+
+	return nil
+}
+
+// MarkdownErrorFile returns the markdown error page of a deployment, or nil
+// when it ships none.
+//
+// Unlike ErrorFile this never derives a name from the configured errorFile. A
+// SPA points errorFile at its app shell (/index.html), whose markdown twin is
+// the homepage — serving that as the body of a 404 would tell an agent it had
+// landed on the homepage. A markdown error page is opted into by name.
+func MarkdownErrorFile(cnf *appconf.Config) *appconf.StaticFile {
+	for _, name := range []string{"/404.md", "/500.md", "/error.md"} {
+		if file := cnf.StaticFiles[name]; file != nil {
 			return file
 		}
 	}


### PR DESCRIPTION
Part of the #459 breakdown. **Based on #468** (unmatched-path routing) — review that one first; this diff shows only its own change.

Implements [acceptmarkdown.com](https://acceptmarkdown.com) in the hosting layer: an agent asks for a page with `Accept: text/markdown` and gets the markdown source instead of scraping the rendered HTML.

```
$ curl -H 'Accept: text/markdown' https://www.stormkit.io/docs/welcome/getting-started
content-type: text/markdown; charset=utf-8
vary: Accept
```

## Opt-in

`markdown: true` on the environment, **defaulting to off**. A deployment becomes negotiable only when it asks to. This matters: plenty of builds copy their markdown sources into the output (VitePress, Docusaurus, Hugo's `static/`), and those deployments must keep serving exactly what they served before. The flag rides the existing build-config JSON to `appconf.Config`, the same path `errorFile` takes.

## Behaviour

- The twin must be a file the build actually published — `/docs/foo` is negotiable exactly when the deployment contains `/docs/foo.md` (or `/docs/foo/index.md`). Negotiation can never invent a URL.
- q-values decide: `text/html;q=0.9, text/markdown;q=0.5` gets HTML. A bare `*/*` (curl, most crawlers) keeps HTML.
- **Negotiation never refuses.** A client accepting neither type gets the HTML it would have got before. An earlier draft answered 406 here; serving the page is the better answer, and it keeps JSON-Accept probes and uptime monitors working.
- `Vary: Accept` is stamped in `finalize()`, the one place every response path passes through — static twin, server-rendered HTML, the deployment's 404 and the built-in one. It runs after `injectHeaders` so a custom header rule cannot drop the header that keeps a cache from serving markdown to a browser, and it preserves any `Vary` tokens the deployment already set.
- The markdown twin takes the **page's** cache policy (`no-cache, must-revalidate`), not the asset policy. Classifying it by its own content type would have filed it under `public, max-age=86400` and left a corrected page stale for a day.
- The markdown 404 comes from `404.md` / `500.md` / `error.md` only — never derived from `errorFile`, because a SPA points that at its app shell, whose twin is the homepage, and answering a 404 with the homepage tells an agent it has landed there.
- Assets exit before any allocation: anything with an extension that is not `.md` or `.html` can never have a twin.

## Verification

`go build`, `go vet`, `gofmt` clean. 17 tests in a new `ContentNegotiationSuite` cover the opt-out default, markdown/HTML selection, q-values, wildcard and absent Accept, unsupported Accept still serving HTML, the cache policy, `Vary` on the server-rendered and built-in-404 paths, `Vary` token preservation, and the error-page rules. **They have not been executed** — the local Postgres test volume is out of disk space, which fails `databasetest` at package init. `go test ./src/ce/hosting/ -p 1` needs running before merge.

Note the docs update here covers both error pages and markdown representations, since they are one "how requests are served" section.
