### PR TITLE
fix: hide resource existence from unowned callers

### DIFF
--- a/src/ce/api/public/v1/handler_access_logs_get_test.go
+++ b/src/ce/api/public/v1/handler_access_logs_get_test.go
@@ -240,7 +240,7 @@ func (s *HandlerAccessLogsGetSuite) Test_Forbidden_NotMember() {
 
 	res := s.request("", usertest.Authorization(other.ID))
 
-	s.Equal(http.StatusForbidden, res.Code)
+	s.Equal(http.StatusNotFound, res.Code)
 }
 
 func TestHandlerAccessLogsGet(t *testing.T) {

--- a/src/ce/api/public/v1/handler_deployment_create_test.go
+++ b/src/ce/api/public/v1/handler_deployment_create_test.go
@@ -151,7 +151,7 @@ func (s *HandlerDeploymentCreateSuite) Test_NotFound_Env() {
 }
 
 // Test_Forbidden_TeamTokenNotOwner verifies that a team-scoped token whose TeamID does not
-// match the application's TeamID is rejected with 403.
+// match the application's TeamID is answered with 404 (existence hidden).
 func (s *HandlerDeploymentCreateSuite) Test_Forbidden_TeamTokenNotOwner() {
 	usr1 := s.MockUser()
 	appl := s.MockApp(usr1)
@@ -179,12 +179,12 @@ func (s *HandlerDeploymentCreateSuite) Test_Forbidden_TeamTokenNotOwner() {
 		},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
 }
 
 // Test_Forbidden_UserNotTeamMember verifies that a user-scoped token whose owner is not a
-// member of the application's team is rejected with 403.
+// member of the application's team is answered with 404 (existence hidden).
 func (s *HandlerDeploymentCreateSuite) Test_Forbidden_UserNotTeamMember() {
 	usr1 := s.MockUser()
 	appl := s.MockApp(usr1)
@@ -212,12 +212,12 @@ func (s *HandlerDeploymentCreateSuite) Test_Forbidden_UserNotTeamMember() {
 		},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
 }
 
 // Test_Forbidden_AppTokenNotOwner verifies that an app-scoped token whose AppID does not
-// match the application derived from envId is rejected with 403.
+// match the application derived from envId is answered with 404 (existence hidden).
 func (s *HandlerDeploymentCreateSuite) Test_Forbidden_AppTokenNotOwner() {
 	usr := s.MockUser()
 	appl1 := s.MockApp(usr)
@@ -241,7 +241,7 @@ func (s *HandlerDeploymentCreateSuite) Test_Forbidden_AppTokenNotOwner() {
 		},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
 }
 

--- a/src/ce/api/public/v1/handler_deployment_delete_test.go
+++ b/src/ce/api/public/v1/handler_deployment_delete_test.go
@@ -131,7 +131,7 @@ func (s *HandlerDeploymentDeleteSuite) Test_Forbidden_UserNotMember() {
 		map[string]string{"Authorization": key.Value},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func TestHandlerDeploymentDelete(t *testing.T) {

--- a/src/ce/api/public/v1/handler_deployment_get_test.go
+++ b/src/ce/api/public/v1/handler_deployment_get_test.go
@@ -130,7 +130,7 @@ func (s *HandlerDeploymentGetSuite) Test_Forbidden_NoAPIKey() {
 }
 
 // Test_Forbidden_UserNotMember verifies that a user-scoped key whose owner is not a member
-// of the environment's team is rejected with 403.
+// of the environment's team is answered with 404 (existence hidden).
 func (s *HandlerDeploymentGetSuite) Test_Forbidden_UserNotMember() {
 	usr1 := s.MockUser()
 	appl := s.MockApp(usr1)
@@ -156,7 +156,7 @@ func (s *HandlerDeploymentGetSuite) Test_Forbidden_UserNotMember() {
 		},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 // Test_WithLogs_IncludesLogsAndStatusChecks verifies that ?logs=true causes the stored

--- a/src/ce/api/public/v1/handler_deployment_list_test.go
+++ b/src/ce/api/public/v1/handler_deployment_list_test.go
@@ -171,7 +171,7 @@ func (s *HandlerDeploymentListSuite) Test_Forbidden_UserNotMember() {
 	})
 
 	response := s.get(key.Value, fmt.Sprintf("envId=%d", env.ID))
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func TestHandlerDeploymentList(t *testing.T) {

--- a/src/ce/api/public/v1/handler_deployment_prioritize_test.go
+++ b/src/ce/api/public/v1/handler_deployment_prioritize_test.go
@@ -184,7 +184,7 @@ func (s *HandlerDeploymentPrioritizeSuite) Test_Forbidden_UserNotMember() {
 		map[string]string{"Authorization": key.Value},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func TestHandlerDeploymentPrioritize(t *testing.T) {

--- a/src/ce/api/public/v1/handler_deployment_publish_test.go
+++ b/src/ce/api/public/v1/handler_deployment_publish_test.go
@@ -162,7 +162,7 @@ func (s *HandlerDeploymentPublishSuite) Test_Forbidden_NoAPIKey() {
 }
 
 // Test_Forbidden_UserNotMember verifies that a user-scoped key whose owner is not a member
-// of the environment team is rejected with 403.
+// of the environment team is answered with 404 (existence hidden).
 func (s *HandlerDeploymentPublishSuite) Test_Forbidden_UserNotMember() {
 	usr1 := s.MockUser()
 	appl := s.MockApp(usr1)
@@ -188,7 +188,7 @@ func (s *HandlerDeploymentPublishSuite) Test_Forbidden_UserNotMember() {
 		map[string]string{"Authorization": key.Value},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 // Test_BadRequest_FailedDeployment verifies that attempting to publish a deployment

--- a/src/ce/api/public/v1/handler_deployment_restart_test.go
+++ b/src/ce/api/public/v1/handler_deployment_restart_test.go
@@ -155,7 +155,7 @@ func (s *HandlerDeploymentRestartSuite) Test_Forbidden_UserNotMember() {
 		map[string]string{"Authorization": key.Value},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func (s *HandlerDeploymentRestartSuite) Test_Success() {

--- a/src/ce/api/public/v1/handler_deployment_runtime_logs_get_test.go
+++ b/src/ce/api/public/v1/handler_deployment_runtime_logs_get_test.go
@@ -162,7 +162,7 @@ func (s *HandlerDeploymentRuntimeLogsGetSuite) Test_Forbidden_NotMember() {
 
 	response := s.request("", usertest.Authorization(other.ID))
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func TestHandlerDeploymentRuntimeLogsGet(t *testing.T) {

--- a/src/ce/api/public/v1/handler_deployment_stop_test.go
+++ b/src/ce/api/public/v1/handler_deployment_stop_test.go
@@ -148,7 +148,7 @@ func (s *HandlerDeploymentStopSuite) Test_Forbidden_UserNotMember() {
 		map[string]string{"Authorization": key.Value},
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 func TestHandlerDeploymentStop(t *testing.T) {

--- a/src/ce/api/public/v1/handler_env_list_test.go
+++ b/src/ce/api/public/v1/handler_env_list_test.go
@@ -114,7 +114,7 @@ func (s *HandlerEnvListSuite) Test_Forbidden_UserNotMember() {
 
 	// The app can be resolved from the appId query parameter; this is forbidden
 	// because the user-scoped key belongs to a user who is not a member of the app's team.
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 // Test_MasksEnvVarValues verifies that /v1/envs — the endpoint the dashboard

--- a/src/ce/api/public/v1/handler_mailer_test.go
+++ b/src/ce/api/public/v1/handler_mailer_test.go
@@ -284,7 +284,7 @@ func (s *HandlerMailerSuite) Test_Forbidden_ForNonMember() {
 		s.auth(),
 	)
 
-	s.Equal(http.StatusForbidden, response.Code)
+	s.Equal(http.StatusNotFound, response.Code)
 }
 
 // Test_ConfigSet_AuditsPasswordRotation covers the one mailer write that

--- a/src/ce/api/public/v1/request_context.go
+++ b/src/ce/api/public/v1/request_context.go
@@ -297,7 +297,10 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if app == nil {
-				return shttp.NotFoundJSON("The application owning this environment does not exist.")
+				// An env whose owning app row is gone still must not be
+				// distinguishable from a missing env, so it answers with the
+				// same body rather than a message of its own.
+				return shttp.NotFoundJSON(msgEnvNotFound)
 			}
 
 			request.Env = env

--- a/src/ce/api/public/v1/request_context.go
+++ b/src/ce/api/public/v1/request_context.go
@@ -18,6 +18,14 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
+// A resource that exists but is not owned by the caller must answer exactly as
+// one that does not exist -- same status, same body -- so a valid key cannot
+// probe the existence of another tenant's app or env by the 403-vs-404 split.
+const (
+	msgAppNotFound = "The application does not exist."
+	msgEnvNotFound = "The environment does not exist. Pass a valid 'envId', or use an environment-scoped API key."
+)
+
 type RequestContext struct {
 	*shttp.RequestContext
 	Token  *apikey.Token
@@ -242,23 +250,26 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if app == nil {
-				return shttp.NotFoundJSON("The application does not exist.")
+				return shttp.NotFoundJSON(msgAppNotFound)
 			}
 
 			request.App = app
 			request.TeamID = app.TeamID
 
-			// Validate membership if the key is not already tied to an app.
+			// Validate membership if the key is not already tied to an app. A
+			// caller who does not own the app is answered as if it did not
+			// exist, so the 404-vs-403 difference cannot be used to enumerate
+			// other tenants' app IDs.
 			if request.Token.AppID == 0 {
 				if request.Token.TeamID != 0 {
 					if app.TeamID != request.Token.TeamID {
-						return shttp.ForbiddenAPIKey()
+						return shttp.NotFoundJSON(msgAppNotFound)
 					}
 				} else if request.Token.UserID != 0 {
 					isMember := team.NewStore().IsMember(req.Context(), request.Token.UserID, app.TeamID)
 
 					if !isMember {
-						return shttp.ForbiddenAPIKey()
+						return shttp.NotFoundJSON(msgAppNotFound)
 					}
 				}
 			}
@@ -276,7 +287,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			}
 
 			if env == nil {
-				return shttp.NotFoundJSON("The environment does not exist. Pass a valid 'envId', or use an environment-scoped API key.")
+				return shttp.NotFoundJSON(msgEnvNotFound)
 			}
 
 			app, err := app.NewStore().AppByID(req.Context(), env.AppID)
@@ -293,13 +304,16 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 			request.App = app
 			request.TeamID = app.TeamID
 
-			// Validate membership if the key is not already tied to an environment.
+			// Validate membership if the key is not already tied to an
+			// environment. A caller who does not own the environment is answered
+			// as if it did not exist, so the 404-vs-403 difference cannot be
+			// used to enumerate other tenants' environment IDs.
 			if request.Token.EnvID == 0 {
 				if request.Token.AppID != 0 && request.Token.AppID != env.AppID {
-					return shttp.ForbiddenAPIKey()
+					return shttp.NotFoundJSON(msgEnvNotFound)
 				} else if request.Token.TeamID != 0 {
 					if app.TeamID != request.Token.TeamID {
-						return shttp.ForbiddenAPIKey()
+						return shttp.NotFoundJSON(msgEnvNotFound)
 					}
 
 					request.App = app
@@ -308,7 +322,7 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 					isMember := buildconf.NewStore().IsMember(req.Context(), env.ID, request.Token.UserID)
 
 					if !isMember {
-						return shttp.ForbiddenAPIKey()
+						return shttp.NotFoundJSON(msgEnvNotFound)
 					}
 				}
 			}

--- a/src/ce/api/public/v1/request_context_test.go
+++ b/src/ce/api/public/v1/request_context_test.go
@@ -88,6 +88,43 @@ func (s *RequestContextSuite) Test_ForbiddenOrNotFound() {
 	}
 }
 
+// Test_NotOwnedIsIndistinguishableFromMissing guards against app/env
+// enumeration (issue #460): a resource the caller does not own must answer
+// exactly as one that does not exist, so the 404-vs-403 split cannot reveal
+// which IDs are live on the platform.
+func (s *RequestContextSuite) Test_NotOwnedIsIndistinguishableFromMissing() {
+	attacker := s.MockUser()
+	victim := s.MockUser()
+	victimApp := s.MockApp(victim)
+	victimEnv := s.MockEnv(victimApp)
+
+	attackerKey := s.MockAPIKey(nil, nil, map[string]any{
+		"UserID": attacker.ID,
+		"AppID":  types.ID(0),
+		"EnvID":  types.ID(0),
+	})
+
+	missingID := types.ID(999999999)
+
+	s.Run("SCOPE_APP", func() {
+		owned := s.invoke(http.MethodGet, fmt.Sprintf("/?appId=%d", victimApp.ID), "", "", attackerKey.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_APP})
+		missing := s.invoke(http.MethodGet, fmt.Sprintf("/?appId=%d", missingID), "", "", attackerKey.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_APP})
+
+		s.Equal(http.StatusNotFound, owned.Status, "another tenant's app must not answer 403")
+		s.Equal(missing.Status, owned.Status)
+		s.Equal(missing.Data, owned.Data)
+	})
+
+	s.Run("SCOPE_ENV", func() {
+		owned := s.invoke(http.MethodGet, fmt.Sprintf("/?envId=%d", victimEnv.ID), "", "", attackerKey.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_ENV})
+		missing := s.invoke(http.MethodGet, fmt.Sprintf("/?envId=%d", missingID), "", "", attackerKey.Value, &publicapiv1.Opts{MinimumScope: apikey.SCOPE_ENV})
+
+		s.Equal(http.StatusNotFound, owned.Status, "another tenant's env must not answer 403")
+		s.Equal(missing.Status, owned.Status)
+		s.Equal(missing.Data, owned.Data)
+	})
+}
+
 func (s *RequestContextSuite) Test_Success_WithTokenScope() {
 	usr := s.MockUser()
 	envKey := s.MockAPIKey(nil, nil)


### PR DESCRIPTION
## Problem

`WithAPIKey` (`src/ce/api/public/v1/request_context.go`) checked whether a resource *exists* before whether the caller *owns* it, and the two failures were distinguishable from outside:

- app/env does not exist → `404`
- app/env exists but belongs to another tenant → `403`

So any holder of a valid low-scope API key could walk `?appId=1..N` / `?envId=1..N` against e.g. `GET /v1/app/config` and read off which IDs are live (403) versus unused (404) — a platform-wide census of app and env IDs, and a growth signal over time.

## Fix

Answer both cases identically with the same `404` body for `SCOPE_APP` and `SCOPE_ENV`, so existence cannot be probed. A caller who does not own the resource is told it does not exist — the standard "hide existence from unauthorized callers" model.

- Shared message constants (`msgAppNotFound`, `msgEnvNotFound`) guarantee the not-owned and not-exist responses are byte-identical (status **and** body).
- Unchanged: missing-key, invalid-key, and scope failures still return `403`; the team-scope path has no existence oracle and is untouched.

## Behaviour change for clients

A client that passes an `appId`/`envId` it does not own now gets `404` instead of `403`. This is intentional and matches how platforms like GitHub treat private resources you can't see.

## Tests

New middleware test `Test_NotOwnedIsIndistinguishableFromMissing`: an attacker's user-scoped key hitting a victim's app/env gets a response with the same status and body as a non-existent ID, and specifically not `403`. Full v1 suite passes.

Closes #460
