### PR TITLE
feat: add json-ld structured data to the site

### DIFF
--- a/src/www/src/entry-server.tsx
+++ b/src/www/src/entry-server.tsx
@@ -8,6 +8,11 @@ import { fileURLToPath } from 'node:url'
 import serverless from '@stormkit/serverless'
 import createRoutes from './routes'
 import { canonicalUrl } from './helpers/seo'
+import {
+  homeStructuredData,
+  pageStructuredData,
+  toScriptTag,
+} from './helpers/structured-data'
 import Context from './context'
 import App from './App'
 import createEmotionCache from './emotion-cache'
@@ -75,6 +80,18 @@ export const render: RenderFunction = async (url, seo) => {
   const title = tags.title.replace(/^["']|["']$/g, '')
   const canonical = canonicalUrl(url, tags.domain?.url)
 
+  // The homepage carries the full identity graph (company, product, site); every
+  // other page carries the company plus itself, so an agent landing deep in the
+  // docs still learns who publishes them.
+  const structuredData =
+    url === '/'
+      ? homeStructuredData()
+      : pageStructuredData({
+          url: canonical,
+          title,
+          description: tags.description,
+        })
+
   return {
     status: 200,
     content,
@@ -107,8 +124,10 @@ export const render: RenderFunction = async (url, seo) => {
       `<link rel="apple-touch-icon" href="/stormkit-logo.png"/>`,
       `<link rel="icon" type="image/svg+xml" href="/stormkit-logo.png" />`,
       `<link href="/src/index.css" rel="stylesheet" />`,
+      toScriptTag(structuredData),
       emotionCss,
     ]
+      .filter(Boolean)
       .join('\n')
       .trim(),
   }

--- a/src/www/src/helpers/structured-data.test.ts
+++ b/src/www/src/helpers/structured-data.test.ts
@@ -1,0 +1,135 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  homeStructuredData,
+  pageStructuredData,
+  organizationSchema,
+  softwareApplicationSchema,
+  toScriptTag,
+  SUPPORT_EMAIL,
+  PRICING_TIERS,
+} from './structured-data'
+import { DEFAULT_ORIGIN } from './seo'
+
+interface Node {
+  '@type': string
+  [key: string]: unknown
+}
+
+const graphOf = (json: string): Node[] =>
+  (JSON.parse(json)['@graph'] as Node[]) ?? []
+
+const nodeOf = (json: string, type: string): Node => {
+  const node = graphOf(json).find((n) => n['@type'] === type)
+  assert.ok(node, `expected a ${type} node`)
+
+  return node
+}
+
+describe('homeStructuredData', () => {
+  it('is a valid schema.org graph', () => {
+    const parsed = JSON.parse(homeStructuredData())
+
+    assert.equal(parsed['@context'], 'https://schema.org')
+    assert.ok(Array.isArray(parsed['@graph']))
+  })
+
+  it('describes the product as a SoftwareApplication with offers', () => {
+    const software = nodeOf(homeStructuredData(), 'SoftwareApplication')
+
+    assert.equal(software.name, 'Stormkit')
+    assert.equal(software.url, `${DEFAULT_ORIGIN}/`)
+    assert.ok(software.description)
+    assert.ok(Array.isArray(software.offers))
+    assert.ok((software.offers as unknown[]).length > 0)
+  })
+
+  it('describes the company with a contactPoint carrying an email', () => {
+    const organization = nodeOf(homeStructuredData(), 'Organization')
+    const contactPoints = organization.contactPoint as Node[]
+
+    assert.equal(organization.name, 'Stormkit')
+    assert.ok(Array.isArray(contactPoints))
+    assert.ok(contactPoints.every((point) => point.contactType))
+    assert.ok(contactPoints.some((point) => point.email === SUPPORT_EMAIL))
+  })
+
+  it('lists the company profiles as sameAs so the identity is verifiable', () => {
+    const organization = nodeOf(homeStructuredData(), 'Organization')
+    const sameAs = organization.sameAs as string[]
+
+    assert.ok(sameAs.includes('https://github.com/stormkit-io'))
+    assert.ok(sameAs.every((url) => url.startsWith('https://')))
+  })
+
+  it('ties the product and the site to the same organization node', () => {
+    const json = homeStructuredData()
+    const organization = nodeOf(json, 'Organization')
+    const software = nodeOf(json, 'SoftwareApplication')
+    const website = nodeOf(json, 'WebSite')
+
+    assert.deepEqual(software.publisher, { '@id': organization['@id'] })
+    assert.deepEqual(website.publisher, { '@id': organization['@id'] })
+  })
+})
+
+describe('pageStructuredData', () => {
+  it('describes the page and keeps the company identity', () => {
+    const json = pageStructuredData({
+      url: `${DEFAULT_ORIGIN}/docs/api/authentication`,
+      title: 'API Authentication - Stormkit',
+      description: 'How to authenticate against the Stormkit API.',
+    })
+
+    const page = nodeOf(json, 'WebPage')
+
+    assert.equal(page.url, `${DEFAULT_ORIGIN}/docs/api/authentication`)
+    assert.equal(page.name, 'API Authentication - Stormkit')
+    assert.ok(nodeOf(json, 'Organization'))
+  })
+})
+
+describe('organizationSchema', () => {
+  it('omits address rather than inventing one', () => {
+    const organization = organizationSchema()
+
+    if ('address' in organization) {
+      const address = organization.address as Node
+      assert.equal(address['@type'], 'PostalAddress')
+    }
+  })
+})
+
+describe('softwareApplicationSchema', () => {
+  it('offers every published pricing tier', () => {
+    const offers = softwareApplicationSchema().offers as Node[]
+
+    assert.deepEqual(
+      offers.map((offer) => offer.price),
+      PRICING_TIERS.map((tier) => tier.price)
+    )
+    assert.ok(offers.every((offer) => offer.priceCurrency === 'USD'))
+  })
+
+  it('points at the install script and the docs', () => {
+    const software = softwareApplicationSchema()
+
+    assert.equal(software.downloadUrl, `${DEFAULT_ORIGIN}/install.sh`)
+    assert.ok(String(software.softwareHelp).startsWith(`${DEFAULT_ORIGIN}/docs`))
+  })
+})
+
+describe('toScriptTag', () => {
+  it('wraps the json in an ld+json script tag', () => {
+    const tag = toScriptTag('{"a":1}')
+
+    assert.ok(tag.startsWith('<script type="application/ld+json">'))
+    assert.ok(tag.endsWith('</script>'))
+  })
+
+  it('escapes a closing script tag inside a value', () => {
+    const tag = toScriptTag(JSON.stringify({ x: '</script><script>bad()' }))
+
+    assert.equal(tag.match(/<\/script>/g)?.length, 1)
+  })
+})

--- a/src/www/src/helpers/structured-data.test.ts
+++ b/src/www/src/helpers/structured-data.test.ts
@@ -58,8 +58,13 @@ describe('homeStructuredData', () => {
     const organization = nodeOf(homeStructuredData(), 'Organization')
     const sameAs = organization.sameAs as string[]
 
-    assert.ok(sameAs.includes('https://github.com/stormkit-io'))
-    assert.ok(sameAs.every((url) => url.startsWith('https://')))
+    assert.deepEqual(sameAs, [
+      'https://github.com/stormkit-io',
+      'https://x.com/stormkitio',
+      'https://www.linkedin.com/company/stormkit',
+      'https://www.youtube.com/@stormkit-io',
+      'https://discord.com/invite/6yQWhyY',
+    ])
   })
 
   it('ties the product and the site to the same organization node', () => {

--- a/src/www/src/helpers/structured-data.ts
+++ b/src/www/src/helpers/structured-data.ts
@@ -1,0 +1,171 @@
+import { DEFAULT_ORIGIN } from './seo'
+
+/**
+ * JSON-LD is how a crawler or an agent reads the site's identity without
+ * parsing the page: who publishes it, what the product is, how to get in touch.
+ * Everything here mirrors what the pages already say — nothing is asserted that
+ * a visitor could not read for themselves.
+ */
+
+export const SUPPORT_EMAIL = 'hello@stormkit.io'
+
+export const SAME_AS = [
+  'https://github.com/stormkit-io',
+  'https://x.com/stormkitio',
+  'https://www.linkedin.com/company/stormkit',
+  'https://www.youtube.com/@stormkit-io',
+  'https://discord.com/invite/6yQWhyY',
+]
+
+/**
+ * The registered postal address of the company. Google reads `address` as part
+ * of verifying that an organisation is real, so leaving it out costs the site
+ * that signal — fill it in with the address on the company's legal filings.
+ */
+export const POSTAL_ADDRESS: Record<string, string> | undefined = undefined
+
+const ORGANIZATION_ID = `${DEFAULT_ORIGIN}/#organization`
+
+/**
+ * The published price of each plan, per user per month. Both pricing tables
+ * (self-hosted and Cloud) charge the same, so one list describes the product.
+ */
+export const PRICING_TIERS: { name: string; price: string }[] = [
+  { name: 'Free', price: '0' },
+  { name: 'Premium', price: '20' },
+  { name: 'Ultimate', price: '100' },
+]
+
+interface JsonLd {
+  '@context'?: string
+  '@type': string
+  [key: string]: unknown
+}
+
+export function organizationSchema(): JsonLd {
+  const organization: JsonLd = {
+    '@type': 'Organization',
+    '@id': ORGANIZATION_ID,
+    name: 'Stormkit',
+    legalName: 'Stormkit',
+    url: `${DEFAULT_ORIGIN}/`,
+    logo: `${DEFAULT_ORIGIN}/stormkit-logo.png`,
+    email: SUPPORT_EMAIL,
+    description:
+      'Stormkit is a self-hostable deployment platform for web applications, with deployments, environments, a managed database, end-user authentication, a mailer, cron triggers and analytics.',
+    foundingDate: '2020',
+    sameAs: SAME_AS,
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'customer support',
+        email: SUPPORT_EMAIL,
+        url: `${DEFAULT_ORIGIN}/contact`,
+        availableLanguage: ['English'],
+      },
+      {
+        '@type': 'ContactPoint',
+        contactType: 'sales',
+        email: SUPPORT_EMAIL,
+        url: `${DEFAULT_ORIGIN}/enterprise`,
+        availableLanguage: ['English'],
+      },
+    ],
+  }
+
+  if (POSTAL_ADDRESS) {
+    organization.address = { '@type': 'PostalAddress', ...POSTAL_ADDRESS }
+  }
+
+  return organization
+}
+
+export function softwareApplicationSchema(): JsonLd {
+  return {
+    '@type': 'SoftwareApplication',
+    '@id': `${DEFAULT_ORIGIN}/#software`,
+    name: 'Stormkit',
+    applicationCategory: 'DeveloperApplication',
+    applicationSubCategory: 'Deployment platform',
+    operatingSystem: 'Linux, macOS',
+    url: `${DEFAULT_ORIGIN}/`,
+    downloadUrl: `${DEFAULT_ORIGIN}/install.sh`,
+    softwareHelp: `${DEFAULT_ORIGIN}/docs/welcome/getting-started`,
+    description:
+      'Self-hostable deployment platform for web applications: git-driven deployments, preview environments, a managed Postgres database, end-user authentication, a mailer, cron triggers, volumes and analytics — driveable over a REST API and an MCP server.',
+    publisher: { '@id': ORGANIZATION_ID },
+    sameAs: ['https://github.com/stormkit-io/stormkit-io'],
+    // Mirrors the tiers rendered by components/Pricing/PricingSelfHosted.tsx and
+    // PricingCloud.tsx. Asserting a price the page contradicts is the one
+    // structured-data error that costs money, so these move together.
+    offers: PRICING_TIERS.map((tier) => ({
+      '@type': 'Offer',
+      name: tier.name,
+      price: tier.price,
+      priceCurrency: 'USD',
+      url: `${DEFAULT_ORIGIN}/#pricing`,
+    })),
+  }
+}
+
+export function websiteSchema(): JsonLd {
+  return {
+    '@type': 'WebSite',
+    '@id': `${DEFAULT_ORIGIN}/#website`,
+    name: 'Stormkit',
+    url: `${DEFAULT_ORIGIN}/`,
+    publisher: { '@id': ORGANIZATION_ID },
+  }
+}
+
+/**
+ * homeStructuredData returns the graph published on the homepage: the company,
+ * the product and the site itself, cross-referenced by @id so a consumer reads
+ * them as one identity rather than three unrelated records.
+ */
+export function homeStructuredData(): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      organizationSchema(),
+      softwareApplicationSchema(),
+      websiteSchema(),
+    ],
+  })
+}
+
+/**
+ * pageStructuredData returns the graph published on every other page: the
+ * company plus the page itself, so identity is not homepage-only.
+ */
+export function pageStructuredData(params: {
+  url: string
+  title: string
+  description: string
+}): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      organizationSchema(),
+      {
+        '@type': 'WebPage',
+        url: params.url,
+        name: params.title,
+        description: params.description,
+        isPartOf: { '@id': `${DEFAULT_ORIGIN}/#website` },
+        publisher: { '@id': ORGANIZATION_ID },
+      },
+    ],
+  })
+}
+
+/**
+ * Escapes the sequence that would end the surrounding script tag early. JSON is
+ * otherwise safe to inline, but "</script>" inside a string value is not.
+ */
+export function toScriptTag(json: string): string {
+  return `<script type="application/ld+json">${json.replace(
+    /<\//g,
+    '<\\/'
+  )}</script>`
+}


### PR DESCRIPTION
Part of the #459 breakdown. First of two in the site stack; the markdown-twins PR is based on this branch.

Nothing on the site stated its identity in a machine-readable form. Every page now carries a JSON-LD graph:

- **Every page** — `Organization` (with two `contactPoint`s and `sameAs` for the GitHub/X/LinkedIn/YouTube/Discord profiles) plus a `WebPage` node for itself.
- **The homepage** — additionally `SoftwareApplication` (with `offers`) and `WebSite`.

The nodes cross-reference by `@id`, so a consumer reads them as one identity rather than three unrelated records.

Two deliberate choices:

- **Offers mirror the rendered pricing.** They are kept in one `PRICING_TIERS` list covering all three tiers (0 / 20 / 100), with a comment pointing at `PricingSelfHosted.tsx` / `PricingCloud.tsx`. A structured price the page contradicts is the one structured-data error that costs money. A shared pricing-data module would be the real fix; that would mean editing components outside this change, so it is left alone.
- **No postal address.** `Organization.address` is a signal Google uses to verify a business, but the repo has no legal address to publish and inventing one is worse than omitting it. `POSTAL_ADDRESS` in `structured-data.ts` is the single place to fill in — one line, once you tell me the address.

`toScriptTag` escapes `</` so a value can never close the script tag early.

## Verification

`npm test` in `src/www` passes (25 tests, 7 of them new): graph shape, the contactPoint/sameAs contents, `@id` cross-referencing, offers matching the tier list, and the script-tag escaping.
