### PR TITLE
feat: fail deploys early when the build host is out of disk

### DIFF
--- a/src/ce/runner/disk_preflight.go
+++ b/src/ce/runner/disk_preflight.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+)
+
+// MinFreeDiskEnvVar overrides how much free disk a deployment requires before
+// it starts, in megabytes. Set it to 0 to disable the check entirely.
+const MinFreeDiskEnvVar = "STORMKIT_MIN_FREE_DISK_MB"
+
+// DefaultMinFreeDiskMB is the headroom a build needs before it is worth
+// starting. A checkout plus a node_modules tree routinely exceeds a gigabyte,
+// and running out mid-build wastes the whole deployment.
+const DefaultMinFreeDiskMB = 2048
+
+// diskPreflight refuses to start a build that has no room to finish.
+//
+// Without it a full disk surfaces as `No space left on device` from whichever
+// command happened to run first — a checkout, an npm install, a nix build —
+// which tells the operator nothing about what to clean up.
+type diskPreflight struct {
+	dir      string
+	reporter *ReporterModel
+}
+
+// minFreeBytes returns the required headroom, or 0 when the check is disabled.
+func (p diskPreflight) minFreeBytes() uint64 {
+	mb := int64(DefaultMinFreeDiskMB)
+
+	if v := os.Getenv(MinFreeDiskEnvVar); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+
+		if err != nil || parsed < 0 {
+			slog.Errorf("ignoring invalid %s=%q", MinFreeDiskEnvVar, v)
+		} else {
+			mb = parsed
+		}
+	}
+
+	if mb <= 0 {
+		return 0
+	}
+
+	return uint64(mb) << 20
+}
+
+// check verifies there is room to build, reclaiming Nix store space first if
+// there is not. A build host that cannot report its own disk usage is allowed
+// to proceed: the check exists to give a better error, not to add a new way to
+// fail.
+func (p diskPreflight) check(ctx context.Context) error {
+	required := p.minFreeBytes()
+
+	if required == 0 {
+		return nil
+	}
+
+	usage, err := nixstore.DiskUsage(p.dir)
+
+	if err != nil {
+		slog.Errorf("could not read disk usage of %s: %v", p.dir, err)
+		return nil
+	}
+
+	if usage.FreeBytes >= required {
+		return nil
+	}
+
+	// Last chance before failing: the Nix store is usually what filled the
+	// disk, and it is always safe to drop paths outside the retention window.
+	if nixstore.Available() {
+		p.reporter.AddStep("reclaim disk space")
+		p.reporter.AddLine(fmt.Sprintf(
+			"Low disk space (%s free). Reclaiming space from the Nix store...",
+			humanBytes(usage.FreeBytes),
+		))
+
+		if err := nixstore.CollectGarbage(ctx, nixstore.CollectGarbageParams{}); err != nil {
+			slog.Errorf("error collecting nix garbage during preflight: %v", err)
+		}
+
+		if usage, err = nixstore.DiskUsage(p.dir); err != nil {
+			slog.Errorf("could not read disk usage of %s: %v", p.dir, err)
+			return nil
+		}
+
+		if usage.FreeBytes >= required {
+			p.reporter.AddLine(fmt.Sprintf("Reclaimed enough space (%s free).", humanBytes(usage.FreeBytes)))
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"Not enough disk space on the build host: %s free of %s, and this deployment needs at least %s. "+
+			"Free up space on the server, then retry the deployment.",
+		humanBytes(usage.FreeBytes), humanBytes(usage.TotalBytes), humanBytes(required),
+	)
+}
+
+// humanBytes formats a byte count for a customer-facing build log.
+func humanBytes(b uint64) string {
+	const gb = 1 << 30
+
+	if b >= gb {
+		return fmt.Sprintf("%.1fGB", float64(b)/gb)
+	}
+
+	return fmt.Sprintf("%dMB", b/(1<<20))
+}

--- a/src/ce/runner/disk_preflight_test.go
+++ b/src/ce/runner/disk_preflight_test.go
@@ -1,0 +1,129 @@
+package runner_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/runner"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore/nixstoretest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type DiskPreflightSuite struct {
+	suite.Suite
+	mockCommand  *mocks.CommandInterface
+	originalPath string
+	restore      func()
+	dir          string
+	reporter     *runner.ReporterModel
+}
+
+func (s *DiskPreflightSuite) check() error {
+	return runner.DiskPreflightCheck(context.Background(), s.dir, s.reporter)
+}
+
+func (s *DiskPreflightSuite) BeforeTest(_, _ string) {
+	s.mockCommand = &mocks.CommandInterface{}
+	sys.DefaultCommand = s.mockCommand
+
+	s.originalPath = nixstore.DefaultPath
+	nixstore.DefaultPath = s.T().TempDir()
+	s.restore = nixstoretest.StubLookPath(false)
+
+	s.dir = s.T().TempDir()
+	s.reporter = runner.NewReporter("https://example.com")
+}
+
+func (s *DiskPreflightSuite) AfterTest(_, _ string) {
+	sys.DefaultCommand = nil
+	nixstore.DefaultPath = s.originalPath
+	s.restore()
+}
+
+func (s *DiskPreflightSuite) Test_MinFreeBytes_Default() {
+	s.Equal(uint64(runner.DefaultMinFreeDiskMB)<<20, runner.DiskPreflightMinFreeBytes())
+}
+
+func (s *DiskPreflightSuite) Test_MinFreeBytes_Override() {
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "512")
+
+	s.Equal(uint64(512)<<20, runner.DiskPreflightMinFreeBytes())
+}
+
+func (s *DiskPreflightSuite) Test_MinFreeBytes_Disabled() {
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "0")
+
+	s.Equal(uint64(0), runner.DiskPreflightMinFreeBytes())
+}
+
+// A typo in the env var must not silently disable the check.
+func (s *DiskPreflightSuite) Test_MinFreeBytes_InvalidFallsBackToDefault() {
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "plenty")
+
+	s.Equal(uint64(runner.DefaultMinFreeDiskMB)<<20, runner.DiskPreflightMinFreeBytes())
+}
+
+func (s *DiskPreflightSuite) Test_Check_Disabled() {
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "0")
+
+	s.NoError(s.check())
+}
+
+func (s *DiskPreflightSuite) Test_Check_EnoughSpace() {
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "1")
+
+	s.NoError(s.check())
+}
+
+// The check exists to give a better error, not to add a new way to fail: a
+// build host that cannot report its own usage is allowed to proceed.
+func (s *DiskPreflightSuite) Test_Check_UnreadablePathProceeds() {
+	s.NoError(runner.DiskPreflightCheck(context.Background(), "/does-not-exist", s.reporter))
+}
+
+func (s *DiskPreflightSuite) Test_Check_NotEnoughSpace() {
+	// Larger than any real disk, so the branch is deterministic.
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "1099511627776")
+
+	err := s.check()
+
+	s.Error(err)
+	s.Contains(err.Error(), "Not enough disk space on the build host")
+	s.Contains(err.Error(), "retry the deployment")
+	s.mockCommand.AssertNotCalled(s.T(), "Run")
+}
+
+// When Nix is present the store is collected before giving up, since it is
+// the usual reason the disk filled in the first place.
+func (s *DiskPreflightSuite) Test_Check_CollectsNixGarbageBeforeFailing() {
+	s.restore()
+	s.restore = nixstoretest.StubLookPath(true)
+
+	s.T().Setenv(runner.MinFreeDiskEnvVar, "1099511627776")
+
+	s.mockCommand.On("SetOpts", sys.CommandOpts{
+		Name: "nix-collect-garbage",
+		Args: []string{"--delete-older-than", "7d"},
+	}).Return(s.mockCommand).Once()
+
+	s.mockCommand.On("Run").Return(nil).Once()
+
+	err := s.check()
+
+	s.Error(err)
+	s.mockCommand.AssertExpectations(s.T())
+	s.Contains(s.reporter.Logs(), "Reclaiming space from the Nix store")
+}
+
+func (s *DiskPreflightSuite) Test_HumanBytes() {
+	s.Equal("512MB", runner.HumanBytes(512<<20))
+	s.Equal("2.0GB", runner.HumanBytes(2<<30))
+	s.Equal("0MB", runner.HumanBytes(0))
+}
+
+func TestDiskPreflightSuite(t *testing.T) {
+	suite.Run(t, new(DiskPreflightSuite))
+}

--- a/src/ce/runner/export_test.go
+++ b/src/ce/runner/export_test.go
@@ -1,0 +1,19 @@
+package runner
+
+import "context"
+
+// DiskPreflightCheck exposes diskPreflight.check. The test lives in the
+// external package because src/mocks imports this one.
+func DiskPreflightCheck(ctx context.Context, dir string, reporter *ReporterModel) error {
+	return diskPreflight{dir: dir, reporter: reporter}.check(ctx)
+}
+
+// DiskPreflightMinFreeBytes exposes diskPreflight.minFreeBytes.
+func DiskPreflightMinFreeBytes() uint64 {
+	return diskPreflight{}.minFreeBytes()
+}
+
+// HumanBytes exposes humanBytes.
+func HumanBytes(b uint64) string {
+	return humanBytes(b)
+}

--- a/src/ce/runner/runner.go
+++ b/src/ce/runner/runner.go
@@ -329,6 +329,12 @@ func Run(opts RunnerOpts) *RunResult {
 
 	slog.Infof("reporting back to %s", opts.Reporter.CallbackURL)
 
+	preflight := diskPreflight{dir: opts.RootDir, reporter: opts.Reporter}
+
+	if err := preflight.check(ctx); err != nil {
+		return &RunResult{opts: opts, err: err}
+	}
+
 	repo := NewRepo(opts)
 
 	var artifacts *Artifacts


### PR DESCRIPTION
Third of the series for #504. **Stacked on #507**, which is stacked on #506.

The reporter's deployment got stuck with a bare `No space left on device`. That error comes from whichever command happened to run first — a checkout, an `npm install`, a `nix build` — and tells the operator nothing about what is full or what to clean up.

The runner now checks free space before checking out the repository:

```
Not enough disk space on the build host: 299MB free of 38.0GB, and this
deployment needs at least 2.0GB. Free up space on the server, then retry
the deployment.
```

Before giving up it garbage collects the Nix store — usually what filled the disk in the first place — and proceeds if that reclaimed enough. That step shows up as its own build-log step so the operator can see it happened.

### Not a new way to fail

Deliberately conservative, following the same reasoning as the repo-size gate in #503:

- a build host that cannot read its own disk usage proceeds
- a failed garbage collection is logged, not fatal
- `STORMKIT_MIN_FREE_DISK_MB=0` disables the check; any other value overrides the 2GB default
- an unparseable value falls back to the default rather than silently disabling the check

## Testing

`go test ./src/ce/runner/... -p 1` — covers the threshold parsing (default, override, disabled, invalid), the pass and fail paths, the unreadable-path escape hatch, and that a Nix collection is attempted before failing.