### PR TITLE
refactor: drop redundant env request assignment

### DIFF
--- a/src/ce/api/public/v1/request_context.go
+++ b/src/ce/api/public/v1/request_context.go
@@ -318,9 +318,6 @@ func WithAPIKey(handler func(*RequestContext) *shttp.Response, opts ...*Opts) sh
 					if app.TeamID != request.Token.TeamID {
 						return shttp.NotFoundJSON(msgEnvNotFound)
 					}
-
-					request.App = app
-					request.TeamID = app.TeamID
 				} else if request.Token.UserID != 0 {
 					isMember := buildconf.NewStore().IsMember(req.Context(), env.ID, request.Token.UserID)
 


### PR DESCRIPTION
In the SCOPE_ENV branch of `WithAPIKey` (`src/ce/api/public/v1/request_context.go`), `request.App` and `request.TeamID` are set unconditionally once the owning app is resolved. The team-scoped sub-branch then set the same two fields again — dead code. Removed it.

No behavior change: the handler still receives the same populated `request`. Build, vet, and the request-context middleware tests pass.

Closes #489