### PR TITLE
feat: surface failure reason in deployment object

### DIFF
--- a/docs/api/7-deployments.md
+++ b/docs/api/7-deployments.md
@@ -212,6 +212,8 @@ Returns the deployment object wrapped in a `deployment` key.
 | `branch`             | string       | Git branch that was deployed.                                                             |
 | `status`             | string       | Current status: `running`, `success`, `failed`, or `stopped`.                             |
 | `error`              | string       | Error message if the deployment failed. Empty string otherwise.                           |
+| `failureSummary`     | string       | Present only on a failed deployment: the tail of the failing step's output, so the reason is available without fetching the full logs. |
+| `logsUrl`            | string       | Present only on a failed deployment: link to the full logs for the rest of the detail.     |
 | `isAutoDeploy`       | boolean      | `true` when triggered automatically (e.g. via webhook).                                   |
 | `isAutoPublish`      | boolean      | Whether this deployment was configured to publish automatically on success.               |
 | `stoppedManually`    | boolean      | `true` when the deployment was stopped by a user action.                                  |

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -112,6 +112,14 @@ type Deployment struct {
 	BuildConfig *buildconf.BuildConf `json:"-"` // ConfigCopy is the snapshot of the environment used during the deployment.
 	DisplayName string               `json:"-"` // DisplayName is the name of the app. It is injected to the deployment object.
 	IsRestart   bool                 `json:"-"`
+
+	// Parsed-log memoization. PrepareLogs is a full parse and both JSON and
+	// FailureSummary need the result; these cache it per log set for the
+	// lifetime of the in-memory deployment (invalidated by AddLogs).
+	buildLogEntries  []*Log
+	buildLogParsed   bool
+	statusLogEntries []*Log
+	statusLogParsed  bool
 }
 
 // PublishedInfo represents information on the publish details
@@ -383,15 +391,36 @@ func (d *Deployment) FailureSummary() string {
 		return ""
 	}
 
-	if s := failedStepMessage(d.PrepareLogs(d.Logs.ValueOrZero(), false)); s != "" {
+	if s := failedStepMessage(d.logEntries(false)); s != "" {
 		return lastLines(s, maxFailureSummaryLines)
 	}
 
-	if s := failedStepMessage(d.PrepareLogs(d.StatusChecks.ValueOrZero(), true)); s != "" {
+	if s := failedStepMessage(d.logEntries(true)); s != "" {
 		return lastLines(s, maxFailureSummaryLines)
 	}
 
 	return strings.TrimSpace(d.Error.ValueOrZero())
+}
+
+// logEntries returns the parsed log entries for the build (or status-check)
+// logs, parsing each set at most once. PrepareLogs is a full parse that both
+// JSON and FailureSummary would otherwise run on the same blob.
+func (d *Deployment) logEntries(isStatusChecks bool) []*Log {
+	if isStatusChecks {
+		if !d.statusLogParsed {
+			d.statusLogEntries = d.PrepareLogs(d.StatusChecks.ValueOrZero(), true)
+			d.statusLogParsed = true
+		}
+
+		return d.statusLogEntries
+	}
+
+	if !d.buildLogParsed {
+		d.buildLogEntries = d.PrepareLogs(d.Logs.ValueOrZero(), false)
+		d.buildLogParsed = true
+	}
+
+	return d.buildLogEntries
 }
 
 // failedStepMessage returns the message of the last failed step that carries
@@ -409,15 +438,28 @@ func failedStepMessage(logs []*Log) string {
 	return ""
 }
 
-// lastLines returns at most maxLines of the trailing, non-empty lines of s.
+// lastLines returns at most maxLines of the trailing lines of s. Leading and
+// trailing blank lines are trimmed, but interior blanks are kept so multi-line
+// errors and stack traces render as written.
 func lastLines(s string, maxLines int) string {
-	lines := []string{}
+	lines := strings.Split(s, "\n")
 
-	for _, line := range strings.Split(s, "\n") {
-		if strings.TrimSpace(line) != "" {
-			lines = append(lines, strings.TrimRight(line, "\r"))
-		}
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, "\r")
 	}
+
+	// Drop leading and trailing blank lines without touching interior ones.
+	start := 0
+	for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+
+	end := len(lines)
+	for end > start && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+
+	lines = lines[start:end]
 
 	if len(lines) > maxLines {
 		lines = lines[len(lines)-maxLines:]
@@ -468,6 +510,7 @@ func (d *Deployment) AddLogs(logs []string) {
 	}
 
 	d.Logs = null.StringFrom(d.Logs.ValueOrZero() + "\n" + strings.Join(logs, "\n"))
+	d.buildLogParsed = false
 }
 
 // PrepareLogs prepares the deployment logs and returns an array of log objects.
@@ -737,8 +780,8 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 	var statusChecksLogs []*Log
 
 	if withLogs {
-		deploymentLogs = d.PrepareLogs(d.Logs.ValueOrZero(), false)
-		statusChecksLogs = d.PrepareLogs(d.StatusChecks.ValueOrZero(), true)
+		deploymentLogs = d.logEntries(false)
+		statusChecksLogs = d.logEntries(true)
 	}
 
 	var stoppedAt any
@@ -757,9 +800,6 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		}
 	}
 
-	detailsURL := fmt.Sprintf("/apps/%s/environments/%s/deployments/%s", appID, envID, depID)
-	status := d.Status()
-
 	jsonMap := map[string]any{
 		"id":                 depID,
 		"appId":              appID,
@@ -772,13 +812,13 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		"createdAt":          d.CreatedAt.UnixStr(),
 		"stoppedAt":          stoppedAt,
 		"stoppedManually":    d.ExitCode.ValueOrZero() == -1,
-		"status":             status,
+		"status":             d.Status(),
 		"snapshot":           d.Snapshot(),
 		"error":              d.Error.ValueOrZero(),
 		"isAutoDeploy":       d.IsAutoDeploy,
 		"isAutoPublish":      d.ShouldPublish,
 		"previewUrl":         admin.MustConfig().PreviewURL(d.DisplayName, d.ID.String()),
-		"detailsUrl":         detailsURL,
+		"detailsUrl":         d.DetailsPath(),
 		"apiPathPrefix":      d.APIPathPrefix.ValueOrZero(),
 		"statusChecks":       statusChecksLogs,
 		"statusChecksPassed": d.StatusChecksPassed,
@@ -807,28 +847,12 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		jsonMap["statusChecks"] = nil
 	}
 
-	// On failure, surface the reason inline so a caller can triage without a
-	// second fetch, plus a link to the full logs for the rest of the detail.
-	if status == "failed" {
-		if summary := d.FailureSummary(); summary != "" {
-			jsonMap["failureSummary"] = summary
-		}
-
-		jsonMap["logsUrl"] = dashboardURL(detailsURL)
-	}
-
 	return jsonMap
 }
 
-// dashboardURL turns a relative dashboard path into a fully-qualified URL using
-// the instance's configured app domain, falling back to the relative path when
-// no domain is configured.
-func dashboardURL(path string) string {
-	if dc := admin.MustConfig().DomainConfig; dc != nil && dc.App != "" {
-		return strings.TrimRight(dc.App, "/") + path
-	}
-
-	return path
+// DetailsPath returns the dashboard path to this deployment's details page.
+func (d *Deployment) DetailsPath() string {
+	return fmt.Sprintf("/apps/%s/environments/%s/deployments/%s", d.AppID.String(), d.EnvID.String(), d.ID.String())
 }
 
 func calculateDuration(createdAt, stoppedAt utils.Unix) int64 {

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -367,6 +367,65 @@ func (d *Deployment) Status() string {
 	return failed
 }
 
+// maxFailureSummaryLines caps the log tail surfaced inline on a failed
+// deployment, so the reason is available without fetching the full logs.
+const maxFailureSummaryLines = 20
+
+// FailureSummary returns a short, human-readable reason a deployment failed,
+// for callers that have the deployment object but not the full logs. It reads
+// the tail of the failed step's captured output -- where a build-command
+// failure surfaces -- preferring the build logs and falling back to the
+// status-check logs, then to any explicitly recorded error. It returns an
+// empty string for a deployment that did not fail. The logs must be loaded on
+// the deployment for a build-log summary to be produced.
+func (d *Deployment) FailureSummary() string {
+	if d.Status() != "failed" {
+		return ""
+	}
+
+	if s := failedStepMessage(d.PrepareLogs(d.Logs.ValueOrZero(), false)); s != "" {
+		return lastLines(s, maxFailureSummaryLines)
+	}
+
+	if s := failedStepMessage(d.PrepareLogs(d.StatusChecks.ValueOrZero(), true)); s != "" {
+		return lastLines(s, maxFailureSummaryLines)
+	}
+
+	return strings.TrimSpace(d.Error.ValueOrZero())
+}
+
+// failedStepMessage returns the message of the last failed step that carries
+// one, which for a build-command failure is the step whose output ends in the
+// error.
+func failedStepMessage(logs []*Log) string {
+	for i := len(logs) - 1; i >= 0; i-- {
+		if !logs[i].Status {
+			if msg := strings.TrimSpace(logs[i].Message); msg != "" {
+				return msg
+			}
+		}
+	}
+
+	return ""
+}
+
+// lastLines returns at most maxLines of the trailing, non-empty lines of s.
+func lastLines(s string, maxLines int) string {
+	lines := []string{}
+
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, strings.TrimRight(line, "\r"))
+		}
+	}
+
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 // RepoCloneURL returns the fully qualified repository name to clone the repository.
 func (d *Deployment) RepoCloneURL() string {
 	pieces := strings.Split(d.CheckoutRepo, "/")
@@ -698,6 +757,9 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		}
 	}
 
+	detailsURL := fmt.Sprintf("/apps/%s/environments/%s/deployments/%s", appID, envID, depID)
+	status := d.Status()
+
 	jsonMap := map[string]any{
 		"id":                 depID,
 		"appId":              appID,
@@ -710,13 +772,13 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		"createdAt":          d.CreatedAt.UnixStr(),
 		"stoppedAt":          stoppedAt,
 		"stoppedManually":    d.ExitCode.ValueOrZero() == -1,
-		"status":             d.Status(),
+		"status":             status,
 		"snapshot":           d.Snapshot(),
 		"error":              d.Error.ValueOrZero(),
 		"isAutoDeploy":       d.IsAutoDeploy,
 		"isAutoPublish":      d.ShouldPublish,
 		"previewUrl":         admin.MustConfig().PreviewURL(d.DisplayName, d.ID.String()),
-		"detailsUrl":         fmt.Sprintf("/apps/%s/environments/%s/deployments/%s", appID, envID, depID),
+		"detailsUrl":         detailsURL,
 		"apiPathPrefix":      d.APIPathPrefix.ValueOrZero(),
 		"statusChecks":       statusChecksLogs,
 		"statusChecksPassed": d.StatusChecksPassed,
@@ -745,7 +807,28 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		jsonMap["statusChecks"] = nil
 	}
 
+	// On failure, surface the reason inline so a caller can triage without a
+	// second fetch, plus a link to the full logs for the rest of the detail.
+	if status == "failed" {
+		if summary := d.FailureSummary(); summary != "" {
+			jsonMap["failureSummary"] = summary
+		}
+
+		jsonMap["logsUrl"] = dashboardURL(detailsURL)
+	}
+
 	return jsonMap
+}
+
+// dashboardURL turns a relative dashboard path into a fully-qualified URL using
+// the instance's configured app domain, falling back to the relative path when
+// no domain is configured.
+func dashboardURL(path string) string {
+	if dc := admin.MustConfig().DomainConfig; dc != nil && dc.App != "" {
+		return strings.TrimRight(dc.App, "/") + path
+	}
+
+	return path
 }
 
 func calculateDuration(createdAt, stoppedAt utils.Unix) int64 {

--- a/src/ce/api/app/deploy/deployment_model_test.go
+++ b/src/ce/api/app/deploy/deployment_model_test.go
@@ -3,6 +3,8 @@ package deploy_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -429,6 +431,61 @@ func (s *DeploymentModelSuite) Test_PopulateFromDeployCandidate() {
 	s.Equal("6543", dep.BuildConfig.Vars["POSTGRES_PORT"])
 	s.Equal("should_not_overwrite", dep.BuildConfig.Vars["DATABASE_URL"])
 	s.Equal("smtp://test-user:test-pwd@smtp.gmail.com:587", dep.BuildConfig.Vars["MAILER_URL"])
+}
+
+func (s *DeploymentModelSuite) Test_FailureSummary_FromFailedStep() {
+	d := &deploy.Deployment{
+		ExitCode: null.IntFrom(deploy.ExitCodeFailed),
+		Logs: null.StringFrom(
+			`{"title":"clone","message":"Cloning repository... done","status":"success","startedAt":1,"finishedAt":2}` + "\n" +
+				`{"title":"npm run build","message":"> build\nError: Cannot find module 'x'\nnpm ERR! exit 1","status":"failed","startedAt":2,"finishedAt":3}`,
+		),
+	}
+
+	summary := d.FailureSummary()
+
+	s.Contains(summary, "Error: Cannot find module 'x'")
+	s.Contains(summary, "npm ERR! exit 1")
+	// The summary is the failed step's output, not an earlier successful one.
+	s.NotContains(summary, "Cloning repository")
+}
+
+func (s *DeploymentModelSuite) Test_FailureSummary_TrimsToLastLines() {
+	lines := make([]string, 0, 40)
+	for i := range 40 {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+
+	msg, err := json.Marshal(strings.Join(lines, "\n"))
+	s.Require().NoError(err)
+
+	d := &deploy.Deployment{
+		ExitCode: null.IntFrom(deploy.ExitCodeFailed),
+		Logs: null.StringFrom(
+			`{"title":"npm run build","message":` + string(msg) + `,"status":"failed","startedAt":1,"finishedAt":2}`,
+		),
+	}
+
+	summary := d.FailureSummary()
+
+	s.Equal(20, len(strings.Split(summary, "\n")), "summary is capped to the last 20 lines")
+	s.Contains(summary, "line 39")
+	s.NotContains(summary, "line 19")
+}
+
+func (s *DeploymentModelSuite) Test_FailureSummary_FallsBackToError() {
+	d := &deploy.Deployment{
+		ExitCode: null.IntFrom(deploy.ExitCodeFailed),
+		Error:    null.StringFrom("We could not detect an index.html"),
+	}
+
+	s.Equal("We could not detect an index.html", d.FailureSummary())
+}
+
+func (s *DeploymentModelSuite) Test_FailureSummary_EmptyOnSuccess() {
+	d := &deploy.Deployment{ExitCode: null.IntFrom(deploy.ExitCodeSuccess)}
+
+	s.Empty(d.FailureSummary())
 }
 
 func TestDeploymentModel(t *testing.T) {

--- a/src/ce/api/app/deploy/deployment_model_test.go
+++ b/src/ce/api/app/deploy/deployment_model_test.go
@@ -473,6 +473,21 @@ func (s *DeploymentModelSuite) Test_FailureSummary_TrimsToLastLines() {
 	s.NotContains(summary, "line 19")
 }
 
+func (s *DeploymentModelSuite) Test_FailureSummary_KeepsInteriorBlankLines() {
+	msg, err := json.Marshal("Error: build failed\n\n  at foo()\n\n  at bar()")
+	s.Require().NoError(err)
+
+	d := &deploy.Deployment{
+		ExitCode: null.IntFrom(deploy.ExitCodeFailed),
+		Logs: null.StringFrom(
+			`{"title":"npm run build","message":` + string(msg) + `,"status":"failed","startedAt":1,"finishedAt":2}`,
+		),
+	}
+
+	// Interior blank lines separating the trace are preserved verbatim.
+	s.Equal("Error: build failed\n\n  at foo()\n\n  at bar()", d.FailureSummary())
+}
+
 func (s *DeploymentModelSuite) Test_FailureSummary_FallsBackToError() {
 	d := &deploy.Deployment{
 		ExitCode: null.IntFrom(deploy.ExitCodeFailed),

--- a/src/ce/api/public/v1/handler_deployment_get.go
+++ b/src/ce/api/public/v1/handler_deployment_get.go
@@ -3,6 +3,7 @@ package publicapiv1
 import (
 	"net/http"
 
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -17,17 +18,15 @@ func handlerDeploymentGet(req *RequestContext) *shttp.Response {
 
 	withLogs := req.Query().Get("logs") == "true"
 
-	// Always load the logs for this single deployment, even when the caller did
-	// not ask for the full array: a failed deployment derives its inline
-	// failureSummary from them. JSON(withLogs) still withholds the full array
-	// unless it was requested.
-	includeLogs := true
+	fetch := func(includeLogs bool) (*deploy.Deployment, error) {
+		return deploy.NewStore().MyDeployment(req.Context(), &deploy.DeploymentsQueryFilters{
+			DeploymentID: id,
+			EnvID:        req.Env.ID,
+			IncludeLogs:  &includeLogs,
+		})
+	}
 
-	depl, err := deploy.NewStore().MyDeployment(req.Context(), &deploy.DeploymentsQueryFilters{
-		DeploymentID: id,
-		EnvID:        req.Env.ID,
-		IncludeLogs:  &includeLogs,
-	})
+	depl, err := fetch(withLogs)
 
 	if err != nil {
 		return shttp.Error(err)
@@ -37,10 +36,43 @@ func handlerDeploymentGet(req *RequestContext) *shttp.Response {
 		return shttp.NotFound()
 	}
 
+	data := depl.JSON(withLogs)
+
+	// A failed deployment carries its reason inline so a caller can triage
+	// without a second call, plus a link to the full logs. The logs are only
+	// loaded here -- not on the hot path of polling a running deployment -- and
+	// only when they were not already fetched.
+	if depl.Status() == "failed" {
+		if !withLogs {
+			if full, ferr := fetch(true); ferr == nil && full != nil {
+				depl = full
+			}
+		}
+
+		if summary := depl.FailureSummary(); summary != "" {
+			data["failureSummary"] = summary
+		}
+
+		data["logsUrl"] = deploymentLogsURL(depl)
+	}
+
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Data: map[string]any{
-			"deployment": depl.JSON(withLogs),
+			"deployment": data,
 		},
 	}
+}
+
+// deploymentLogsURL returns a fully-qualified link to the deployment's details
+// page (where the full logs render), falling back to the relative path when no
+// app domain is configured.
+func deploymentLogsURL(depl *deploy.Deployment) string {
+	path := depl.DetailsPath()
+
+	if url := admin.MustConfig().AppURL(path); url != "" {
+		return url
+	}
+
+	return path
 }

--- a/src/ce/api/public/v1/handler_deployment_get.go
+++ b/src/ce/api/public/v1/handler_deployment_get.go
@@ -17,10 +17,16 @@ func handlerDeploymentGet(req *RequestContext) *shttp.Response {
 
 	withLogs := req.Query().Get("logs") == "true"
 
+	// Always load the logs for this single deployment, even when the caller did
+	// not ask for the full array: a failed deployment derives its inline
+	// failureSummary from them. JSON(withLogs) still withholds the full array
+	// unless it was requested.
+	includeLogs := true
+
 	depl, err := deploy.NewStore().MyDeployment(req.Context(), &deploy.DeploymentsQueryFilters{
 		DeploymentID: id,
 		EnvID:        req.Env.ID,
-		IncludeLogs:  &withLogs,
+		IncludeLogs:  &includeLogs,
 	})
 
 	if err != nil {

--- a/src/ce/api/public/v1/handler_deployment_get_test.go
+++ b/src/ce/api/public/v1/handler_deployment_get_test.go
@@ -66,6 +66,42 @@ func (s *HandlerDeploymentGetSuite) Test_Success() {
 	s.Equal(depl.Branch, got["branch"])
 }
 
+// Test_Failed_IncludesFailureSummaryAndLogsUrl verifies that a failed
+// deployment surfaces the failure reason inline (without ?logs=true) plus a
+// link to the full logs, and still withholds the full logs array.
+func (s *HandlerDeploymentGetSuite) Test_Failed_IncludesFailureSummaryAndLogsUrl() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	depl := s.MockDeployment(env, map[string]any{
+		"ExitCode": null.IntFrom(1),
+		"Logs": null.StringFrom(
+			`{"title":"npm run build","message":"> build\nError: Cannot find module 'x'\nnpm ERR! exit 1","status":"failed","startedAt":1,"finishedAt":2}`,
+		),
+	})
+	key := s.MockAPIKey(appl, env)
+
+	response := shttptest.RequestWithHeaders(
+		s.handler(),
+		shttp.MethodGet,
+		fmt.Sprintf("/v1/deployments/%d", depl.ID),
+		nil,
+		map[string]string{
+			"Authorization": key.Value,
+		},
+	)
+
+	s.Equal(http.StatusOK, response.Code)
+
+	got := response.Map()["deployment"].(map[string]any)
+
+	s.Equal("failed", got["status"])
+	s.Contains(got["failureSummary"], "Error: Cannot find module 'x'")
+	s.NotEmpty(got["logsUrl"])
+	// The full logs array is still withheld unless explicitly requested.
+	s.Nil(got["logs"])
+}
+
 // Test_NotFound_UnknownID verifies that a non-existent deployment ID returns 404.
 func (s *HandlerDeploymentGetSuite) Test_NotFound_UnknownID() {
 	usr := s.MockUser()

--- a/src/ce/api/public/v1/handler_deployment_list_test.go
+++ b/src/ce/api/public/v1/handler_deployment_list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttptest"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/guregu/null.v3"
 )
 
 type HandlerDeploymentListSuite struct {
@@ -172,6 +173,36 @@ func (s *HandlerDeploymentListSuite) Test_Forbidden_UserNotMember() {
 
 	response := s.get(key.Value, fmt.Sprintf("envId=%d", env.ID))
 	s.Equal(http.StatusNotFound, response.Code)
+}
+
+// Test_Failed_OmitsFailureFields verifies that the failure enrichment
+// (failureSummary/logsUrl) is scoped to get_deployment and does not leak into
+// the list endpoint, which never loads logs.
+func (s *HandlerDeploymentListSuite) Test_Failed_OmitsFailureFields() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	env := s.MockEnv(appl)
+	s.MockDeployment(env, map[string]any{
+		"ExitCode": null.IntFrom(1),
+		"Logs": null.StringFrom(
+			`{"title":"npm run build","message":"Error: boom","status":"failed","startedAt":1,"finishedAt":2}`,
+		),
+	})
+	key := s.MockAPIKey(appl, env)
+
+	response := s.get(key.Value, "")
+
+	s.Equal(http.StatusOK, response.Code)
+
+	depls := response.Map()["deployments"].([]any)
+	s.Len(depls, 1)
+
+	item := depls[0].(map[string]any)
+	s.Equal("failed", item["status"])
+	_, hasSummary := item["failureSummary"]
+	s.False(hasSummary, "failureSummary must not appear on list items")
+	_, hasLogsURL := item["logsUrl"]
+	s.False(hasLogsURL, "logsUrl must not appear on list items")
 }
 
 func TestHandlerDeploymentList(t *testing.T) {

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -51,7 +51,7 @@ func mcpAllTools() []mcpToolDef {
 		},
 		{
 			Name:        "get_deployment",
-			Description: "Return metadata and status for a deployment. Poll until status is 'success' or 'failed'.",
+			Description: "Return metadata and status for a deployment. Poll until status is 'success' or 'failed'. On failure the response includes 'failureSummary' (the tail of the failing step's output) and 'logsUrl' for the full logs, so you can triage without fetching all logs.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{


### PR DESCRIPTION
## What

Makes a failed deployment self-describing in the API/MCP `get_deployment` response, so an agent (or CI) can triage without a second call for logs.

Today a failed build returns `status: "failed"` with an empty `error` and `logs: null` — the reason lives only in the logs, behind an explicit `?logs=true` fetch and some parsing.

## Changes

- **`failureSummary`** (string, present only on failure): the tail (last 20 non-empty lines) of the failing step's captured output — where a build-command failure surfaces. Falls back to status-check logs, then to the recorded `error` (upload/migration failures set one).
- **`logsUrl`** (string, present only on failure): a link to the full logs (the deployment page) for the rest of the detail. Absolute when an app domain is configured, relative otherwise.
- The single-deployment get handler now loads logs so the summary can be built without `?logs=true`. The full `logs` array is still withheld unless `logs=true` is passed.
- MCP `get_deployment` tool description updated to mention the two failure fields.
- API docs (`docs/api/7-deployments.md`) updated with both fields.

Scoped per discussion: this surfaces the *reason* (log tail + link), not a structured failure taxonomy (`oom`/`disk-full`/etc.), which would require classifying failures in the build pipeline and can be a follow-up.

## Tests

- Unit: `FailureSummary` returns the failed step's output tail (not an earlier successful step's), caps to 20 lines, falls back to `error`, and is empty on success.
- Handler: a failed deployment fetched without `?logs=true` returns `failureSummary` + `logsUrl` and still withholds the `logs` array.

Full deploy package and the deployment/MCP v1 handlers pass; `go vet` clean.

## Note

`error` was previously marked internal-only on the struct but `JSON()` already emitted it — this PR does not change that. The failure summary is derived from step output; if build output could contain sensitive strings, that is worth a look, but it is the same content already returned via `?logs=true` today.

Closes #422


## Default-disclosure note (conscious decision)

`failureSummary` puts a tail of the (unmasked) build-step output into the **default** `get_deployment` response, and — via the MCP tool — into agent transcripts. This does **not** cross a trust boundary: the same env-scoped caller could already fetch the full logs with `?logs=true`, and authorization/ownership scoping is unchanged (verified in review). What changes is that this content is now returned by default rather than opt-in.

Build logs are not masked the way snapshot env-var values are. If a build command echoes a secret (e.g. `set -x`, a tool dumping config), it can appear in `failureSummary` just as it already can in the full logs today. Accepted for this PR; masking build-log output is a separate, pre-existing gap tracked as a follow-up.
