### PR TITLE
feat: keep the nix store from growing without bound

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/time v0.14.0
 	gopkg.in/go-playground/webhooks.v5 v5.17.0
 	gopkg.in/guregu/null.v3 v3.5.0
@@ -126,7 +127,6 @@ require (
 	go.uber.org/zap/exp v0.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/src/ce/api/admin/maintenance.go
+++ b/src/ce/api/admin/maintenance.go
@@ -1,0 +1,78 @@
+package admin
+
+import (
+	"context"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"go.uber.org/zap"
+)
+
+// nixGarbageCollectInterval is how often each container collects its own Nix
+// store. It is a variable so tests do not have to wait a day.
+var nixGarbageCollectInterval = 24 * time.Hour
+
+// nixGarbageCollectDelay staggers the first run so a container that is
+// restarting in a loop does not spend its whole life garbage collecting.
+var nixGarbageCollectDelay = 5 * time.Minute
+
+// CollectNixGarbage garbage collects this container's Nix store. It matches the
+// rediscache.Handler signature so it can also be triggered on demand, and never
+// returns an error: a failed collection must not take the container down.
+func CollectNixGarbage(ctx context.Context, _ ...string) {
+	if !nixstore.Available() {
+		return
+	}
+
+	before, _ := nixstore.DiskUsage(nixstore.DefaultPath)
+
+	if err := nixstore.CollectGarbage(ctx, nixstore.CollectGarbageParams{}); err != nil {
+		slog.Errorf("error collecting nix garbage: %v", err)
+		return
+	}
+
+	after, _ := nixstore.DiskUsage(nixstore.DefaultPath)
+
+	slog.Debug(slog.LogOpts{
+		Msg:   "collected nix garbage",
+		Level: slog.DL1,
+		Payload: []zap.Field{
+			zap.Int("retentionDays", nixstore.DefaultRetentionDays),
+			zap.Uint64("freeBytesBefore", before.FreeBytes),
+			zap.Uint64("freeBytesAfter", after.FreeBytes),
+		},
+	})
+}
+
+// StartDiskMaintenance periodically garbage collects the Nix store of the
+// container it runs in. Both hosting and workerserver mount their own /nix
+// volume, and neither can clean up the other's, so each starts its own loop
+// rather than this being a leader-elected workerserver job.
+func StartDiskMaintenance(ctx context.Context) {
+	if !nixstore.Available() {
+		return
+	}
+
+	timer := time.NewTimer(nixGarbageCollectDelay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-timer.C:
+	}
+
+	ticker := time.NewTicker(nixGarbageCollectInterval)
+	defer ticker.Stop()
+
+	for {
+		CollectNixGarbage(ctx)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/src/ce/api/admin/maintenance_test.go
+++ b/src/ce/api/admin/maintenance_test.go
@@ -1,0 +1,110 @@
+package admin_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore/nixstoretest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type AdminMaintenanceSuite struct {
+	suite.Suite
+	conn             databasetest.TestDB
+	mockCommand      *mocks.CommandInterface
+	originalPath     string
+	originalProfiles string
+	restore          func()
+}
+
+func (s *AdminMaintenanceSuite) BeforeTest(suiteName, _ string) {
+	s.conn = databasetest.InitTx(suiteName)
+	utils.SetAppKey([]byte(utils.RandomToken(32)))
+	admin.ResetCache(context.Background())
+
+	s.mockCommand = &mocks.CommandInterface{}
+	sys.DefaultCommand = s.mockCommand
+
+	s.originalPath = nixstore.DefaultPath
+	s.originalProfiles = nixstore.ProfilesDir
+	nixstore.DefaultPath = s.T().TempDir()
+	nixstore.ProfilesDir = filepath.Join(s.T().TempDir(), "stormkit")
+	s.restore = nixstoretest.StubLookPath(true)
+}
+
+func (s *AdminMaintenanceSuite) AfterTest(_, _ string) {
+	sys.DefaultCommand = nil
+	nixstore.DefaultPath = s.originalPath
+	nixstore.ProfilesDir = s.originalProfiles
+	s.restore()
+	admin.ResetCache(context.Background())
+	s.conn.CloseTx()
+}
+
+func (s *AdminMaintenanceSuite) Test_CollectNixGarbage() {
+	s.mockCommand.On("SetOpts", sys.CommandOpts{
+		Name: "nix-collect-garbage",
+		Args: []string{"--delete-older-than", "7d"},
+	}).Return(s.mockCommand).Once()
+
+	s.mockCommand.On("CombinedOutput").Return([]byte(""), nil).Once()
+
+	admin.CollectNixGarbage(context.Background())
+	s.mockCommand.AssertExpectations(s.T())
+}
+
+// A container without Nix runs the same code path and must not shell out.
+func (s *AdminMaintenanceSuite) Test_CollectNixGarbage_WithoutNix() {
+	s.restore()
+	s.restore = nixstoretest.StubLookPath(false)
+
+	admin.CollectNixGarbage(context.Background())
+	s.mockCommand.AssertNotCalled(s.T(), "CombinedOutput")
+}
+
+// A failing collection is logged, not propagated: a full disk must not take
+// the container down.
+func (s *AdminMaintenanceSuite) Test_CollectNixGarbage_SurvivesFailure() {
+	s.mockCommand.On("SetOpts", sys.CommandOpts{
+		Name: "nix-collect-garbage",
+		Args: []string{"--delete-older-than", "7d"},
+	}).Return(s.mockCommand).Once()
+
+	s.mockCommand.On("CombinedOutput").Return([]byte("cannot open lock file"), assertError{}).Once()
+
+	s.NotPanics(func() { admin.CollectNixGarbage(context.Background()) })
+}
+
+func (s *AdminMaintenanceSuite) Test_StartDiskMaintenance_ReturnsWithoutNix() {
+	s.restore()
+	s.restore = nixstoretest.StubLookPath(false)
+
+	done := make(chan struct{})
+
+	go func() {
+		admin.StartDiskMaintenance(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		s.Fail("StartDiskMaintenance did not return on a container without Nix")
+	}
+}
+
+type assertError struct{}
+
+func (assertError) Error() string { return "boom" }
+
+func TestAdminMaintenanceSuite(t *testing.T) {
+	suite.Run(t, new(AdminMaintenanceSuite))
+}

--- a/src/ce/runner/installer.go
+++ b/src/ce/runner/installer.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/mise"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
 )
 
@@ -77,6 +79,8 @@ type Installer struct {
 	runtime            string // The runtime that is going to be used to build the project
 	envVars            map[string]string
 	autoInstall        bool
+	appID              string
+	envID              string
 }
 
 // For testing purposes
@@ -101,6 +105,8 @@ func NewInstaller(opts RunnerOpts) InstallerInterface {
 		isBun:              opts.Repo.IsBun,
 		runtime:            opts.Repo.Runtime,
 		autoInstall:        opts.AutoInstall,
+		appID:              opts.Build.AppID,
+		envID:              opts.Build.EnvID,
 	}
 
 	return p
@@ -143,18 +149,61 @@ func (p Installer) RuntimeVersion(ctx context.Context) error {
 	}).Run()
 }
 
+// flakeProfile returns the profile that should root this environment's dev
+// shell, or an empty string when the store cannot be rooted. Building into a
+// profile is what keeps the packages alive between deployments: without one
+// they are unreferenced the moment the build exits, and the next garbage
+// collection takes them.
+func (p *Installer) flakeProfile() string {
+	if !nixstore.Available() {
+		return ""
+	}
+
+	profile := nixstore.ProfilePath(nixstore.ProfileParams{AppID: p.appID, EnvID: p.envID})
+
+	if profile == "" {
+		return ""
+	}
+
+	if err := nixstore.EnsureProfilesDir(); err != nil {
+		slog.Errorf("could not create nix profiles directory: %v", err)
+		return ""
+	}
+
+	return profile
+}
+
 // installFlake pre-builds the nix dev shell so its packages are in the store
 // before the build command runs. The build command itself is wrapped by the
 // builder using `nix develop --command` to get the full shell environment.
 func (p *Installer) installFlake(ctx context.Context, flakeDir string) error {
-	return sys.Command(ctx, sys.CommandOpts{
+	develop := `nix --extra-experimental-features "nix-command flakes" develop`
+	profile := p.flakeProfile()
+
+	if profile != "" {
+		develop += ` --profile "` + profile + `"`
+	}
+
+	err := sys.Command(ctx, sys.CommandOpts{
 		Name:   "sh",
-		Args:   []string{"-c", `nix --extra-experimental-features "nix-command flakes" develop --command true`},
+		Args:   []string{"-c", develop + " --command true"},
 		Dir:    flakeDir,
 		Env:    PrepareEnvVars(p.envVars),
 		Stdout: p.reporter.File(),
 		Stderr: p.reporter.File(),
 	}).Run()
+
+	if err != nil || profile == "" {
+		return err
+	}
+
+	// A profile keeps its previous generations, each rooting the toolchain of
+	// an older deployment. Pruning is not worth failing a successful build for.
+	if err := nixstore.PruneGenerations(ctx, nixstore.PruneGenerationsParams{ProfilePath: profile}); err != nil {
+		slog.Errorf("could not prune nix profile generations: %v", err)
+	}
+
+	return nil
 }
 
 // InstallRuntimeDependencies installs runtime dependencies using mise and flake.nix (if present).

--- a/src/ce/runner/installer_test.go
+++ b/src/ce/runner/installer_test.go
@@ -13,8 +13,11 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/mise"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore/nixstoretest"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
 	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -486,6 +489,72 @@ func (s *InstallerSuite) Test_InstallingRuntimeDeps_WithFlake() {
 	installed, err := p.InstallRuntimeDependencies(ctx)
 	s.NoError(err)
 	s.Equal([]string{"go@1.24"}, installed)
+}
+
+// A flake build must land in this environment's profile. Without that root its
+// packages are unreferenced the moment the build exits, and the next collection
+// deletes them, so the following deployment downloads the toolchain again.
+func (s *InstallerSuite) Test_InstallFlake_BuildsIntoTheEnvironmentProfile() {
+	ctx := context.Background()
+	workDir := s.config.Repo.Dir
+	stdout := s.config.Reporter.File()
+
+	s.NoError(os.WriteFile(path.Join(workDir, "flake.nix"), []byte("{}"), 0776))
+	s.NoError(os.WriteFile(path.Join(workDir, "mise.toml"), []byte(`[tools]\ngo = "1.24"`), 0776))
+
+	originalStore, originalProfiles := nixstore.DefaultPath, nixstore.ProfilesDir
+	nixstore.DefaultPath = s.T().TempDir()
+	nixstore.ProfilesDir = path.Join(s.T().TempDir(), "stormkit")
+	restore := nixstoretest.StubLookPath(true)
+
+	defer func() {
+		nixstore.DefaultPath, nixstore.ProfilesDir = originalStore, originalProfiles
+		restore()
+	}()
+
+	s.mockMise.On("InstallMise", ctx).Return(nil).Once()
+	s.mockMise.On("InstallLocal", ctx, mise.LocalOpts{Dir: workDir, Stdout: stdout, Stderr: stdout}).Return(nil).Once()
+	s.mockMise.On("ListLocal", ctx, mise.LocalOpts{Dir: workDir}).Return([]string{"go@1.24"}, nil).Once()
+	s.mockMise.On("BinPaths", ctx).Return(map[string]string{}, nil).Once()
+
+	s.config.Build.AppID = "12"
+	s.config.Build.EnvID = "34"
+	s.config.Repo.Runtime = "go"
+
+	profile := path.Join(nixstore.ProfilesDir, "app-12-env-34")
+
+	var opts []sys.CommandOpts
+
+	s.mockCmd.On("SetOpts", mock.Anything).Return(s.mockCmd).Run(func(args mock.Arguments) {
+		opts = append(opts, args.Get(0).(sys.CommandOpts))
+	})
+
+	s.mockCmd.On("Run").Return(nil, nil)
+	s.mockCmd.On("CombinedOutput").Return([]byte(""), nil)
+
+	_, err := runner.NewInstaller(s.config).InstallRuntimeDependencies(ctx)
+
+	s.NoError(err)
+
+	var develop, prune *sys.CommandOpts
+
+	for i, opt := range opts {
+		if opt.Name == "sh" && strings.Contains(strings.Join(opt.Args, " "), "nix ") {
+			develop = &opts[i]
+		}
+
+		if opt.Name == "nix-env" {
+			prune = &opts[i]
+		}
+	}
+
+	s.Require().NotNil(develop, "expected the dev shell to be built")
+	s.Contains(develop.Args[1], `--profile "`+profile+`"`)
+
+	// Every deploy adds a generation, and each one roots the toolchain it was
+	// built with; only the newest may survive.
+	s.Require().NotNil(prune, "expected older generations to be pruned")
+	s.Equal([]string{"--profile", profile, "--delete-generations", "+1"}, prune.Args)
 }
 
 func TestInstallerSuite(t *testing.T) {

--- a/src/ee/hosting/main.go
+++ b/src/ee/hosting/main.go
@@ -101,6 +101,7 @@ func main() {
 		migrations.Up(conn, database.Config)
 		admin.InstallDependencies(context.Background())
 		bootstrap.FromEnv(context.Background())
+		go admin.StartDiskMaintenance(context.Background())
 	}
 
 	// Register redis listeners

--- a/src/ee/workerserver/main.go
+++ b/src/ee/workerserver/main.go
@@ -32,6 +32,7 @@ func main() {
 	if conn := database.Connection(); conn != nil {
 		migrations.Up(conn, database.Config)
 		go admin.InstallDependencies(context.Background())
+		go admin.StartDiskMaintenance(context.Background())
 	}
 
 	slog.Infof("deployer service: %s", conf.Deployer.Service)

--- a/src/lib/integrations/client_process_manager.go
+++ b/src/lib/integrations/client_process_manager.go
@@ -19,8 +19,10 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/shutdown"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/file"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
 	"go.uber.org/zap"
 )
@@ -206,18 +208,63 @@ func hasNixFlake(workDir string) bool {
 	return file.Exists(path.Join(workDir, "flake.nix"))
 }
 
+// BuildServerCommandParams describes the service whose command is being built.
+type BuildServerCommandParams struct {
+	Command string
+	WorkDir string
+	AppID   types.ID
+	EnvID   types.ID
+}
+
 // BuildServerCommand wraps command with nix develop when flake.nix is present in workDir,
 // so that all nix-provided libraries are available at runtime.
-func (pm *ProcessManager) BuildServerCommand(command, workDir string) string {
-	if hasNixFlake(workDir) {
-		// Quote the command so it is passed as a single argument to sh -c.
-		// Without quoting, shlex splits multi-word commands (e.g. "node build")
-		// into separate nix --command args, causing sh to run only the first word.
-		quoted := "'" + strings.ReplaceAll(command, "'", `'\''`) + "'"
-		return `nix --extra-experimental-features "nix-command flakes" develop --command sh -c ` + quoted
+//
+// The dev shell is entered through this environment's profile, which roots its
+// packages. A service is killed once it goes idle, and without a root its
+// closure would be collected while it is down: the next request would then wait
+// for the whole toolchain to download again before the server could start.
+func (pm *ProcessManager) BuildServerCommand(p BuildServerCommandParams) string {
+	if !hasNixFlake(p.WorkDir) {
+		return p.Command
 	}
 
-	return command
+	develop := `nix --extra-experimental-features "nix-command flakes" develop`
+
+	if profile := serviceProfile(p.AppID, p.EnvID); profile != "" {
+		develop += ` --profile "` + profile + `"`
+	}
+
+	// Quote the command so it is passed as a single argument to sh -c.
+	// Without quoting, shlex splits multi-word commands (e.g. "node build")
+	// into separate nix --command args, causing sh to run only the first word.
+	quoted := "'" + strings.ReplaceAll(p.Command, "'", `'\''`) + "'"
+
+	return develop + ` --command sh -c ` + quoted
+}
+
+// serviceProfile returns the profile rooting this environment's dev shell, or
+// an empty string when it cannot be created. An unrooted shell still runs; it
+// just risks a cold start after the next collection.
+func serviceProfile(appID, envID types.ID) string {
+	if !nixstore.Available() {
+		return ""
+	}
+
+	profile := nixstore.ProfilePath(nixstore.ProfileParams{
+		AppID: appID.String(),
+		EnvID: envID.String(),
+	})
+
+	if profile == "" {
+		return ""
+	}
+
+	if err := nixstore.EnsureProfilesDir(); err != nil {
+		slog.Errorf("could not create nix profiles directory: %v", err)
+		return ""
+	}
+
+	return profile
 }
 
 // Start starts a new service with the given arguments and working directory.
@@ -299,7 +346,12 @@ func (pm *ProcessManager) Start(ctx context.Context, args *InvokeArgs, workDir s
 		}
 
 		s.cmd = sys.Command(ctx, sys.CommandOpts{
-			String:      pm.BuildServerCommand(args.Command, workDir),
+			String: pm.BuildServerCommand(BuildServerCommandParams{
+				Command: args.Command,
+				WorkDir: workDir,
+				AppID:   args.AppID,
+				EnvID:   args.EnvID,
+			}),
 			Dir:         workDir,
 			Env:         vars,
 			Stdout:      outfile,

--- a/src/lib/integrations/client_process_manager_test.go
+++ b/src/lib/integrations/client_process_manager_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/html"
 	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore/nixstoretest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -455,7 +458,11 @@ func (s *ProcessManagerSuite) Test_Invoke_FailedStart_EvictsService() {
 }
 
 func (s *ProcessManagerSuite) Test_BuildServerCommand_WithoutFlake() {
-	cmd := s.pm.BuildServerCommand("node index.js", s.tmpdir)
+	cmd := s.pm.BuildServerCommand(integrations.BuildServerCommandParams{
+		Command: "node index.js",
+		WorkDir: s.tmpdir,
+	})
+
 	s.Equal("node index.js", cmd)
 }
 
@@ -465,8 +472,42 @@ func (s *ProcessManagerSuite) Test_BuildServerCommand_WithFlake() {
 
 	defer os.Remove(flakePath)
 
-	cmd := s.pm.BuildServerCommand("node index.js", s.tmpdir)
+	cmd := s.pm.BuildServerCommand(integrations.BuildServerCommandParams{
+		Command: "node index.js",
+		WorkDir: s.tmpdir,
+	})
+
 	s.Equal(`nix --extra-experimental-features "nix-command flakes" develop --command sh -c 'node index.js'`, cmd)
+}
+
+// A service that goes idle is killed, so its packages survive a collection only
+// while a profile roots them.
+func (s *ProcessManagerSuite) Test_BuildServerCommand_RootsTheEnvironment() {
+	flakePath := path.Join(s.tmpdir, "flake.nix")
+	s.NoError(os.WriteFile(flakePath, []byte("{}"), 0664))
+
+	defer os.Remove(flakePath)
+
+	originalStore, originalProfiles := nixstore.DefaultPath, nixstore.ProfilesDir
+	nixstore.DefaultPath = s.T().TempDir()
+	nixstore.ProfilesDir = path.Join(s.T().TempDir(), "stormkit")
+	restore := nixstoretest.StubLookPath(true)
+
+	defer func() {
+		nixstore.DefaultPath, nixstore.ProfilesDir = originalStore, originalProfiles
+		restore()
+	}()
+
+	cmd := s.pm.BuildServerCommand(integrations.BuildServerCommandParams{
+		Command: "node index.js",
+		WorkDir: s.tmpdir,
+		AppID:   types.ID(42),
+		EnvID:   types.ID(7),
+	})
+
+	s.Contains(cmd, `--profile "`+path.Join(nixstore.ProfilesDir, "app-42-env-7")+`"`)
+	s.Contains(cmd, `--command sh -c 'node index.js'`)
+	s.DirExists(nixstore.ProfilesDir)
 }
 
 func TestProcessManager(t *testing.T) {

--- a/src/lib/utils/nixstore/nixstore.go
+++ b/src/lib/utils/nixstore/nixstore.go
@@ -1,0 +1,137 @@
+// Package nixstore reports disk usage for a filesystem path and garbage
+// collects the Nix store.
+//
+// Self-hosted instances persist /nix in a Docker volume so packages survive
+// restarts. Every deployment whose repository ships a flake.nix adds new store
+// paths, and nothing ever removes them, so the volume grows without bound until
+// the host disk is full.
+//
+// Collecting alone is not enough. Nix keeps only what a garbage collection root
+// points at, and a deployment leaves none behind: once its build finishes, or
+// its service goes idle and is killed, its packages are unreferenced and a
+// collection deletes them all. This package therefore registers one profile per
+// environment (see profile.go) and settles those roots before collecting, so a
+// run reclaims superseded deployments while leaving each active environment its
+// dev shell.
+package nixstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+)
+
+// LookPath resolves a binary on PATH. It is a variable so tests, in this
+// package and in callers, can simulate a container with or without Nix.
+var LookPath = exec.LookPath
+
+// DefaultPath is where the Nix store lives inside Stormkit containers.
+// It is a variable so tests can point it at a temporary directory.
+var DefaultPath = "/nix"
+
+// DefaultRetentionDays is how long an environment keeps its packages after its
+// last deployment, so redeploying or waking an idle service does not have to
+// download the dev shell again.
+const DefaultRetentionDays = 7
+
+// Usage describes the filesystem backing a path.
+type Usage struct {
+	Path        string  `json:"path"`
+	TotalBytes  uint64  `json:"totalBytes"`
+	FreeBytes   uint64  `json:"freeBytes"`
+	UsedBytes   uint64  `json:"usedBytes"`
+	UsedPercent float64 `json:"usedPercent"`
+}
+
+// Available reports whether this container has a Nix store to collect.
+// The hosting and workerserver images ship Nix; other callers (tests, the API
+// container, external runners) do not, and must not fail because of it.
+func Available() bool {
+	if _, err := os.Stat(DefaultPath); err != nil {
+		return false
+	}
+
+	_, err := LookPath("nix-collect-garbage")
+
+	return err == nil
+}
+
+// DiskUsage reports the usage of the filesystem containing path. It describes
+// the whole filesystem, not the path's own size: /nix and / usually share one
+// device, which is exactly the disk that runs out.
+func DiskUsage(path string) (Usage, error) {
+	var stat syscall.Statfs_t
+
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return Usage{}, err
+	}
+
+	blockSize := uint64(stat.Bsize)
+	total := stat.Blocks * blockSize
+	// Bavail, not Bfree: blocks reserved for root are not free to us.
+	free := stat.Bavail * blockSize
+
+	usage := Usage{
+		Path:       path,
+		TotalBytes: total,
+		FreeBytes:  free,
+	}
+
+	if total > 0 {
+		usage.UsedBytes = total - free
+		usage.UsedPercent = float64(usage.UsedBytes) / float64(total) * 100
+	}
+
+	return usage, nil
+}
+
+// CollectGarbageParams configures a garbage collection run.
+type CollectGarbageParams struct {
+	// RetentionDays keeps store generations younger than this many days.
+	// Values below 1 fall back to DefaultRetentionDays.
+	RetentionDays int
+}
+
+// CollectGarbage deletes Nix store paths that no longer belong to a live
+// environment. It is a no-op when the container has no Nix store.
+//
+// Roots are settled before collecting, because nix-collect-garbage only keeps
+// what something points at: stale generations are pruned so a redeployed
+// environment stops pinning its previous toolchain, then the profiles of
+// environments that have not deployed within the retention window are dropped.
+// What remains is one dev shell per active environment.
+func CollectGarbage(ctx context.Context, p CollectGarbageParams) error {
+	if !Available() {
+		return nil
+	}
+
+	if p.RetentionDays < 1 {
+		p.RetentionDays = DefaultRetentionDays
+	}
+
+	if err := PruneAllGenerations(ctx); err != nil {
+		slog.Errorf("error pruning nix profile generations: %v", err)
+	}
+
+	if _, err := ReapProfiles(ReapProfilesParams{RetentionDays: p.RetentionDays}); err != nil {
+		slog.Errorf("error reaping nix profiles: %v", err)
+	}
+
+	out, err := sys.Command(ctx, sys.CommandOpts{
+		Name: "nix-collect-garbage",
+		Args: []string{"--delete-older-than", strconv.Itoa(p.RetentionDays) + "d"},
+	}).CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf("nix-collect-garbage: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}

--- a/src/lib/utils/nixstore/nixstore_test.go
+++ b/src/lib/utils/nixstore/nixstore_test.go
@@ -1,0 +1,155 @@
+package nixstore_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore/nixstoretest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/sys/unix"
+)
+
+type NixStoreSuite struct {
+	suite.Suite
+	mockCommand  *mocks.CommandInterface
+	originalPath string
+	restore      func()
+}
+
+func (s *NixStoreSuite) SetupSuite() {
+	s.originalPath = nixstore.DefaultPath
+}
+
+func (s *NixStoreSuite) BeforeTest(_, _ string) {
+	s.mockCommand = &mocks.CommandInterface{}
+	sys.DefaultCommand = s.mockCommand
+	nixstore.DefaultPath = s.T().TempDir()
+	s.restore = nixstoretest.StubLookPath(true)
+}
+
+func (s *NixStoreSuite) AfterTest(_, _ string) {
+	sys.DefaultCommand = nil
+	nixstore.DefaultPath = s.originalPath
+	s.restore()
+}
+
+func (s *NixStoreSuite) Test_Available() {
+	s.True(nixstore.Available())
+}
+
+func (s *NixStoreSuite) Test_Available_WithoutNixBinary() {
+	s.restore()
+	s.restore = nixstoretest.StubLookPath(false)
+
+	s.False(nixstore.Available())
+}
+
+func (s *NixStoreSuite) Test_Available_WithoutStore() {
+	nixstore.DefaultPath = "/does-not-exist"
+
+	s.False(nixstore.Available())
+}
+
+func (s *NixStoreSuite) Test_DiskUsage() {
+	usage, err := nixstore.DiskUsage(nixstore.DefaultPath)
+
+	s.NoError(err)
+	s.Equal(nixstore.DefaultPath, usage.Path)
+	s.Greater(usage.TotalBytes, uint64(0))
+	s.Equal(usage.TotalBytes-usage.FreeBytes, usage.UsedBytes)
+	s.GreaterOrEqual(usage.UsedPercent, float64(0))
+	s.LessOrEqual(usage.UsedPercent, float64(100))
+}
+
+func (s *NixStoreSuite) Test_DiskUsage_UnknownPath() {
+	_, err := nixstore.DiskUsage("/does-not-exist")
+
+	s.Error(err)
+}
+
+func (s *NixStoreSuite) Test_CollectGarbage() {
+	s.mockCommand.On("SetOpts", sys.CommandOpts{
+		Name: "nix-collect-garbage",
+		Args: []string{"--delete-older-than", "3d"},
+	}).Return(s.mockCommand).Once()
+
+	s.mockCommand.On("CombinedOutput").Return([]byte(""), nil).Once()
+
+	s.NoError(nixstore.CollectGarbage(context.Background(), nixstore.CollectGarbageParams{RetentionDays: 3}))
+	s.mockCommand.AssertExpectations(s.T())
+}
+
+func (s *NixStoreSuite) Test_CollectGarbage_DefaultsRetention() {
+	s.mockCommand.On("SetOpts", sys.CommandOpts{
+		Name: "nix-collect-garbage",
+		Args: []string{"--delete-older-than", "7d"},
+	}).Return(s.mockCommand).Once()
+
+	s.mockCommand.On("CombinedOutput").Return([]byte(""), nil).Once()
+
+	s.NoError(nixstore.CollectGarbage(context.Background(), nixstore.CollectGarbageParams{}))
+	s.mockCommand.AssertExpectations(s.T())
+}
+
+// Containers without Nix must not report an error: the same code path runs in
+// images that never install it.
+func (s *NixStoreSuite) Test_CollectGarbage_WithoutNix() {
+	s.restore()
+	s.restore = nixstoretest.StubLookPath(false)
+
+	s.NoError(nixstore.CollectGarbage(context.Background(), nixstore.CollectGarbageParams{}))
+	s.mockCommand.AssertNotCalled(s.T(), "CombinedOutput")
+}
+
+// Collecting before the roots are settled would delete an environment's
+// packages while it still owns them, or keep a superseded generation alive.
+func (s *NixStoreSuite) Test_CollectGarbage_SettlesRootsFirst() {
+	originalProfiles := nixstore.ProfilesDir
+	nixstore.ProfilesDir = filepath.Join(s.T().TempDir(), "stormkit")
+
+	defer func() { nixstore.ProfilesDir = originalProfiles }()
+
+	s.Require().NoError(nixstore.EnsureProfilesDir())
+
+	stale := filepath.Join(nixstore.ProfilesDir, "app-1-env-1")
+	s.Require().NoError(os.Symlink("/nix/store/fake-profile", stale+"-1-link"))
+	s.Require().NoError(os.Symlink(stale+"-1-link", stale))
+
+	old := time.Now().AddDate(0, 0, -30)
+	ts := unix.NsecToTimespec(old.UnixNano())
+	s.Require().NoError(unix.UtimesNanoAt(unix.AT_FDCWD, stale, []unix.Timespec{ts, ts}, unix.AT_SYMLINK_NOFOLLOW))
+
+	var calls []string
+
+	s.mockCommand.On("SetOpts", mock.Anything).Return(s.mockCommand).Run(func(args mock.Arguments) {
+		calls = append(calls, args.Get(0).(sys.CommandOpts).Name)
+	})
+
+	s.mockCommand.On("CombinedOutput").Return([]byte(""), nil)
+
+	s.NoError(nixstore.CollectGarbage(context.Background(), nixstore.CollectGarbageParams{RetentionDays: 7}))
+
+	s.Equal([]string{"nix-env", "nix-collect-garbage"}, calls)
+	s.NoFileExists(stale)
+}
+
+func (s *NixStoreSuite) Test_CollectGarbage_ReportsOutput() {
+	s.mockCommand.On("SetOpts", mock.Anything).Return(s.mockCommand).Once()
+	s.mockCommand.On("CombinedOutput").Return([]byte("cannot open lock file"), errCommandFailed).Once()
+
+	err := nixstore.CollectGarbage(context.Background(), nixstore.CollectGarbageParams{})
+
+	s.Error(err)
+	s.Contains(err.Error(), "cannot open lock file")
+}
+
+func TestNixStoreSuite(t *testing.T) {
+	suite.Run(t, new(NixStoreSuite))
+}

--- a/src/lib/utils/nixstore/nixstoretest/nixstoretest.go
+++ b/src/lib/utils/nixstore/nixstoretest/nixstoretest.go
@@ -1,0 +1,23 @@
+// Package nixstoretest provides helpers for tests that exercise code paths
+// guarded by nixstore.Available.
+package nixstoretest
+
+import (
+	"errors"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+)
+
+// StubLookPath makes nixstore.Available behave as if the Nix binaries are (or
+// are not) installed, and returns a function that restores the real lookup.
+func StubLookPath(found bool) (restore func()) {
+	original := nixstore.LookPath
+
+	if found {
+		nixstore.LookPath = func(file string) (string, error) { return "/usr/bin/" + file, nil }
+	} else {
+		nixstore.LookPath = func(string) (string, error) { return "", errors.New("not found") }
+	}
+
+	return func() { nixstore.LookPath = original }
+}

--- a/src/lib/utils/nixstore/profile.go
+++ b/src/lib/utils/nixstore/profile.go
@@ -1,0 +1,210 @@
+package nixstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+)
+
+// ProfilesDir holds one Nix profile per environment. It is a variable so tests
+// can point it at a temporary directory.
+//
+// A profile is a garbage collection root. Without one, the only thing keeping
+// an environment's dev shell alive is its running process, so an idle service
+// loses its packages on the next collection and has to download them again
+// before it can answer the request that woke it up.
+var ProfilesDir = "/nix/var/nix/profiles/stormkit"
+
+// unsafeProfileChars matches everything that must not reach a file name.
+var unsafeProfileChars = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
+// generationSuffix matches the per-generation links Nix maintains next to a
+// profile, for example "app-1-env-2-13-link".
+var generationSuffix = regexp.MustCompile(`-[0-9]+-link$`)
+
+// ProfileParams identifies the environment that owns a profile.
+type ProfileParams struct {
+	AppID string
+	EnvID string
+}
+
+// ProfilePath returns the profile that roots an environment's dev shell, or an
+// empty string when the environment cannot be identified. Callers fall back to
+// an unrooted `nix develop` in that case: a missing root costs a re-download,
+// a failed deployment costs more.
+func ProfilePath(p ProfileParams) string {
+	appID := unsafeProfileChars.ReplaceAllString(p.AppID, "")
+	envID := unsafeProfileChars.ReplaceAllString(p.EnvID, "")
+
+	if appID == "" || envID == "" {
+		return ""
+	}
+
+	return filepath.Join(ProfilesDir, fmt.Sprintf("app-%s-env-%s", appID, envID))
+}
+
+// EnsureProfilesDir creates the directory that holds environment profiles.
+func EnsureProfilesDir() error {
+	return os.MkdirAll(ProfilesDir, 0o755)
+}
+
+// Profile is a registered environment root and the time it was last deployed.
+type Profile struct {
+	Name     string
+	Path     string
+	Modified time.Time
+}
+
+// ListProfiles returns the environment profiles, most recently deployed first.
+// A missing directory is not an error: nothing has been deployed yet.
+func ListProfiles() ([]Profile, error) {
+	entries, err := os.ReadDir(ProfilesDir)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	profiles := make([]Profile, 0, len(entries))
+
+	for _, entry := range entries {
+		name := entry.Name()
+
+		// Generation links belong to a profile and are removed along with it.
+		if generationSuffix.MatchString(name) {
+			continue
+		}
+
+		info, err := entry.Info()
+
+		if err != nil {
+			continue
+		}
+
+		profiles = append(profiles, Profile{
+			Name:     name,
+			Path:     filepath.Join(ProfilesDir, name),
+			Modified: info.ModTime(),
+		})
+	}
+
+	sort.Slice(profiles, func(i, j int) bool {
+		return profiles[i].Modified.After(profiles[j].Modified)
+	})
+
+	return profiles, nil
+}
+
+// RemoveProfile deletes a profile and every generation link belonging to it,
+// which makes its closure collectable on the next run.
+func RemoveProfile(p Profile) error {
+	links, err := filepath.Glob(p.Path + "-*-link")
+
+	if err != nil {
+		return err
+	}
+
+	for _, link := range append(links, p.Path) {
+		if err := os.Remove(link); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ReapProfilesParams configures which environment roots are dropped.
+type ReapProfilesParams struct {
+	// RetentionDays drops profiles that have not been deployed within this
+	// many days. Values below 1 fall back to DefaultRetentionDays.
+	RetentionDays int
+}
+
+// ReapProfiles removes the roots of environments that have not deployed within
+// the retention window, so the next collection can reclaim their packages.
+func ReapProfiles(p ReapProfilesParams) (int, error) {
+	if p.RetentionDays < 1 {
+		p.RetentionDays = DefaultRetentionDays
+	}
+
+	profiles, err := ListProfiles()
+
+	if err != nil {
+		return 0, err
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -p.RetentionDays)
+	removed := 0
+
+	for _, profile := range profiles {
+		if profile.Modified.After(cutoff) {
+			continue
+		}
+
+		if err := RemoveProfile(profile); err != nil {
+			return removed, err
+		}
+
+		removed++
+	}
+
+	return removed, nil
+}
+
+// PruneGenerationsParams configures generation pruning.
+type PruneGenerationsParams struct {
+	ProfilePath string
+}
+
+// PruneGenerations deletes every generation of a profile except the newest.
+//
+// Nix keeps the previous version on every write, and each generation is a root
+// of its own. Without pruning, an environment that deploys daily pins a new
+// toolchain every day and the store grows per deployment rather than per
+// environment.
+func PruneGenerations(ctx context.Context, p PruneGenerationsParams) error {
+	if p.ProfilePath == "" {
+		return nil
+	}
+
+	out, err := sys.Command(ctx, sys.CommandOpts{
+		Name: "nix-env",
+		Args: []string{"--profile", p.ProfilePath, "--delete-generations", "+1"},
+	}).CombinedOutput()
+
+	if err != nil {
+		return fmt.Errorf("nix-env --delete-generations %s: %w: %s", p.ProfilePath, err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}
+
+// PruneAllGenerations prunes every registered environment profile, returning
+// the first error while still pruning the rest.
+func PruneAllGenerations(ctx context.Context) error {
+	profiles, err := ListProfiles()
+
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+
+	for _, profile := range profiles {
+		if err := PruneGenerations(ctx, PruneGenerationsParams{ProfilePath: profile.Path}); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}

--- a/src/lib/utils/nixstore/profile_test.go
+++ b/src/lib/utils/nixstore/profile_test.go
@@ -1,0 +1,214 @@
+package nixstore_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/nixstore/nixstoretest"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils/sys"
+	"github.com/stormkit-io/stormkit-io/src/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/sys/unix"
+)
+
+// errCommandFailed stands in for the exit status a failed nix command returns.
+var errCommandFailed = errors.New("exit status 1")
+
+// lchtimes backdates a symlink without following it, which is what os.Chtimes
+// would do: profiles are symlinks and their own timestamp is what marks a
+// deployment.
+func lchtimes(path string, modified time.Time) error {
+	ts := unix.NsecToTimespec(modified.UnixNano())
+
+	return unix.UtimesNanoAt(unix.AT_FDCWD, path, []unix.Timespec{ts, ts}, unix.AT_SYMLINK_NOFOLLOW)
+}
+
+type ProfileSuite struct {
+	suite.Suite
+	mockCommand      *mocks.CommandInterface
+	originalStore    string
+	originalProfiles string
+	restore          func()
+}
+
+func (s *ProfileSuite) SetupSuite() {
+	s.originalStore = nixstore.DefaultPath
+	s.originalProfiles = nixstore.ProfilesDir
+}
+
+func (s *ProfileSuite) BeforeTest(_, _ string) {
+	s.mockCommand = &mocks.CommandInterface{}
+	sys.DefaultCommand = s.mockCommand
+	nixstore.DefaultPath = s.T().TempDir()
+	nixstore.ProfilesDir = filepath.Join(s.T().TempDir(), "stormkit")
+	s.restore = nixstoretest.StubLookPath(true)
+}
+
+func (s *ProfileSuite) AfterTest(_, _ string) {
+	sys.DefaultCommand = nil
+	nixstore.DefaultPath = s.originalStore
+	nixstore.ProfilesDir = s.originalProfiles
+	s.restore()
+}
+
+// writeProfile creates a profile and its newest generation link, backdated by
+// age so retention can be exercised without waiting.
+func (s *ProfileSuite) writeProfile(name string, age time.Duration) string {
+	s.Require().NoError(nixstore.EnsureProfilesDir())
+
+	profile := filepath.Join(nixstore.ProfilesDir, name)
+	generation := profile + "-1-link"
+
+	s.Require().NoError(os.Symlink("/nix/store/fake-profile", generation))
+	s.Require().NoError(os.Symlink(generation, profile))
+
+	// Both links dangle until Nix builds the closure they point at, and their
+	// own timestamps are what mark the deployment, so neither may be followed.
+	modified := time.Now().Add(-age)
+	s.Require().NoError(lchtimes(generation, modified))
+	s.Require().NoError(lchtimes(profile, modified))
+
+	return profile
+}
+
+func (s *ProfileSuite) Test_ProfilePath() {
+	s.Equal(
+		filepath.Join(nixstore.ProfilesDir, "app-12-env-34"),
+		nixstore.ProfilePath(nixstore.ProfileParams{AppID: "12", EnvID: "34"}),
+	)
+}
+
+func (s *ProfileSuite) Test_ProfilePath_SanitizesIdentifiers() {
+	path := nixstore.ProfilePath(nixstore.ProfileParams{AppID: "../../etc", EnvID: "3 4"})
+
+	s.Equal(filepath.Join(nixstore.ProfilesDir, "app-etc-env-34"), path)
+	s.Equal(nixstore.ProfilesDir, filepath.Dir(path))
+}
+
+// Without identifiers there is nothing to key a profile on. The caller falls
+// back to an unrooted shell rather than sharing one profile between apps.
+func (s *ProfileSuite) Test_ProfilePath_WithoutIdentifiers() {
+	s.Empty(nixstore.ProfilePath(nixstore.ProfileParams{EnvID: "34"}))
+	s.Empty(nixstore.ProfilePath(nixstore.ProfileParams{AppID: "12"}))
+	s.Empty(nixstore.ProfilePath(nixstore.ProfileParams{AppID: "///", EnvID: "34"}))
+}
+
+func (s *ProfileSuite) Test_ListProfiles_IsEmptyWithoutDirectory() {
+	profiles, err := nixstore.ListProfiles()
+
+	s.NoError(err)
+	s.Empty(profiles)
+}
+
+// Generation links belong to their profile and must not be listed as roots of
+// their own, or reaping would count the same environment twice.
+func (s *ProfileSuite) Test_ListProfiles_SkipsGenerationsAndSortsByNewest() {
+	s.writeProfile("app-1-env-1", 10*24*time.Hour)
+	s.writeProfile("app-2-env-2", time.Hour)
+
+	profiles, err := nixstore.ListProfiles()
+
+	s.NoError(err)
+	s.Len(profiles, 2)
+	s.Equal("app-2-env-2", profiles[0].Name)
+	s.Equal("app-1-env-1", profiles[1].Name)
+}
+
+func (s *ProfileSuite) Test_RemoveProfile_RemovesGenerations() {
+	profile := s.writeProfile("app-1-env-1", time.Hour)
+	profiles, err := nixstore.ListProfiles()
+
+	s.Require().NoError(err)
+	s.Require().Len(profiles, 1)
+	s.NoError(nixstore.RemoveProfile(profiles[0]))
+	s.NoFileExists(profile)
+
+	remaining, err := os.ReadDir(nixstore.ProfilesDir)
+
+	s.NoError(err)
+	s.Empty(remaining)
+}
+
+func (s *ProfileSuite) Test_ReapProfiles_DropsOnlyStaleEnvironments() {
+	fresh := s.writeProfile("app-1-env-1", 2*24*time.Hour)
+	stale := s.writeProfile("app-2-env-2", 30*24*time.Hour)
+
+	reaped, err := nixstore.ReapProfiles(nixstore.ReapProfilesParams{RetentionDays: 7})
+
+	s.NoError(err)
+	s.Equal(1, reaped)
+	s.NoFileExists(stale)
+
+	_, err = os.Lstat(fresh)
+	s.NoError(err)
+}
+
+func (s *ProfileSuite) Test_ReapProfiles_DefaultsRetention() {
+	s.writeProfile("app-1-env-1", nixstore.DefaultRetentionDays*24*time.Hour+time.Hour)
+
+	reaped, err := nixstore.ReapProfiles(nixstore.ReapProfilesParams{})
+
+	s.NoError(err)
+	s.Equal(1, reaped)
+}
+
+func (s *ProfileSuite) Test_PruneGenerations() {
+	profile := filepath.Join(nixstore.ProfilesDir, "app-1-env-1")
+
+	s.mockCommand.On("SetOpts", sys.CommandOpts{
+		Name: "nix-env",
+		Args: []string{"--profile", profile, "--delete-generations", "+1"},
+	}).Return(s.mockCommand).Once()
+
+	s.mockCommand.On("CombinedOutput").Return([]byte(""), nil).Once()
+
+	s.NoError(nixstore.PruneGenerations(context.Background(), nixstore.PruneGenerationsParams{ProfilePath: profile}))
+	s.mockCommand.AssertExpectations(s.T())
+}
+
+func (s *ProfileSuite) Test_PruneGenerations_WithoutProfile() {
+	s.NoError(nixstore.PruneGenerations(context.Background(), nixstore.PruneGenerationsParams{}))
+	s.mockCommand.AssertNotCalled(s.T(), "CombinedOutput")
+}
+
+// A failure has to name the profile and carry the command output: a bare exit
+// status leaves an operator nothing to act on.
+func (s *ProfileSuite) Test_PruneGenerations_ReportsOutput() {
+	profile := filepath.Join(nixstore.ProfilesDir, "app-1-env-1")
+
+	s.mockCommand.On("SetOpts", mock.Anything).Return(s.mockCommand).Once()
+	s.mockCommand.On("CombinedOutput").Return([]byte("permission denied"), errCommandFailed).Once()
+
+	err := nixstore.PruneGenerations(context.Background(), nixstore.PruneGenerationsParams{ProfilePath: profile})
+
+	s.Error(err)
+	s.Contains(err.Error(), "permission denied")
+	s.Contains(err.Error(), profile)
+}
+
+func (s *ProfileSuite) Test_PruneAllGenerations() {
+	first := s.writeProfile("app-1-env-1", time.Hour)
+	second := s.writeProfile("app-2-env-2", time.Hour)
+
+	for _, profile := range []string{second, first} {
+		s.mockCommand.On("SetOpts", sys.CommandOpts{
+			Name: "nix-env",
+			Args: []string{"--profile", profile, "--delete-generations", "+1"},
+		}).Return(s.mockCommand).Once()
+	}
+
+	s.mockCommand.On("CombinedOutput").Return([]byte(""), nil).Twice()
+
+	s.NoError(nixstore.PruneAllGenerations(context.Background()))
+	s.mockCommand.AssertExpectations(s.T())
+}
+
+func TestProfileSuite(t *testing.T) {
+	suite.Run(t, new(ProfileSuite))
+}


### PR DESCRIPTION
Self-hosted instances persist `/nix` in a Docker volume, and every deployment of a flake-based app adds store paths that nothing ever removed. The volume grows until the host disk is full.

Collecting on its own would have made things worse. Nix keeps only what a garbage collection root points at, and a deployment leaves none behind. Measured on a self-hosted instance before this change:

| | workerserver | hosting |
|---|---|---|
| Store entries | 12,478 | 12,419 |
| Live | 68 | 9,309 |
| Dead | 12,410 (99.5%) | 3,110 |
| Store size | 7.9 GB | 11 GB |
| Persistent roots | 1 (Nix itself) | 1 (Nix itself) |

Every `nodejs`, `python3`, `go`, `rustc` and `opencv` path was in the dead set, including the newest ones. The only live paths on the build host belong to Nix's own installation from image-build day. The hosting container looks healthier only because 1,541 of its 1,542 roots are `/proc/<pid>` entries from running processes — services are killed after `STORMKIT_MAX_IDLE` (default 10 minutes), so an idle app's closure is dead by definition, and the next request would have waited on a full toolchain download behind the "Installing dependencies" interstitial.

## What changed

- **Disk usage and collection helpers.** A `nixstore` package reports usage of the filesystem backing a path and collects the store, no-oping in images that ship no Nix.
- **A profile per environment.** `installFlake` and the hosting process manager both enter the dev shell through `/nix/var/nix/profiles/stormkit/app-<id>-env-<id>`. A profile is a root, so the closure survives whether or not anything is running it. Identifiers are sanitised so they cannot escape the directory; a profile that cannot be created falls back to an unrooted shell rather than failing the deployment.
- **One generation per profile.** Nix keeps the previous version on every write and each generation roots its own toolchain, so they are pruned to the newest. The store grows per environment rather than per deploy.
- **Roots settled before collecting.** `CollectGarbage` prunes generations, reaps profiles that have not deployed within a week, and only then runs `nix-collect-garbage`.
- **A daily collection loop** in hosting and workerserver, each cleaning its own `/nix` volume, staggered so a container in a restart loop does not spend its life collecting.

The retention window is a fixed week rather than a setting, and the collection runs daily.

## Deliberately out of scope

The build-host disk preflight and its profile eviction are not here, so this can be observed on its own. Note the trade-off while it is out: once environments are rooted, a collection on a nearly full host frees less than it does today, and there is no path that drops roots to make room. A host that fills up will still fail builds with `No space left on device` until an environment ages past the retention window.

## Testing

New suites for the store helpers, profiles, the installer and the process manager — covering identifier sanitisation, generation links being excluded from profile listings, retention boundaries, prune-before-collect ordering, and command output surfacing in errors. `go build ./...` and `go vet ./src/...` are clean; affected packages pass with `-p 1`.

`go.mod` moves `golang.org/x/sys` from indirect to direct — the tests backdate symlinks without following them, which stdlib cannot do portably.

## After deploying

`nix-store --gc --print-dead | wc -l` should fall to roughly the superseded-deploy paths rather than the whole store, and `/nix/var/nix/profiles/stormkit/` should gain one profile per environment as apps redeploy.
