### PR TITLE
fix: prefer etag over date on conditional requests

### DIFF
--- a/src/ce/hosting/content_negotiation_test.go
+++ b/src/ce/hosting/content_negotiation_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stormkit-io/stormkit-io/src/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -100,7 +101,9 @@ func (s *ContentNegotiationSuite) mockFile(fileName, content string) {
 	}, nil)
 }
 
-func (s *ContentNegotiationSuite) request(host *hosting.Host, path, accept string) *shttp.Response {
+// requestContext builds the request a test is about to serve, so a test that
+// needs more than an Accept header can add one before forwarding it.
+func (s *ContentNegotiationSuite) requestContext(host *hosting.Host, path, accept string) *hosting.RequestContext {
 	headers := make(http.Header)
 
 	if accept != "" {
@@ -116,6 +119,12 @@ func (s *ContentNegotiationSuite) request(host *hosting.Host, path, accept strin
 	}
 
 	req.OriginalPath = path
+
+	return req
+}
+
+func (s *ContentNegotiationSuite) request(host *hosting.Host, path, accept string) *shttp.Response {
+	req := s.requestContext(host, path, accept)
 
 	return hosting.HandlerForward(req)
 }
@@ -292,6 +301,60 @@ func (s *ContentNegotiationSuite) Test_MarkdownNotFoundHonoursSpecificity() {
 
 	s.Equal(http.StatusNotFound, res.Status)
 	s.Equal(hosting.MarkdownContentType, res.Headers.Get("Content-Type"))
+}
+
+// The regression behind issue #479: both representations of a negotiable URL
+// carry the deployment timestamp as Last-Modified, so a bare If-Modified-Since
+// cannot say which one the client is holding. Answering 304 to a browser that
+// replayed the markdown variant's date hands a Vary-ignoring cache a markdown
+// body to serve as the page.
+func (s *ContentNegotiationSuite) Test_ModifiedSinceIgnoredOnNegotiableUrl() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	host := s.host()
+	host.Config.UpdatedAt = utils.NewUnix()
+	host.Config.UpdatedAt.Time = time.Unix(1700489144, 0).UTC()
+
+	req := s.requestContext(host, "/docs", "text/html,application/xhtml+xml,*/*;q=0.8")
+	req.Header.Add("If-Modified-Since", "Sat, 19 Dec 2023 11:25:44 GMT")
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.NotNil(res.Data)
+}
+
+// The entity tag is per file, so it does distinguish the representations and
+// still earns a 304. Losing revalidation entirely on these URLs would be a
+// worse trade than the one the test above makes.
+func (s *ContentNegotiationSuite) Test_ETagStillRevalidatesOnNegotiableUrl() {
+	host := s.host()
+	host.Config.StaticFiles["/docs.html"].Headers["etag"] = "html-etag"
+
+	req := s.requestContext(host, "/docs", "text/html,application/xhtml+xml,*/*;q=0.8")
+	req.Header.Add("If-None-Match", "html-etag")
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusNotModified, res.Status)
+	s.Nil(res.Data)
+}
+
+// The markdown twin's entity tag must not satisfy a request for the page.
+func (s *ContentNegotiationSuite) Test_ETagDoesNotCrossRepresentations() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	host := s.host()
+	host.Config.StaticFiles["/docs.html"].Headers["etag"] = "html-etag"
+	host.Config.StaticFiles["/docs.md"].Headers["etag"] = "markdown-etag"
+
+	req := s.requestContext(host, "/docs", "text/html,application/xhtml+xml,*/*;q=0.8")
+	req.Header.Add("If-None-Match", "markdown-etag")
+
+	res := hosting.HandlerForward(req)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.NotNil(res.Data)
 }
 
 // Explicitly requesting the .md URL serves markdown regardless of Accept.

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -404,8 +404,21 @@ func (r *RequestServer) Static() *shttp.Response {
 		Payload: r.req.Fields,
 	})
 
-	// Check If-Modified-Since header -- give this priority
-	if modifiedSinceHeader != "" && r.req.Host.Config.UpdatedAt.Valid {
+	// RFC 9110 §13.2.2: an entity tag validator takes precedence, and
+	// If-Modified-Since is evaluated only when the request carries none. The
+	// order matters here beyond conformance — the ETag is a per-file content
+	// hash, so it is the only validator that can tell the two representations
+	// of a negotiable URL apart. Last-Modified is the deployment timestamp and
+	// is identical for the page and its markdown twin.
+	if noneMatchHeader := r.req.Header.Get("If-None-Match"); noneMatchHeader != "" {
+		notModified = headers.Get("ETag") == noneMatchHeader
+	} else if modifiedSinceHeader != "" && r.req.Host.Config.UpdatedAt.Valid && !r.varyAccept {
+		// Skipped entirely on a negotiable URL: a bare If-Modified-Since cannot
+		// say which representation the client is holding, so honouring it would
+		// answer "your copy is current" to a client whose copy is the other
+		// representation — a cache that ignores Vary then serves markdown as the
+		// page. Answering with the full body costs a response these URLs already
+		// pay, since both representations are no-cache, must-revalidate.
 		modifiedSinceTime, err := time.Parse(http.TimeFormat, modifiedSinceHeader)
 
 		if err == nil {
@@ -420,13 +433,8 @@ func (r *RequestServer) Static() *shttp.Response {
 				time.UTC,
 			)
 
-			notModified = !lastModifiedTime.After(modifiedSinceTime) || lastModifiedTime.Equal(modifiedSinceTime)
+			notModified = !lastModifiedTime.After(modifiedSinceTime)
 		}
-	}
-
-	// If-None-Match headers is checked only if the check above is not performed
-	if noneMatchHeader := r.req.Header.Get("If-None-Match"); noneMatchHeader != "" && modifiedSinceHeader == "" {
-		notModified = headers.Get("ETag") == noneMatchHeader
 	}
 
 	if r.markdown {

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -916,10 +916,14 @@ func (s *HandlerForwardSuite) Test_CacheControl_ETag_WithIFModifiedSince() {
 
 	res := hosting.HandlerForward(req)
 
-	s.Equal(http.StatusOK, res.Status)
+	// The entity tag matches, so the answer is 304 even though the
+	// If-Modified-Since date is older than the deployment. RFC 9110 §13.2.2
+	// requires the weaker validator to be ignored whenever the request carries
+	// an entity tag, and this used to assert the opposite.
+	s.Equal(http.StatusNotModified, res.Status)
 	s.Equal("no-cache, must-revalidate", res.Headers.Get("Cache-Control"))
 	s.Equal("Mon, 20 Nov 2023 14:05:44 GMT", res.Headers.Get("Last-Modified"))
-	s.NotNil(res.Data)
+	s.Nil(res.Data)
 }
 
 func (s *HandlerForwardSuite) Test_404() {


### PR DESCRIPTION
Fixes #479, reproduced on www.stormkit.io now that negotiation is live there.

Both representations of a negotiable URL carry the deployment timestamp as `Last-Modified`, so a bare `If-Modified-Since` cannot say which one the client is holding:

    $ curl -o /dev/null -w '%{http_code} %{content_type} %{size_download}\n' \
        -H 'Accept: text/html,application/xhtml+xml,*/*;q=0.8' \
        -H 'If-Modified-Since: Sun, 23 Aug 2026 09:30:03 GMT' \
        https://www.stormkit.io/docs/welcome/getting-started
    304 text/html; charset=utf-8 0

That date came from the markdown variant. A cache that ignores `Vary` now treats its markdown copy as fresh HTML.

The etags are already correct and distinct — `"20-5be9…"` for the markdown, `"20-867f…"` for the page — so the entity tag was always able to tell the two apart. It just never got the chance: `If-None-Match` was skipped whenever `If-Modified-Since` was present.

Two changes:

- `If-None-Match` takes precedence, and `If-Modified-Since` is read only when the request carries no entity tag. This is what RFC 9110 §13.2.2 requires, and here it also happens to be the only validator that distinguishes representations.
- `If-Modified-Since` is skipped entirely on a negotiable URL, since a client may send no etag at all. It costs a full body where a 304 would have done, on URLs that are already `no-cache, must-revalidate` — non-negotiable URLs keep the date shortcut untouched.

### Behaviour change worth a look

`Test_CacheControl_ETag_WithIFModifiedSince` pinned the old precedence: a matching etag served a 200 because the `If-Modified-Since` date looked stale. That is the case the RFC says must be a 304, so the test now asserts the opposite. Flagging it rather than burying it, since it is a deliberate reversal of documented behaviour and applies to every deployment, not only markdown-enabled ones.

### Tests

Three new cases in the negotiation suite: a browser replaying the markdown variant's date gets a full body, an etag still earns its 304 on a negotiable URL, and the markdown twin's etag does not satisfy a request for the page. Confirmed the first fails without the fix. The existing IMS-only test on a non-negotiable URL still passes unchanged.
