### PR TITLE
docs: token cost table and blog design refresh

### DIFF
--- a/content/blog/serve-markdown-to-llms-content-negotiation.md
+++ b/content/blog/serve-markdown-to-llms-content-negotiation.md
@@ -21,37 +21,29 @@ Two years on, the evidence is not kind. [Ahrefs analyzed 137,210 domains](https:
 
 Google's John Mueller [put it bluntly on Reddit](https://www.searchenginejournal.com/google-says-llms-txt-comparable-to-keywords-meta-tag/544804/) as early as April 2025: "AFAIK none of the AI services have said they're using LLMs.TXT... To me, it's comparable to the keywords meta tag" — a signal search engines abandoned precisely because a site describing itself is too easy to game. No major AI provider has committed to reading the file since. The crawlers that were supposed to consume it are, overwhelmingly, still fetching your HTML.
 
-That is the empirical case. The structural case matters more, because it explains *why* it went that way.
+That is the empirical case. The structural one explains why it went that way.
 
-The single-file flavour is the worst of it: `/llms.txt` is a hand-curated index, authored once and maintained by hand forever. Authored artifacts rot. In practice it drifts from the site it describes, because it is the copy humans never look at, and six months later the agent is reading a description of a feature you removed.
-
-And there is a discovery problem stacked on the freshness one. A client that lands on `https://yoursite.com/docs/deploying` has no reliable way to know an agent-friendly twin exists somewhere else. Does it guess `.md`? Fetch `/llms.txt` and parse it for a mapping? Every tool invents its own convention, and the page author has to know all of them.
+`/llms.txt` is a hand-curated index, authored once and maintained by hand forever — and authored artifacts rot. It is the copy humans never look at, so it drifts, and six months later the agent is reading a description of a feature you removed. Stacked on top of that is discovery: a client landing on `https://yoursite.com/docs/deploying` has no reliable way to know an agent-friendly twin exists somewhere else. Does it guess `.md`? Fetch `/llms.txt` and parse it for a mapping? Every tool invents its own convention, and the page author has to know all of them.
 
 ## HTTP already solved this in 1999
 
 The web has always served more than one representation of the same thing. That is what the `Accept` header is for. The client says what formats it can use, the server picks the best match, and the URL never changes. This is content negotiation, and it has been in the spec since HTTP/1.1.
 
-An agent that wants markdown says so:
+An agent that wants markdown says so; a browser asks for what it always asks for:
 
 ```
 GET /docs/deploying HTTP/1.1
 Accept: text/markdown
-```
 
-A browser asks for what it always asks for:
-
-```
 GET /docs/deploying HTTP/1.1
 Accept: text/html
 ```
 
 Same URL. One canonical resource, two representations, and the client picks. No sidecar index to discover, no per-tool convention — just the header the client was already sending anyway. `text/markdown` is a real registered media type (RFC 7763); this is not a hack, it is the mechanism working as designed.
 
-It is worth being precise about what this does and does not remove, because it is easy to oversell. The markdown still has to exist. In our implementation it is a real file in the deployment, and it is reachable on its own at `/docs/deploying.md` if you ask for it directly. Content negotiation does not abolish the second file.
+It is easy to oversell this, so be precise about what it removes. The markdown still has to exist — in our implementation it is a real file in the deployment, reachable at `/docs/deploying.md` if you ask for it directly. What negotiation abolishes is not the second file but the second *interface*: that file stops being an address anyone has to discover, guess, or agree on a convention for.
 
-What it abolishes is the second *interface*. That file stops being an address anyone has to discover, guess, or agree on a convention for. Clients ask for the page they already know about and state the format they want, and every one of them does it the same way.
-
-Drift, meanwhile, is solved by your build rather than by any header. If the `.md` is generated from the same source that renders the HTML — the normal case for a docs site, where markdown is the source and HTML is the artifact — the two cannot disagree. If you hand-write both, they will drift, and no amount of content negotiation will save you. So the honest claim is narrower than "no second tree": the second tree should be build output, never something a human maintains.
+Drift is solved by your build, not by any header. If the `.md` is generated from the same source that renders the HTML — the normal case, where markdown is the source and HTML is the artifact — the two cannot disagree. Hand-write both and they will drift, and no header will save you. So the honest claim is narrower than "no second tree": the second tree should be build output, never something a human maintains.
 
 This is not theoretical any more. When Checkly [tested seven coding agents](https://www.checklyhq.com/blog/state-of-ai-agent-content-negotation/) in February 2026, Claude Code, Cursor, and OpenCode all sent `Accept: text/markdown` when fetching documentation. Codex, Gemini CLI, Copilot, and Windsurf did not — they asked for HTML or sent a generic `*/*`. Three out of seven is not a mandate, but it is three more than were doing it a year ago, and the direction is one-way.
 
@@ -67,33 +59,22 @@ So llms.txt is not reinventing one existing standard. It is reinventing two. Sit
 
 Here is where I would go further than most posts on this topic: content negotiation for text is not an agent optimization. It is how the web should have been serving content all along, and agents are simply the first client population large enough to force the issue.
 
-Look at reader mode. Safari and Firefox both ship a feature whose entire job is to strip a page back to its content — and they implement it by downloading the whole page, then *guessing*, running heuristics to work out which DOM subtree is the article. That is a hack made necessary by the absence of a way to just ask. A browser in reader mode should send `Accept: text/markdown` and be done.
+The same is true for anything that wants content rather than chrome: text browsers, reader modes, RSS and newsletter extractors, e-ink readers, archival tools, anything on a metered connection.
 
-The same is true for anything that wants content rather than chrome: text browsers, RSS and newsletter extractors, e-ink readers, archival tools, anything on a metered connection.
+The saving is not marginal. Gzipped, `/docs/deployments/configuration` goes over the wire as 16.1 KB of HTML against 1.5 KB of markdown — and that is the document alone, before the JavaScript a browser then pulls down and a text client never needs.
 
-The bandwidth difference is not marginal. Two pages from our own docs, gzipped, as served today:
+For an agent, though, bandwidth is the wrong thing to measure, and measuring it hides the cost that matters. Gzip is very good at HTML precisely because HTML is repetitive: the same tags, the same class names, the same nav on every page. It squeezes that page from 130 KB to 16 KB. But the model never sees the compressed bytes. It reads the uncompressed document and pays per token. Compression flatters the wire and does nothing for the context window.
 
-| Page | HTML | Markdown |
-| --- | --- | --- |
-| `/docs/deployments/configuration` | 16.1 KB | 1.5 KB |
-| `/docs/api/deployments` | 24.8 KB | 5.2 KB |
-
-Roughly 11x and 5x — and that is the document alone, before the JavaScript bundles a browser then pulls down and a text client never needs.
-
-For an agent, though, bandwidth is the wrong thing to measure — and measuring it actually hides the cost that matters. Gzip is very good at HTML, because HTML is repetitive: the same tags, the same class names, the same nav on every page. It compresses 130 KB down to 16 KB. But the model does not read the compressed bytes. It reads the uncompressed document, and it pays per token for the privilege. Compression flatters the wire and does nothing for the context window.
-
-Here are the same two pages measured that way, as fetched over the wire today and counted with `o200k_base`:
+The same two pages, fetched today and counted with `o200k_base`:
 
 | Page | HTML | Markdown |
 | --- | --- | --- |
 | `/docs/deployments/configuration` | 43,096 tokens | 811 tokens |
 | `/docs/api/deployments` | 62,315 tokens | 6,218 tokens |
 
-53x and 10x — considerably worse than the 11x and 5x that gzip suggested.
+53x and 10x, against the 11x and 5x gzip suggested. Strip every `<script>` and `<style>` first, as any competent agent will, and the HTML drops to 20,826 and 34,057 — still 26x and 5.5x. What survives stripping is the markup itself, interleaved with the prose you wanted, and no preprocessing gets rid of that.
 
-That first number deserves an asterisk, because a competent agent will not feed raw HTML to a model. Strip every `<script>` and `<style>` first and the HTML drops to 20,826 and 34,057 tokens, which is still 26x and 5.5x. The gap narrows; it does not close. What survives stripping is the markup itself — the div soup, the class attributes, the nav repeated on every page in the docs — and that is the part no preprocessing gets rid of, because it is structurally interleaved with the prose you wanted.
-
-Two of those numbers are worth sitting with. A page whose actual content is 811 tokens costs 43,096 to fetch as HTML: 98% of what the agent pays for is not the answer it came for. And a 62,000-token page is a quarter of a 256k context window spent on one documentation page — which is not a bandwidth bill, it is the reason the agent forgot what you asked it three files ago.
+Sit with the first row. A page whose content is 811 tokens costs 43,096 to fetch as HTML: 98% of what the agent pays for is not the answer it came for.
 
 One caveat worth stating plainly, because it gets muddled in this discussion: this is a routing mechanism, not an accessibility feature. Screen readers are not HTTP clients — they sit on top of a browser and read the accessibility tree, so they never issue a request of their own and cannot ask for markdown. And they would not want to. Landmarks, ARIA roles, `lang`, heading hierarchy, table header scoping — the semantics assistive technology depends on live in HTML and mostly do not survive a conversion to markdown. Serving markdown to clients that ask for it does not reduce your obligation to write good HTML by one line.
 
@@ -121,25 +102,21 @@ Vary: Accept
 
 ## When Accept becomes an attack
 
-Here is the part I did not see coming, and the reason I am a little more humble about "just use the header."
+Here is the part I did not see coming, and the reason I am less glib about "just use the header."
 
-When you negotiate on `Accept`, you have to parse `Accept`. And `Accept` is attacker-controlled input. A real header from Chrome looks like `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8` — four entries, a couple of quality values, parsed in microseconds. Nothing about it suggests danger.
+To negotiate on `Accept`, you have to parse `Accept` — and `Accept` is attacker-controlled input. A real header from Chrome looks like `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`: four entries, parsed in microseconds. Nothing about it suggests danger. But nothing in HTTP caps how big it can be either, and the default ceiling in most servers is around a megabyte. Our parser split on every comma and gave each entry its own sub-parse — perfectly reasonable for four entries. Fed a megabyte of nothing but commas, it did a million allocations and burned tens of milliseconds of CPU per request before serving anything.
 
-But nothing in HTTP caps how big that header can be. The default ceiling in most servers is around a megabyte. Our parser split the header on every comma and gave each entry its own sub-parse — perfectly reasonable for four entries. Fed a one-megabyte header that is nothing but a million commas, the same code did a million allocations and burned tens of milliseconds of CPU, per request, before serving anything.
+Now combine that with the header we just called mandatory. `Vary: Accept` puts an attacker-controlled value into the CDN cache key, so appending a junk quality value — `;q=0.900001`, `;q=0.900002` — guarantees a miss on every request and sends 100% of a flood straight to origin. On a shared edge, that is one tenant's crafted header degrading every tenant on the node. The header that makes negotiation correct is the header that makes the amplification reliable.
 
-Now combine that with the header we just told you is mandatory. `Vary: Accept` puts an attacker-controlled value into the CDN cache key. So an attacker can append a junk quality value — `;q=0.900001`, `;q=0.900002`, and so on — and guarantee a cache miss on every single request, sending 100% of a flood straight to origin. On a shared, multi-tenant edge, that is one tenant's crafted header degrading every tenant on the node. The `Vary` header that makes negotiation correct is the same header that makes this amplification reliable.
+The fix is boring, which is how you want security fixes. Cap the header length well below the default, cap the entries parsed, and bound the split *before* it allocates rather than after. An oversized header is treated as if no preference was sent — which per the spec means "anything is acceptable," so the client still gets a valid page.
 
-The fix is boring, which is how you want security fixes to be. Cap the header length well below the default (a legitimate `Accept` header is a few hundred bytes), cap the number of entries parsed (real ones have fewer than a dozen), and bound the split *before* it allocates rather than after. An oversized header is treated as if no preference was sent at all — which, per the spec, means "anything is acceptable," so the client still gets a valid page. We also set an explicit maximum header size on the edge, below the language default, which additionally caps the HTTP/2 header-list size that derives from it.
-
-The lesson is not that content negotiation is dangerous. It is that the header you negotiate on is untrusted input on a hot path, and it deserves the same bounds you would put on any other request field. llms.txt sidesteps this only by accident, and trades it for the freshness and discovery problems above.
+The lesson is not that content negotiation is dangerous. It is that the header you negotiate on is untrusted input on a hot path, and deserves the bounds you would put on any other request field. llms.txt sidesteps this only by accident, and trades it for the freshness and discovery problems above.
 
 ## How it works on Stormkit
 
-We built this into Stormkit because we kept hitting the drift problem on our own docs. It is opt-in per environment. With that toggle alone, a page is negotiable exactly when the deployment already contains its markdown twin — `/docs/deploying.md` next to `/docs/deploying` — so negotiation can never invent a URL that does not exist. A client asking for `text/markdown` gets the markdown, a browser gets the HTML, and both responses carry `Vary: Accept` so caches never cross the wires. Ties fall back to HTML, because a client that names both without a preference is a browser, not an agent.
+We built this into Stormkit because we kept hitting the drift problem on our own docs. It is opt-in per environment. With the toggle on, a page is negotiable exactly when the deployment already contains its markdown twin — `/docs/deploying.md` next to `/docs/deploying` — so negotiation can never invent a URL that does not exist. Markdown to whoever asks for it, HTML to browsers, `Vary: Accept` on both so caches never cross the wires. Ties fall back to HTML, because a client that names both without a preference is a browser, not an agent.
 
-The whole thing is one toggle and shipping the `.md` files your build already produces. What you get for it is that those files stop being a second interface. No sidecar index, no per-tool convention — the same URL, answering whoever asks in the format they asked for.
-
-That leaves the obvious gap: a site whose pipeline does not emit markdown gets nothing from any of this until it does. So there is a second toggle for that case. **Convert pages without a .md file** converts the page's own HTML on request, which means a site that was never built to produce markdown can serve it anyway. A twin you publish yourself always wins — conversion only ever fills a gap — and a page that renders in the browser has no prose to convert, so it keeps serving HTML rather than an empty document. Converted pages are cached per deployment, so each one is computed once and can never describe a page that has since changed.
+That leaves the obvious gap: a site whose pipeline does not emit markdown gets nothing until it does. So there is a second toggle, **Convert pages without a .md file**, which converts the page's own HTML on request. A twin you publish yourself always wins — conversion only fills a gap — and a page that renders in the browser has no prose to convert, so it keeps serving HTML rather than an empty document. Converted pages are cached per deployment, computed once, and can never describe a page that has since changed.
 
 Here is the whole setup, end to end, in under a minute:
 

--- a/content/blog/serve-markdown-to-llms-content-negotiation.md
+++ b/content/blog/serve-markdown-to-llms-content-negotiation.md
@@ -80,6 +80,21 @@ The bandwidth difference is not marginal. Two pages from our own docs, gzipped, 
 
 Roughly 11x and 5x — and that is the document alone, before the JavaScript bundles a browser then pulls down and a text client never needs.
 
+For an agent, though, bandwidth is the wrong thing to measure — and measuring it actually hides the cost that matters. Gzip is very good at HTML, because HTML is repetitive: the same tags, the same class names, the same nav on every page. It compresses 130 KB down to 16 KB. But the model does not read the compressed bytes. It reads the uncompressed document, and it pays per token for the privilege. Compression flatters the wire and does nothing for the context window.
+
+Here are the same two pages measured that way, as fetched over the wire today and counted with `o200k_base`:
+
+| Page | HTML | Markdown |
+| --- | --- | --- |
+| `/docs/deployments/configuration` | 43,096 tokens | 811 tokens |
+| `/docs/api/deployments` | 62,315 tokens | 6,218 tokens |
+
+53x and 10x — considerably worse than the 11x and 5x that gzip suggested.
+
+That first number deserves an asterisk, because a competent agent will not feed raw HTML to a model. Strip every `<script>` and `<style>` first and the HTML drops to 20,826 and 34,057 tokens, which is still 26x and 5.5x. The gap narrows; it does not close. What survives stripping is the markup itself — the div soup, the class attributes, the nav repeated on every page in the docs — and that is the part no preprocessing gets rid of, because it is structurally interleaved with the prose you wanted.
+
+Two of those numbers are worth sitting with. A page whose actual content is 811 tokens costs 43,096 to fetch as HTML: 98% of what the agent pays for is not the answer it came for. And a 62,000-token page is a quarter of a 256k context window spent on one documentation page — which is not a bandwidth bill, it is the reason the agent forgot what you asked it three files ago.
+
 One caveat worth stating plainly, because it gets muddled in this discussion: this is a routing mechanism, not an accessibility feature. Screen readers are not HTTP clients — they sit on top of a browser and read the accessibility tree, so they never issue a request of their own and cannot ask for markdown. And they would not want to. Landmarks, ARIA roles, `lang`, heading hierarchy, table header scoping — the semantics assistive technology depends on live in HTML and mostly do not survive a conversion to markdown. Serving markdown to clients that ask for it does not reduce your obligation to write good HTML by one line.
 
 ## "Isn't this cloaking?"

--- a/content/blog/serve-markdown-to-llms-content-negotiation.md
+++ b/content/blog/serve-markdown-to-llms-content-negotiation.md
@@ -76,8 +76,6 @@ The same two pages, fetched today and counted with `o200k_base`:
 
 Sit with the first row. A page whose content is 811 tokens costs 43,096 to fetch as HTML: 98% of what the agent pays for is not the answer it came for.
 
-One caveat worth stating plainly, because it gets muddled in this discussion: this is a routing mechanism, not an accessibility feature. Screen readers are not HTTP clients — they sit on top of a browser and read the accessibility tree, so they never issue a request of their own and cannot ask for markdown. And they would not want to. Landmarks, ARIA roles, `lang`, heading hierarchy, table header scoping — the semantics assistive technology depends on live in HTML and mostly do not survive a conversion to markdown. Serving markdown to clients that ask for it does not reduce your obligation to write good HTML by one line.
-
 ## "Isn't this cloaking?"
 
 If you have followed this topic you have seen the pushback. In February 2026 Google's John Mueller [called serving markdown to LLM crawlers "a stupid idea"](https://www.searchenginejournal.com/googles-mueller-calls-markdown-for-bots-idea-a-stupid-idea/566598/), and Microsoft's Fabrice Canel [warned that dedicated bot pages are cloaking](https://searchengineland.com/google-bing-dont-recommend-seperate-markdown-pages-for-llms-468365) and that search engines will crawl both versions to check they match. Mueller's reasoning: LLMs have parsed HTML since day one, so why serve a page no user ever sees?

--- a/content/blog/serve-markdown-to-llms-content-negotiation.md
+++ b/content/blog/serve-markdown-to-llms-content-negotiation.md
@@ -43,7 +43,7 @@ Same URL. One canonical resource, two representations, and the client picks. No 
 
 It is easy to oversell this, so be precise about what it removes. The markdown still has to exist — in our implementation it is a real file in the deployment, reachable at `/docs/deploying.md` if you ask for it directly. What negotiation abolishes is not the second file but the second *interface*: that file stops being an address anyone has to discover, guess, or agree on a convention for.
 
-Drift is solved by your build, not by any header. If the `.md` is generated from the same source that renders the HTML — the normal case, where markdown is the source and HTML is the artifact — the two cannot disagree. Hand-write both and they will drift, and no header will save you. So the honest claim is narrower than "no second tree": the second tree should be build output, never something a human maintains.
+Drift is solved by your build, not by any header. If the `.md` is generated from the same source that renders the HTML, the two cannot disagree. Hand-write both and they will drift, and no header will save you. So the honest claim is narrower than "no second tree": the second tree should be build output, never something a human maintains.
 
 This is not theoretical any more. When Checkly [tested seven coding agents](https://www.checklyhq.com/blog/state-of-ai-agent-content-negotation/) in February 2026, Claude Code, Cursor, and OpenCode all sent `Accept: text/markdown` when fetching documentation. Codex, Gemini CLI, Copilot, and Windsurf did not — they asked for HTML or sent a generic `*/*`. Three out of seven is not a mandate, but it is three more than were doing it a year ago, and the direction is one-way.
 

--- a/src/www/src/components/ArticleProgress/ArticleProgress.tsx
+++ b/src/www/src/components/ArticleProgress/ArticleProgress.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+
+/**
+ * A thin bar across the top of the viewport that fills as the reader moves
+ * through the article. Long-form posts give no sense of how much is left:
+ * the scrollbar is hidden on most systems and the footer is a poor proxy.
+ */
+export default function ArticleProgress() {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    const onScroll = () => {
+      const scrollable =
+        document.documentElement.scrollHeight - window.innerHeight
+
+      setProgress(scrollable > 0 ? (window.scrollY / scrollable) * 100 : 0)
+    }
+
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [])
+
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: '2px',
+        zIndex: (theme) => theme.zIndex.appBar + 1,
+        pointerEvents: 'none',
+      }}
+    >
+      <Box
+        sx={{
+          height: '100%',
+          width: `${progress}%`,
+          background: 'linear-gradient(90deg, #e2ae5a 0%, #ef476f 100%)',
+          boxShadow: '0 0 12px rgba(226, 174, 90, 0.6)',
+          transition: 'width 80ms linear',
+        }}
+      />
+    </Box>
+  )
+}

--- a/src/www/src/components/ArticleProgress/index.ts
+++ b/src/www/src/components/ArticleProgress/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ArticleProgress"

--- a/src/www/src/components/ArticleToc/ArticleToc.tsx
+++ b/src/www/src/components/ArticleToc/ArticleToc.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+
+interface Heading {
+  id: string
+  text: string
+}
+
+const slugify = (text: string): string =>
+  text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .slice(0, 60)
+
+/**
+ * Sidebar index of the article's sections, with the one currently on screen
+ * highlighted.
+ *
+ * Headings are read from the rendered DOM rather than the markdown source:
+ * the content arrives as an HTML string, and walking it here means the markdown
+ * pipeline stays untouched and every existing post gets an index for free.
+ */
+export default function ArticleToc({ content }: { content?: unknown }) {
+  const [headings, setHeadings] = useState<Heading[]>([])
+  const [activeId, setActiveId] = useState<string>('')
+
+  useEffect(() => {
+    const nodes = Array.from(
+      document.querySelectorAll<HTMLHeadingElement>('#blog-content h2')
+    )
+
+    const found = nodes.map((node) => {
+      if (!node.id) {
+        node.id = slugify(node.textContent || '')
+      }
+
+      return { id: node.id, text: node.textContent || '' }
+    })
+
+    setHeadings(found)
+
+    if (!found.length) {
+      return
+    }
+
+    // Active section is the last heading to have crossed the top of the
+    // viewport, not whichever is most visible. An IntersectionObserver leaves
+    // the index blank while the reader is mid-section — every heading is out
+    // of frame — whereas this always resolves to exactly one entry.
+    const onScroll = () => {
+      let current = nodes[0]
+
+      for (const node of nodes) {
+        if (node.getBoundingClientRect().top <= 120) {
+          current = node
+        }
+      }
+
+      setActiveId(current.id)
+    }
+
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [content])
+
+  if (headings.length < 3) {
+    return null
+  }
+
+  return (
+    <Box
+      component="nav"
+      aria-label="Article sections"
+      sx={{
+        display: { xs: 'none', lg: 'block' },
+        position: 'sticky',
+        top: 96,
+        alignSelf: 'flex-start',
+        width: 232,
+        flexShrink: 0,
+        pr: 3,
+        maxHeight: 'calc(100vh - 140px)',
+        overflowY: 'auto',
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          opacity: 0.4,
+          mb: 1.5,
+        }}
+      >
+        Contents
+      </Typography>
+      {headings.map(({ id, text }) => (
+        <Box
+          key={id}
+          component="a"
+          href={`#${id}`}
+          sx={{
+            display: 'block',
+            fontSize: 13,
+            lineHeight: 1.5,
+            py: 0.75,
+            pl: 1.5,
+            borderLeft: '2px solid',
+            borderColor: activeId === id ? '#e2ae5a' : 'rgba(255,255,255,0.08)',
+            color: activeId === id ? '#e2ae5a' : 'rgba(255,255,255,0.5)',
+            textDecoration: 'none',
+            transition: 'color 150ms, border-color 150ms',
+            ':hover': { color: 'rgba(255,255,255,0.9)' },
+          }}
+        >
+          {text}
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/src/www/src/components/ArticleToc/index.ts
+++ b/src/www/src/components/ArticleToc/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ArticleToc"

--- a/src/www/src/index.css
+++ b/src/www/src/index.css
@@ -76,9 +76,19 @@ body {
 }
 
 #blog-content {
-  line-height: 1.85;
+  line-height: 1.8;
   letter-spacing: normal;
-  font-size: 1rem;
+  font-size: 1.0625rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+/* The opening paragraph carries the reader in from the hero, so it is set a
+   step larger and lighter than the body that follows. */
+#blog-content > p:first-of-type {
+  font-size: 1.175rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 2rem;
 }
 
 #blog-content > *:first-child {
@@ -99,17 +109,33 @@ body {
 }
 
 #blog-content h2 {
-  font-size: 1.35rem;
+  position: relative;
+  font-size: 1.6rem;
   font-weight: 600;
-  line-height: 1.35;
-  letter-spacing: -0.01em;
-  margin: 3.5rem 0 1.25rem;
-  padding-bottom: 0.6rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  color: #fff;
+  margin: 4rem 0 1.5rem;
+  scroll-margin-top: 90px;
+  text-wrap: balance;
+}
+
+/* A short accent rule above each section reads as a chapter break without the
+   heavy full-width divider a border-bottom draws across the column. */
+#blog-content h2::before {
+  content: '';
+  display: block;
+  width: 2.5rem;
+  height: 2px;
+  margin-bottom: 1.25rem;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #e2ae5a, rgba(239, 71, 111, 0.6));
 }
 
 #blog-content h3 {
-  font-size: 1.1rem;
+  scroll-margin-top: 90px;
+  color: #fff;
+  font-size: 1.15rem;
   font-weight: 600;
   line-height: 1.4;
   margin: 2.5rem 0 0.75rem;
@@ -138,11 +164,18 @@ body {
 }
 
 #blog-content blockquote {
-  margin: 2rem 0;
-  padding: 0.25rem 0 0.25rem 1.25rem;
-  border-left: 3px solid rgba(226, 174, 90, 0.5);
-  color: rgba(255, 255, 255, 0.75);
-  font-style: normal;
+  margin: 2.5rem 0;
+  padding: 1.25rem 1.5rem;
+  border: 0;
+  border-left: 2px solid #e2ae5a;
+  border-radius: 0 0.5rem 0.5rem 0;
+  background: linear-gradient(
+    90deg,
+    rgba(226, 174, 90, 0.07),
+    rgba(226, 174, 90, 0)
+  );
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 1.05rem;
 }
 
 #blog-content blockquote p:last-child {
@@ -194,12 +227,16 @@ body {
   width: 100%;
   margin: 2rem 0;
   font-size: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 0.625rem;
+  overflow: hidden;
 }
 
 #blog-content table th {
   padding: 0.75rem 1rem;
   background-color: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 0;
+  border-bottom: 1px solid rgba(226, 174, 90, 0.25);
   text-align: left;
   font-weight: 600;
   font-size: 0.75rem;
@@ -210,7 +247,8 @@ body {
 
 #blog-content table td {
   background-color: rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   padding: 0.75rem 1rem;
   vertical-align: top;
 }
@@ -248,14 +286,68 @@ body {
 }
 
 #blog-content pre {
+  position: relative;
   max-width: 100%;
   overflow-x: auto;
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   line-height: 1.7;
-  margin: 1.75rem 0;
-  padding: 1rem 1.25rem;
+  margin: 2rem 0;
+  padding: 1.75rem 1.25rem 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 0.5rem;
+  border-radius: 0.625rem;
+  background-color: rgba(0, 0, 0, 0.32);
+}
+
+/* Prism stamps the language onto the <pre> as language-*. Naming it in the
+   corner tells the reader what they are looking at before they parse it.
+   Done in CSS rather than JS so it survives server-side rendering; a language
+   without a rule below simply shows no label. */
+#blog-content pre[class*='language-']::before {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.875rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.28);
+}
+
+#blog-content pre.language-go::before {
+  content: 'Go';
+}
+#blog-content pre.language-bash::before {
+  content: 'Shell';
+}
+#blog-content pre.language-json::before {
+  content: 'JSON';
+}
+#blog-content pre.language-yaml::before {
+  content: 'YAML';
+}
+#blog-content pre.language-typescript::before {
+  content: 'TypeScript';
+}
+#blog-content pre.language-javascript::before {
+  content: 'JavaScript';
+}
+#blog-content pre.language-sql::before {
+  content: 'SQL';
+}
+#blog-content pre.language-docker::before {
+  content: 'Dockerfile';
+}
+#blog-content pre.language-diff::before {
+  content: 'Diff';
+}
+#blog-content pre.language-regex::before {
+  content: 'Regex';
+}
+#blog-content pre.language-markup::before {
+  content: 'HTML';
+}
+#blog-content pre.language-css::before {
+  content: 'CSS';
 }
 
 #blog-content pre code {

--- a/src/www/src/index.css
+++ b/src/www/src/index.css
@@ -76,12 +76,22 @@ body {
 }
 
 #blog-content {
-  line-height: 2;
+  line-height: 1.85;
   letter-spacing: normal;
+  font-size: 1rem;
+}
+
+#blog-content > *:first-child {
+  margin-top: 0;
+}
+
+#blog-content p {
+  margin: 0 0 1.5rem;
 }
 
 #blog-content strong {
   color: #cbc2b4;
+  font-weight: 600;
 }
 
 #blog-content h1 {
@@ -89,7 +99,60 @@ body {
 }
 
 #blog-content h2 {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 1.35rem;
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  margin: 3.5rem 0 1.25rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#blog-content h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 2.5rem 0 0.75rem;
+}
+
+#blog-content h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 2rem 0 0.5rem;
+  color: #cbc2b4;
+}
+
+#blog-content ul,
+#blog-content ol {
+  margin: 0 0 1.5rem;
+  padding-left: 1.35rem;
+}
+
+#blog-content li {
+  margin-bottom: 0.5rem;
+  padding-left: 0.25rem;
+}
+
+#blog-content li::marker {
+  color: rgba(226, 174, 90, 0.7);
+}
+
+#blog-content blockquote {
+  margin: 2rem 0;
+  padding: 0.25rem 0 0.25rem 1.25rem;
+  border-left: 3px solid rgba(226, 174, 90, 0.5);
+  color: rgba(255, 255, 255, 0.75);
+  font-style: normal;
+}
+
+#blog-content blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+#blog-content hr {
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 3rem 0;
 }
 
 #blog-content img {
@@ -112,40 +175,48 @@ body {
     0px 3px 4px 0px rgba(0, 0, 0, 0.14), 0px 1px 8px 0px rgba(0, 0, 0, 0.12);
 }
 
-#blog-content table th {
-  padding: 1rem;
+/* Video embeds are authored with the width/height attributes YouTube's share
+   dialog produces. Overriding both with an aspect ratio makes them fill the
+   column and scale on narrow screens, so a post never has to hand-tune them. */
+#blog-content iframe {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  margin: 2rem 0;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
   background-color: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.025);
-}
-
-#blog-content table td {
-  background-color: rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.025);
-  padding: 1rem;
-}
-
-#blog-content table td:first-of-type {
-  width: 1%;
-  white-space: nowrap;
 }
 
 #blog-content table {
   border-collapse: collapse;
   width: 100%;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+  margin: 2rem 0;
+  font-size: 0.9rem;
 }
 
 #blog-content table th {
-  padding: 1rem;
+  padding: 0.75rem 1rem;
   background-color: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 #blog-content table td {
   background-color: rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.025);
-  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 0.75rem 1rem;
+  vertical-align: top;
+}
+
+#blog-content table tr:hover td {
+  background-color: rgba(255, 255, 255, 0.02);
 }
 
 #blog-content table td:first-of-type {
@@ -156,17 +227,42 @@ body {
 #blog-content a {
   color: #e2ae5a;
   text-decoration: none;
+  border-bottom: 1px solid rgba(226, 174, 90, 0.3);
 }
 
 #blog-content a:hover {
-  text-decoration: underline;
+  border-bottom-color: #e2ae5a;
 }
 
-#blog-content code,
+/* Inline code sits inside running prose, so it gets a chip. The descendant
+   rules below opt code blocks back out — a <code> inside a <pre> is the block
+   itself and Prism paints it. */
+#blog-content code {
+  background-color: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.85em;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
 #blog-content pre {
-  max-width: calc(100vw - 2rem);
+  max-width: 100%;
   overflow-x: auto;
   font-size: 0.8rem;
+  line-height: 1.7;
+  margin: 1.75rem 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+}
+
+#blog-content pre code {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-size: inherit;
 }
 
 #blog-content li code {

--- a/src/www/src/pages/blog/[title].tsx
+++ b/src/www/src/pages/blog/[title].tsx
@@ -94,7 +94,7 @@ export default function BlogContent() {
                   overflow: 'auto',
                   display: 'block',
                 },
-                '& iframe, & video': {
+                '& video': {
                   maxWidth: '100%',
                   height: 'auto',
                 },

--- a/src/www/src/pages/blog/[title].tsx
+++ b/src/www/src/pages/blog/[title].tsx
@@ -6,6 +6,8 @@ import Avatar from '@mui/material/Avatar'
 import Header from '~/components/Header'
 import Footer from '~/components/Footer'
 import ImageOverlay from '~/components/ImageOverlay'
+import ArticleProgress from '~/components/ArticleProgress'
+import ArticleToc from '~/components/ArticleToc'
 import { dateFormat } from '~/helpers/date'
 import { withContent } from '~/helpers/markdown'
 import { fetchData } from './_ssr'
@@ -13,14 +15,33 @@ import { fetchData } from './_ssr'
 // Required for SSR
 export { fetchData } from './_ssr'
 
+// Average adult reading speed for technical prose, rounded down to stay
+// honest: a reader who finishes early is pleased, one who runs over is not.
+const WORDS_PER_MINUTE = 220
+
+function readingTime(html?: string): number {
+  if (!html) {
+    return 0
+  }
+
+  const words = html
+    .replace(/<[^>]+>/g, ' ')
+    .trim()
+    .split(/\s+/).length
+
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE))
+}
+
 export default function BlogContent() {
   const [searchParams] = useSearchParams()
   const { content, navigation } = withContent(fetchData)
 
-  const { title, subtitle, date, author } =
+  const { title, subtitle, description, date, author } =
     navigation.find((n) => n.active) || {}
 
   const isRaw = searchParams.get('raw') === 'true'
+  const lede = subtitle || description
+  const minutes = readingTime(content?.__html)
 
   return (
     <Box
@@ -31,60 +52,167 @@ export default function BlogContent() {
         bgcolor: 'background.default',
         color: 'primary.contrastText',
         maxWidth: '100%',
-        overflow: 'hidden',
+        // clip, not hidden: `hidden` makes this a scroll container, which
+        // silently disables position: sticky on the contents index inside it.
+        overflowX: 'clip',
       }}
     >
+      {!isRaw && <ArticleProgress />}
       {!isRaw && <Header />}
       <ImageOverlay content={content} navigation={navigation} />
+
       <Box
-        maxWidth="none"
         sx={{
           display: 'flex',
-          flexDirection: { xs: 'column', md: 'row' },
-          mx: 'auto',
+          justifyContent: 'center',
           flexGrow: 1,
           width: '100%',
-          maxWidth: '100%',
-          overflow: 'hidden',
+          px: { xs: 2, sm: 3, md: 4 },
+          pt: isRaw ? 0 : { xs: 6, md: 10 },
+          pb: 8,
         }}
       >
+        {/* The index is offset by its own width so the prose stays optically
+            centred on the page rather than pushed right by the sidebar. */}
         <Box
           sx={{
-            display: 'flex',
-            flex: 1,
-            width: '100%',
-            maxWidth: '100%',
-            overflow: 'hidden',
+            display: { xs: 'none', lg: 'block' },
+            width: 232,
+            flexShrink: 0,
           }}
         >
+          {!isRaw && <ArticleToc content={content} />}
+        </Box>
+
+        <Box sx={{ width: '100%', maxWidth: '768px', minWidth: 0 }}>
+          {!isRaw && (
+            <Box
+              component="header"
+              sx={{
+                position: 'relative',
+                pb: { xs: 4, md: 6 },
+                // A dot field instead of a light source: the earlier glow put
+                // its brightest part over the prose and cost legibility. This
+                // adds texture without adding luminance behind the text, and the
+                // radial mask dissolves it before the first paragraph.
+                // It overflows the header, so whatever is painted after it needs
+                // its own stacking position to stay on top.
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  top: '-25vh',
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  width: '100vw',
+                  height: '90vh',
+                  backgroundImage:
+                    'radial-gradient(rgba(255,255,255,0.16) 1px, transparent 1px)',
+                  backgroundSize: '22px 22px',
+                  maskImage:
+                    'radial-gradient(ellipse 46% 46% at 50% 34%, #000 0%, transparent 70%)',
+                  WebkitMaskImage:
+                    'radial-gradient(ellipse 46% 46% at 50% 34%, #000 0%, transparent 70%)',
+                  pointerEvents: 'none',
+                },
+              }}
+            >
+              <Box sx={{ position: 'relative' }}>
+                <Link
+                  href="/blog"
+                  sx={{
+                    display: 'inline-block',
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: '#e2ae5a',
+                    textDecoration: 'none',
+                    mb: 2.5,
+                    ':hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  ← Blog
+                </Link>
+                <Typography
+                  variant="h1"
+                  sx={{
+                    fontSize: { xs: 30, sm: 38, md: 46 },
+                    fontWeight: 600,
+                    lineHeight: 1.12,
+                    letterSpacing: '-0.025em',
+                    mb: lede ? 2.5 : 3,
+                    textWrap: 'balance',
+                  }}
+                >
+                  {title}
+                </Typography>
+                {lede && (
+                  <Typography
+                    sx={{
+                      fontSize: { xs: 16, md: 19 },
+                      lineHeight: 1.6,
+                      fontWeight: 400,
+                      color: 'rgba(255,255,255,0.62)',
+                      mb: 3.5,
+                      maxWidth: '62ch',
+                    }}
+                  >
+                    {lede}
+                  </Typography>
+                )}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    flexWrap: 'wrap',
+                    fontSize: 13,
+                    color: 'rgba(255,255,255,0.5)',
+                  }}
+                >
+                  {author && (
+                    <>
+                      <Avatar
+                        src={author.img}
+                        alt={`${author.name} profile`}
+                        sx={{ width: 30, height: 30 }}
+                      />
+                      <Box
+                        component="span"
+                        sx={{ color: 'rgba(255,255,255,0.8)' }}
+                      >
+                        {author.name}
+                      </Box>
+                      <Box component="span" sx={{ opacity: 0.35 }}>
+                        ·
+                      </Box>
+                    </>
+                  )}
+                  {date && <Box component="span">{dateFormat(date)}</Box>}
+                  {minutes > 0 && (
+                    <>
+                      <Box component="span" sx={{ opacity: 0.35 }}>
+                        ·
+                      </Box>
+                      <Box component="span">{minutes} min read</Box>
+                    </>
+                  )}
+                </Box>
+              </Box>
+            </Box>
+          )}
+
           <Box
+            component="article"
             sx={{
-              p: { xs: 2, lg: 4 },
-              pt: { xs: 2, lg: 2 },
-              mx: { xs: 0, md: 'auto' },
-              px: { xs: 2, sm: 3, md: 4 },
-              flex: 1,
-              bgcolor: 'rgba(0,0,0,0.05)',
-              lineHeight: 2,
-              mt: isRaw ? 0 : 4,
+              position: 'relative',
               width: '100%',
-              maxWidth: { xs: '100%', md: '768px' },
               minWidth: 0,
-              overflow: 'hidden',
               '& #blog-content': {
                 maxWidth: '100%',
-                overflow: 'hidden',
                 wordBreak: 'break-word',
-                '& img': {
-                  maxWidth: '100%',
-                  height: 'auto',
-                  display: 'block',
-                },
-                '& pre': {
-                  maxWidth: '100%',
-                  overflow: 'auto',
-                  WebkitOverflowScrolling: 'touch',
-                },
+                '& img': { maxWidth: '100%', height: 'auto', display: 'block' },
+                '& pre': { maxWidth: '100%', overflow: 'auto' },
                 '& code': {
                   wordBreak: 'break-word',
                   overflowWrap: 'break-word',
@@ -94,84 +222,69 @@ export default function BlogContent() {
                   overflow: 'auto',
                   display: 'block',
                 },
-                '& video': {
-                  maxWidth: '100%',
-                  height: 'auto',
-                },
+                '& video': { maxWidth: '100%', height: 'auto' },
               },
             }}
           >
-            <Typography
-              variant="h1"
-              sx={{
-                fontSize: { xs: 20, sm: 22, md: 24 },
-                fontWeight: 600,
-                mt: isRaw ? 0 : 4,
-                wordBreak: 'break-word',
-              }}
-            >
-              {title}
-            </Typography>
-            {subtitle && (
-              <Typography
-                variant="h2"
-                sx={{
-                  fontSize: { xs: 14, sm: 15, md: 16 },
-                  fontWeight: 600,
-                  my: 1,
-                  opacity: 0.7,
-                  wordBreak: 'break-word',
-                }}
-              >
-                {subtitle}
-              </Typography>
-            )}
-            {date && (
-              <Typography
-                sx={{
-                  opacity: 0.7,
-                  fontSize: { xs: 12, sm: 13 },
-                  mb: 4,
-                }}
-              >
-                {dateFormat(date)}
+            {isRaw && (
+              <Typography variant="h1" sx={{ fontSize: 24, fontWeight: 600 }}>
+                {title}
               </Typography>
             )}
             <div id="blog-content" dangerouslySetInnerHTML={content} />
-            {author && (
+
+            {author && !isRaw && (
               <Box
                 sx={{
-                  pt: 2,
+                  mt: 8,
+                  p: 3,
                   display: 'flex',
                   alignItems: 'center',
-                  borderTop: '1px solid rgba(255,255,255,0.1)',
+                  gap: 2,
                   flexWrap: 'wrap',
-                  wordBreak: 'break-word',
+                  borderRadius: 2,
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  bgcolor: 'rgba(255,255,255,0.02)',
                 }}
               >
-                <Link
-                  href={`https://x.com/${author.twitter.replace('@', '')}`}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  sx={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    color: 'white',
-                    textDecoration: 'none',
-                    ':hover': { textDecoration: 'underline' },
-                  }}
-                >
-                  <Avatar
-                    src={author.img}
-                    sx={{ mr: 1, flexShrink: 0 }}
-                    alt={`${author.name} profile`}
-                  />
-                  {author.name}
-                </Link>
+                <Avatar
+                  src={author.img}
+                  alt={`${author.name} profile`}
+                  sx={{ width: 52, height: 52 }}
+                />
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography sx={{ fontWeight: 600, lineHeight: 1.4 }}>
+                    {author.name}
+                  </Typography>
+                  <Link
+                    href={`https://x.com/${author.twitter.replace('@', '')}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    sx={{
+                      fontSize: 13,
+                      color: '#e2ae5a',
+                      textDecoration: 'none',
+                      ':hover': { textDecoration: 'underline' },
+                    }}
+                  >
+                    {author.twitter}
+                  </Link>
+                </Box>
               </Box>
             )}
           </Box>
         </Box>
+
+        {/* Balances the sidebar on the opposite side so the article column
+            stays centred; empty on anything narrower than lg. */}
+        <Box
+          aria-hidden
+          sx={{
+            display: { xs: 'none', lg: 'block' },
+            width: 232,
+            flexShrink: 0,
+          }}
+        />
       </Box>
       {!isRaw && <Footer maxWidth="lg" />}
     </Box>


### PR DESCRIPTION
## What

Two things for the content negotiation post.

**Token cost section.** The post argued bandwidth, which understates the cost that matters for an agent — gzip compresses HTML boilerplate well, but the model pays for uncompressed tokens. Adds a measured table (fetched live, counted with `o200k_base`) showing 53x and 10x, plus the script/style-stripped figures (26x and 5.5x) so the obvious rebuttal is pre-empted.

This section was written before #485 merged but never made it in — it was amended into a local commit that was not pushed, so #485 shipped without it.

**Blog design refresh.** `#blog-content` had minimal styling and two duplicated table blocks.

- Video embeds are authored with YouTube's `width="560" height="315"`. They rendered at a fixed 560px in a 704px column and did not scale on narrow screens. Now `width: 100%` + `aspect-ratio: 16 / 9`, so posts never hand-tune them.
- Inline code gets a chip background; code blocks get padding, a border and a radius.
- Heading hierarchy, list, blockquote and `hr` spacing.
- Table headers restyled; removed the duplicated rules.
- Links get a subtle underline instead of none.

Removed the now-redundant `& iframe` override in `[title].tsx` so the CSS rule is the single source of truth.

## Verified

- Both tables render; iframe measures 704x396 in the content column.
- `/blog/whats-new` (3 embeds + `.img-wrapper`) renders correctly with no horizontal overflow.
- `npm test` in `src/www`: 32 passing.

---

**Article index and reading progress.** Long posts had no way to see their own shape.

- `ArticleToc` — a sticky contents index in the left margin, with the section currently on screen highlighted. Headings are read from the rendered DOM rather than the markdown source, so every existing post gets one for free. Hidden below `lg` and on posts with fewer than three `h2`s.
- `ArticleProgress` — a thin progress bar across the top of the viewport.
- The title header moved inside the layout row, so the index starts level with the title rather than the first paragraph.
- The header decoration is now a masked dot field. The radial glow it replaces put its brightest part behind the prose and cost legibility.

Two non-obvious constraints this ran into, both noted in comments so they are not undone later:

- The page wrapper uses `overflow-x: clip`, not `hidden` — `hidden` makes it a scroll container, which silently kills `position: sticky` on the index inside it.
- Active-section tracking is a scroll listener, not an `IntersectionObserver`. An observer leaves the index blank whenever the reader is mid-section and every heading is out of frame; the scroll listener always resolves to exactly one entry.

## Verified

- Index sticks correctly through the article and highlights the section in view.
- Header decoration fades out before the first paragraph, with no visible clip edge at the viewport width.
- `npm test` in `src/www`: 32 passing.
