### PR TITLE
fix: environment page loading flash and config scroll

### DIFF
--- a/src/ui/src/pages/apps/[id]/App.context.tsx
+++ b/src/ui/src/pages/apps/[id]/App.context.tsx
@@ -10,6 +10,10 @@ import { useFetchEnvironments } from "./environments/actions";
 export interface AppContextProps {
   app: App;
   environments: Array<Environment>;
+  // Optional so the many test wrappers that build their own context value need
+  // not set it; the real provider below always does. Absent reads as "not
+  // loading".
+  environmentsLoading?: boolean;
   setRefreshToken: (val: number) => void;
 }
 
@@ -63,6 +67,7 @@ export default function AppProvider({ children }: Props) {
       value={{
         app,
         environments: envs.environments,
+        environmentsLoading: envs.loading,
         setRefreshToken,
       }}
     >

--- a/src/ui/src/pages/apps/[id]/environments/Environment.context.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/Environment.context.tsx
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import EmptyList from "~/components/EmptyPage";
 import Error404 from "~/components/Errors/Error404";
+import Spinner from "~/components/Spinner";
 import { AppContext } from "~/pages/apps/[id]/App.context";
 import EnvironmentFormModal from "./_components/EnvironmentFormModal";
 
@@ -21,8 +22,17 @@ interface Props {
 
 export default function Provider({ children }: Props) {
   const { envId } = useParams();
-  const { app, environments } = useContext(AppContext);
+  const { app, environments, environmentsLoading } = useContext(AppContext);
   const [isModalOpen, toggleModal] = useState(false);
+
+  const environment = environments?.filter(e => e.id === envId)?.[0];
+
+  // While the first fetch is in flight there is nothing to decide yet, so wait
+  // instead of flashing the empty or not-found states. A later refresh keeps
+  // the environment on screen (environment stays resolved), so it never blanks.
+  if (environmentsLoading && !environment) {
+    return <Spinner primary pageCenter />;
+  }
 
   if (environments?.length === 0) {
     return (
@@ -53,8 +63,6 @@ export default function Provider({ children }: Props) {
       </EmptyList>
     );
   }
-
-  const environment = environments?.filter(e => e.id === envId)?.[0];
 
   if (!environment) {
     return <Error404 withLogo={false}>This environment is not found.</Error404>;

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.spec.tsx
@@ -1,5 +1,5 @@
 import { RenderResult, waitFor } from "@testing-library/react";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { MemoryRouter } from "react-router";
 import { fireEvent, render } from "@testing-library/react";
 import { EnvironmentContext } from "~/pages/apps/[id]/environments/Environment.context";
@@ -101,6 +101,38 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx",
       expect(
         wrapper.getByTestId("env-config-nav").getAttribute("data-selected"),
       ).toBe("#env-vars");
+    });
+  });
+
+  describe("scrolling to a section", () => {
+    let scrolledIds: Array<string>;
+
+    beforeEach(() => {
+      scrolledIds = [];
+      // jsdom does not implement scrollIntoView; capture the element it targets.
+      Element.prototype.scrollIntoView = vi.fn(function (this: Element) {
+        scrolledIds.push(this.id);
+      });
+    });
+
+    afterEach(() => {
+      // scrollIntoView is not implemented by jsdom, so remove the stand-in
+      // rather than vi.restoreAllMocks(), which would also strip the shared
+      // ResizeObserver mock other tests rely on.
+      delete (Element.prototype as unknown as Record<string, unknown>)
+        .scrollIntoView;
+    });
+
+    // The click path (navigate to #redirects, then scroll) cannot be exercised
+    // here because setup.tsx mocks useNavigate to a no-op, so the hash never
+    // changes. The hash-driven case below covers the same scroll code path:
+    // #redirects mounts the Redirects section and it is scrolled into view.
+    it("should scroll to Redirects when deep-linked via the hash", async () => {
+      createWrapper({ hash: "#redirects" });
+
+      await waitFor(() => {
+        expect(scrolledIds).toContain("redirects");
+      });
     });
   });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/EnvironmentConfig.tsx
@@ -163,12 +163,24 @@ export default function EnvironmentConfig() {
   }, [hash, environment?.id]);
 
   useEffect(() => {
-    if (selectedItem) {
-      document
-        ?.querySelector(selectedItem)
-        ?.scrollIntoView?.({ behavior: "smooth" });
+    // selectedItem is set on click; hash covers deep links where nothing was
+    // clicked. Either way it names the section to scroll to.
+    const target = selectedItem || hash;
+
+    if (!target) {
+      return;
     }
-  }, [selectedItem]);
+
+    // Wait one frame before scrolling. Switching between tab groups remounts
+    // the whole panel in this same commit, so a synchronous scrollIntoView
+    // measures the not-yet-laid-out content and under-shoots -- most visibly
+    // for Redirects, the furthest section down. A rAF lets layout settle first.
+    const frame = requestAnimationFrame(() => {
+      document?.querySelector(target)?.scrollIntoView?.({ behavior: "smooth" });
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [selectedItem, hash]);
 
   return (
     <Box

--- a/src/ui/src/pages/apps/[id]/environments/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/actions.ts
@@ -22,7 +22,10 @@ export const useFetchEnvironments = ({
 }: FetchEnvironmentsProps): FetchEnvironmentsReturnValue => {
   const [environments, setEnvironments] = useState<Array<Environment>>([]);
   const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(false);
+  // Defaults to true: whenever there is an app, an environments fetch is
+  // imminent, so the first render must already read as loading rather than
+  // briefly as "no environments".
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let unmounted = false;

--- a/src/ui/src/testing/setup.tsx
+++ b/src/ui/src/testing/setup.tsx
@@ -48,13 +48,14 @@ interface RechartsProps {
   data: any;
 }
 
-window.ResizeObserver =
-  window.ResizeObserver ||
-  vi.fn().mockImplementation(() => ({
-    disconnect: vi.fn(),
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-  }));
+// Assigned unconditionally: recent jsdom ships a ResizeObserver stub whose
+// observe() is missing, which breaks auto-sizing MUI inputs, so the working
+// mock must win over it rather than defer to it.
+window.ResizeObserver = vi.fn().mockImplementation(() => ({
+  disconnect: vi.fn(),
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+}));
 
 vi.mock("recharts", async importOriginal => {
   const OriginalModule = await importOriginal<typeof import("recharts")>();


### PR DESCRIPTION
Two frontend glitches on the environment/config pages.

## 1. "No environments" / "not found" flashes on first load

`useFetchEnvironments` started with `loading: false`, and `AppProvider` only waited on the *app* fetch — so once the app loaded, the environment page rendered with `environments` still `[]` and briefly showed the empty / not-found state until the environments arrived.

- Default the environments fetch to `loading: true` (a fetch is always imminent once there's an app).
- Expose `environmentsLoading` on `AppContext` and, in `Environment.context`, show a spinner while the first fetch is in flight **and** no environment has resolved yet. A later refresh keeps the current environment on screen, so in-place refreshes (snippets, webhooks, …) never blank the page.

## 2. Clicking "Redirects" doesn't scroll to the section

Switching between config tab groups remounts the whole panel in the same commit, so the synchronous `scrollIntoView` in the scroll effect measured not-yet-laid-out content and under-shot — most visibly for Redirects, the furthest section down. Deep links (`#redirects`) didn't scroll at all because the effect only reacted to click state.

- Defer the scroll one animation frame (after layout), and drive it off the URL hash as well as the click, so deep links scroll too.

## Tests

- New regression test: deep-linking `#redirects` scrolls the Redirects section into view. (The click path can't be tested — `setup.tsx` mocks `useNavigate` to a no-op, so the hash never changes in tests.)
- Made the shared `ResizeObserver` test mock unconditional; the Redirects tab is the first test to render an auto-sizing MUI textarea, which otherwise hit jsdom's broken stub.

Changed test file passes; full UI suite is green aside from pre-existing parallel-run flakes (confirmed nondeterministic on a clean tree, unrelated to this change).
