### PR TITLE
feat: surface proxy timeouts as a distinct error

### DIFF
--- a/docs/deployments/10-application-runtime.md
+++ b/docs/deployments/10-application-runtime.md
@@ -43,10 +43,14 @@ may take to start sending response headers. This is the only request deadline on
 self-hosted instance — the 15 second function timeout is a Stormkit Cloud limit and does
 not apply here. Raise it, or set it to `0`, if a request legitimately needs longer.
 
-When the deadline is hit, Stormkit answers `504 Gateway Timeout` with a page that names
-`STORMKIT_HTTP_PROXY_TIMEOUT` and marks the response with `X-Stormkit-Error: proxy-timeout`.
-Your server is usually still running and finishes the work afterwards — a 504 here means the
-proxy stopped waiting, not that the process crashed.
+When the deadline is hit, Stormkit answers `504 Gateway Timeout` and marks the response with
+`X-Stormkit-Error: proxy-timeout`. Your server is usually still running and finishes the work
+afterwards — a 504 here means the proxy stopped waiting, not that the process crashed.
+
+Requests served by your application get a page naming `STORMKIT_HTTP_PROXY_TIMEOUT`; if the
+deployment ships its own error page that page is served instead, and the header is how you
+tell a timeout from a crash. Note the variable belongs to the Stormkit instance's own process
+environment — setting it in an application's environment variables has no effect.
 
 The runtime is not Go-specific — any process that listens on `PORT` works, including a
 Node/Express or Fastify server. Go is used in the examples below because compiling a

--- a/docs/deployments/10-application-runtime.md
+++ b/docs/deployments/10-application-runtime.md
@@ -43,6 +43,11 @@ may take to start sending response headers. This is the only request deadline on
 self-hosted instance — the 15 second function timeout is a Stormkit Cloud limit and does
 not apply here. Raise it, or set it to `0`, if a request legitimately needs longer.
 
+When the deadline is hit, Stormkit answers `504 Gateway Timeout` with a page that names
+`STORMKIT_HTTP_PROXY_TIMEOUT` and marks the response with `X-Stormkit-Error: proxy-timeout`.
+Your server is usually still running and finishes the work afterwards — a 504 here means the
+proxy stopped waiting, not that the process crashed.
+
 The runtime is not Go-specific — any process that listens on `PORT` works, including a
 Node/Express or Fastify server. Go is used in the examples below because compiling a
 binary is the most common case.

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -591,7 +591,7 @@ func (r *RequestServer) Error(requestErr error) *shttp.Response {
 		status = http.StatusGatewayTimeout
 		pageTitle = "Stormkit - Upstream Timeout"
 		pageContent = html.Templates["timeout"]
-		contentData["timeout"] = timeoutErr.After.String()
+		contentData["timeout"] = timeoutErr.Limit.String()
 		contentData["timeout_env_var"] = shttp.ProxyTimeoutEnvVar
 	}
 
@@ -608,8 +608,6 @@ func (r *RequestServer) Error(requestErr error) *shttp.Response {
 	}
 
 	if timeoutErr != nil {
-		// Machine-readable even when the deployment's own error page replaces the
-		// body below, so the reason survives a custom 500 page.
 		r.res.Headers.Set("X-Stormkit-Error", "proxy-timeout")
 	}
 
@@ -632,6 +630,13 @@ func (r *RequestServer) Error(requestErr error) *shttp.Response {
 	r.res.Data = file.Content
 	r.res.Headers = shttp.HeadersFromMap(customErrorFile.Headers)
 	r.res.Headers.Set("Content-Type", file.ContentType)
+
+	if timeoutErr != nil {
+		// Re-applied because the line above replaces the header map wholesale. A
+		// deployment's own error page keeps the body, but the reason the request
+		// failed has to stay machine-readable.
+		r.res.Headers.Set("X-Stormkit-Error", "proxy-timeout")
+	}
 
 	return r.res
 }

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -569,19 +570,47 @@ func (r *RequestServer) Error(requestErr error) *shttp.Response {
 	})
 
 	cnf := r.req.Host.Config
+	runtimeLogsURL := admin.MustConfig().RuntimeLogsURL(cnf.AppID, cnf.EnvID, cnf.DeploymentID)
+
+	status := http.StatusInternalServerError
+	pageTitle := "Stormkit - Error"
+	pageContent := html.Templates["error"]
+	contentData := map[string]any{
+		"error_msg":        requestErr.Error(),
+		"runtime_logs_url": runtimeLogsURL,
+	}
+
+	// A proxy timeout is not an application crash: the upstream process is
+	// usually alive and still working when the proxy gives up, and the fix is a
+	// configuration change. Answering 500 with the generic page made that
+	// indistinguishable from a crash and took manual investigation to trace
+	// back to the timeout (issue #421).
+	var timeoutErr *shttp.ProxyTimeoutError
+
+	if errors.As(requestErr, &timeoutErr) {
+		status = http.StatusGatewayTimeout
+		pageTitle = "Stormkit - Upstream Timeout"
+		pageContent = html.Templates["timeout"]
+		contentData["timeout"] = timeoutErr.After.String()
+		contentData["timeout_env_var"] = shttp.ProxyTimeoutEnvVar
+	}
+
 	r.res = &shttp.Response{
-		Status: http.StatusInternalServerError,
+		Status: status,
 		Headers: shttp.HeadersFromMap(map[string]string{
 			"Content-Type": "text/html",
 		}),
 		Data: html.MustRender(html.RenderArgs{
-			PageTitle:   "Stormkit - Error",
-			PageContent: html.Templates["error"],
-			ContentData: map[string]any{
-				"error_msg":        requestErr.Error(),
-				"runtime_logs_url": admin.MustConfig().RuntimeLogsURL(cnf.AppID, cnf.EnvID, cnf.DeploymentID),
-			},
+			PageTitle:   pageTitle,
+			PageContent: pageContent,
+			ContentData: contentData,
 		}),
+	}
+
+	if timeoutErr != nil {
+		// Machine-readable even when the deployment's own error page replaces the
+		// body below, so the reason survives a custom 500 page.
+		r.res.Headers.Set("X-Stormkit-Error", "proxy-timeout")
 	}
 
 	customErrorFile := ErrorFile(cnf)

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -3,6 +3,7 @@ package hosting_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -1397,6 +1398,74 @@ func (s *HandlerForwardSuite) Test_AuthWall_AlreadyLoggedIn() {
 	s.Equal(http.StatusNotFound, res.Status)
 	s.Equal("text/html; charset=utf-8", res.Headers.Get("Content-Type"))
 	s.Contains(data, "Whoops! We've got nothing under this link.")
+}
+
+// A proxy timeout must be distinguishable from an application crash: the
+// upstream is usually still running and the fix is a configuration change
+// (issue #421).
+func (s *HandlerForwardSuite) Test_ProxyTimeout_ServesADistinctError() {
+	timeoutErr := &shttp.ProxyTimeoutError{
+		Target: "http://localhost:3000/slow",
+		After:  30 * time.Second,
+	}
+
+	s.mockClient.On("Invoke", mock.Anything).Return(nil, timeoutErr)
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			AppID:            types.ID(25),
+			EnvID:            types.ID(100),
+			StorageLocation:  "aws:my-bucket/my-key-prefix",
+			FunctionLocation: "aws:my-server-function",
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/slow"))
+
+	s.Equal(http.StatusGatewayTimeout, res.Status)
+	s.Equal("proxy-timeout", res.Headers.Get("X-Stormkit-Error"))
+
+	body, ok := res.Data.([]byte)
+	s.Require().True(ok)
+
+	page := string(body)
+
+	s.Contains(page, "Upstream timed out")
+	s.Contains(page, shttp.ProxyTimeoutEnvVar)
+	s.Contains(page, "30s")
+	s.NotContains(page, "Whoops! We got something wrong.")
+}
+
+// Every other upstream failure keeps the crash page and its 500.
+func (s *HandlerForwardSuite) Test_NonTimeoutErrorKeepsTheGenericPage() {
+	s.mockClient.On("Invoke", mock.Anything).Return(nil, errors.New("boom"))
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			AppID:            types.ID(25),
+			EnvID:            types.ID(100),
+			StorageLocation:  "aws:my-bucket/my-key-prefix",
+			FunctionLocation: "aws:my-server-function",
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/boom"))
+
+	s.Equal(http.StatusInternalServerError, res.Status)
+	s.Empty(res.Headers.Get("X-Stormkit-Error"))
+
+	body, ok := res.Data.([]byte)
+	s.Require().True(ok)
+
+	page := string(body)
+
+	s.Contains(page, "Whoops! We got something wrong.")
+	s.Contains(page, "boom")
+	s.NotContains(page, shttp.ProxyTimeoutEnvVar)
 }
 
 func TestHandlerForward(t *testing.T) {

--- a/src/ce/hosting/handler_forward_test.go
+++ b/src/ce/hosting/handler_forward_test.go
@@ -1406,7 +1406,8 @@ func (s *HandlerForwardSuite) Test_AuthWall_AlreadyLoggedIn() {
 func (s *HandlerForwardSuite) Test_ProxyTimeout_ServesADistinctError() {
 	timeoutErr := &shttp.ProxyTimeoutError{
 		Target: "http://localhost:3000/slow",
-		After:  30 * time.Second,
+		After:  31 * time.Second,
+		Limit:  30 * time.Second,
 	}
 
 	s.mockClient.On("Invoke", mock.Anything).Return(nil, timeoutErr)
@@ -1435,6 +1436,7 @@ func (s *HandlerForwardSuite) Test_ProxyTimeout_ServesADistinctError() {
 	s.Contains(page, "Upstream timed out")
 	s.Contains(page, shttp.ProxyTimeoutEnvVar)
 	s.Contains(page, "30s")
+	s.Contains(page, "not this application's environment variables")
 	s.NotContains(page, "Whoops! We got something wrong.")
 }
 
@@ -1466,6 +1468,45 @@ func (s *HandlerForwardSuite) Test_NonTimeoutErrorKeepsTheGenericPage() {
 	s.Contains(page, "Whoops! We got something wrong.")
 	s.Contains(page, "boom")
 	s.NotContains(page, shttp.ProxyTimeoutEnvVar)
+}
+
+// A deployment's own error page keeps the body, but the machine-readable reason
+// has to survive the header map being replaced along with it.
+func (s *HandlerForwardSuite) Test_ProxyTimeout_HeaderSurvivesCustomErrorPage() {
+	s.mockClient.On("GetFile", integrations.GetFileArgs{
+		Location:     "aws:my-bucket/my-key-prefix",
+		FileName:     "/custom-error.html",
+		DeploymentID: types.ID(1),
+	}).Return(&integrations.GetFileResult{
+		Content: []byte("Our own error page"),
+	}, nil)
+
+	s.mockClient.On("Invoke", mock.Anything).Return(nil, &shttp.ProxyTimeoutError{
+		Target: "http://localhost:3000/slow",
+		After:  31 * time.Second,
+		Limit:  30 * time.Second,
+	})
+
+	host := &hosting.Host{
+		Name: "www.stormkit.io",
+		Config: &appconf.Config{
+			DeploymentID:     types.ID(1),
+			AppID:            types.ID(25),
+			EnvID:            types.ID(100),
+			StorageLocation:  "aws:my-bucket/my-key-prefix",
+			FunctionLocation: "aws:my-server-function",
+			ErrorFile:        "/custom-error.html",
+			StaticFiles: appconf.StaticFileConfig{
+				"/custom-error.html": {FileName: "/custom-error.html"},
+			},
+		},
+	}
+
+	res := hosting.HandlerForward(s.newRequest(host, "/slow"))
+
+	s.Equal(http.StatusGatewayTimeout, res.Status)
+	s.Equal([]byte("Our own error page"), res.Data.([]byte))
+	s.Equal("proxy-timeout", res.Headers.Get("X-Stormkit-Error"))
 }
 
 func TestHandlerForward(t *testing.T) {

--- a/src/lib/html/html.go
+++ b/src/lib/html/html.go
@@ -213,7 +213,7 @@ var Templates = map[string]string{
 			<h3 class="text-left mb-1">What happened</h3>
 			<div class="code mb-3">{{ .error_msg }}</div>
 			<h3 class="text-left mb-1">How to fix it</h3>
-			<div class="code mb-3">Set {{ .timeout_env_var }} to a value above the time this endpoint needs, then redeploy. The current value is {{ .timeout }}.</div>
+			<div class="code mb-3">{{ .timeout_env_var }} is currently {{ .timeout }}. Raise it on the Stormkit instance itself — its process environment, not this application's environment variables — and restart the instance.</div>
 		</div>
 	</div>
 	<footer>

--- a/src/lib/html/html.go
+++ b/src/lib/html/html.go
@@ -205,6 +205,25 @@ var Templates = map[string]string{
 		{{ end }}
 	</footer>`,
 
+	"timeout": `
+	<h1>Upstream timed out.</h1>
+	<h3>Your application did not start sending response headers before the proxy gave up.<br />The process is often still running and finishes the work afterwards, so this is usually a timeout rather than a crash.</h3>
+	<div class="container wrapper">
+		<div>
+			<h3 class="text-left mb-1">What happened</h3>
+			<div class="code mb-3">{{ .error_msg }}</div>
+			<h3 class="text-left mb-1">How to fix it</h3>
+			<div class="code mb-3">Set {{ .timeout_env_var }} to a value above the time this endpoint needs, then redeploy. The current value is {{ .timeout }}.</div>
+		</div>
+	</div>
+	<footer>
+		{{ if .runtime_logs_url }}
+		You can view additional logs under your <a href="{{ .runtime_logs_url }}" class="secondary">runtime logs</a>.
+		{{ else }}
+		You can view additional logs under your application runtime logs.
+		{{ end }}
+	</footer>`,
+
 	"login": `
 	<form method="POST" action="{{ .api_host }}/auth-wall/login" class="container">
 		<input type="hidden" name="token" value="{{ .token }}" />

--- a/src/lib/shttp/proxy_error.go
+++ b/src/lib/shttp/proxy_error.go
@@ -19,18 +19,28 @@ const ProxyTimeoutEnvVar = "STORMKIT_HTTP_PROXY_TIMEOUT"
 // and the fix is a configuration change rather than a code change. Callers
 // match on it with errors.As to answer 504 and name the knob.
 type ProxyTimeoutError struct {
-	Target  string
-	After   time.Duration
+	// Target is the upstream that was being proxied. It is an internal
+	// host:port, so it belongs in logs and never in a rendered page.
+	Target string
+	// After is how long the proxy actually waited before giving up.
+	After time.Duration
+	// Limit is the configured deadline that fired.
+	Limit   time.Duration
 	Wrapped error
 }
 
+// Error states what happened and nothing else. The remedy belongs to whoever
+// renders this — the hosting error page already spells it out, and repeating it
+// here printed the same advice twice on the same page.
+//
+// Target is deliberately left out: this string is rendered into a page served
+// to a deployment's visitors, and the target is an internal host:port.
 func (e *ProxyTimeoutError) Error() string {
-	return fmt.Sprintf(
-		"upstream did not send response headers within %s (%s). The server may still be processing the request — raise %s if this endpoint is expected to take longer.",
-		e.After, ProxyTimeoutEnvVar, ProxyTimeoutEnvVar,
-	)
+	return fmt.Sprintf("upstream did not send response headers within %s (%s)", e.Limit, ProxyTimeoutEnvVar)
 }
 
+// Unwrap exposes the transport error, so a caller can still inspect the
+// underlying *url.Error or net.Error.
 func (e *ProxyTimeoutError) Unwrap() error {
 	return e.Wrapped
 }

--- a/src/lib/shttp/proxy_error.go
+++ b/src/lib/shttp/proxy_error.go
@@ -1,0 +1,51 @@
+package shttp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// ProxyTimeoutEnvVar is the environment variable that controls how long the
+// proxy waits for an upstream to start sending response headers.
+const ProxyTimeoutEnvVar = "STORMKIT_HTTP_PROXY_TIMEOUT"
+
+// ProxyTimeoutError reports that an upstream did not start sending response
+// headers within the configured proxy timeout.
+//
+// It exists so the failure is distinguishable from an application crash: the
+// upstream process is usually alive and still working when the proxy gives up,
+// and the fix is a configuration change rather than a code change. Callers
+// match on it with errors.As to answer 504 and name the knob.
+type ProxyTimeoutError struct {
+	Target  string
+	After   time.Duration
+	Wrapped error
+}
+
+func (e *ProxyTimeoutError) Error() string {
+	return fmt.Sprintf(
+		"upstream did not send response headers within %s (%s). The server may still be processing the request — raise %s if this endpoint is expected to take longer.",
+		e.After, ProxyTimeoutEnvVar, ProxyTimeoutEnvVar,
+	)
+}
+
+func (e *ProxyTimeoutError) Unwrap() error {
+	return e.Wrapped
+}
+
+// Timeout mirrors net.Error's method so a caller holding this error can ask the
+// question directly rather than unwrapping to the transport's error first.
+func (e *ProxyTimeoutError) Timeout() bool {
+	return true
+}
+
+// isTimeout reports whether err is a transport deadline — the overall client
+// timeout on a buffered request or ResponseHeaderTimeout on a streaming one.
+// Both surface as a *url.Error whose Timeout() is true.
+func isTimeout(err error) bool {
+	var netErr net.Error
+
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/src/lib/shttp/proxy_timeout_test.go
+++ b/src/lib/shttp/proxy_timeout_test.go
@@ -54,7 +54,7 @@ func (s *ProxyTimeoutSuite) Test_SlowUpstreamYieldsGatewayTimeout() {
 	var timeoutErr *shttp.ProxyTimeoutError
 
 	s.Require().True(errors.As(res.Error, &timeoutErr), "expected a ProxyTimeoutError, got %v", res.Error)
-	s.Equal(100*time.Millisecond, timeoutErr.After)
+	s.Equal(100*time.Millisecond, timeoutErr.Limit, "the reported deadline must be the one that was enforced")
 	s.Equal(upstream.URL, timeoutErr.Target)
 	s.True(timeoutErr.Timeout())
 
@@ -115,6 +115,51 @@ func (s *ProxyTimeoutSuite) Test_HealthyUpstreamIsUnaffected() {
 	s.Equal(http.StatusOK, res.Status)
 	s.Nil(res.Error)
 	s.Equal([]byte("ok"), res.Data)
+}
+
+func (s *ProxyTimeoutSuite) Test_TargetIsNotRenderedIntoTheBody() {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer upstream.Close()
+
+	res := s.proxy(upstream.URL)
+
+	// The body reaches a deployment's visitors; the upstream is an internal
+	// host:port and must stay in the logs.
+	body, _ := res.Data.(string)
+	s.NotContains(body, upstream.URL)
+}
+
+func (s *ProxyTimeoutSuite) Test_DisabledDeadlineStillFailsAsAServerError() {
+	// `0` disables the deadline, and the runtime docs offer it for long
+	// requests. Nothing under that setting may be reported as a proxy timeout.
+	//
+	// This covers the connection failure only. The case the `timeout > 0` guard
+	// in Proxy exists for — a dial or TLS-handshake timeout, which isTimeout
+	// also matches but STORMKIT_HTTP_PROXY_TIMEOUT does not govern — needs a
+	// blackholed route and the transport's own 30s dialer deadline, so it is not
+	// reproducible cheaply here.
+	config.Get().HTTPTimeouts.ProxyTimeout = 0
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	target := upstream.URL
+	upstream.Close()
+
+	res := s.proxy(target)
+
+	var timeoutErr *shttp.ProxyTimeoutError
+
+	s.False(errors.As(res.Error, &timeoutErr))
+	s.Equal(http.StatusInternalServerError, res.Status)
+
+	body, _ := res.Data.(string)
+	s.False(strings.Contains(body, "0s"), "must never tell the operator the deadline was 0s")
 }
 
 func TestProxyTimeoutSuite(t *testing.T) {

--- a/src/lib/shttp/proxy_timeout_test.go
+++ b/src/lib/shttp/proxy_timeout_test.go
@@ -1,0 +1,122 @@
+package shttp_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stretchr/testify/suite"
+)
+
+// ProxyTimeoutSuite covers the distinct upstream-timeout failure (issue #421).
+// A slow upstream used to surface as a 500 carrying a raw transport error,
+// indistinguishable from an application crash.
+type ProxyTimeoutSuite struct {
+	suite.Suite
+
+	previousTimeout time.Duration
+}
+
+func (s *ProxyTimeoutSuite) SetupTest() {
+	s.previousTimeout = config.Get().HTTPTimeouts.ProxyTimeout
+	config.Get().HTTPTimeouts.ProxyTimeout = 100 * time.Millisecond
+}
+
+func (s *ProxyTimeoutSuite) TearDownTest() {
+	config.Get().HTTPTimeouts.ProxyTimeout = s.previousTimeout
+}
+
+func (s *ProxyTimeoutSuite) proxy(target string) *shttp.Response {
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	s.Require().NoError(err)
+
+	return shttp.Proxy(shttp.NewRequestContext(req), shttp.ProxyArgs{Target: target})
+}
+
+func (s *ProxyTimeoutSuite) Test_SlowUpstreamYieldsGatewayTimeout() {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer upstream.Close()
+
+	res := s.proxy(upstream.URL)
+
+	s.Equal(http.StatusGatewayTimeout, res.Status)
+
+	var timeoutErr *shttp.ProxyTimeoutError
+
+	s.Require().True(errors.As(res.Error, &timeoutErr), "expected a ProxyTimeoutError, got %v", res.Error)
+	s.Equal(100*time.Millisecond, timeoutErr.After)
+	s.Equal(upstream.URL, timeoutErr.Target)
+	s.True(timeoutErr.Timeout())
+
+	// The message has to name the knob, otherwise tracing the failure back to
+	// the proxy is a manual investigation.
+	s.Contains(timeoutErr.Error(), shttp.ProxyTimeoutEnvVar)
+	s.Contains(timeoutErr.Error(), "did not send response headers")
+
+	body, ok := res.Data.(string)
+	s.Require().True(ok)
+	s.Contains(body, shttp.ProxyTimeoutEnvVar)
+}
+
+func (s *ProxyTimeoutSuite) Test_UnwrapsToTheTransportError() {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+
+	defer upstream.Close()
+
+	res := s.proxy(upstream.URL)
+
+	var urlErr *url.Error
+
+	s.Require().True(errors.As(res.Error, &urlErr), "the transport error must stay reachable for callers that inspect it")
+	s.True(urlErr.Timeout())
+}
+
+func (s *ProxyTimeoutSuite) Test_NonTimeoutFailureStaysAServerError() {
+	// A closed port fails to connect rather than timing out, so it must not be
+	// reported as a timeout and must not name the timeout env var.
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	target := upstream.URL
+	upstream.Close()
+
+	res := s.proxy(target)
+
+	s.Equal(http.StatusInternalServerError, res.Status)
+
+	var timeoutErr *shttp.ProxyTimeoutError
+
+	s.False(errors.As(res.Error, &timeoutErr))
+
+	body, _ := res.Data.(string)
+	s.False(strings.Contains(body, shttp.ProxyTimeoutEnvVar))
+}
+
+func (s *ProxyTimeoutSuite) Test_HealthyUpstreamIsUnaffected() {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	defer upstream.Close()
+
+	res := s.proxy(upstream.URL)
+
+	s.Equal(http.StatusOK, res.Status)
+	s.Nil(res.Error)
+	s.Equal([]byte("ok"), res.Data)
+}
+
+func TestProxyTimeoutSuite(t *testing.T) {
+	suite.Run(t, new(ProxyTimeoutSuite))
+}

--- a/src/lib/shttp/request_v2.go
+++ b/src/lib/shttp/request_v2.go
@@ -279,6 +279,26 @@ func Proxy(req *RequestContext, args ProxyArgs) *Response {
 		}
 	}
 
+	if isTimeout(err) {
+		timeoutErr := &ProxyTimeoutError{
+			Target:  args.Target,
+			After:   config.Get().HTTPTimeouts.ProxyTimeout,
+			Wrapped: err,
+		}
+
+		// Logged here rather than left to the caller: the upstream is usually
+		// still alive and working, so nothing else in the request path has a
+		// reason to record that the proxy gave up.
+		slog.Errorf("proxy timeout after %s waiting for response headers from %s (%s)",
+			timeoutErr.After, args.Target, ProxyTimeoutEnvVar)
+
+		return &Response{
+			Status: http.StatusGatewayTimeout,
+			Data:   timeoutErr.Error(),
+			Error:  timeoutErr,
+		}
+	}
+
 	return &Response{
 		Status: http.StatusInternalServerError,
 		Data:   err.Error(),

--- a/src/lib/shttp/request_v2.go
+++ b/src/lib/shttp/request_v2.go
@@ -241,6 +241,11 @@ func Proxy(req *RequestContext, args ProxyArgs) *Response {
 		}
 	}
 
+	// Read once, before the request, so the deadline reported on failure is the
+	// one NewRequestV2 seeded the client with rather than whatever the global
+	// config happens to say by the time the request fails.
+	timeout := config.Get().HTTPTimeouts.ProxyTimeout
+
 	client := NewRequestV2(req.Method, args.Target).Headers(headers)
 
 	if args.FollowRedirects != nil && !*args.FollowRedirects {
@@ -251,6 +256,7 @@ func Proxy(req *RequestContext, args ProxyArgs) *Response {
 		client.Stream(req.Body, req.ContentLength)
 	}
 
+	start := time.Now()
 	response, err := client.Do()
 
 	if err == nil {
@@ -279,18 +285,25 @@ func Proxy(req *RequestContext, args ProxyArgs) *Response {
 		}
 	}
 
-	if isTimeout(err) {
+	// Only a configured proxy deadline is reported as one. isTimeout also matches
+	// dial, TLS-handshake and DNS timeouts, which STORMKIT_HTTP_PROXY_TIMEOUT does
+	// not govern — and with the deadline disabled (`0`, which the runtime docs
+	// offer for long requests) it cannot have fired at all. Naming the knob for
+	// those would be the same misdirection this error exists to remove, so they
+	// keep the transport error and its 500.
+	if timeout > 0 && isTimeout(err) {
 		timeoutErr := &ProxyTimeoutError{
 			Target:  args.Target,
-			After:   config.Get().HTTPTimeouts.ProxyTimeout,
+			After:   time.Since(start).Round(time.Second),
+			Limit:   timeout,
 			Wrapped: err,
 		}
 
 		// Logged here rather than left to the caller: the upstream is usually
 		// still alive and working, so nothing else in the request path has a
 		// reason to record that the proxy gave up.
-		slog.Errorf("proxy timeout after %s waiting for response headers from %s (%s)",
-			timeoutErr.After, args.Target, ProxyTimeoutEnvVar)
+		slog.Errorf("proxy timeout after %s waiting for response headers from %s (%s=%s)",
+			timeoutErr.After, timeoutErr.Target, ProxyTimeoutEnvVar, timeoutErr.Limit)
 
 		return &Response{
 			Status: http.StatusGatewayTimeout,


### PR DESCRIPTION
Closes #421.

When an upstream exceeded `STORMKIT_HTTP_PROXY_TIMEOUT`, `shttp.Proxy` returned a 500 carrying the raw transport error (`context deadline exceeded (Client.Timeout exceeded while awaiting headers)`), rendered by the generic "Whoops! We got something wrong" crash page. The upstream process is usually still alive and finishes the work afterwards, so the failure read like a crash — the real cause took a manual investigation to find.

## What changed

**`src/lib/shttp/proxy_error.go`** — new `ProxyTimeoutError{Target, After, Wrapped}`. It unwraps to the transport error so callers that already inspect `*url.Error` / `net.Error` keep working, and exports `ProxyTimeoutEnvVar` so the knob name is written once.

**`src/lib/shttp/request_v2.go`** — `Proxy()` now distinguishes a transport deadline (the client timeout on buffered requests, `ResponseHeaderTimeout` on streaming ones — both surface as a `*url.Error` with `Timeout() == true`) from every other failure. On a deadline it answers **504 Gateway Timeout**, sets `Error` to the typed error, and logs the event server-side (issue point 3) — nothing else in the request path has a reason to record that the proxy gave up.

**`src/ce/hosting/handler_forward.go`** — `Error()` branches on the typed error: a dedicated timeout page (new `html.Templates["timeout"]`) that says the process may still be running and names `STORMKIT_HTTP_PROXY_TIMEOUT` plus its current value, and `X-Stormkit-Error: proxy-timeout` on the response. The header is set outside the body so the reason survives when a deployment's own error page replaces the body. Every other error keeps its 500 and the crash page.

**`docs/deployments/10-application-runtime.md`** — documents the 504 and the header next to the existing `STORMKIT_HTTP_PROXY_TIMEOUT` paragraph.

## Deliberate choices

- **A deployment's custom error page still wins the body**, as it does today — only the status, the built-in copy and the header changed. That keeps branding intact while the machine-readable reason is still on the response.
- **`ProxyTimeoutError.Timeout()`** mirrors `net.Error` without claiming to implement it (`Temporary()` is still part of that interface); a caller holding the error can ask directly instead of unwrapping first.

## Tests

`ProxyTimeoutSuite` (new, `src/lib/shttp/proxy_timeout_test.go`) drives real `httptest` upstreams against a 100ms configured timeout:
- slow upstream → 504, typed error, correct `After`/`Target`, message names the env var
- the transport error stays reachable through `errors.As(*url.Error)`
- a closed port (connection refused, not a deadline) stays a 500 and never names the env var
- a healthy upstream is unaffected

`HandlerForwardSuite` gains `Test_ProxyTimeout_ServesADistinctError` (504 + `X-Stormkit-Error` + page names the env var and the duration, and is *not* the crash page) and `Test_NonTimeoutErrorKeepsTheGenericPage` pinning the unchanged path.

`go build ./...` clean; `go test ./src/lib/shttp/ ./src/ce/hosting/ ./src/lib/integrations/ -p 1` green.