### PR TITLE
fix: prefer explicitly accepted type in negotiation

### DIFF
--- a/docs/deployments/6-how-do-we-deploy.md
+++ b/docs/deployments/6-how-do-we-deploy.md
@@ -94,6 +94,10 @@ means:
   representation, it never refuses a request that used to succeed.
 - `q` values are honoured, so `Accept: text/html;q=0.9, text/markdown;q=0.5`
   still gets HTML.
+- `q` values are read from the most specific media range that matches, and a
+  type the client named explicitly beats one it only covered with a wildcard —
+  `Accept: text/markdown, */*` gets the markdown, a bare `Accept: */*` gets the
+  HTML.
 - Every answer carries `Vary: Accept`, so a CDN caches the two variants
   separately instead of serving one to the wrong client, and both share the
   page's cache policy.

--- a/docs/deployments/6-how-do-we-deploy.md
+++ b/docs/deployments/6-how-do-we-deploy.md
@@ -98,6 +98,14 @@ means:
   type the client named explicitly beats one it only covered with a wildcard —
   `Accept: text/markdown, */*` gets the markdown, a bare `Accept: */*` gets the
   HTML.
+- The converse follows: a `q` on `text/html` is read from the `text/html` range
+  alone, so a wildcard at a higher `q` outranks it and
+  `Accept: text/html;q=0.9, */*` gets the markdown even though it never named
+  markdown. A client that wants the page should name `text/html` at full weight,
+  which every browser and HTTP library already does.
+- Listing order carries no weight, so `Accept: text/markdown, text/html` is a tie
+  and gets the HTML. Say it with a `q` instead.
+- A `q` outside the `0`–`1` range is clamped into it.
 - Every answer carries `Vary: Accept`, so a CDN caches the two variants
   separately instead of serving one to the wrong client, and both share the
   page's cache policy.

--- a/src/ce/hosting/content_negotiation.go
+++ b/src/ce/hosting/content_negotiation.go
@@ -62,34 +62,87 @@ func parseAccept(header string) acceptPreference {
 	return pref
 }
 
-// qualityFor returns the q-value the client assigned to a media type, honouring
-// the `type/*` and `*/*` wildcards. It returns 0 when the type is not accepted.
-func (p acceptPreference) qualityFor(mime string) float64 {
-	if p.empty {
+// acceptMatch is how a media type matched an Accept header: the q-value that
+// applies to it, and how specifically the client named it.
+type acceptMatch struct {
+	quality float64
+	// specificity is 2 for an exact `type/subtype`, 1 for `type/*`, 0 for
+	// `*/*`, and -1 when nothing matched.
+	specificity int
+}
+
+// specificityOf reports how precisely a media range names a media type, or -1
+// when the range does not cover it at all.
+func specificityOf(entry, mime, family string) int {
+	switch entry {
+	case mime:
+		return 2
+	case family + "/*":
 		return 1
+	case "*/*":
+		return 0
+	}
+
+	return -1
+}
+
+// matchFor returns the q-value a client assigned to a media type, taken from
+// the most specific range that covers it.
+//
+// Most specific and not the highest q across every matching range, per RFC 9110
+// §12.5.1: in `text/html;q=0.1, */*` the client downweighted HTML and the
+// wildcard does not undo that.
+func (p acceptPreference) matchFor(mime string) acceptMatch {
+	if p.empty {
+		return acceptMatch{quality: 1, specificity: 0}
 	}
 
 	family, _, _ := strings.Cut(mime, "/")
-	best := 0.0
+	best := acceptMatch{specificity: -1}
 
 	for _, entry := range p.types {
-		switch entry.mime {
-		case mime, family + "/*", "*/*":
-			if entry.quality > best {
-				best = entry.quality
-			}
+		specificity := specificityOf(entry.mime, mime, family)
+
+		if specificity < 0 {
+			continue
 		}
+
+		// A more specific range replaces a less specific one outright; among
+		// equally specific ranges the client's highest q wins.
+		if specificity > best.specificity ||
+			(specificity == best.specificity && entry.quality > best.quality) {
+			best = acceptMatch{quality: entry.quality, specificity: specificity}
+		}
+	}
+
+	if best.specificity < 0 {
+		return acceptMatch{specificity: -1}
 	}
 
 	return best
 }
 
 // prefersMarkdown reports whether the client would rather have markdown than
-// HTML. A tie goes to HTML, so a browser sending `*/*` keeps its page.
+// HTML.
+//
+// A tie on q-value goes to whichever type the client named more specifically,
+// so `text/markdown, */*` — an agent asking for markdown but taking anything —
+// gets markdown, while a bare `*/*` from curl still gets the page. A tie at
+// equal specificity goes to HTML.
 func (p acceptPreference) prefersMarkdown() bool {
-	markdown := p.qualityFor("text/markdown")
+	markdown := p.matchFor("text/markdown")
 
-	return markdown > 0 && markdown > p.qualityFor("text/html")
+	if markdown.quality <= 0 || markdown.specificity < 0 {
+		return false
+	}
+
+	html := p.matchFor("text/html")
+
+	if markdown.quality != html.quality {
+		return markdown.quality > html.quality
+	}
+
+	return markdown.specificity > html.specificity
 }
 
 // markdownTwinParams are the arguments of markdownTwin.

--- a/src/ce/hosting/content_negotiation.go
+++ b/src/ce/hosting/content_negotiation.go
@@ -1,6 +1,7 @@
 package hosting
 
 import (
+	"math"
 	"path"
 	"strconv"
 	"strings"
@@ -50,8 +51,19 @@ func parseAccept(header string) acceptPreference {
 				continue
 			}
 
-			if q, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
-				entry.quality = q
+			// Clamped, and NaN dropped, because the q decides which file is
+			// served and the header is whatever the client sent. An out-of-range
+			// q used to be harmless — the old comparison took the highest q
+			// across every matching range, so an illegal one lifted both types
+			// equally — but a q now applies to one type and not the other, and
+			// `text/html, */*;q=5` would hand markdown to a client that named
+			// HTML at full weight.
+			//
+			// A q that does not parse at all keeps the default of 1 rather than
+			// dropping to 0: a browser sending a truncated `text/html;q=` must
+			// still get its page.
+			if q, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil && !math.IsNaN(q) {
+				entry.quality = math.Min(math.Max(q, 0), 1)
 			}
 		}
 
@@ -115,10 +127,6 @@ func (p acceptPreference) matchFor(mime string) acceptMatch {
 		}
 	}
 
-	if best.specificity < 0 {
-		return acceptMatch{specificity: -1}
-	}
-
 	return best
 }
 
@@ -129,10 +137,15 @@ func (p acceptPreference) matchFor(mime string) acceptMatch {
 // so `text/markdown, */*` — an agent asking for markdown but taking anything —
 // gets markdown, while a bare `*/*` from curl still gets the page. A tie at
 // equal specificity goes to HTML.
+//
+// Listing order is not a signal, per RFC 9110 §12.5.1, so `text/markdown,
+// text/html` is a tie and serves HTML. A client that wants markdown while
+// naming HTML too has to say so with a q-value.
 func (p acceptPreference) prefersMarkdown() bool {
 	markdown := p.matchFor("text/markdown")
 
-	if markdown.quality <= 0 || markdown.specificity < 0 {
+	// Covers "not matched" as well: an unmatched type carries a zero quality.
+	if markdown.quality <= 0 {
 		return false
 	}
 
@@ -142,6 +155,9 @@ func (p acceptPreference) prefersMarkdown() bool {
 		return markdown.quality > html.quality
 	}
 
+	// Reachable only with both qualities equal and markdown's above zero, so
+	// HTML matched too and its specificity is a real rank rather than the
+	// no-match sentinel.
 	return markdown.specificity > html.specificity
 }
 

--- a/src/ce/hosting/content_negotiation_test.go
+++ b/src/ce/hosting/content_negotiation_test.go
@@ -184,6 +184,55 @@ func (s *ContentNegotiationSuite) Test_HonoursQValues() {
 	s.True(strings.HasPrefix(htmlPreferred.Headers.Get("Content-Type"), "text/html"))
 }
 
+// An agent that names markdown and then accepts anything gets markdown. The
+// wildcard says "anything is fine", not "HTML is equally wanted": comparing
+// q-values alone made the two tie, and the tie handed back the HTML the agent
+// had just said it did not want.
+func (s *ContentNegotiationSuite) Test_ExplicitMarkdownBeatsWildcard() {
+	s.mockFile("/docs.md", "# Docs\n")
+
+	for _, accept := range []string{
+		"text/markdown, */*",
+		"*/*, text/markdown",
+		"text/markdown, text/*",
+	} {
+		res := s.request(s.host(), "/docs", accept)
+
+		s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"), accept)
+	}
+}
+
+// The mirror image: naming HTML explicitly beats a wildcard that happens to
+// cover markdown, so a client asking for pages keeps getting them.
+func (s *ContentNegotiationSuite) Test_ExplicitHtmlBeatsWildcard() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	res := s.request(s.host(), "/docs", "text/html, */*")
+
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+}
+
+// A q-value on the type itself still outranks specificity: the client named
+// markdown only to say it would rather not have it.
+func (s *ContentNegotiationSuite) Test_DownweightedMarkdownKeepsHtml() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	res := s.request(s.host(), "/docs", "text/markdown;q=0.1, */*")
+
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"))
+}
+
+// A wildcard does not undo a q-value the client put on HTML itself. RFC 9110
+// takes the q of the most specific matching range, so HTML here is 0.1 and the
+// markdown twin wins on 1.0.
+func (s *ContentNegotiationSuite) Test_DownweightedHtmlLosesToWildcard() {
+	s.mockFile("/docs.md", "# Docs\n")
+
+	res := s.request(s.host(), "/docs", "text/html;q=0.1, */*")
+
+	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
+}
+
 // Explicitly requesting the .md URL serves markdown regardless of Accept.
 func (s *ContentNegotiationSuite) Test_DirectMarkdownUrl() {
 	s.mockFile("/docs.md", "# Docs\n")

--- a/src/ce/hosting/content_negotiation_test.go
+++ b/src/ce/hosting/content_negotiation_test.go
@@ -233,6 +233,67 @@ func (s *ContentNegotiationSuite) Test_DownweightedHtmlLosesToWildcard() {
 	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
 }
 
+// An out-of-range q must not decide which representation is served. The client
+// named text/html at full weight; an illegal q on a wildcard does not outrank
+// that.
+func (s *ContentNegotiationSuite) Test_OutOfRangeQualityIsClamped() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	for _, accept := range []string{
+		"text/html, */*;q=5",
+		"*/*;q=5, text/html",
+		"text/html, */*;q=1e9",
+	} {
+		res := s.request(s.host(), "/docs", accept)
+
+		s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"), accept)
+	}
+}
+
+// The rule is "HTML below the wildcard loses", at any q — not just at the
+// extreme q=0.1 the downweighting test uses. Pinned at the boundary so a
+// future rewrite cannot quietly narrow it to the obvious case.
+func (s *ContentNegotiationSuite) Test_SlightlyDownweightedHtmlLosesToWildcard() {
+	s.mockFile("/docs.md", "# Docs\n")
+
+	res := s.request(s.host(), "/docs", "text/html;q=0.9, */*")
+
+	s.Equal(hosting.MarkdownContentType, res.Headers.Get("Content-Type"))
+}
+
+// The headers real clients actually send. None of them names markdown, and
+// every one of them must keep getting the page — this is the regression that
+// would matter if the precedence rules were ever reworked again.
+func (s *ContentNegotiationSuite) Test_RealWorldClientsKeepHtml() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	for name, accept := range map[string]string{
+		"chrome": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+		"axios":  "application/json, text/plain, */*",
+		"java":   "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2",
+		"curl":   "*/*",
+	} {
+		res := s.request(s.host(), "/docs", accept)
+
+		s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"), name)
+	}
+}
+
+// The 404 path is the second caller of prefersMarkdown, and it has to read the
+// header the same way the page path does.
+func (s *ContentNegotiationSuite) Test_MarkdownNotFoundHonoursSpecificity() {
+	host := s.host()
+	host.Config.StaticFiles["/404.html"] = &appconf.StaticFile{FileName: "/404.html"}
+	host.Config.StaticFiles["/404.md"] = &appconf.StaticFile{FileName: "/404.md"}
+
+	s.mockFile("/404.md", "# Not found\n")
+
+	res := s.request(host, "/no-such-page", "text/markdown, */*")
+
+	s.Equal(http.StatusNotFound, res.Status)
+	s.Equal(hosting.MarkdownContentType, res.Headers.Get("Content-Type"))
+}
+
 // Explicitly requesting the .md URL serves markdown regardless of Accept.
 func (s *ContentNegotiationSuite) Test_DirectMarkdownUrl() {
 	s.mockFile("/docs.md", "# Docs\n")


### PR DESCRIPTION
`Accept: text/markdown, */*` served HTML.

`qualityFor` took the highest q across every matching range, so the `*/*` lent
its 1.0 to `text/html`, the two types tied, and the tie-goes-to-HTML rule then
discarded the markdown the client had just named. That header is a plausible way
for an agent to say "markdown please, but anything works", and it got back the
rendered page it was trying to avoid.

A media type's q now comes from the most specific range that covers it, per RFC
9110 §12.5.1, and a tie on q is broken by which type the client named more
specifically — exact `type/subtype` over `type/*` over `*/*`. A tie at equal
specificity still goes to HTML.

| Accept | Before | After |
|---|---|---|
| `text/markdown, */*` | HTML | **markdown** |
| `text/markdown, text/*` | HTML | **markdown** |
| `text/html;q=0.1, */*` | HTML | **markdown** |
| `*/*` | HTML | HTML |
| `text/html,application/xhtml+xml,*/*;q=0.8` | HTML | HTML |
| `text/markdown;q=0.1, */*` | HTML | HTML |
| `text/markdown` | markdown | markdown |

A bare `*/*` — curl, crawlers, most HTTP libraries — is unaffected: both types
match it at the same specificity, so the tie still favours HTML. Browsers are
unaffected too, naming `text/html` exactly at 1.0.

Taking q from the most specific range also stops a wildcard from undoing a
q-value the client put on a type itself: `text/html;q=0.1, */*` now reads HTML as
0.1 rather than 1.0. A q-value on the type still outranks specificity, so
`text/markdown;q=0.1, */*` keeps serving HTML — naming a type only to downweight
it is not a request for it.

The existing suite covered `*/*` and the browser header; the explicit-plus-
wildcard combination was the gap. Four cases added, and the docs now state the
precedence rule rather than only promising that q values are honoured.
