### PR TITLE
feat: expose the markdown flag on environments

### DIFF
--- a/docs/api/3-environments.md
+++ b/docs/api/3-environments.md
@@ -100,6 +100,7 @@ Creates a new environment for an application.
 | `headers`            | string                  | No       | Inline custom HTTP response headers.                                                                        |
 | `headersFile`        | string                  | No       | Path to the custom HTTP headers file.                                                                       |
 | `installCmd`         | string                  | No       | Command to install dependencies.                                                                            |
+| `markdown`           | boolean                 | No       | Serve the `.md` twin of a page to clients sending `Accept: text/markdown`. Off unless enabled.               |
 | `previewLinks`       | boolean                 | No       | Whether Stormkit posts a preview URL on pull/merge requests.                                                |
 | `redirects`          | `Redirect[]`            | No       | Inline redirect/rewrite rules. See the Redirects API for the `Redirect` object shape.                       |
 | `redirectsFile`      | string                  | No       | Path to a file containing redirect/rewrite rules.                                                           |
@@ -180,6 +181,7 @@ All fields are **optional**. Only the fields you include will be updated.
 | `headers`            | string                  | Inline custom HTTP response headers.                                                                                                         |
 | `headersFile`        | string                  | Path to the custom HTTP headers file.                                                                                                        |
 | `installCmd`         | string                  | Command to install dependencies.                                                                                                             |
+| `markdown`           | boolean                 | Serve the `.md` twin of a page to clients sending `Accept: text/markdown`. Off unless enabled.                                                |
 | `previewLinks`       | boolean                 | Whether Stormkit posts a preview URL on pull/merge requests.                                                                                 |
 | `redirects`          | `Redirect[]`            | Inline redirect/rewrite rules. Replaces all existing inline rules. See the Redirects API for the `Redirect` object shape.                    |
 | `redirectsFile`      | string                  | Path to a file containing redirect/rewrite rules.                                                                                            |

--- a/docs/deployments/6-how-do-we-deploy.md
+++ b/docs/deployments/6-how-do-we-deploy.md
@@ -82,10 +82,10 @@ real `404` — never a `200` carrying your app shell.
 
 ### Markdown representations
 
-Set `markdown: true` on the environment and Stormkit serves any `.md` file in
-your output as a second representation of the page next to it.
-`/docs/getting-started.md` published alongside `/docs/getting-started.html`
-means:
+Turn **Markdown representations** on under **Environment** > **Config** >
+**Redirects**, and Stormkit serves any `.md` file in your output as a second
+representation of the page next to it. `/docs/getting-started.md` published
+alongside `/docs/getting-started.html` means:
 
 - `GET /docs/getting-started` with `Accept: text/markdown` answers with the
   markdown, as `text/markdown; charset=utf-8`.
@@ -117,6 +117,10 @@ rendered page.
 
 The setting defaults to off: a build that copies its markdown sources into the
 output keeps serving exactly what it served before until you turn it on.
+
+It is also the `markdown` field on the [environment API](/docs/api/environments)
+and on the `create_environment` / `update_environment` MCP tools, so an agent can
+enable it on an environment it just created.
 
 ## Example
 

--- a/src/ce/api/public/v1/handler_env_add.go
+++ b/src/ce/api/public/v1/handler_env_add.go
@@ -29,6 +29,7 @@ type EnvAddRequest struct {
 	Headers            string                  `json:"headers,omitempty"`
 	HeadersFile        string                  `json:"headersFile,omitempty"`
 	InstallCmd         string                  `json:"installCmd,omitempty"`
+	Markdown           null.Bool               `json:"markdown,omitempty"`
 	Name               string                  `json:"name"`
 	PreviewLinks       null.Bool               `json:"previewLinks,omitempty"`
 	Redirects          []redirects.Redirect    `json:"redirects,omitempty"`
@@ -64,6 +65,7 @@ func handlerEnvAdd(req *RequestContext) *shttp.Response {
 			BuildCmd:      data.BuildCmd,
 			InstallCmd:    data.InstallCmd,
 			PreviewLinks:  data.PreviewLinks,
+			Markdown:      data.Markdown,
 			ServerCmd:     data.ServerCmd,
 			Redirects:     data.Redirects,
 			Vars:          data.EnvVars,

--- a/src/ce/api/public/v1/handler_env_add_test.go
+++ b/src/ce/api/public/v1/handler_env_add_test.go
@@ -94,6 +94,7 @@ func (s *HandlerEnvAddSuite) Test_Success() {
 			"errorFile":          "error.html",
 			"headersFile":        "headers.json",
 			"previewLinks":       true,
+			"markdown":           true,
 			"envVars": map[string]string{
 				"NODE_ENV": "production",
 				"API_URL":  "https://api.my-app.com",
@@ -127,6 +128,7 @@ func (s *HandlerEnvAddSuite) Test_Success() {
 	s.Equal("", env.AutoDeployCommits.ValueOrZero())
 	s.True(env.AutoDeploy)
 	s.True(env.Data.PreviewLinks.ValueOrZero())
+	s.True(env.Data.Markdown.ValueOrZero())
 	s.Equal("/functions", env.Data.APIFolder)
 	s.Equal("npm run build:prod", env.Data.BuildCmd)
 	s.Equal("npm run start", env.Data.ServerCmd)

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -31,6 +31,7 @@ type EnvUpdateRequest struct {
 	Headers            *string                 `json:"headers,omitempty"`
 	HeadersFile        *string                 `json:"headersFile,omitempty"`
 	InstallCmd         *string                 `json:"installCmd,omitempty"`
+	Markdown           *bool                   `json:"markdown,omitempty"`
 	PreviewLinks       *bool                   `json:"previewLinks,omitempty"`
 	Redirects          *[]redirects.Redirect   `json:"redirects,omitempty"`
 	RedirectsFile      *string                 `json:"redirectsFile,omitempty"`
@@ -125,6 +126,10 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 
 	if data.InstallCmd != nil {
 		env.Data.InstallCmd = *data.InstallCmd
+	}
+
+	if data.Markdown != nil {
+		env.Data.Markdown = null.BoolFrom(*data.Markdown)
 	}
 
 	if data.PreviewLinks != nil {

--- a/src/ce/api/public/v1/handler_env_update_test.go
+++ b/src/ce/api/public/v1/handler_env_update_test.go
@@ -76,6 +76,7 @@ func (s *HandlerEnvUpdateSuite) Test_Success() {
 			"distFolder":   "dist",
 			"autoPublish":  true,
 			"previewLinks": true,
+			"markdown":     true,
 			"envVars": map[string]string{
 				"NODE_ENV": "staging",
 			},
@@ -97,6 +98,7 @@ func (s *HandlerEnvUpdateSuite) Test_Success() {
 	s.Equal("/dist", updated.Data.DistFolder)
 	s.True(updated.AutoPublish)
 	s.True(updated.Data.PreviewLinks.ValueOrZero())
+	s.True(updated.Data.Markdown.ValueOrZero())
 	s.Equal("staging", updated.Data.Vars["NODE_ENV"])
 
 	audits, err := audit.NewStore().SelectAudits(context.Background(), audit.AuditFilters{

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -711,6 +711,28 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_Success() {
 	s.True(ok)
 }
 
+// The markdown flag is what turns content negotiation on for a deployment, so
+// an agent has to be able to set it the same way it sets any other build
+// setting.
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_SetsMarkdown() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":    mockEnv.ID.String(),
+		"markdown": true,
+	}))
+
+	s.rpcOK(resp)
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+
+	s.Require().NoError(err)
+	s.True(updated.Data.Markdown.ValueOrZero())
+}
+
 func (s *HandlerMCPSuite) Test_UpdateEnvironment_Forbidden_NotMember() {
 	usr1 := s.MockUser()
 	usr2 := s.MockUser()

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -251,6 +251,7 @@ func mcpAllTools() []mcpToolDef {
 					"autoDeployBranches": map[string]any{"type": "string", "description": "Comma-separated branch patterns that trigger auto-deploy."},
 					"autoDeployCommits":  map[string]any{"type": "string", "description": "Regex pattern for commit messages that trigger auto-deploy."},
 					"autoPublish":        map[string]any{"type": "boolean", "description": "Automatically publish every successful deployment."},
+					"markdown":           map[string]any{"type": "boolean", "description": "Serve the .md twin of a page to clients that send Accept: text/markdown. Off unless enabled."},
 					"previewLinks":       map[string]any{"type": "boolean", "description": "Generate preview links for each deployment."},
 					"envVars":            map[string]any{"type": "object", "description": "Environment variables injected at build and runtime.", "additionalProperties": map[string]any{"type": "string"}},
 					"redirects": map[string]any{
@@ -314,6 +315,7 @@ func mcpAllTools() []mcpToolDef {
 					"headers":            map[string]any{"type": "string", "description": "Custom response headers in Netlify / Caddy format."},
 					"headersFile":        map[string]any{"type": "string", "description": "Path to a headers file (relative to repo root)."},
 					"redirectsFile":      map[string]any{"type": "string", "description": "Path to a redirects file (relative to repo root)."},
+					"markdown":           map[string]any{"type": "boolean", "description": "Serve the .md twin of a page to clients that send Accept: text/markdown. Off unless enabled."},
 					"previewLinks":       map[string]any{"type": "boolean", "description": "Generate preview links for each deployment."},
 					"priorityPattern":    map[string]any{"type": "string", "description": "Regex matched against the commit message of auto-deploys; matching deployments are automatically routed to the priority queue. Leave empty to disable."},
 					"envVars":            map[string]any{"type": "object", "description": "Environment variables to set or update. Merged into the existing set: keys not listed here keep their current value, and a key set to an empty string is removed.", "additionalProperties": map[string]any{"type": "string"}},
@@ -1008,6 +1010,10 @@ func mcpCreateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 		body.AutoDeployCommits = null.StringFrom(v)
 	}
 
+	if raw, ok := args["markdown"].(bool); ok {
+		body.Markdown = null.BoolFrom(raw)
+	}
+
 	if raw, ok := args["previewLinks"].(bool); ok {
 		body.PreviewLinks = null.BoolFrom(raw)
 	}
@@ -1173,6 +1179,7 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	setString("priorityPattern", &update.PriorityPattern)
 	setBool("autoDeploy", &update.AutoDeploy)
 	setBool("autoPublish", &update.AutoPublish)
+	setBool("markdown", &update.Markdown)
 	setBool("previewLinks", &update.PreviewLinks)
 
 	update.EnvVars = mergeEnvVarsArg(req.Env.Data.Vars, args)

--- a/src/ce/api/public/v1/openapi.json
+++ b/src/ce/api/public/v1/openapi.json
@@ -3730,6 +3730,10 @@
             "type": "boolean",
             "description": "Publish every successful deployment automatically."
           },
+          "markdown": {
+            "type": "boolean",
+            "description": "Serve the .md twin of a page to clients that send Accept: text/markdown. Off unless enabled."
+          },
           "previewLinks": {
             "type": "boolean",
             "description": "Generate a preview link for each deployment."

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.spec.tsx
@@ -78,7 +78,35 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRe
     );
 
     const scope = mockUpdateEnvironment({
-      payload: { redirectsFile: "/redirects.json", errorFile: "/index.html" },
+      payload: {
+        redirectsFile: "/redirects.json",
+        errorFile: "/index.html",
+        markdown: false,
+      },
+      status: 200,
+      response: {
+        ok: true,
+      },
+    });
+
+    fireEvent.click(wrapper.getByText("Save"));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  it("should submit the markdown toggle", async () => {
+    createWrapper({});
+
+    fireEvent.click(wrapper.getByText("Markdown representations"));
+
+    const scope = mockUpdateEnvironment({
+      payload: {
+        redirectsFile: "",
+        errorFile: "",
+        markdown: true,
+      },
       status: 200,
       response: {
         ok: true,
@@ -110,6 +138,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRe
         redirects: [],
         redirectsFile: "/redirects.json",
         errorFile: "/index.html",
+        markdown: false,
       },
       status: 200,
       response: {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigRedirects.tsx
@@ -37,6 +37,7 @@ export default function TabConfigRedirects({
   const initialRedirects =
     JSON.stringify(env.build.redirects, null, 2) || defaultRedirects;
 
+  const [markdown, setMarkdown] = useState(env.build.markdown === true);
   const [showModal, setShowModal] = useState(false);
   const [showRedirects, setShowRedirects] = useState(hasRedirects);
   const [redirects, setRedirects] = useState(initialRedirects);
@@ -77,6 +78,7 @@ export default function TabConfigRedirects({
             redirects: build.redirects,
             redirectsFile: build.redirectsFile,
             errorFile: build.errorFile,
+            markdown,
           },
           setError,
           setLoading,
@@ -125,6 +127,30 @@ export default function TabConfigRedirects({
             "The error file displayed when Stormkit does not find a page. Default is 404.html."
           }
         />
+      </Box>
+      <Box sx={{ bgcolor: "container.paper", p: 1.75, pt: 1, mb: 4 }}>
+        <FormControlLabel
+          sx={{ pl: 0, ml: 0 }}
+          label="Markdown representations"
+          control={
+            <Switch
+              name="build.markdown"
+              color="secondary"
+              checked={markdown}
+              onChange={e => {
+                setMarkdown(e.target.checked);
+              }}
+            />
+          }
+          labelPlacement="start"
+        />
+        <Typography sx={{ color: "text.secondary" }}>
+          Turn on to serve any <Box component="code">.md</Box> file in your
+          output as a second representation of the page next to it. A client
+          that sends <Box component="code">Accept: text/markdown</Box> gets the
+          markdown, a browser still gets the HTML. Useful for letting agents
+          read your documentation without scraping the rendered page.
+        </Typography>
       </Box>
       <Box sx={{ bgcolor: "container.paper", p: 1.75, pt: 1, mb: 4 }}>
         <FormControlLabel

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -180,6 +180,7 @@ export interface EnvUpdatePayload {
   autoDeployBranches?: string;
   autoDeployCommits?: string;
   previewLinks?: boolean;
+  markdown?: boolean;
   priorityPattern?: string;
   buildCmd?: string;
   serverCmd?: string;

--- a/src/ui/src/types/environment.d.ts
+++ b/src/ui/src/types/environment.d.ts
@@ -6,6 +6,7 @@ declare type StatusCheck = {
 
 declare type BuildConfig = {
   previewLinks?: boolean;
+  markdown?: boolean;
   apiFolder?: string; // The folder where serverless functions are located
   apiPathPrefix?: string; // The path prefix to match in the URL for serverless functions
   headers?: string;


### PR DESCRIPTION
The content negotiation added in #469 reads `BuildConf.Markdown`, but nothing could ever set it.

The field was absent from the environment create/update handlers, from the MCP tools and from the dashboard, and no handler binds a whole `BuildConf` from a request body — `handler_env_add.go` constructs it field by field and `handler_env_update.go` assigns fields individually. `stormkit.config.yml` is not a route either: `StormkitFile()` has no callers outside its own file. The only way to turn the feature on was a direct write to the `build_conf` jsonb column.

So #469 and #477 have been unreachable in production since they merged, and `docs/deployments/6-how-do-we-deploy.md` told users to "set `markdown: true` on the environment" without saying where.

This exposes it the same four ways every sibling build setting is exposed:

- `POST /v1/envs` and `PUT /v1/envs`
- the `create_environment` and `update_environment` MCP tools
- the OpenAPI document
- a toggle in the dashboard

The toggle sits under **Config > Redirects**, next to the custom error file, because both decide what gets served for a request rather than how the app is built.

Modelled on `previewLinks` throughout: `null.Bool` on create, `*bool` on update so a partial update cannot clear it, `boolean` in the tool schemas and the spec.

Docs now name the toggle's location and mention the API/MCP field, and `docs/api/3-environments.md` lists `markdown` in both field tables.

Tests: the create and update handler suites assert the flag round-trips, a new MCP case asserts `update_environment` persists it, and a dashboard case asserts the toggle reaches the request body.
