### PR TITLE
fix: report upload errors in the deploy step

### DIFF
--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -333,6 +333,7 @@ func Run(opts RunnerOpts) *RunResult {
 
 	var artifacts *Artifacts
 	var miseOutput []string
+	var uploadErr error
 
 	if err := repo.Checkout(ctx); err != nil {
 		return &RunResult{opts: opts, err: err}
@@ -460,10 +461,15 @@ func Run(opts RunnerOpts) *RunResult {
 		if err != nil {
 			slog.Errorf("upload failed: %v", err)
 			manifest.Success = false
+
+			// The error has to travel back to the reporter, otherwise the
+			// deploy step is rendered as failed with an empty message and
+			// the user has no way of telling what went wrong.
+			uploadErr = err
 		}
 	}
 
-	return &RunResult{opts: opts, result: result, manifest: manifest}
+	return &RunResult{opts: opts, result: result, manifest: manifest, err: uploadErr}
 }
 
 // GetRuntimeStringForLambdas returns the runtime string for the uploader based on

--- a/src/ce/runner/runner_test.go
+++ b/src/ce/runner/runner_test.go
@@ -2,9 +2,13 @@ package runner_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deployservice"
@@ -116,6 +120,84 @@ func (s *RunnerSuite) Test_AllProcess() {
 	b, err := json.Marshal(payload)
 	s.NoError(err)
 	s.NoError(runner.Start(string(b), ""))
+}
+
+// A failing upload must reach the reporter: the deploy step is otherwise
+// rendered as failed with an empty message and the user cannot tell why.
+func (s *RunnerSuite) Test_UploadError_IsReported() {
+	payloads := []map[string]any{}
+	mux := sync.Mutex{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{}
+
+		s.NoError(json.NewDecoder(r.Body).Decode(&payload))
+
+		mux.Lock()
+		payloads = append(payloads, payload)
+		mux.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer server.Close()
+
+	s.mockRepo.On("Checkout", mock.Anything).Return(nil)
+	s.mockRepo.On("CommitInfo").Return(map[string]string{})
+	s.mockInstaller.On("InstallRuntimeDependencies", mock.Anything).Return([]string{"node@24.10"}, nil)
+	s.mockInstaller.On("RuntimeVersion", mock.Anything).Return(nil)
+	s.mockInstaller.On("Install", mock.Anything).Return(nil)
+	s.mockBuilder.On("ExecCommands", mock.Anything).Return(nil)
+	s.mockBuilder.On("BuildApiIfNecessary", mock.Anything).Return(false, nil)
+	s.mockBundler.On("Bundle", mock.Anything).Return(&runner.Artifacts{}, nil)
+	s.mockBundler.On("ParseRedirects", mock.Anything).Return(nil)
+	s.mockBundler.On("ParseHeaders", mock.Anything).Return(nil)
+	s.mockBundler.On("Zip", mock.Anything).Return(nil)
+	s.mockUploader.On("Upload", mock.Anything).
+		Return(nil, errors.New("Deployment size is larger than allowed."))
+
+	msg := &deployservice.DeploymentMessage{
+		Client: deployservice.ClientConfig{
+			Repo:        "https://github.com/stormkit-dev/e2e-npm",
+			AccessToken: "some-token",
+		},
+		Build: deployservice.BuildConfig{
+			Branch: "main",
+			AppID:  "2501",
+			EnvID:  "51191",
+		},
+	}
+
+	encryptedMsg, err := msg.Encrypt()
+
+	s.NoError(err)
+
+	b, err := json.Marshal(runner.Payload{
+		DeploymentID:  "1234",
+		DeploymentMsg: encryptedMsg,
+		RootDir:       s.config.RootDir,
+		BaseURL:       server.URL,
+	})
+
+	s.NoError(err)
+	s.NoError(runner.Start(string(b), ""))
+
+	exit := map[string]any{}
+	logs := ""
+
+	for _, payload := range payloads {
+		if outcome, ok := payload["outcome"]; ok && outcome != nil {
+			exit = payload
+		}
+
+		if l, ok := payload["logs"].(string); ok {
+			logs += l
+		}
+	}
+
+	s.Equal("failure", exit["outcome"])
+	s.Equal("Deployment size is larger than allowed.", exit["error"])
+	s.Contains(logs, "Deployment size is larger than allowed.")
 }
 
 func TestRunnerSuite(t *testing.T) {

--- a/src/ce/runner/uploader.go
+++ b/src/ce/runner/uploader.go
@@ -1,13 +1,12 @@
 package runner
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
-	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
@@ -53,35 +52,54 @@ func NewUploader(opts *config.RunnerConfig) RunnerUploaderInterface {
 	}
 }
 
-func (u *Uploader) isDeploymentSizeWithinLimits(args UploadArgs) bool {
-	zips := map[string]int64{}
-	zips[args.ClientZip] = 50<<20 + 1024  // 50MB
-	zips[args.ServerZip] = 100<<20 + 1024 // 100MB
-	zips[args.ApiZip] = 100<<20 + 1024    // 100 MB
+type bundleSizeLimit struct {
+	name    string
+	zipFile string
+	maxSize int64
+}
 
-	for zipFile, maxSize := range zips {
-		if zipFile == "" {
+// checkDeploymentSize returns an error naming the bundle that busts its size
+// limit, together with the actual size, so that the failure is actionable in
+// the deployment logs.
+func (u *Uploader) checkDeploymentSize(args UploadArgs) error {
+	limits := []bundleSizeLimit{
+		{name: "client", zipFile: args.ClientZip, maxSize: 50<<20 + 1024},  // 50MB
+		{name: "server", zipFile: args.ServerZip, maxSize: 100<<20 + 1024}, // 100MB
+		{name: "api", zipFile: args.ApiZip, maxSize: 100<<20 + 1024},       // 100MB
+	}
+
+	for _, limit := range limits {
+		if limit.zipFile == "" {
 			continue
 		}
 
-		info, err := Stat(zipFile)
+		info, err := Stat(limit.zipFile)
 
 		if err != nil {
-			slog.Errorf("cannot check file info: %s", err.Error())
-			return false
+			return fmt.Errorf("cannot check the size of the %s bundle: %w", limit.name, err)
 		}
 
+		// no file to upload
 		if info == nil {
-			// no file to upload
 			continue
 		}
 
-		if info.Size() > maxSize {
-			return false
+		if info.Size() > limit.maxSize {
+			//lint:ignore ST1005 This message is being consumed by the frontend
+			return fmt.Errorf(
+				"Deployment size is larger than allowed.\n"+
+					"The %s bundle is %s while the limit is %s.\n"+
+					"For client-side applications, the limit is 50MB and for serverless applications 100MB.",
+				limit.name, megabytes(info.Size()), megabytes(limit.maxSize),
+			)
 		}
 	}
 
-	return true
+	return nil
+}
+
+func megabytes(b int64) string {
+	return fmt.Sprintf("%.1fMB", float64(b)/(1<<20))
 }
 
 func (u *Uploader) Upload(args UploadArgs) (*integrations.UploadResult, error) {
@@ -114,13 +132,10 @@ func (u *Uploader) Upload(args UploadArgs) (*integrations.UploadResult, error) {
 		args.Runtime = config.NodeRuntime18
 	}
 
-	if config.IsStormkitCloud() && !u.isDeploymentSizeWithinLimits(args) {
-		msg := "Deployment size is larger than allowed.\n" +
-			"For client-side applications, the limit is 50MB and " +
-			"for serverless applications 100MB."
-
-		//lint:ignore ST1005 This message is being consumed by the frontend
-		return nil, errors.New(msg)
+	if config.IsStormkitCloud() {
+		if err := u.checkDeploymentSize(args); err != nil {
+			return nil, err
+		}
 	}
 
 	return integrations.

--- a/src/ce/runner/uploader_test.go
+++ b/src/ce/runner/uploader_test.go
@@ -1,6 +1,7 @@
 package runner_test
 
 import (
+	"errors"
 	"os"
 	"path"
 	"strings"
@@ -61,6 +62,8 @@ func (s *UploaderSuite) BeforeTest(_, _ string) {
 }
 
 func (s *UploaderSuite) AfterTest(_, _ string) {
+	runner.Stat = os.Stat
+
 	if strings.Contains(s.config.RootDir, os.TempDir()) {
 		s.config.RemoveAll()
 	}
@@ -117,10 +120,50 @@ func (s *UploaderSuite) Test_UploadLimits_StormkitCloud() {
 		ClientZip: path.Join(s.config.RootDir, "dist", "sk-client.zip"),
 	})
 
-	msg := "Deployment size is larger than allowed.\nFor client-side applications, the limit is 50MB and for serverless applications 100MB."
+	msg := "Deployment size is larger than allowed.\n" +
+		"The client bundle is 51.0MB while the limit is 50.0MB.\n" +
+		"For client-side applications, the limit is 50MB and for serverless applications 100MB."
 
 	s.Error(err)
 	s.Equal(msg, err.Error())
+	s.Nil(result)
+}
+
+func (s *UploaderSuite) Test_UploadLimits_NamesTheOversizedBundle() {
+	config.SetIsStormkitCloud(true)
+
+	serverZip := path.Join(s.config.RootDir, "dist", "sk-server.zip")
+
+	runner.Stat = func(name string) (os.FileInfo, error) {
+		if name == serverZip {
+			return MockFileInfo{size: 120 << 20}, nil
+		}
+
+		return MockFileInfo{size: 1 << 20}, nil
+	}
+
+	result, err := runner.NewUploader(s.config.Uploader).Upload(runner.UploadArgs{
+		ClientZip: path.Join(s.config.RootDir, "dist", "sk-client.zip"),
+		ServerZip: serverZip,
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "The server bundle is 120.0MB while the limit is 100.0MB.")
+	s.Nil(result)
+}
+
+func (s *UploaderSuite) Test_UploadLimits_StatError() {
+	config.SetIsStormkitCloud(true)
+
+	runner.Stat = func(name string) (os.FileInfo, error) {
+		return nil, errors.New("permission denied")
+	}
+
+	result, err := runner.NewUploader(s.config.Uploader).Upload(runner.UploadArgs{
+		ClientZip: path.Join(s.config.RootDir, "dist", "sk-client.zip"),
+	})
+
+	s.EqualError(err, "cannot check the size of the client bundle: permission denied")
 	s.Nil(result)
 }
 


### PR DESCRIPTION
## Problem

When the upload fails, the deploy step renders red with **no message at all** — no chevron, no reason, 0s duration. Every upload failure looks identical and unexplained.

The cause is in `src/ce/runner/runner.go`: the error returned by `Upload` was captured into a local `err`, logged via `slog`, and used only to flip `manifest.Success = false`. It never reached `RunResult.err`, so `PostRun` called `SendExit(..., uploadErr: nil)` and posted `"error": ""`. The API then hit `deployment_logs.go:128` — deploy step, empty message, no `deployment.Error`, no `UploadResult` — and left the message blank. The real reason only existed in the runner's own logs.

## Fix

- Propagate the upload error through `RunResult.err`. The reporter sends it to the exit callback, which stores it on `deployment.Error`, and the deploy step renders it. It also lands in the streamed step log, since `runner.go:311` writes `result.err` into the still-open deploy step.
- Name the oversized bundle and its actual size instead of only restating the limits, and stop reporting a `Stat` failure as an oversize error.

Before:

```
Deployment size is larger than allowed.
For client-side applications, the limit is 50MB and for serverless applications 100MB.
```

After:

```
Deployment size is larger than allowed.
The server bundle is 120.0MB while the limit is 100.0MB.
For client-side applications, the limit is 50MB and for serverless applications 100MB.
```

## Tests

- `Test_UploadError_IsReported` runs the full runner against an httptest callback and asserts the exit payload carries the error and the step logs contain it. Verified it fails without the fix, reproducing the bug exactly: `{"title":"deploy","status":"failed"}` with no message.
- `Test_UploadLimits_NamesTheOversizedBundle` and `Test_UploadLimits_StatError` cover the new uploader messages.

`go test -p 1 ./src/ce/runner/` and `go vet` pass.