### PR TITLE
feat: add publish warm-up job plumbing

### DIFF
--- a/src/ce/api/app/deploy/publish_warmup.go
+++ b/src/ce/api/app/deploy/publish_warmup.go
@@ -1,0 +1,410 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+// Publish job statuses. A job is terminal once it is published or failed.
+const (
+	PublishStatusPublishing = "publishing"
+	PublishStatusPublished  = "published"
+	PublishStatusFailed     = "failed"
+)
+
+// maxWarmupLogBytes caps how much of a failing deployment's boot output is
+// carried back to the user, so a server that logs in a loop cannot fill Redis.
+const maxWarmupLogBytes = 8 * 1024
+
+// maxWarmupReasonBytes caps the human-readable failure reason a node reports.
+const maxWarmupReasonBytes = 1024
+
+// finalizeLockTTL has to outlast a finalization, which writes the published
+// rows, resets the hosting cache and dispatches the publish webhooks.
+const finalizeLockTTL = 2 * time.Minute
+
+// unlockScript releases a lock only when the caller still owns it.
+var unlockScript = redis.NewScript(`
+	if redis.call("get", KEYS[1]) == ARGV[1] then
+		return redis.call("del", KEYS[1])
+	end
+
+	return 0
+`)
+
+// publishedPercentage is what every published deployment gets. Percentage-based
+// releases are a retired feature: PublishSettings still carries the field
+// because the stored column and the public API do, but nothing chooses a value
+// other than this one.
+const publishedPercentage = 100
+
+// WarmupRequest is what a hosting node receives over the event bus. It carries
+// the app's display name because a config can only be resolved for an
+// unpublished deployment by deployment id *and* display name, and the display
+// name is not part of the config itself.
+type WarmupRequest struct {
+	JobID        string   `json:"jobId"`
+	AppID        types.ID `json:"appId,string"`
+	EnvID        types.ID `json:"envId,string"`
+	DisplayName  string   `json:"displayName"`
+	DeploymentID types.ID `json:"deploymentId,string"`
+	Deadline     int64    `json:"deadline"`
+}
+
+// DeadlineAt returns the moment after which a node must stop probing.
+func (r WarmupRequest) DeadlineAt() time.Time {
+	return time.Unix(r.Deadline, 0)
+}
+
+// WarmupResult is one hosting node's verdict for a publish job.
+type WarmupResult struct {
+	ServiceID    string   `json:"serviceId"`
+	ServiceName  string   `json:"serviceName"`
+	Status       string   `json:"status"`
+	DeploymentID types.ID `json:"deploymentId,string,omitempty"`
+	StatusCode   int      `json:"statusCode,omitempty"`
+	Reason       string   `json:"reason,omitempty"`
+	Logs         string   `json:"logs,omitempty"`
+	Skipped      bool     `json:"skipped,omitempty"`
+}
+
+// PublishJob is the record a publish request creates before any traffic moves.
+// It is the single source of truth for "is a publish in flight, and did it
+// work" — the deployments_published table is only written once the job
+// succeeds.
+type PublishJob struct {
+	ID           string         `json:"id"`
+	AppID        types.ID       `json:"appId,string"`
+	EnvID        types.ID       `json:"envId,string"`
+	DeploymentID types.ID       `json:"deploymentId,string"`
+	Nodes        []string       `json:"nodes"`
+	Status       string         `json:"status"`
+	Reason       string         `json:"reason,omitempty"`
+	Failures     []WarmupResult `json:"failures,omitempty"`
+	StartedAt    int64          `json:"startedAt"`
+	Deadline     int64          `json:"deadline"`
+}
+
+// IsTerminal reports whether the job has already been decided.
+func (j *PublishJob) IsTerminal() bool {
+	return j.Status == PublishStatusPublished || j.Status == PublishStatusFailed
+}
+
+// DeadlineAt returns the moment after which the job can no longer succeed.
+func (j *PublishJob) DeadlineAt() time.Time {
+	return time.Unix(j.Deadline, 0)
+}
+
+// Settings turns the job into the arguments the publish itself needs.
+func (j *PublishJob) Settings() []*PublishSettings {
+	return []*PublishSettings{
+		{
+			EnvID:        j.EnvID,
+			DeploymentID: j.DeploymentID,
+			Percentage:   publishedPercentage,
+		},
+	}
+}
+
+// TruncateWarmupLogs trims boot output to what is worth storing and showing.
+// The tail is kept: the last thing a crashing server printed is the useful
+// part.
+func TruncateWarmupLogs(logs string) string {
+	if len(logs) <= maxWarmupLogBytes {
+		return logs
+	}
+
+	return logs[len(logs)-maxWarmupLogBytes:]
+}
+
+// truncateReason bounds a node's failure reason.
+func truncateReason(reason string) string {
+	if len(reason) <= maxWarmupReasonBytes {
+		return reason
+	}
+
+	return reason[:maxWarmupReasonBytes]
+}
+
+// PublishJobStore persists publish jobs and the per-node warm-up results.
+//
+// The state is deliberately transient: a lost job means the environment keeps
+// serving whatever it served before, which is the safe outcome.
+type PublishJobStore struct{}
+
+// NewPublishJobStore returns the store used to read and write publish jobs.
+func NewPublishJobStore() PublishJobStore {
+	return PublishJobStore{}
+}
+
+func (PublishJobStore) jobKey(jobID string) string {
+	return fmt.Sprintf("publish:job:%s", jobID)
+}
+
+func (PublishJobStore) nodeKey(jobID, serviceID string) string {
+	return fmt.Sprintf("publish:job:%s:node:%s", jobID, serviceID)
+}
+
+func (PublishJobStore) lockKey(jobID string) string {
+	return fmt.Sprintf("publish:job:%s:lock", jobID)
+}
+
+func (PublishJobStore) envKey(envID types.ID) string {
+	return fmt.Sprintf("publish:env:%s", envID.String())
+}
+
+// ttl keeps a job readable for a while after it is decided, so the dashboard
+// can still show why a publish failed.
+func (PublishJobStore) ttl(job *PublishJob) time.Duration {
+	return max(time.Until(job.DeadlineAt()), 0) + time.Hour
+}
+
+// Create writes a new job and points its environment at it.
+//
+// Only creation moves the environment pointer. An older job recording its
+// outcome must not steal the pointer from a publish that started after it.
+func (s PublishJobStore) Create(ctx context.Context, job *PublishJob) error {
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil
+	}
+
+	if err := s.Update(ctx, job); err != nil {
+		return err
+	}
+
+	return client.Set(ctx, s.envKey(job.EnvID), job.ID, s.ttl(job)).Err()
+}
+
+// Update writes the job's current state, leaving the environment pointer alone.
+func (s PublishJobStore) Update(ctx context.Context, job *PublishJob) error {
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(job)
+
+	if err != nil {
+		return err
+	}
+
+	return client.Set(ctx, s.jobKey(job.ID), data, s.ttl(job)).Err()
+}
+
+// Load returns the job, or nil when there is no such job.
+//
+// A Redis failure is reported as an error rather than as a missing job: a
+// caller that mistook one for the other would abandon a publish that is still
+// in flight, leaving it neither committed nor marked failed.
+func (s PublishJobStore) Load(ctx context.Context, jobID string) (*PublishJob, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil, nil
+	}
+
+	data, err := client.Get(ctx, s.jobKey(jobID)).Bytes()
+
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	job := &PublishJob{}
+
+	if err := json.Unmarshal(data, job); err != nil {
+		return nil, err
+	}
+
+	return job, nil
+}
+
+// LoadByEnv returns the most recent job of an environment, or nil when it has
+// never published. As with Load, a Redis failure is an error and not an
+// absence: callers use this to decide whether a publish is already running.
+func (s PublishJobStore) LoadByEnv(ctx context.Context, envID types.ID) (*PublishJob, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil, nil
+	}
+
+	jobID, err := client.Get(ctx, s.envKey(envID)).Result()
+
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if jobID == "" {
+		return nil, nil
+	}
+
+	return s.Load(ctx, jobID)
+}
+
+// SaveNodeResult records one hosting node's verdict.
+//
+// The size caps are applied here rather than by the caller: this is where data
+// reported by a hosting node enters Redis, and a server that crash-loops with
+// noisy output must not be able to write an unbounded value.
+func (s PublishJobStore) SaveNodeResult(ctx context.Context, job *PublishJob, result WarmupResult) error {
+	if result.ServiceID == "" {
+		return errors.New("cannot record a warm-up result without a service id")
+	}
+
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil
+	}
+
+	result.Logs = TruncateWarmupLogs(result.Logs)
+	result.Reason = truncateReason(result.Reason)
+
+	data, err := json.Marshal(result)
+
+	if err != nil {
+		return err
+	}
+
+	// The verdict has to outlive the job that is waiting for it, or a node that
+	// already succeeded reads back as pending and the publish fails at its
+	// deadline.
+	return client.Set(ctx, s.nodeKey(job.ID, result.ServiceID), data, s.ttl(job)).Err()
+}
+
+// NodeResults returns the verdicts reported so far, keyed by service id. A
+// service that has not reported is absent from the map — never assume silence
+// means success.
+func (s PublishJobStore) NodeResults(ctx context.Context, job *PublishJob) map[string]WarmupResult {
+	results := map[string]WarmupResult{}
+	client := rediscache.Client()
+
+	if client == nil {
+		return results
+	}
+
+	for _, serviceID := range job.Nodes {
+		data, err := client.Get(ctx, s.nodeKey(job.ID, serviceID)).Bytes()
+
+		// A node that cannot be read counts as pending, which fails the publish
+		// safely rather than committing one that was never verified. Log the
+		// real errors, or a Redis hiccup near the deadline would fail a healthy
+		// publish with nothing to explain it.
+		if err != nil {
+			if !errors.Is(err, redis.Nil) {
+				slog.Errorf("cannot read warm-up result for job %s node %s: %s", job.ID, serviceID, err.Error())
+			}
+
+			continue
+		}
+
+		result := WarmupResult{}
+
+		if err := json.Unmarshal(data, &result); err != nil {
+			slog.Errorf("cannot decode warm-up result for job %s node %s: %s", job.ID, serviceID, err.Error())
+			continue
+		}
+
+		results[serviceID] = result
+	}
+
+	return results
+}
+
+// Lock takes the finalization lock for a job. The returned token identifies
+// this holder and must be handed back to Unlock. A false second return means
+// another process holds the lock and the caller must do nothing: the holder is
+// about to decide the same job.
+func (s PublishJobStore) Lock(ctx context.Context, jobID string) (string, bool) {
+	token := uuid.New().String()
+	client := rediscache.Client()
+
+	if client == nil {
+		return token, true
+	}
+
+	ok, err := client.SetNX(ctx, s.lockKey(jobID), token, finalizeLockTTL).Result()
+
+	if err != nil || !ok {
+		return "", false
+	}
+
+	return token, true
+}
+
+// Unlock releases the finalization lock, but only if this caller still holds
+// it.
+//
+// Finalizing writes to the database, resets the hosting cache and dispatches
+// publish webhooks, so it can outrun the lock's expiry. Without the token check
+// a slow finalizer would delete the lock a second one had since taken, and the
+// same publish would be committed twice.
+func (s PublishJobStore) Unlock(ctx context.Context, jobID, token string) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return
+	}
+
+	if err := unlockScript.Run(ctx, client, []string{s.lockKey(jobID)}, token).Err(); err != nil && !errors.Is(err, redis.Nil) {
+		slog.Errorf("cannot release publish lock for job %s: %s", jobID, err.Error())
+	}
+}
+
+// JobIDs returns every job currently held in Redis, decided or not.
+func (s PublishJobStore) JobIDs(ctx context.Context) ([]string, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil, nil
+	}
+
+	keys, err := client.Keys(ctx, "publish:job:*")
+
+	if err != nil {
+		return nil, err
+	}
+
+	ids := []string{}
+
+	for _, key := range keys {
+		// Skip the per-node and lock keys, which share the prefix.
+		if len(key) > len("publish:job:") && !hasSubKeySuffix(key) {
+			ids = append(ids, key[len("publish:job:"):])
+		}
+	}
+
+	return ids, nil
+}
+
+// hasSubKeySuffix reports whether a key under the job prefix belongs to a node
+// result or a lock rather than to a job itself.
+func hasSubKeySuffix(key string) bool {
+	for i := len("publish:job:"); i < len(key); i++ {
+		if key[i] == ':' {
+			return true
+		}
+	}
+
+	return false
+}

--- a/src/ce/api/app/deploy/publish_warmup_test.go
+++ b/src/ce/api/app/deploy/publish_warmup_test.go
@@ -1,0 +1,281 @@
+package deploy_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type PublishWarmupSuite struct {
+	suite.Suite
+
+	ctx   context.Context
+	store deploy.PublishJobStore
+}
+
+func (s *PublishWarmupSuite) SetupSuite() {
+	s.ctx = context.Background()
+	s.store = deploy.NewPublishJobStore()
+}
+
+// newJob returns a job with a unique id so tests never collide in a shared Redis.
+func (s *PublishWarmupSuite) newJob() *deploy.PublishJob {
+	return &deploy.PublishJob{
+		ID:           uuid.New().String(),
+		AppID:        types.ID(1),
+		EnvID:        types.ID(time.Now().UnixNano()),
+		DeploymentID: types.ID(42),
+		Nodes:        []string{"node-a", "node-b"},
+		Status:       deploy.PublishStatusPublishing,
+		StartedAt:    time.Now().Unix(),
+		Deadline:     time.Now().Add(3 * time.Minute).Unix(),
+	}
+}
+
+func (s *PublishWarmupSuite) Test_SaveAndLoad() {
+	job := s.newJob()
+
+	s.NoError(s.store.Create(s.ctx, job))
+
+	loaded, err := s.store.Load(s.ctx, job.ID)
+	s.NoError(err)
+	s.Require().NotNil(loaded)
+	s.Equal(job.ID, loaded.ID)
+	s.Equal(deploy.PublishStatusPublishing, loaded.Status)
+	s.Equal([]string{"node-a", "node-b"}, loaded.Nodes)
+	s.Equal(types.ID(42), loaded.DeploymentID)
+}
+
+func (s *PublishWarmupSuite) Test_Load_UnknownJob() {
+	loaded, err := s.store.Load(s.ctx, uuid.New().String())
+
+	s.NoError(err)
+	s.Nil(loaded)
+}
+
+func (s *PublishWarmupSuite) Test_LoadByEnv_ReturnsLatestJob() {
+	first := s.newJob()
+	second := s.newJob()
+	second.EnvID = first.EnvID
+
+	s.NoError(s.store.Create(s.ctx, first))
+	s.NoError(s.store.Create(s.ctx, second))
+
+	loaded, err := s.store.LoadByEnv(s.ctx, first.EnvID)
+	s.NoError(err)
+	s.Require().NotNil(loaded)
+	s.Equal(second.ID, loaded.ID)
+}
+
+// Test_NodeResults_MissingNodeIsAbsent guards the core safety rule: a node that
+// has not reported must never be mistaken for a node that reported success.
+func (s *PublishWarmupSuite) Test_NodeResults_MissingNodeIsAbsent() {
+	job := s.newJob()
+	s.NoError(s.store.Create(s.ctx, job))
+
+	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
+		ServiceID:   "node-a",
+		ServiceName: rediscache.ServiceHosting,
+		Status:      rediscache.StatusOK,
+	}))
+
+	results := s.store.NodeResults(s.ctx, job)
+
+	s.Len(results, 1)
+	s.Equal(rediscache.StatusOK, results["node-a"].Status)
+
+	_, reported := results["node-b"]
+	s.False(reported)
+}
+
+func (s *PublishWarmupSuite) Test_NodeResults_CarriesFailureDetail() {
+	job := s.newJob()
+	s.NoError(s.store.Create(s.ctx, job))
+
+	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
+		ServiceID:    "node-a",
+		ServiceName:  rediscache.ServiceHosting,
+		Status:       rediscache.StatusErr,
+		DeploymentID: types.ID(42),
+		StatusCode:   502,
+		Reason:       "timed out after 180s",
+		Logs:         "Error: connect ECONNREFUSED",
+	}))
+
+	result := s.store.NodeResults(s.ctx, job)["node-a"]
+
+	s.Equal(rediscache.StatusErr, result.Status)
+	s.Equal(502, result.StatusCode)
+	s.Equal("timed out after 180s", result.Reason)
+	s.Contains(result.Logs, "ECONNREFUSED")
+}
+
+func (s *PublishWarmupSuite) Test_Lock_IsExclusiveUntilReleased() {
+	job := s.newJob()
+
+	token, ok := s.store.Lock(s.ctx, job.ID)
+	s.True(ok)
+	s.NotEmpty(token)
+
+	_, ok = s.store.Lock(s.ctx, job.ID)
+	s.False(ok)
+
+	s.store.Unlock(s.ctx, job.ID, token)
+
+	token, ok = s.store.Lock(s.ctx, job.ID)
+	s.True(ok)
+	s.store.Unlock(s.ctx, job.ID, token)
+}
+
+// Test_Unlock_OnlyReleasesOwnLock covers a finalizer that outran the lock's
+// expiry: it must not release the lock a second finalizer has since taken, or
+// the same publish would be committed twice.
+func (s *PublishWarmupSuite) Test_Unlock_OnlyReleasesOwnLock() {
+	job := s.newJob()
+
+	stale, ok := s.store.Lock(s.ctx, job.ID)
+	s.Require().True(ok)
+
+	// Simulate the first holder's lock expiring and a second one taking over.
+	s.store.Unlock(s.ctx, job.ID, stale)
+
+	current, ok := s.store.Lock(s.ctx, job.ID)
+	s.Require().True(ok)
+
+	defer s.store.Unlock(s.ctx, job.ID, current)
+
+	s.store.Unlock(s.ctx, job.ID, stale)
+
+	_, ok = s.store.Lock(s.ctx, job.ID)
+	s.False(ok, "the second holder's lock must survive the first holder's release")
+}
+
+// Test_Update_DoesNotStealTheEnvironmentPointer covers an older job recording
+// its outcome after a newer publish has already started.
+func (s *PublishWarmupSuite) Test_Update_DoesNotStealTheEnvironmentPointer() {
+	first := s.newJob()
+	second := s.newJob()
+	second.EnvID = first.EnvID
+
+	s.NoError(s.store.Create(s.ctx, first))
+	s.NoError(s.store.Create(s.ctx, second))
+
+	first.Status = deploy.PublishStatusFailed
+	s.NoError(s.store.Update(s.ctx, first))
+
+	loaded, err := s.store.LoadByEnv(s.ctx, first.EnvID)
+	s.NoError(err)
+	s.Require().NotNil(loaded)
+	s.Equal(second.ID, loaded.ID)
+}
+
+func (s *PublishWarmupSuite) Test_SaveNodeResult_RejectsAnUnidentifiedNode() {
+	job := s.newJob()
+	s.NoError(s.store.Create(s.ctx, job))
+
+	s.Error(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{Status: rediscache.StatusOK}))
+}
+
+// Test_SaveNodeResult_BoundsWhatANodeReports keeps a crash-looping server from
+// writing unbounded output into Redis on every publish.
+func (s *PublishWarmupSuite) Test_SaveNodeResult_BoundsWhatANodeReports() {
+	job := s.newJob()
+	s.NoError(s.store.Create(s.ctx, job))
+
+	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
+		ServiceID: "node-a",
+		Status:    rediscache.StatusErr,
+		Logs:      strings.Repeat("x", 40_000),
+		Reason:    strings.Repeat("y", 4_000),
+	}))
+
+	result := s.store.NodeResults(s.ctx, job)["node-a"]
+
+	s.Len(result.Logs, 8*1024)
+	s.Len(result.Reason, 1024)
+}
+
+// Test_NodeResults_OutliveTheJobDeadline guards a job whose warm-up window is
+// longer than an hour: a node that already succeeded must not read back as
+// pending and fail an otherwise healthy publish.
+func (s *PublishWarmupSuite) Test_NodeResults_OutliveTheJobDeadline() {
+	job := s.newJob()
+	job.Deadline = time.Now().Add(4 * time.Hour).Unix()
+
+	s.NoError(s.store.Create(s.ctx, job))
+	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
+		ServiceID: "node-a",
+		Status:    rediscache.StatusOK,
+	}))
+
+	ttl, err := rediscache.Client().TTL(s.ctx, "publish:job:"+job.ID+":node:node-a").Result()
+	s.NoError(err)
+	s.Greater(ttl, 4*time.Hour)
+}
+
+// Test_JobIDs_SkipsNodeAndLockKeys verifies the sweeper is not handed the
+// per-node and lock keys, which live under the same prefix.
+func (s *PublishWarmupSuite) Test_JobIDs_SkipsNodeAndLockKeys() {
+	job := s.newJob()
+
+	s.NoError(s.store.Create(s.ctx, job))
+	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{ServiceID: "node-a"}))
+	token, ok := s.store.Lock(s.ctx, job.ID)
+	s.True(ok)
+
+	defer s.store.Unlock(s.ctx, job.ID, token)
+
+	ids, err := s.store.JobIDs(s.ctx)
+	s.NoError(err)
+	s.Contains(ids, job.ID)
+
+	for _, id := range ids {
+		s.False(strings.Contains(id, ":"), "job id %q must not contain a sub-key separator", id)
+	}
+}
+
+func (s *PublishWarmupSuite) Test_IsTerminal() {
+	job := s.newJob()
+	s.False(job.IsTerminal())
+
+	job.Status = deploy.PublishStatusPublished
+	s.True(job.IsTerminal())
+
+	job.Status = deploy.PublishStatusFailed
+	s.True(job.IsTerminal())
+}
+
+// Test_Settings_PublishesTheDeploymentInFull verifies a job always resolves to
+// a single deployment at 100%: percentage-based releases are retired.
+func (s *PublishWarmupSuite) Test_Settings_PublishesTheDeploymentInFull() {
+	job := s.newJob()
+
+	settings := job.Settings()
+
+	s.Require().Len(settings, 1)
+	s.Equal(job.EnvID, settings[0].EnvID)
+	s.Equal(types.ID(42), settings[0].DeploymentID)
+	s.Equal(float64(100), settings[0].Percentage)
+}
+
+func (s *PublishWarmupSuite) Test_TruncateWarmupLogs_KeepsTail() {
+	short := "boot failed"
+	s.Equal(short, deploy.TruncateWarmupLogs(short))
+
+	long := strings.Repeat("a", 9000) + "TAIL"
+	truncated := deploy.TruncateWarmupLogs(long)
+
+	s.Len(truncated, 8*1024)
+	s.True(strings.HasSuffix(truncated, "TAIL"))
+}
+
+func TestPublishWarmupSuite(t *testing.T) {
+	suite.Run(t, new(PublishWarmupSuite))
+}

--- a/src/ce/api/app/deploy/publisher.go
+++ b/src/ce/api/app/deploy/publisher.go
@@ -85,6 +85,16 @@ func AutoPublishIfNecessary(ctx context.Context, d *Deployment) error {
 
 // Publish publishes a new deployment.
 func Publish(ctx context.Context, settings []*PublishSettings) error {
+	return publishNow(ctx, settings)
+}
+
+// publishNow points the environment at the given deployments and makes the
+// change visible: it writes the published rows, drops the hosting config cache
+// and fires the publish webhooks.
+//
+// It is the commit step of a publish and assumes any readiness check has
+// already passed.
+func publishNow(ctx context.Context, settings []*PublishSettings) error {
 	if err := NewStore().Publish(ctx, settings...); err != nil {
 		return err
 	}

--- a/src/lib/rediscache/service.go
+++ b/src/lib/rediscache/service.go
@@ -33,6 +33,7 @@ const (
 	EventInvalidateHostingCache = "cache_invalidate"
 	EventMiseUpdate             = "mise_update"
 	EventRuntimesInstall        = "runtimes_install"
+	EventPublishWarmup          = "publish_warmup"
 )
 
 const (
@@ -69,6 +70,7 @@ type MicroService struct {
 
 type MicroServiceInterface interface {
 	Key(string) string
+	ServiceID() string
 	Subscribe(string, Handler) error
 	SubscribeAsync(string, Handler) error
 	Broadcast(string, ...string) error
@@ -207,6 +209,12 @@ func Service() MicroServiceInterface {
 	}
 
 	return _service
+}
+
+// ServiceID returns the identifier this process registered itself under, so it
+// can write a key that only it is expected to fill in.
+func (s *MicroService) ServiceID() string {
+	return s.ID
 }
 
 // Key generates a unique key for the microservice based on its name and ID.

--- a/src/mocks/micro_service_interface.go
+++ b/src/mocks/micro_service_interface.go
@@ -133,6 +133,24 @@ func (_m *MicroServiceInterface) List(_a0 []string) ([]*rediscache.MicroService,
 	return r0, r1
 }
 
+// ServiceID provides a mock function with no fields
+func (_m *MicroServiceInterface) ServiceID() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ServiceID")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // SetAll provides a mock function with given fields: _a0, _a1, _a2
 func (_m *MicroServiceInterface) SetAll(_a0 string, _a1 string, _a2 []string) error {
 	ret := _m.Called(_a0, _a1, _a2)


### PR DESCRIPTION
First of five PRs for async publish: a publish should wait until the new deployment actually answers before traffic moves to it, instead of flipping the pointer and letting the next visitor absorb the cold start (today that is Stormkit's own 503 interstitial, seconds to minutes on a slow boot).

This PR is plumbing only. Nothing calls any of it, so behaviour is unchanged.

### What's here

- **`deploy/publish_warmup.go`** — the `PublishJob` record, the `WarmupRequest` broadcast to hosting nodes, the `WarmupResult` a node reports back, and the Redis-backed `PublishJobStore`.
- **`rediscache`** — `EventPublishWarmup`, and `ServiceID()` on `MicroServiceInterface` so a node can write the single result key it owns. Mock regenerated with mockery v2.53.5 (only the new method differs).
- **`publisher.go`** — today's `Publish` body extracted into `publishNow`, so the finalizer can later drive the flip without duplicating the cache reset and the publish webhooks. `Publish` still calls it.

### No percentages

A job publishes exactly one deployment in full — no target list, no percentage. Percentage-based releases are retired, so the only value `PublishSettings` still needs is the `publishedPercentage` constant.

Worth knowing for a follow-up: the retired feature is still load-bearing elsewhere. `POST /app/deployments/publish` validates that a caller's percentages sum to 100 and accepts an array, `deployments_published.percentage_released` is still a column, and `Host.ChooseVersion` still does a weighted random pick across configs. None of that is touched here.

### The one design point worth reviewing

`NodeResults` returns only the nodes that actually reported. This is deliberate and is the property the finalizer will rest on: `rediscache.Status` treats a missing value as success, and `GetAll` re-resolves the live service list on every call, so a node that joins late would read as ready. Instead a job snapshots its node set at creation and a missing key means *pending*, never ok.

### Testing

`PublishWarmupSuite` covers the store round-trip, `LoadByEnv`, the missing-node rule above, failure detail carried back to the user, lock exclusivity, that a job resolves to one deployment at 100%, and that `JobIDs` does not hand the sweeper the per-node and lock keys that share its prefix.

```
go test -p 1 ./src/ce/api/app/deploy/... ./src/lib/rediscache/... ./src/ce/api/admin/...
```
all green.

https://claude.ai/code/session_01CZVLZsDVpKVy7tfr4suAyr