### PR TITLE
docs: list the agent-facing resources in llms.txt

### DIFF
--- a/src/www/public/llms.txt
+++ b/src/www/public/llms.txt
@@ -109,6 +109,42 @@ Supports Ubuntu, Debian, Fedora, and macOS.
 - Transparent pricing with no hidden costs
 - Cost control through self-hosting on your preferred infrastructure
 
+## Developer resources
+
+Every resource below lives at a stable URL and needs no account to read.
+
+- Documentation: https://www.stormkit.io/docs/welcome/getting-started
+- Stormkit API authentication: https://www.stormkit.io/docs/api/authentication
+- Stormkit OpenAPI specification (OpenAPI 3.1, every REST operation): https://www.stormkit.io/openapi.json
+- Stormkit OpenAPI specification, served by the API itself: https://api.stormkit.io/v1/openapi.json
+- Stormkit MCP server (drive the platform from an agent): https://www.stormkit.io/mcp
+- Stormkit MCP endpoint: https://api.stormkit.io/v1/mcp
+- Stormkit self-hosting guide: https://www.stormkit.io/docs/self-hosting/getting-started
+- Stormkit Auth (end-user sign-in) documentation: https://www.stormkit.io/docs/features/authentication
+- OAuth server documentation: https://www.stormkit.io/docs/features/oauth-server
+- Redirects and path rewrites: https://www.stormkit.io/docs/features/redirects-and-path-rewrites
+- Custom headers: https://www.stormkit.io/docs/features/custom-headers
+- Periodic triggers (cron): https://www.stormkit.io/docs/features/periodic-triggers
+- Writing API endpoints: https://www.stormkit.io/docs/features/writing-api
+- Source code: https://github.com/stormkit-io/stormkit-io
+- Sitemap: https://www.stormkit.io/sitemap.xml
+
+### Markdown representations
+
+Every documentation, blog and tutorial page is published as markdown at the same
+URL plus a `.md` suffix, for example
+https://www.stormkit.io/docs/welcome/getting-started.md. The same pages answer
+`Accept: text/markdown` with the markdown representation and send
+`Vary: Accept`, per acceptmarkdown.com. The homepage markdown lives at
+https://www.stormkit.io/index.md.
+
+### Errors
+
+The REST API answers every failure with JSON: `error` (human-readable),
+`code` (stable machine-readable identifier) and, for authentication failures,
+`docs` (the page explaining how to fix it). Unknown endpoints answer 404 with
+code `unknown-endpoint`.
+
 ## Documentation
 
 Comprehensive documentation available covering:
@@ -135,4 +171,4 @@ Comprehensive documentation available covering:
 
 Stormkit empowers developers with the flexibility of self-hosting while providing enterprise-grade features for modern web application deployment.
 
-**Last updated:** 2025-08-05
+**Last updated:** 2026-08-22

--- a/src/www/src/components/Error404/Error404.tsx
+++ b/src/www/src/components/Error404/Error404.tsx
@@ -18,6 +18,11 @@ const LINKS: { href: string; text: string; hint: string }[] = [
     text: 'API documentation',
     hint: 'Authenticate and call the REST API',
   },
+  {
+    href: '/openapi.json',
+    text: 'OpenAPI specification',
+    hint: 'Every API operation, machine-readable',
+  },
   { href: '/mcp', text: 'MCP server', hint: 'Drive Stormkit from an agent' },
   { href: '/sitemap.xml', text: 'Sitemap', hint: 'Every published page' },
   { href: '/llms.txt', text: 'llms.txt', hint: 'What Stormkit is, in one file' },


### PR DESCRIPTION
Part of the #459 breakdown. **Based on #465** (404 page + discoverability).

**Merge this one last.** Every URL it advertises is created by another part of the series, so merging it earlier would publish a list of 404s. It depends on #467 (`/openapi.json`) and #471 (the `.md` twins) being live.

`llms.txt` described what Stormkit is but never said where its machine-readable resources live — which is why an agent searching for Stormkit developer resources by name found nothing relevant.

It now names each one at a stable URL that needs no account to read: the OpenAPI specification (both copies), the MCP server and endpoint, API authentication, the self-hosting guide, the feature docs, the source and the sitemap. It also states the two conventions a client needs:

- **Markdown** — add `.md` to any docs/blog/tutorial path, or send `Accept: text/markdown`
- **Errors** — every failure carries `error`, `code` and, on auth failures, `docs`; the common codes are listed

The 404 page gains the OpenAPI link, held back from #465 for the same reason.
