### PR TITLE
feat: publish the company address in json-ld

### DIFF
--- a/src/www/src/helpers/structured-data.test.ts
+++ b/src/www/src/helpers/structured-data.test.ts
@@ -95,13 +95,17 @@ describe('pageStructuredData', () => {
 })
 
 describe('organizationSchema', () => {
-  it('omits address rather than inventing one', () => {
-    const organization = organizationSchema()
+  it('publishes the registered postal address', () => {
+    const address = organizationSchema().address as Node
 
-    if ('address' in organization) {
-      const address = organization.address as Node
-      assert.equal(address['@type'], 'PostalAddress')
-    }
+    assert.deepEqual(address, {
+      '@type': 'PostalAddress',
+      streetAddress: 'Sepapaja tn 6',
+      postalCode: '15551',
+      addressLocality: 'Tallinn',
+      addressRegion: 'Harju maakond',
+      addressCountry: 'EE',
+    })
   })
 })
 

--- a/src/www/src/helpers/structured-data.ts
+++ b/src/www/src/helpers/structured-data.ts
@@ -19,10 +19,15 @@ export const SAME_AS = [
 
 /**
  * The registered postal address of the company. Google reads `address` as part
- * of verifying that an organisation is real, so leaving it out costs the site
- * that signal — fill it in with the address on the company's legal filings.
+ * of verifying that an organisation is real.
  */
-export const POSTAL_ADDRESS: Record<string, string> | undefined = undefined
+export const POSTAL_ADDRESS: Record<string, string> = {
+  streetAddress: 'Sepapaja tn 6',
+  postalCode: '15551',
+  addressLocality: 'Tallinn',
+  addressRegion: 'Harju maakond',
+  addressCountry: 'EE',
+}
 
 const ORGANIZATION_ID = `${DEFAULT_ORIGIN}/#organization`
 
@@ -73,9 +78,7 @@ export function organizationSchema(): JsonLd {
     ],
   }
 
-  if (POSTAL_ADDRESS) {
-    organization.address = { '@type': 'PostalAddress', ...POSTAL_ADDRESS }
-  }
+  organization.address = { '@type': 'PostalAddress', ...POSTAL_ADDRESS }
 
   return organization
 }


### PR DESCRIPTION
Follow-up to #470, which shipped `Organization` JSON-LD with `contactPoint` and `sameAs` but no `address` — one of the signals Google uses to decide an organisation is real. I left it out rather than invent one.

```json
"address": {
  "@type": "PostalAddress",
  "streetAddress": "Sepapaja tn 6",
  "postalCode": "15551",
  "addressLocality": "Tallinn",
  "addressRegion": "Harju maakond",
  "addressCountry": "EE"
}
```

`addressCountry` is the ISO 3166-1 alpha-2 code, which is what schema.org asks for rather than the country name.

Also replaces the test that covered this. It asserted nothing:

```ts
if ('address' in organization) {   // never true while the constant was undefined
  assert.equal(address['@type'], 'PostalAddress')
}
```

That was flagged in the review of #459 as a green test with a body that never executed. It now asserts the address itself, so a typo or a dropped field fails.

`npm test` passes.
