### PR TITLE
fix: bound accept header parsing on the edge

### DIFF
--- a/src/ce/hosting/certmagic_server.go
+++ b/src/ce/hosting/certmagic_server.go
@@ -25,6 +25,13 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// MaxRequestHeaderBytes caps the total size of request headers the edge will
+// accept, well below Go's 1MB DefaultMaxHeaderBytes. It bounds header-parsing
+// work on a shared multi-tenant edge and, since HTTP/2 derives
+// SETTINGS_MAX_HEADER_LIST_SIZE from the same value, applies over both
+// protocols.
+const MaxRequestHeaderBytes = 64 * 1024
+
 func storage(logger *zap.Logger) certmagic.Storage {
 	slog.Infof("using redis storage for certificates")
 
@@ -177,6 +184,7 @@ func httpsServe(cfg *certmagic.Config, handler http.Handler) error {
 		ReadTimeout:       5 * time.Second,
 		WriteTimeout:      5 * time.Second,
 		IdleTimeout:       5 * time.Second,
+		MaxHeaderBytes:    MaxRequestHeaderBytes,
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 	}
 
@@ -192,6 +200,7 @@ func httpsServe(cfg *certmagic.Config, handler http.Handler) error {
 	httpsServer := &http.Server{
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       config.Get().HTTPTimeouts.IdleTimeout,
+		MaxHeaderBytes:    MaxRequestHeaderBytes,
 		Handler:           handler,
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 	}

--- a/src/ce/hosting/content_negotiation.go
+++ b/src/ce/hosting/content_negotiation.go
@@ -13,6 +13,16 @@ import (
 // registers text/markdown; the charset removes any doubt about the encoding.
 const MarkdownContentType = "text/markdown; charset=utf-8"
 
+// maxAcceptHeaderLen and maxAcceptEntries bound the work parseAccept will do on
+// a single request. A legitimate Accept header is well under a kilobyte with a
+// handful of entries; these ceilings sit far above any real client while
+// keeping a hostile 1MB header from turning one request into tens of
+// milliseconds of CPU and tens of megabytes of allocation on a shared edge.
+const (
+	maxAcceptHeaderLen = 4096
+	maxAcceptEntries   = 32
+)
+
 // acceptedType is one entry of a parsed Accept header.
 type acceptedType struct {
 	mime    string
@@ -34,7 +44,24 @@ type acceptPreference struct {
 func parseAccept(header string) acceptPreference {
 	pref := acceptPreference{empty: true}
 
-	for _, part := range strings.Split(header, ",") {
+	// An oversized header is treated as if none was sent: RFC 9110 says that
+	// means everything is acceptable, so the caller serves what it would have
+	// served anyway (HTML) rather than paying to parse an attacker-sized value.
+	if len(header) > maxAcceptHeaderLen {
+		return pref
+	}
+
+	// SplitN caps allocation and scanning at maxAcceptEntries: the raw split of
+	// a comma-heavy header is itself the expense, so it must be bounded before
+	// the loop, not inside it. The final chunk holds the unscanned remainder and
+	// is dropped.
+	parts := strings.SplitN(header, ",", maxAcceptEntries+1)
+
+	if len(parts) > maxAcceptEntries {
+		parts = parts[:maxAcceptEntries]
+	}
+
+	for _, part := range parts {
 		fields := strings.Split(strings.TrimSpace(part), ";")
 		mime := strings.ToLower(strings.TrimSpace(fields[0]))
 

--- a/src/ce/hosting/content_negotiation_internal_test.go
+++ b/src/ce/hosting/content_negotiation_internal_test.go
@@ -1,0 +1,66 @@
+package hosting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// ParseAcceptBoundsSuite covers the caps that keep a hostile Accept header from
+// turning one request into tens of milliseconds of CPU and tens of megabytes of
+// allocation on a shared edge (issue #478). parseAccept is unexported, so these
+// live in an internal test.
+type ParseAcceptBoundsSuite struct {
+	suite.Suite
+}
+
+func (s *ParseAcceptBoundsSuite) Test_NormalHeaderParsesEveryEntry() {
+	pref := parseAccept("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+	s.False(pref.empty)
+	s.Len(pref.types, 4)
+}
+
+func (s *ParseAcceptBoundsSuite) Test_OversizedHeaderIsTreatedAsAbsent() {
+	pref := parseAccept(strings.Repeat("*/*,", (1<<20)/4))
+
+	s.True(pref.empty, "an oversized header must degrade to no preference")
+	s.Empty(pref.types)
+	// The safe default: everything matches, so HTML is served.
+	s.False(pref.prefersMarkdown())
+}
+
+func (s *ParseAcceptBoundsSuite) Test_CommaBombIsTreatedAsAbsent() {
+	pref := parseAccept(strings.Repeat(",", 1<<20))
+
+	s.True(pref.empty)
+	s.Empty(pref.types)
+}
+
+func (s *ParseAcceptBoundsSuite) Test_EntryCountIsCappedBelowTheLengthLimit() {
+	// Many short entries stay under maxAcceptHeaderLen but must still not parse
+	// past maxAcceptEntries.
+	header := strings.TrimSuffix(strings.Repeat("a/b,", maxAcceptEntries+50), ",")
+	s.LessOrEqual(len(header), maxAcceptHeaderLen)
+
+	pref := parseAccept(header)
+
+	s.False(pref.empty)
+	s.Len(pref.types, maxAcceptEntries)
+}
+
+func (s *ParseAcceptBoundsSuite) Test_HeaderAtTheLengthLimitStillParses() {
+	one := "text/html,"
+	repeats := maxAcceptHeaderLen / len(one)
+	header := strings.TrimSuffix(strings.Repeat(one, repeats), ",")
+	s.LessOrEqual(len(header), maxAcceptHeaderLen)
+
+	pref := parseAccept(header)
+
+	s.False(pref.empty)
+}
+
+func TestParseAcceptBoundsSuite(t *testing.T) {
+	suite.Run(t, new(ParseAcceptBoundsSuite))
+}

--- a/src/ce/hosting/content_negotiation_test.go
+++ b/src/ce/hosting/content_negotiation_test.go
@@ -517,6 +517,20 @@ func (s *ContentNegotiationSuite) Test_MarkdownNotFoundAcceptsFiveHundred() {
 	s.Equal("text/markdown; charset=utf-8", res.Headers.Get("Content-Type"))
 }
 
+// An attacker-sized Accept header must not decide negotiation: it is ignored
+// (issue #478), so a markdown deployment falls back to serving HTML rather than
+// paying to parse a megabyte of media ranges.
+func (s *ContentNegotiationSuite) Test_OversizedAcceptFallsBackToHtml() {
+	s.mockFile("/docs.html", "<h1>Docs</h1>")
+
+	oversized := strings.Repeat("text/markdown,", (1<<20)/14)
+	res := s.request(s.host(), "/docs", oversized)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.True(strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html"),
+		"an oversized Accept must not be honored as a markdown preference")
+}
+
 func TestContentNegotiationSuite(t *testing.T) {
 	suite.Run(t, new(ContentNegotiationSuite))
 }

--- a/src/ee/hosting/main.go
+++ b/src/ee/hosting/main.go
@@ -66,7 +66,10 @@ func nonMagic(handler http.Handler, port string) {
 		ln = &proxyproto.Listener{Listener: ln}
 	}
 
-	srv := &http.Server{Handler: handler}
+	srv := &http.Server{
+		Handler:        handler,
+		MaxHeaderBytes: hosting.MaxRequestHeaderBytes,
+	}
 
 	log.Fatal(srv.Serve(ln))
 }


### PR DESCRIPTION
## What

Bounds the work `parseAccept` does per request and caps request-header size on the hosting servers.

`parseAccept` (`src/ce/hosting/content_negotiation.go`) split an unbounded `Accept` header on every comma, giving each entry its own `strings.Split(";")`. With no `MaxHeaderBytes` set anywhere, the ceiling was Go's 1MB default. A 1MB `Accept` header measured at ~30ms CPU and ~34MB of transient allocation per request — vs ~1µs / 584B for a real browser header.

On the shared multi-tenant edge this is an amplification vector: both call sites are reachable on any deployment with markdown enabled (the NotFound path needs no valid URL), and `Vary: Accept` puts the attacker-controlled header in the CDN cache key, so varying the q-value guarantees a cache miss and sends 100% of a flood to origin.

## Fix

- **`parseAccept`**: bail out above a 4KB header length (an oversized header degrades to "no preference", so a markdown deployment serves HTML — the existing safe default), and cap parsed entries at 32 via `strings.SplitN`, which bounds the split itself rather than the loop after it.
- **`MaxHeaderBytes` = 64KB** on the hosting servers (`certmagic_server.go` HTTP + HTTPS, `ee/hosting/main.go`), below Go's 1MB default. This also caps HTTP/2's `SETTINGS_MAX_HEADER_LIST_SIZE`, which derives from the same value. The internal Prometheus server is left alone.

## Tests

- Internal suite on `parseAccept`: comma-bomb and 1MB `*/*` headers degrade to empty, entry cap holds below the length limit, a header at the length limit still parses.
- End-to-end: an oversized `Accept: text/markdown` on a markdown deployment falls back to serving HTML.

Full `src/ce/hosting` package passes; `go vet` clean.

Closes #478
