### PR TITLE
test: expect the markdown field in env config json

### DIFF
--- a/src/ce/api/app/buildconf/buildconfhandlers/handler_env_get_test.go
+++ b/src/ce/api/app/buildconf/buildconfhandlers/handler_env_get_test.go
@@ -59,6 +59,7 @@ func (s *HandlerEnvGetSuite) Test_Success() {
 		   "build":{
 			  "distFolder":"build",
 			  "buildCmd":"npm run build",
+			  "markdown": null,
 			  "previewLinks": null,
 			  "vars":{
 				 "NODE_ENV":""

--- a/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
@@ -70,6 +70,7 @@ func (s *HandlerMyDeploymentsSuite) responseTemplate() (*template.Template, erro
 						"build": {
 							"buildCmd": "npm run build",
 							"distFolder": "build",
+							"markdown": null,
 							"previewLinks": null,
 							"statusChecks": [{
 								"cmd": "npm run e2e",


### PR DESCRIPTION
Fixes `main`, red since #469.

The `markdown` flag added for content negotiation is a `null.Bool`. `omitempty` has no effect on a struct type, so the field always serialises — as `"markdown": null` when unset, exactly like the `previewLinks` field beside it in the same struct. That is consistent with how the environment's build config has always been emitted; what was missing is that two suites assert that JSON exactly and were not updated with it.

```
--- Expected
+++ Actual
   "build": (map[string]interface {}) (len=5) {
     "buildCmd": "npm run build",
     "distFolder": "build",
+    "markdown": (interface {}) <nil>,
     "previewLinks": (interface {}) <nil>,
```

Both expectations now include the field:

- `handler_env_get_test.go` — the one CI reported
- `handler_my_deployments_test.go` — the same failure in the deployment config snapshot; CI stopped before reaching it, but it fails identically

## Why the test and not the field

Making the field genuinely absent when unset would mean `*bool` instead of `null.Bool`, which would make it the only field in `BuildConf` shaped that way and would change the JSON contract for a field that is already public. `previewLinks` establishes the convention; `markdown` follows it.

## Verification

Both suites pass locally, and a full `go test ./src/... -p 1` sweep is running to confirm nothing else asserts on that shape. (My earlier inability to run the Go suites was a full Postgres test volume — that has cleared, so these are actually executed this time.)
