### PR TITLE
fix: drop phantom today bucket in visitors chart

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Visitors.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Visitors.spec.tsx
@@ -98,8 +98,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Visitors.tsx", () =>
   });
 
   it("should fetch with specified time span", async () => {
+    // Local noon so the calendar date is the same in every timezone.
     vi.useFakeTimers({
-      now: new Date("2024-01-14").getTime(),
+      now: new Date(2024, 0, 14, 12, 0, 0).getTime(),
       toFake: ["Date"],
     });
 
@@ -111,11 +112,85 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Visitors.tsx", () =>
       expect(scope.isDone()).toBe(true);
       expect(wrapper.getByText("Visitors")).toBeTruthy();
       expect(wrapper.getAllByText(/Total/).at(0)).toBeTruthy();
-      expect(wrapper.getByText("70")).toBeTruthy();
+      // 2024-01-13 (50) only. Today (2024-01-14, 20) is excluded because the
+      // daily aggregation has not run for it yet.
+      expect(wrapper.getByText("50")).toBeTruthy();
       expect(wrapper.getByText(/visits in the last/)).toBeTruthy();
       expect(wrapper.getByText(/7 days/)).toBeTruthy();
     });
 
     vi.useRealTimers();
+  });
+
+  it("should end the 7d window at yesterday, not today", async () => {
+    vi.useFakeTimers({
+      now: new Date(2024, 0, 14, 12, 0, 0).getTime(),
+      toFake: ["Date"],
+    });
+
+    createWrapper({ ts: "7d" });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByTestId("area-chart").innerHTML).toEqual(
+        JSON.stringify([
+          { name: "2024-01-07", total: 0, unique: 0 },
+          { name: "2024-01-08", total: 0, unique: 0 },
+          { name: "2024-01-09", total: 0, unique: 0 },
+          { name: "2024-01-10", total: 0, unique: 0 },
+          { name: "2024-01-11", total: 0, unique: 0 },
+          { name: "2024-01-12", total: 0, unique: 0 },
+          { name: "2024-01-13", total: 50, unique: 25 },
+        ]),
+      );
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("should end the 30d window at yesterday, not today", async () => {
+    vi.useFakeTimers({
+      now: new Date(2024, 0, 14, 12, 0, 0).getTime(),
+      toFake: ["Date"],
+    });
+
+    createWrapper({ ts: "30d" });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    const series = JSON.parse(wrapper.getByTestId("area-chart").innerHTML);
+
+    expect(series).toHaveLength(30);
+    expect(series[0].name).toBe("2023-12-15");
+    expect(series[series.length - 1]).toEqual({
+      name: "2024-01-13",
+      total: 50,
+      unique: 25,
+    });
+    expect(series.find((s: { name: string }) => s.name === "2024-01-14")).toBe(
+      undefined,
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("should not drop today for the 24h span", async () => {
+    createWrapper({ ts: "24h" });
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+      // 24h renders whatever keys the API returns, untouched.
+      expect(wrapper.getByTestId("area-chart").innerHTML).toEqual(
+        JSON.stringify([
+          { name: "2024-01-14", total: 20, unique: 10 },
+          { name: "2024-01-13", total: 50, unique: 25 },
+          { name: "2023-12-19", total: 46, unique: 19 },
+          { name: "2023-11-04", total: 32, unique: 22 },
+          { name: "2023-07-02", total: 12, unique: 12 },
+        ]),
+      );
+    });
   });
 });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/actions.ts
@@ -15,6 +15,16 @@ interface VisitorsChartData {
   unique: number;
 }
 
+// toLocalDate formats a date as YYYY-MM-DD in the local timezone. The API keys
+// its buckets by the server's calendar date, so formatting in UTC (via
+// toISOString) would shift the whole series by a day for most timezones.
+const toLocalDate = (date: Date): string => {
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+
+  return `${date.getFullYear()}-${month}-${day}`;
+};
+
 export const useFetchVisitors = ({
   envId,
   refreshToken,
@@ -50,19 +60,24 @@ export const useFetchVisitors = ({
             });
           });
         } else {
-          const date = new Date();
+          // The daily aggregation job runs once a day, so today's bucket is
+          // never synced and the API omits it. Ending the window at yesterday
+          // keeps the chart from rendering a phantom zero for today. The API
+          // already returns span + 1 days, which fills the extra leading slot.
           const span = Number(ts.replace("d", ""));
-          date.setDate(date.getDate() - span); // Go back 7 or 30 days
+          const date = new Date();
+          date.setDate(date.getDate() - span);
 
           for (let i = 0; i < span; i++) {
-            // increment 1 by 1 until today
-            date.setDate(date.getDate() + 1);
-            const name = date.toISOString().split("T")[0];
+            const name = toLocalDate(date);
+
             VisitorsChartData.push({
               name,
               total: data[name]?.total || 0,
               unique: data[name]?.unique || 0,
             });
+
+            date.setDate(date.getDate() + 1);
           }
         }
 


### PR DESCRIPTION
## Problem

The **7d** and **30d** visitor charts always render today as `0`, so every chart looks like it ends in a downtrend.

## Cause

Two bugs stacked in `useFetchVisitors`:

1. **Off-by-one.** `SyncAnalyticsVisitorsDaily` runs once a day (`worker_scheduler.go:89`), so today's row in `analytics_visitors_agg_*` is never synced. The handler deliberately deletes it before responding:

   ```go
   // Remove today because the data is not yet synced.
   if args.Span != SPAN_24h {
       delete(dates, time.Now().Format(time.DateOnly))
   }
   ```

   The frontend then built its x-axis as `today - span + 1` … `today` and zero-filled anything the API didn't return — so the trailing today slot was guaranteed to be `0`.

   `prepareVisitorsQuery` already asks for `INTERVAL '8 days'` / `'31 days'` — one day *more* than the span. The intended window was clearly `span` complete days ending **yesterday**; the loop just incremented before pushing instead of after.

2. **Timezone.** The bucket key came from `date.toISOString().split("T")[0]` (UTC) while the API keys buckets by the server's calendar date. For most timezones that shifts the whole series by a day, which can zero-fill *every* bucket, not just today.

## Fix

Push before incrementing, so the series runs `today - span` … `yesterday` — still exactly `span` points, every one a synced day, with the extra leading day already covered by the SQL. And derive the key from local date parts instead of UTC.

**`24h` is untouched.** It takes the other branch, maps `Object.keys(data)` straight through and does no date generation, so neither bug applied and it still shows today.

## Tests

`Visitors.spec.tsx` — 7 passing (26 across the analytics suite).

- Updated the existing 7d test: expected total `70` → `50`, since today (`2024-01-14`, 20 visits) is now correctly excluded. Its fake timer moved from `new Date("2024-01-14")` (UTC midnight, fragile once dates are read locally) to local noon, so the calendar date is stable in any timezone.
- Added: 7d ends at yesterday (full series asserted), 30d ends at yesterday with exactly 30 points and no `2024-01-14`, and 24h still renders today untouched.

## Notes

- `actions.ts` already failed `prettier --check` on `main` before this change, so I left the file's formatting alone rather than adding unrelated churn.
- Tradeoff: "last 7 days" now means the last 7 *complete* days and never includes today. If you'd rather show a live partial today, the handler could pull today's bucket from `analytics_visitors_agg_hourly_200` (synced every 5 min) instead of deleting it — but a partial day still dips early in the morning, so it wouldn't remove the visual downtrend on its own. Happy to do that separately.