### PR TITLE
feat: make the 404 page useful

### DIFF
--- a/src/www/src/components/Error404/Error404.tsx
+++ b/src/www/src/components/Error404/Error404.tsx
@@ -1,32 +1,66 @@
+import { useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Link from '@mui/material/Link'
 import Header from '~/components/Header'
 import Footer from '~/components/Footer'
+import DocSearch from '~/components/DocsNav/DocSearch'
 
-// A dead URL is where both people and agents most need a way out, so the page
-// names the entry points explicitly instead of only apologising. The same list
-// is served as markdown from /404.md.
-const LINKS: { href: string; text: string; hint: string }[] = [
-  {
-    href: '/docs/welcome/getting-started',
-    text: 'Documentation',
-    hint: 'Guides and reference',
-  },
-  {
-    href: '/docs/api/authentication',
-    text: 'API documentation',
-    hint: 'Authenticate and call the REST API',
-  },
-  {
-    href: '/openapi.json',
-    text: 'OpenAPI specification',
-    hint: 'Every API operation, machine-readable',
-  },
-  { href: '/mcp', text: 'MCP server', hint: 'Drive Stormkit from an agent' },
-  { href: '/sitemap.xml', text: 'Sitemap', hint: 'Every published page' },
-  { href: '/llms.txt', text: 'llms.txt', hint: 'What Stormkit is, in one file' },
+// A dead URL is usually a typo or a stale link, so search is the fastest way
+// out and takes the primary position. The links under it are the destinations
+// someone would otherwise go hunting for in the nav. Machine-readable
+// resources are deliberately absent: agents are served /404.md, which lists
+// them, and putting them here only dilutes the three a reader wants.
+const LINKS: { href: string; text: string }[] = [
+  { href: '/docs/welcome/getting-started', text: 'Documentation' },
+  { href: '/docs/api/authentication', text: 'API documentation' },
+  { href: '/', text: 'Homepage' },
 ]
+
+/**
+ * RequestedPath shows the path that produced the 404, which is what lets a
+ * reader spot their own typo. It renders only after mount: this page is
+ * prerendered to /404.html and served for every missing URL, so at build time
+ * the path is not knowable and rendering one would state a falsehood.
+ */
+function RequestedPath() {
+  const [path, setPath] = useState('')
+
+  useEffect(() => {
+    setPath(window.location.pathname)
+  }, [])
+
+  if (!path) {
+    return null
+  }
+
+  return (
+    <Typography
+      component="p"
+      sx={{
+        mt: 1.5,
+        fontSize: 14,
+        color: 'text.secondary',
+        wordBreak: 'break-all',
+      }}
+    >
+      Nothing is served at{' '}
+      <Box
+        component="code"
+        sx={{
+          px: 0.75,
+          py: 0.25,
+          borderRadius: 1,
+          bgcolor: 'page.transparent',
+          fontFamily: 'monospace',
+          color: 'primary.contrastText',
+        }}
+      >
+        {path}
+      </Box>
+    </Typography>
+  )
+}
 
 export default function Error404() {
   return (
@@ -45,51 +79,67 @@ export default function Error404() {
           flex: 1,
           m: 'auto',
           px: { xs: 2, md: 0 },
+          py: { xs: 6, md: 10 },
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
         }}
         maxWidth="lg"
       >
-        <Box sx={{ textAlign: 'center' }}>
+        <Box sx={{ textAlign: 'center', maxWidth: 560 }}>
           <Typography
             variant="h1"
-            color="secondary"
-            sx={{ fontWeight: 'bold' }}
+            sx={{
+              fontWeight: 'bold',
+              fontSize: { xs: 56, md: 80 },
+              lineHeight: 1.1,
+              color: 'secondary.dark',
+            }}
           >
             4 oh 4
           </Typography>
-          <Typography variant="h4" component="p" sx={{ mt: 4 }}>
+          <Typography
+            variant="h4"
+            component="p"
+            sx={{ mt: 2, fontSize: { xs: 20, md: 28 } }}
+          >
             There is nothing under this link
           </Typography>
-          <Typography
-            variant="h2"
-            sx={{ mt: 6, mb: 2, fontSize: 16, fontWeight: 600 }}
+          <RequestedPath />
+
+          <Box
+            sx={{
+              mt: 5,
+              display: 'flex',
+              justifyContent: 'center',
+              // DocSearch lays itself out for the docs nav, where it sits at the
+              // start of a flex row. Centre it here without touching that.
+              '& > div': { flex: 'none', justifyContent: 'center' },
+              '& .MuiTextField-root': { minWidth: { xs: '100%', md: 360 } },
+            }}
           >
-            Where to look next
-          </Typography>
+            <DocSearch />
+          </Box>
+
           <Box
             component="ul"
             sx={{
               m: 0,
+              mt: 4,
               p: 0,
               listStyle: 'none',
               display: 'flex',
-              flexDirection: 'column',
-              gap: 1,
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+              columnGap: 3,
+              rowGap: 1,
             }}
           >
             {LINKS.map((link) => (
               <Box component="li" key={link.href}>
-                <Link href={link.href} color="secondary" underline="hover">
+                <Link href={link.href} underline="hover" sx={{ fontSize: 15 }}>
                   {link.text}
                 </Link>
-                <Typography
-                  component="span"
-                  sx={{ ml: 1, opacity: 0.6, fontSize: 14 }}
-                >
-                  {link.hint}
-                </Typography>
               </Box>
             ))}
           </Box>


### PR DESCRIPTION
Reworks the 404 page shipped in #465, after looking at it rendered.

## What was wrong

- **The list didn't scan.** Six rows of `link + hint`, each centred as a unit, so six labels of different lengths started at six different x positions. There was no column for the eye to follow.
- **No primary action, and no search** — six identical text links, on the page people reach precisely when they have mistyped something.
- **Wrong audience.** OpenAPI, `llms.txt` and the sitemap were there because I was working the agent-readiness audit. Agents don't read this page — they get `404.md`, which lists all of them. On the HTML page they diluted the three links a person actually wants.
- **The headline** was dark maroon on near-black, filling about a third of the viewport to convey nothing, and pushing the links into the footer.

## What it is now

**Search is the primary element**, reusing the existing `DocSearch` — same field, same modal, same ⌘K as the docs, so there is nothing new to learn and no new component to maintain. A dead URL is usually a typo or a stale link, and search is the fastest way out of both.

Under it, three destinations on one line: Documentation, API documentation, Homepage. One line of short labels has no ragged-centring problem.

**The page now names the path that produced the 404**, which is what lets someone spot their own typo. It renders after mount on purpose: this page is prerendered to `/404.html` and served for every missing URL, so at build time there is no path to show and rendering one would state a falsehood.

The headline keeps the joke at roughly half the size, in `secondary.dark` rather than `secondary.main` — brighter against the background, and it lets the rest of the page breathe.

## Cost

`DocSearch` pulls in minisearch plus `search-docs.json` (15.8 KB raw, a few KB gzipped) on a page that previously shipped almost nothing. That is the one real trade-off, and I think it is clearly worth it for the page's primary action.

## Verification

Built and viewed in a browser: the layout above, and the search modal opens from the 404 and returns highlighted results. `npm test` passes (32). Mobile is verified by reading the breakpoints rather than a screenshot — the capture is fixed-width — but they mirror the patterns used elsewhere on the site: `px`/`fontSize` `{xs, md}`, the field at `100%` width on `xs`, and the link row wraps.
