### PR TITLE
refactor: unify the text/html content-type check

### DIFF
--- a/src/ce/hosting/content_type.go
+++ b/src/ce/hosting/content_type.go
@@ -1,0 +1,19 @@
+package hosting
+
+import "strings"
+
+// htmlContentType is the media type every HTML check in hosting agrees on.
+const htmlContentType = "text/html"
+
+// isHTMLContentType reports whether a Content-Type value names an HTML
+// document. Media types are case-insensitive (RFC 9110 §8.3.1) and header
+// values may carry surrounding whitespace, so the value is normalised before
+// the prefix test — anything past the type, such as `; charset=utf-8`, is
+// irrelevant to the question.
+//
+// Every HTML decision in hosting goes through here so that snippet injection,
+// analytics page views, cache policy and markdown conversion can never disagree
+// about the same response.
+func isHTMLContentType(contentType string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), htmlContentType)
+}

--- a/src/ce/hosting/content_type_internal_test.go
+++ b/src/ce/hosting/content_type_internal_test.go
@@ -1,0 +1,46 @@
+package hosting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// IsHTMLContentTypeSuite pins the single normalisation every HTML decision in
+// hosting shares (issue #495). Before it existed, snippet injection, analytics,
+// cache policy and markdown conversion each spelled the test differently and
+// could disagree about the same response.
+type IsHTMLContentTypeSuite struct {
+	suite.Suite
+}
+
+func (s *IsHTMLContentTypeSuite) Test_MatchesPlainAndParameterised() {
+	s.True(isHTMLContentType("text/html"))
+	s.True(isHTMLContentType("text/html; charset=utf-8"))
+	s.True(isHTMLContentType("text/html;charset=UTF-8"))
+}
+
+func (s *IsHTMLContentTypeSuite) Test_MatchesRegardlessOfCase() {
+	// Media types are case-insensitive (RFC 9110 §8.3.1), and custom header
+	// rules pass whatever the deployment wrote through verbatim.
+	s.True(isHTMLContentType("Text/HTML"))
+	s.True(isHTMLContentType("TEXT/HTML; charset=utf-8"))
+	s.True(isHTMLContentType("Text/Html"))
+}
+
+func (s *IsHTMLContentTypeSuite) Test_IgnoresSurroundingWhitespace() {
+	s.True(isHTMLContentType("  text/html  "))
+	s.True(isHTMLContentType("\ttext/html; charset=utf-8"))
+}
+
+func (s *IsHTMLContentTypeSuite) Test_RejectsNonHTML() {
+	s.False(isHTMLContentType(""))
+	s.False(isHTMLContentType("text/plain"))
+	s.False(isHTMLContentType("application/json"))
+	s.False(isHTMLContentType("text/markdown"))
+	s.False(isHTMLContentType("application/xhtml+xml"))
+}
+
+func TestIsHTMLContentTypeSuite(t *testing.T) {
+	suite.Run(t, new(IsHTMLContentTypeSuite))
+}

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -131,9 +131,7 @@ func (r *RequestServer) finalize(res *shttp.Response) *shttp.Response {
 	res = r.applyVary(res)
 
 	if r.req.Host.Config.IsEnterprise {
-		contentType := strings.ToLower(res.Headers.Get("Content-Type"))
-
-		if strings.HasPrefix(contentType, "text/html") {
+		if isHTMLContentType(res.Headers.Get("Content-Type")) {
 			r.record = analyticsRecord(r.req, res)
 		}
 	}
@@ -428,7 +426,7 @@ func (r *RequestServer) Static() *shttp.Response {
 		// page's revalidation policy and not the asset one. Without this it is
 		// classified by its own content type, and one representation of a URL
 		// outlives the other by a day.
-		if r.markdown || strings.HasPrefix(headers.Get("Content-Type"), "text/html") {
+		if r.markdown || isHTMLContentType(headers.Get("Content-Type")) {
 			headers.Add("Cache-Control", "no-cache, must-revalidate")
 		} else {
 			headers.Add("Cache-Control", "public, max-age=86400")
@@ -800,7 +798,7 @@ func (r *RequestServer) OptimizeImage(content []byte) ([]byte, error) {
 func shouldInject(_ *RequestContext, res *shttp.Response) bool {
 	// We only inject snippets into HTML responses. Encoding is handled by
 	// injectSnippets, which decompresses gzip/deflate bodies before injecting.
-	if res == nil || !strings.HasPrefix(res.Headers.Get("Content-Type"), "text/html") {
+	if res == nil || !isHTMLContentType(res.Headers.Get("Content-Type")) {
 		return false
 	}
 

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -808,6 +808,102 @@ func (s *HandlerForwardSuite) Test_Analytics() {
 	}, hosting.AnalyticsRecord(req, res))
 }
 
+// htmlCaseHost builds a deployment whose manifest spells the page's content
+// type unconventionally. Custom header rules pass values through verbatim (see
+// deploy.ParseHeaders), so this is a shape a real build can publish.
+func (s *HandlerForwardSuite) htmlCaseHost(contentType string) *hosting.Host {
+	return &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			IsEnterprise:    true,
+			DeploymentID:    types.ID(1),
+			AppID:           types.ID(25),
+			EnvID:           types.ID(100),
+			DomainID:        types.ID(501),
+			StorageLocation: "aws:my-bucket/my-key-prefix",
+			StaticFiles: appconf.StaticFileConfig{
+				"/some/url/index.html": {
+					FileName: "/some/url/index.html",
+					Headers:  map[string]string{"content-type": contentType},
+				},
+			},
+		},
+	}
+}
+
+func (s *HandlerForwardSuite) Test_CacheControl_UnusuallyCasedHTMLGetsThePagePolicy() {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     "/some/url/index.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("<html><head></head><body></body></html>"),
+	}, nil)
+
+	res := hosting.HandlerForward(s.newRequest(s.htmlCaseHost("Text/HTML; charset=utf-8"), "/some/url"))
+
+	s.Equal(http.StatusOK, res.Status)
+	// Without the shared content-type test this page silently fell into the
+	// 24 hour asset policy (issue #495).
+	s.Equal("no-cache, must-revalidate", res.Headers.Get("Cache-Control"))
+}
+
+func (s *HandlerForwardSuite) Test_CacheControl_NonHTMLKeepsTheAssetPolicy() {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     "/some/url/index.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("{}"),
+	}, nil)
+
+	res := hosting.HandlerForward(s.newRequest(s.htmlCaseHost("application/json"), "/some/url"))
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Equal("public, max-age=86400", res.Headers.Get("Cache-Control"))
+}
+
+func (s *HandlerForwardSuite) Test_Analytics_RecordsUnusuallyCasedHTML() {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     "/some/url/index.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("<html><head></head><body></body></html>"),
+	}, nil)
+
+	records := make(chan *analytics.Record, 1)
+
+	hosting.WaitArtifacts()
+	hosting.ResetBatcher(pool.New(
+		pool.WithSize(1),
+		pool.WithFlushInterval(time.Hour),
+		pool.WithFlusher(pool.FlusherFunc(func(items []any) {
+			for _, item := range items {
+				if rec, ok := item.(*jobs.HostingRecord); ok {
+					records <- rec.Analytics
+				}
+			}
+		})),
+	))
+
+	header := http.Header{}
+	header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+
+	hosting.HandlerForward(s.newRequest(s.htmlCaseHost("Text/HTML; charset=utf-8"), "/some/url", header))
+	hosting.WaitArtifacts()
+
+	select {
+	case record := <-records:
+		// The page view used to be dropped because the gate compared the raw
+		// header against a lowercase prefix (issue #495).
+		s.Require().NotNil(record)
+		s.Equal("/some/url", record.RequestPath)
+	case <-time.After(5 * time.Second):
+		s.Fail("expected a hosting record to be flushed")
+	}
+}
+
 func (s *HandlerForwardSuite) Test_CacheControl_LastModified() {
 	updatedAt := utils.NewUnix()
 	updatedAt.Time = time.Unix(1700489144, 0).UTC()

--- a/src/ce/hosting/handler_markdown.go
+++ b/src/ce/hosting/handler_markdown.go
@@ -270,7 +270,7 @@ func isHTMLFile(meta *FileMeta) bool {
 	}
 
 	if contentType := shttp.HeadersFromMap(meta.Headers).Get("Content-Type"); contentType != "" {
-		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), "text/html")
+		return isHTMLContentType(contentType)
 	}
 
 	// A manifest entry without a content type is classified by its name, the

--- a/src/ce/hosting/snippet_inject_test.go
+++ b/src/ce/hosting/snippet_inject_test.go
@@ -151,6 +151,23 @@ func (s *SnippetInjectSuite) Test_SkipsNonHTML() {
 	s.Equal(`{"ok":true}`, out.Data)
 }
 
+func (s *SnippetInjectSuite) Test_InjectsIntoUnusuallyCasedHTML() {
+	// A custom header rule passes the deployment's spelling through verbatim, so
+	// a page can arrive as `Text/HTML`. Media types are case-insensitive, and
+	// snippet injection must not silently skip such a page (issue #495).
+	res := &shttp.Response{
+		Status:  http.StatusOK,
+		Headers: http.Header{"Content-Type": []string{"Text/HTML; charset=utf-8"}},
+		Data:    []byte(sampleHTML),
+	}
+
+	out := hosting.InjectSnippets(s.request(snippetHost(headAppendSnippet()), "/"), res)
+
+	body, ok := out.Data.(string)
+	s.Require().True(ok)
+	s.Contains(body, "<!--sk-head--></head>")
+}
+
 func TestSnippetInjectSuite(t *testing.T) {
 	suite.Run(t, &SnippetInjectSuite{})
 }


### PR DESCRIPTION
Closes #495.

The `text/html` test was written inline in four places in `src/ce/hosting`, and one of them normalised differently from the other three: `isHTMLFile` lowercased and trimmed, while snippet injection, the analytics page-view gate and the cache-policy branch compared the raw header against a lowercase prefix.

A page whose manifest content type is spelled `Text/HTML` (custom header rules pass values through verbatim) was therefore treated as HTML by markdown conversion and as not-HTML by the other three: no snippets injected, no page view recorded, and the 24 hour asset cache policy instead of the page policy.

## What changed

- New `isHTMLContentType(string) bool` in `src/ce/hosting/content_type.go` — trims, lowercases, prefix-matches `text/html`.
- All four call sites delegate to it: `handler_forward.go` (analytics gate, `Cache-Control` branch, `shouldInject`) and `handler_markdown.go` (`isHTMLFile`, which keeps its fallback to the file extension when a manifest entry carries no content type).

## Behaviour change

Normalising the three raw checks is deliberate, as the issue notes, so it lands with tests rather than as a silent tidy-up:

- `Test_InjectsIntoUnusuallyCasedHTML` — snippets are injected into a `Text/HTML; charset=utf-8` response.
- `Test_Analytics_RecordsUnusuallyCasedHTML` — the page view is recorded end-to-end through `HandlerForward`.
- `Test_CacheControl_UnusuallyCasedHTMLGetsThePagePolicy` — `no-cache, must-revalidate` instead of `public, max-age=86400`, plus a negative case pinning that non-HTML still gets the asset policy.
- `IsHTMLContentTypeSuite` covers the helper directly.

All three behaviour tests fail against the un-normalised helper and pass with it; `go test ./src/ce/hosting/ -p 1` is green.