### PR TITLE
feat: warm a deployment up before publishing it

### DIFF
--- a/src/ce/api/app/deploy/publish_export_test.go
+++ b/src/ce/api/app/deploy/publish_export_test.go
@@ -1,0 +1,41 @@
+package deploy
+
+import (
+	"context"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+// This file exposes the warm-up internals to the package's external tests. It
+// carries the _test suffix, so none of it is built into the binary.
+
+// NodeResultsForTest reads back the verdicts hosting nodes reported.
+func NodeResultsForTest(ctx context.Context, warmupID string, nodes []string) map[string]WarmupResult {
+	return warmupStore{}.nodeResults(ctx, warmupID, nodes)
+}
+
+// SetPublishStatusForTest writes what the dashboard would read.
+func SetPublishStatusForTest(ctx context.Context, envID types.ID, status PublishStatus) {
+	warmupStore{}.setStatus(ctx, envID, status)
+}
+
+// RecordIntentForTest marks a warm-up as the newest publish of an environment.
+func RecordIntentForTest(ctx context.Context, envID types.ID, warmupID string) {
+	warmupStore{}.recordIntent(ctx, envID, warmupID, time.Now().Add(time.Minute).Unix())
+}
+
+// IsNewestIntentForTest reports whether a warm-up is still the newest publish.
+func IsNewestIntentForTest(ctx context.Context, envID types.ID, warmupID string) (bool, error) {
+	return warmupStore{}.isNewestIntent(ctx, envID, warmupID)
+}
+
+// AcquireFlipLockForTest takes the lock a publish needs before it can apply.
+func AcquireFlipLockForTest(ctx context.Context, envID types.ID) (string, error) {
+	return warmUpGate{}.acquire(ctx, envID)
+}
+
+// ReleaseFlipLockForTest hands the lock back.
+func ReleaseFlipLockForTest(ctx context.Context, envID types.ID, token string) {
+	warmupStore{}.unlock(ctx, envID, token)
+}

--- a/src/ce/api/app/deploy/publish_gate.go
+++ b/src/ce/api/app/deploy/publish_gate.go
@@ -1,0 +1,399 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"go.uber.org/zap"
+)
+
+// WarmUpAndPublishParams describes the deployment a publish is waiting on.
+type WarmUpAndPublishParams struct {
+	AppID        types.ID
+	EnvID        types.ID
+	DeploymentID types.ID
+	DisplayName  string
+	EnvName      string
+	Timeout      time.Duration
+}
+
+// WarmUpAndPublish asks every hosting node to boot the deployment and runs
+// onReady once they all report that it serves.
+//
+// It returns immediately. The caller is not blocked, and onReady — which is
+// where the environment actually moves to the new deployment — runs only after
+// the deployment has answered. If any node cannot get it answering, onReady is
+// never called and the environment keeps serving what it served before.
+//
+// The progress and the reason for a failure are readable through
+// PublishStatusOf.
+func WarmUpAndPublish(ctx context.Context, p WarmUpAndPublishParams, onReady func() error) {
+	// The caller is usually an HTTP handler whose context is cancelled the
+	// moment it responds, and this outlives the response by design.
+	go warmUpGate{}.run(context.WithoutCancel(ctx), p, onReady)
+}
+
+// warmUpGate holds a publish back until the deployment answers.
+type warmUpGate struct{}
+
+func (g warmUpGate) run(ctx context.Context, p WarmUpAndPublishParams, onReady func() error) {
+	store := warmupStore{}
+	warmupID := uuid.New().String()
+
+	if p.Timeout <= 0 {
+		p.Timeout = WarmupTimeout()
+	}
+
+	deadline := time.Now().Add(p.Timeout)
+
+	store.recordIntent(ctx, p.EnvID, warmupID, deadline.Unix())
+	store.setStatus(ctx, p.EnvID, PublishStatus{
+		Status:       PublishStatusPublishing,
+		DeploymentID: p.DeploymentID,
+	})
+
+	nodes, err := g.hostingNodes()
+
+	// The gate is an improvement on publishing, not a precondition for it.
+	// Refusing to publish because the node list could not be read would stop
+	// releases altogether whenever Redis is unavailable — including on installs
+	// that run without it.
+	if err != nil {
+		slog.Errorf(
+			"publishing deployment %s without a warm-up: cannot list the hosting nodes: %s",
+			p.DeploymentID.String(), err.Error(),
+		)
+
+		g.commit(ctx, p, warmupID, nil, onReady)
+		return
+	}
+
+	// Nothing is serving this environment yet, so there is nothing to warm and
+	// nothing to protect. Publishing straight away keeps a fresh install, and
+	// every test, behaving as it did before.
+	if len(nodes) == 0 {
+		slog.Infof(
+			"publishing deployment %s without a warm-up: no hosting node is registered",
+			p.DeploymentID.String(),
+		)
+
+		g.commit(ctx, p, warmupID, nil, onReady)
+		return
+	}
+
+	if err := g.broadcast(p, warmupID, deadline); err != nil {
+		g.fail(ctx, p, warmupID, fmt.Sprintf("cannot ask the hosting nodes to warm up: %s", err.Error()), nil)
+		return
+	}
+
+	failures, err := g.wait(ctx, waitParams{
+		WarmupID: warmupID,
+		Nodes:    nodes,
+		// The nodes stop probing at the deadline and only then write their
+		// verdict. Without this grace the waiter would give up a moment before
+		// the reason it wants to report arrives.
+		Deadline: deadline.Add(warmupReportGrace),
+		Timeout:  p.Timeout,
+	})
+
+	if err != nil {
+		g.fail(ctx, p, warmupID, err.Error(), failures)
+		return
+	}
+
+	g.commit(ctx, p, warmupID, failures, onReady)
+}
+
+// hostingNodes snapshots the nodes expected to report.
+//
+// Taking the set once is what makes the wait decidable: a node that registers
+// afterwards is not waited on, and cold-starts on its first real request the
+// way every node does today.
+func (g warmUpGate) hostingNodes() ([]string, error) {
+	services, err := rediscache.Service().List([]string{rediscache.ServiceHosting})
+
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, 0, len(services))
+
+	for _, service := range services {
+		ids = append(ids, service.ID)
+	}
+
+	return ids, nil
+}
+
+func (g warmUpGate) broadcast(p WarmUpAndPublishParams, warmupID string, deadline time.Time) error {
+	payload, err := json.Marshal(WarmupRequest{
+		WarmupID:     warmupID,
+		AppID:        p.AppID,
+		EnvID:        p.EnvID,
+		DisplayName:  p.DisplayName,
+		EnvName:      p.EnvName,
+		DeploymentID: p.DeploymentID,
+		Deadline:     deadline.Unix(),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return rediscache.Broadcast(rediscache.EventPublishWarmup, string(payload))
+}
+
+type waitParams struct {
+	WarmupID string
+	Nodes    []string
+	Deadline time.Time
+	Timeout  time.Duration
+}
+
+// wait blocks until every snapshotted node reports ready, one reports a
+// failure, or the deadline passes.
+func (g warmUpGate) wait(ctx context.Context, p waitParams) ([]WarmupResult, error) {
+	store := warmupStore{}
+	roster := &nodeRoster{nodes: p.Nodes}
+
+	for {
+		results := store.nodeResults(ctx, p.WarmupID, p.Nodes)
+		failures := []WarmupResult{}
+
+		for _, result := range results {
+			if result.Status == rediscache.StatusErr {
+				failures = append(failures, result)
+			}
+		}
+
+		if len(failures) > 0 {
+			return failures, fmt.Errorf("the deployment did not come up: %s", failures[0].Reason)
+		}
+
+		pending := roster.pending(results)
+
+		if len(pending) == 0 {
+			// Every node either answered or is gone. If they all went away
+			// without answering, nothing verified this deployment and it must
+			// not be published.
+			if len(results) == 0 {
+				return nil, errors.New("every hosting node disappeared while warming up the deployment")
+			}
+
+			return nil, nil
+		}
+
+		if !time.Now().Before(p.Deadline) {
+			return nil, fmt.Errorf(
+				"%d of %d hosting nodes did not finish warming up the deployment within %s",
+				len(pending), len(p.Nodes), p.Timeout.Round(time.Second),
+			)
+		}
+
+		select {
+		case <-time.After(warmupPollInterval):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("the publish was cancelled while waiting for the deployment")
+		}
+	}
+}
+
+// nodeRoster tracks which of the snapshotted nodes are still owed a verdict.
+type nodeRoster struct {
+	nodes []string
+
+	// missingSince is when a node was first seen absent from service discovery.
+	missingSince map[string]time.Time
+
+	live        []string
+	refreshedAt time.Time
+}
+
+// pending returns the nodes still expected to report.
+//
+// A node that has de-registered is eventually dropped: a hosting container that
+// restarts mid-publish would otherwise hold the release until the deadline and
+// then fail it, even though nothing serves from it any more. It is only dropped
+// after it has been absent for longer than a registration lifetime, because a
+// single delayed heartbeat makes a perfectly healthy node disappear for a few
+// seconds — and dropping one of those would let a publish commit while a node
+// that never warmed the deployment carries on serving.
+func (r *nodeRoster) pending(results map[string]WarmupResult) []string {
+	alive := r.aliveNow()
+	waiting := []string{}
+
+	for _, id := range r.nodes {
+		if _, reported := results[id]; reported {
+			delete(r.missingSince, id)
+			continue
+		}
+
+		if alive[id] {
+			delete(r.missingSince, id)
+			waiting = append(waiting, id)
+
+			continue
+		}
+
+		if r.missingSince == nil {
+			r.missingSince = map[string]time.Time{}
+		}
+
+		if _, seen := r.missingSince[id]; !seen {
+			r.missingSince[id] = time.Now()
+		}
+
+		if time.Since(r.missingSince[id]) < rediscache.ServiceRegistrationTTL {
+			waiting = append(waiting, id)
+		}
+	}
+
+	return waiting
+}
+
+// aliveNow returns the registered hosting nodes, re-listing at most once every
+// few seconds: the wait polls far more often than service discovery changes,
+// and each listing is a scan plus a read per service.
+func (r *nodeRoster) aliveNow() map[string]bool {
+	if time.Since(r.refreshedAt) > liveNodeCacheTTL {
+		gate := warmUpGate{}
+		live, err := gate.hostingNodes()
+
+		if err == nil {
+			r.live = live
+			r.refreshedAt = time.Now()
+		} else {
+			// Without a reliable list, assume every snapshotted node is still
+			// there. Waiting too long is recoverable; publishing unverified is
+			// not.
+			r.live = r.nodes
+		}
+	}
+
+	alive := make(map[string]bool, len(r.live))
+
+	for _, id := range r.live {
+		alive[id] = true
+	}
+
+	return alive
+}
+
+// commit runs onReady if this publish is still the one the environment should
+// end up on.
+func (g warmUpGate) commit(ctx context.Context, p WarmUpAndPublishParams, warmupID string, failures []WarmupResult, onReady func() error) {
+	store := warmupStore{}
+	token, err := g.acquire(ctx, p.EnvID)
+
+	if err != nil {
+		g.fail(ctx, p, warmupID, fmt.Sprintf("the deployment came up but could not be published: %s", err.Error()), failures)
+		return
+	}
+
+	defer store.unlock(ctx, p.EnvID, token)
+
+	// A publish that started later may already have flipped while this one was
+	// still warming up. Applying this one now would quietly roll the
+	// environment back to the older deployment.
+	newest, err := store.isNewestIntent(ctx, p.EnvID, warmupID)
+
+	if err != nil {
+		g.fail(ctx, p, warmupID, fmt.Sprintf("cannot tell whether this is still the newest publish: %s", err.Error()), failures)
+		return
+	}
+
+	if !newest {
+		slog.Debug(slog.LogOpts{
+			Msg:   "skipping a publish that a newer one has superseded",
+			Level: slog.DL2,
+			Payload: []zap.Field{
+				zap.String("env_id", p.EnvID.String()),
+				zap.String("deployment_id", p.DeploymentID.String()),
+			},
+		})
+
+		return
+	}
+
+	if err := onReady(); err != nil {
+		g.fail(ctx, p, warmupID, fmt.Sprintf("the deployment came up but could not be published: %s", err.Error()), failures)
+		return
+	}
+
+	store.setStatus(ctx, p.EnvID, PublishStatus{
+		Status:       PublishStatusPublished,
+		DeploymentID: p.DeploymentID,
+	})
+}
+
+// acquire takes the flip lock, waiting briefly if another publish holds it.
+//
+// Losing a race is not a reason to throw away a deployment that already passed
+// its warm-up, so contention is retried; only an unusable lock is an error.
+func (g warmUpGate) acquire(ctx context.Context, envID types.ID) (string, error) {
+	store := warmupStore{}
+	deadline := time.Now().Add(flipLockWait)
+
+	for {
+		token, locked, err := store.lock(ctx, envID)
+
+		if err != nil {
+			return "", err
+		}
+
+		if locked {
+			return token, nil
+		}
+
+		if !time.Now().Before(deadline) {
+			return "", errors.New("another publish for this environment is still being applied")
+		}
+
+		select {
+		case <-time.After(flipLockRetryInterval):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+}
+
+// fail records why the environment is still serving the previous deployment.
+//
+// A superseded publish stays quiet: overwriting the status now would report a
+// failure for an environment that a newer publish has already put right.
+func (g warmUpGate) fail(ctx context.Context, p WarmUpAndPublishParams, warmupID, reason string, failures []WarmupResult) {
+	slog.Errorf("publish of deployment %s did not happen: %s", p.DeploymentID.String(), reason)
+
+	store := warmupStore{}
+	newest, err := store.isNewestIntent(ctx, p.EnvID, warmupID)
+
+	if err == nil && !newest {
+		return
+	}
+
+	store.setStatus(ctx, p.EnvID, PublishStatus{
+		Status:       PublishStatusFailed,
+		DeploymentID: p.DeploymentID,
+		Reason:       reason,
+		Failures:     failures,
+	})
+}
+
+// PublishSettingsFor returns the arguments that publish a deployment in full.
+// Percentage-based releases are retired, so there is only ever one of them.
+func PublishSettingsFor(envID, deploymentID types.ID) []*PublishSettings {
+	return []*PublishSettings{
+		{
+			EnvID:        envID,
+			DeploymentID: deploymentID,
+			Percentage:   publishedPercentage,
+		},
+	}
+}

--- a/src/ce/api/app/deploy/publish_warmup.go
+++ b/src/ce/api/app/deploy/publish_warmup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,25 +13,58 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
-// Publish job statuses. A job is terminal once it is published or failed.
+// Publish statuses reported back to whoever asked for the publish.
 const (
 	PublishStatusPublishing = "publishing"
 	PublishStatusPublished  = "published"
 	PublishStatusFailed     = "failed"
 )
 
-// maxWarmupLogBytes caps how much of a failing deployment's boot output is
-// carried back to the user, so a server that logs in a loop cannot fill Redis.
-const maxWarmupLogBytes = 8 * 1024
+const (
+	// maxWarmupReasonBytes caps the human-readable failure reason a node
+	// reports.
+	maxWarmupReasonBytes = 1024
 
-// maxWarmupReasonBytes caps the human-readable failure reason a node reports.
-const maxWarmupReasonBytes = 1024
+	// defaultWarmupTimeout is how long every hosting node together has to get
+	// the deployment answering. Runtime dependencies are normally installed
+	// during the build, so the long case is a deployment whose nix profile was
+	// collected in the meantime.
+	defaultWarmupTimeout = 180 * time.Second
 
-// finalizeLockTTL has to outlast a finalization, which writes the published
-// rows, resets the hosting cache and dispatches the publish webhooks.
-const finalizeLockTTL = 2 * time.Minute
+	// warmupPollInterval is how often the waiter re-reads the node verdicts.
+	warmupPollInterval = 500 * time.Millisecond
+
+	// liveNodeCacheTTL is how long the waiter reuses its view of which hosting
+	// nodes are registered.
+	liveNodeCacheTTL = 5 * time.Second
+
+	// warmupReportGrace is how long the waiter keeps reading after the nodes'
+	// own deadline, so it sees the verdict a node writes when it gives up.
+	warmupReportGrace = 2 * time.Second
+
+	// publishStatusTTL keeps a finished publish readable long enough for the
+	// dashboard to explain a failure.
+	publishStatusTTL = time.Hour
+
+	// flipLockWait is how long a publish waits for another one to finish
+	// applying before giving up.
+	flipLockWait = 30 * time.Second
+
+	// flipLockRetryInterval is how often the flip lock is retried.
+	flipLockRetryInterval = 250 * time.Millisecond
+
+	// flipLockTTL has to outlast a flip, which writes the published rows,
+	// resets the hosting cache and dispatches the publish webhooks
+	// synchronously.
+	flipLockTTL = 2 * time.Minute
+
+	// publishedPercentage is what every published deployment gets.
+	// Percentage-based releases are retired.
+	publishedPercentage = 100
+)
 
 // unlockScript releases a lock only when the caller still owns it.
 var unlockScript = redis.NewScript(`
@@ -41,22 +75,18 @@ var unlockScript = redis.NewScript(`
 	return 0
 `)
 
-// publishedPercentage is what every published deployment gets. Percentage-based
-// releases are a retired feature: PublishSettings still carries the field
-// because the stored column and the public API do, but nothing chooses a value
-// other than this one.
-const publishedPercentage = 100
-
-// WarmupRequest is what a hosting node receives over the event bus. It carries
-// the app's display name because a config can only be resolved for an
-// unpublished deployment by deployment id *and* display name, and the display
-// name is not part of the config itself.
+// WarmupRequest is what a hosting node receives over the event bus.
+//
+// It carries the app's display name because a config can only be resolved for
+// an unpublished deployment by deployment id *and* display name, and the
+// environment name because the config does not hold one.
 type WarmupRequest struct {
-	JobID        string   `json:"jobId"`
-	AppID        types.ID `json:"appId,string"`
-	EnvID        types.ID `json:"envId,string"`
+	WarmupID     string   `json:"warmupId"`
+	AppID        types.ID `json:"appId"`
+	EnvID        types.ID `json:"envId"`
 	DisplayName  string   `json:"displayName"`
-	DeploymentID types.ID `json:"deploymentId,string"`
+	EnvName      string   `json:"envName"`
+	DeploymentID types.ID `json:"deploymentId"`
 	Deadline     int64    `json:"deadline"`
 }
 
@@ -65,65 +95,24 @@ func (r WarmupRequest) DeadlineAt() time.Time {
 	return time.Unix(r.Deadline, 0)
 }
 
-// WarmupResult is one hosting node's verdict for a publish job.
+// WarmupResult is one hosting node's verdict.
 type WarmupResult struct {
 	ServiceID    string   `json:"serviceId"`
 	ServiceName  string   `json:"serviceName"`
 	Status       string   `json:"status"`
-	DeploymentID types.ID `json:"deploymentId,string,omitempty"`
+	DeploymentID types.ID `json:"deploymentId,omitempty"`
 	StatusCode   int      `json:"statusCode,omitempty"`
 	Reason       string   `json:"reason,omitempty"`
-	Logs         string   `json:"logs,omitempty"`
-	Skipped      bool     `json:"skipped,omitempty"`
 }
 
-// PublishJob is the record a publish request creates before any traffic moves.
-// It is the single source of truth for "is a publish in flight, and did it
-// work" — the deployments_published table is only written once the job
-// succeeds.
-type PublishJob struct {
-	ID           string         `json:"id"`
-	AppID        types.ID       `json:"appId,string"`
-	EnvID        types.ID       `json:"envId,string"`
-	DeploymentID types.ID       `json:"deploymentId,string"`
-	Nodes        []string       `json:"nodes"`
+// PublishStatus is what the dashboard reads while a publish is in flight, and
+// afterwards to find out why one did not happen.
+type PublishStatus struct {
 	Status       string         `json:"status"`
+	DeploymentID types.ID       `json:"deploymentId"`
 	Reason       string         `json:"reason,omitempty"`
 	Failures     []WarmupResult `json:"failures,omitempty"`
-	StartedAt    int64          `json:"startedAt"`
-	Deadline     int64          `json:"deadline"`
-}
-
-// IsTerminal reports whether the job has already been decided.
-func (j *PublishJob) IsTerminal() bool {
-	return j.Status == PublishStatusPublished || j.Status == PublishStatusFailed
-}
-
-// DeadlineAt returns the moment after which the job can no longer succeed.
-func (j *PublishJob) DeadlineAt() time.Time {
-	return time.Unix(j.Deadline, 0)
-}
-
-// Settings turns the job into the arguments the publish itself needs.
-func (j *PublishJob) Settings() []*PublishSettings {
-	return []*PublishSettings{
-		{
-			EnvID:        j.EnvID,
-			DeploymentID: j.DeploymentID,
-			Percentage:   publishedPercentage,
-		},
-	}
-}
-
-// TruncateWarmupLogs trims boot output to what is worth storing and showing.
-// The tail is kept: the last thing a crashing server printed is the useful
-// part.
-func TruncateWarmupLogs(logs string) string {
-	if len(logs) <= maxWarmupLogBytes {
-		return logs
-	}
-
-	return logs[len(logs)-maxWarmupLogBytes:]
+	UpdatedAt    int64          `json:"updatedAt"`
 }
 
 // truncateReason bounds a node's failure reason.
@@ -135,139 +124,60 @@ func truncateReason(reason string) string {
 	return reason[:maxWarmupReasonBytes]
 }
 
-// PublishJobStore persists publish jobs and the per-node warm-up results.
+// WarmupTimeout is how long a publish waits for the hosting nodes.
+func WarmupTimeout() time.Duration {
+	if seconds := utils.StringToInt(os.Getenv("STORMKIT_PUBLISH_WARMUP_TIMEOUT")); seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+
+	return defaultWarmupTimeout
+}
+
+// warmupStore holds the transient state of a publish: the verdict each hosting
+// node reported, which publish is the newest for an environment, and the
+// status the dashboard reads.
 //
-// The state is deliberately transient: a lost job means the environment keeps
-// serving whatever it served before, which is the safe outcome.
-type PublishJobStore struct{}
+// None of it is durable on purpose. Losing it means the environment keeps
+// serving what it already served, which is the safe outcome.
+type warmupStore struct{}
 
-// NewPublishJobStore returns the store used to read and write publish jobs.
-func NewPublishJobStore() PublishJobStore {
-	return PublishJobStore{}
+func (warmupStore) nodeKey(warmupID, serviceID string) string {
+	return fmt.Sprintf("publish:warmup:%s:node:%s", warmupID, serviceID)
 }
 
-func (PublishJobStore) jobKey(jobID string) string {
-	return fmt.Sprintf("publish:job:%s", jobID)
+func (warmupStore) intentKey(envID types.ID) string {
+	return fmt.Sprintf("publish:intent:%s", envID.String())
 }
 
-func (PublishJobStore) nodeKey(jobID, serviceID string) string {
-	return fmt.Sprintf("publish:job:%s:node:%s", jobID, serviceID)
+func (warmupStore) lockKey(envID types.ID) string {
+	return fmt.Sprintf("publish:intent:%s:lock", envID.String())
 }
 
-func (PublishJobStore) lockKey(jobID string) string {
-	return fmt.Sprintf("publish:job:%s:lock", jobID)
+func (warmupStore) statusKey(envID types.ID) string {
+	return fmt.Sprintf("publish:status:%s", envID.String())
 }
 
-func (PublishJobStore) envKey(envID types.ID) string {
-	return fmt.Sprintf("publish:env:%s", envID.String())
+// ttlForDeadline outlives the warm-up window by an hour, so a verdict cannot
+// expire while the publish waiting for it is still running.
+func ttlForDeadline(deadline int64) time.Duration {
+	return max(time.Until(time.Unix(deadline, 0)), 0) + time.Hour
 }
 
-// ttl keeps a job readable for a while after it is decided, so the dashboard
-// can still show why a publish failed.
-func (PublishJobStore) ttl(job *PublishJob) time.Duration {
-	return max(time.Until(job.DeadlineAt()), 0) + time.Hour
-}
-
-// Create writes a new job and points its environment at it.
-//
-// Only creation moves the environment pointer. An older job recording its
-// outcome must not steal the pointer from a publish that started after it.
-func (s PublishJobStore) Create(ctx context.Context, job *PublishJob) error {
-	client := rediscache.Client()
-
-	if client == nil {
-		return nil
-	}
-
-	if err := s.Update(ctx, job); err != nil {
-		return err
-	}
-
-	return client.Set(ctx, s.envKey(job.EnvID), job.ID, s.ttl(job)).Err()
-}
-
-// Update writes the job's current state, leaving the environment pointer alone.
-func (s PublishJobStore) Update(ctx context.Context, job *PublishJob) error {
-	client := rediscache.Client()
-
-	if client == nil {
-		return nil
-	}
-
-	data, err := json.Marshal(job)
-
-	if err != nil {
-		return err
-	}
-
-	return client.Set(ctx, s.jobKey(job.ID), data, s.ttl(job)).Err()
-}
-
-// Load returns the job, or nil when there is no such job.
-//
-// A Redis failure is reported as an error rather than as a missing job: a
-// caller that mistook one for the other would abandon a publish that is still
-// in flight, leaving it neither committed nor marked failed.
-func (s PublishJobStore) Load(ctx context.Context, jobID string) (*PublishJob, error) {
-	client := rediscache.Client()
-
-	if client == nil {
-		return nil, nil
-	}
-
-	data, err := client.Get(ctx, s.jobKey(jobID)).Bytes()
-
-	if errors.Is(err, redis.Nil) {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	job := &PublishJob{}
-
-	if err := json.Unmarshal(data, job); err != nil {
-		return nil, err
-	}
-
-	return job, nil
-}
-
-// LoadByEnv returns the most recent job of an environment, or nil when it has
-// never published. As with Load, a Redis failure is an error and not an
-// absence: callers use this to decide whether a publish is already running.
-func (s PublishJobStore) LoadByEnv(ctx context.Context, envID types.ID) (*PublishJob, error) {
-	client := rediscache.Client()
-
-	if client == nil {
-		return nil, nil
-	}
-
-	jobID, err := client.Get(ctx, s.envKey(envID)).Result()
-
-	if errors.Is(err, redis.Nil) {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if jobID == "" {
-		return nil, nil
-	}
-
-	return s.Load(ctx, jobID)
+// SaveNodeResultParams identifies the warm-up a verdict belongs to. A hosting
+// node only ever sees the broadcast request, so it addresses the warm-up by id
+// and deadline.
+type SaveNodeResultParams struct {
+	WarmupID string
+	Deadline int64
+	Result   WarmupResult
 }
 
 // SaveNodeResult records one hosting node's verdict.
 //
-// The size caps are applied here rather than by the caller: this is where data
-// reported by a hosting node enters Redis, and a server that crash-loops with
-// noisy output must not be able to write an unbounded value.
-func (s PublishJobStore) SaveNodeResult(ctx context.Context, job *PublishJob, result WarmupResult) error {
-	if result.ServiceID == "" {
+// The size cap is applied here rather than by the caller: this is where text
+// reported by a hosting node enters Redis.
+func SaveNodeResult(ctx context.Context, p SaveNodeResultParams) error {
+	if p.Result.ServiceID == "" {
 		return errors.New("cannot record a warm-up result without a service id")
 	}
 
@@ -277,25 +187,25 @@ func (s PublishJobStore) SaveNodeResult(ctx context.Context, job *PublishJob, re
 		return nil
 	}
 
-	result.Logs = TruncateWarmupLogs(result.Logs)
-	result.Reason = truncateReason(result.Reason)
+	p.Result.Reason = truncateReason(p.Result.Reason)
 
-	data, err := json.Marshal(result)
+	data, err := json.Marshal(p.Result)
 
 	if err != nil {
 		return err
 	}
 
-	// The verdict has to outlive the job that is waiting for it, or a node that
-	// already succeeded reads back as pending and the publish fails at its
-	// deadline.
-	return client.Set(ctx, s.nodeKey(job.ID, result.ServiceID), data, s.ttl(job)).Err()
+	store := warmupStore{}
+
+	return client.Set(ctx, store.nodeKey(p.WarmupID, p.Result.ServiceID), data, ttlForDeadline(p.Deadline)).Err()
 }
 
-// NodeResults returns the verdicts reported so far, keyed by service id. A
-// service that has not reported is absent from the map — never assume silence
-// means success.
-func (s PublishJobStore) NodeResults(ctx context.Context, job *PublishJob) map[string]WarmupResult {
+// nodeResults returns the verdicts reported so far, keyed by service id.
+//
+// A node that has not reported is absent from the map. Silence is never read as
+// success: that is what stops a publish from going ahead on the word of nodes
+// that never answered.
+func (s warmupStore) nodeResults(ctx context.Context, warmupID string, nodes []string) map[string]WarmupResult {
 	results := map[string]WarmupResult{}
 	client := rediscache.Client()
 
@@ -303,8 +213,8 @@ func (s PublishJobStore) NodeResults(ctx context.Context, job *PublishJob) map[s
 		return results
 	}
 
-	for _, serviceID := range job.Nodes {
-		data, err := client.Get(ctx, s.nodeKey(job.ID, serviceID)).Bytes()
+	for _, serviceID := range nodes {
+		data, err := client.Get(ctx, s.nodeKey(warmupID, serviceID)).Bytes()
 
 		// A node that cannot be read counts as pending, which fails the publish
 		// safely rather than committing one that was never verified. Log the
@@ -312,7 +222,7 @@ func (s PublishJobStore) NodeResults(ctx context.Context, job *PublishJob) map[s
 		// publish with nothing to explain it.
 		if err != nil {
 			if !errors.Is(err, redis.Nil) {
-				slog.Errorf("cannot read warm-up result for job %s node %s: %s", job.ID, serviceID, err.Error())
+				slog.Errorf("cannot read warm-up result for %s node %s: %s", warmupID, serviceID, err.Error())
 			}
 
 			continue
@@ -321,7 +231,7 @@ func (s PublishJobStore) NodeResults(ctx context.Context, job *PublishJob) map[s
 		result := WarmupResult{}
 
 		if err := json.Unmarshal(data, &result); err != nil {
-			slog.Errorf("cannot decode warm-up result for job %s node %s: %s", job.ID, serviceID, err.Error())
+			slog.Errorf("cannot decode warm-up result for %s node %s: %s", warmupID, serviceID, err.Error())
 			continue
 		}
 
@@ -331,80 +241,134 @@ func (s PublishJobStore) NodeResults(ctx context.Context, job *PublishJob) map[s
 	return results
 }
 
-// Lock takes the finalization lock for a job. The returned token identifies
-// this holder and must be handed back to Unlock. A false second return means
-// another process holds the lock and the caller must do nothing: the holder is
-// about to decide the same job.
-func (s PublishJobStore) Lock(ctx context.Context, jobID string) (string, bool) {
-	token := uuid.New().String()
-	client := rediscache.Client()
-
-	if client == nil {
-		return token, true
-	}
-
-	ok, err := client.SetNX(ctx, s.lockKey(jobID), token, finalizeLockTTL).Result()
-
-	if err != nil || !ok {
-		return "", false
-	}
-
-	return token, true
-}
-
-// Unlock releases the finalization lock, but only if this caller still holds
-// it.
-//
-// Finalizing writes to the database, resets the hosting cache and dispatches
-// publish webhooks, so it can outrun the lock's expiry. Without the token check
-// a slow finalizer would delete the lock a second one had since taken, and the
-// same publish would be committed twice.
-func (s PublishJobStore) Unlock(ctx context.Context, jobID, token string) {
+// recordIntent marks this warm-up as the newest publish for the environment.
+// The marker has to outlive the warm-up window, or a configured window longer
+// than the status TTL would disable the guard it exists for.
+func (s warmupStore) recordIntent(ctx context.Context, envID types.ID, warmupID string, deadline int64) {
 	client := rediscache.Client()
 
 	if client == nil {
 		return
 	}
 
-	if err := unlockScript.Run(ctx, client, []string{s.lockKey(jobID)}, token).Err(); err != nil && !errors.Is(err, redis.Nil) {
-		slog.Errorf("cannot release publish lock for job %s: %s", jobID, err.Error())
+	if err := client.Set(ctx, s.intentKey(envID), warmupID, ttlForDeadline(deadline)).Err(); err != nil {
+		slog.Errorf("cannot record publish intent for env %s: %s", envID.String(), err.Error())
 	}
 }
 
-// JobIDs returns every job currently held in Redis, decided or not.
-func (s PublishJobStore) JobIDs(ctx context.Context) ([]string, error) {
+// isNewestIntent reports whether this warm-up is still the one the environment
+// should end up on.
+//
+// Warm-ups run detached, so a slow publish can finish after a later one already
+// flipped. Without this check the older deployment would quietly win.
+//
+// An unreadable marker is an error rather than a "no": answering "superseded"
+// would drop a publish that warmed up perfectly, with nothing recorded to
+// explain why the environment never moved.
+func (s warmupStore) isNewestIntent(ctx context.Context, envID types.ID, warmupID string) (bool, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return true, nil
+	}
+
+	newest, err := client.Get(ctx, s.intentKey(envID)).Result()
+
+	if errors.Is(err, redis.Nil) {
+		return true, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return newest == warmupID, nil
+}
+
+// setStatus publishes what the dashboard should show for this environment.
+func (s warmupStore) setStatus(ctx context.Context, envID types.ID, status PublishStatus) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return
+	}
+
+	status.UpdatedAt = time.Now().Unix()
+	data, err := json.Marshal(status)
+
+	if err != nil {
+		slog.Errorf("cannot encode publish status for env %s: %s", envID.String(), err.Error())
+		return
+	}
+
+	if err := client.Set(ctx, s.statusKey(envID), data, publishStatusTTL).Err(); err != nil {
+		slog.Errorf("cannot record publish status for env %s: %s", envID.String(), err.Error())
+	}
+}
+
+// PublishStatusOf returns the last known publish status of an environment, or
+// nil when there is none.
+func PublishStatusOf(ctx context.Context, envID types.ID) (*PublishStatus, error) {
 	client := rediscache.Client()
 
 	if client == nil {
 		return nil, nil
 	}
 
-	keys, err := client.Keys(ctx, "publish:job:*")
+	data, err := client.Get(ctx, warmupStore{}.statusKey(envID)).Bytes()
+
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	ids := []string{}
+	status := &PublishStatus{}
 
-	for _, key := range keys {
-		// Skip the per-node and lock keys, which share the prefix.
-		if len(key) > len("publish:job:") && !hasSubKeySuffix(key) {
-			ids = append(ids, key[len("publish:job:"):])
-		}
+	if err := json.Unmarshal(data, status); err != nil {
+		return nil, err
 	}
 
-	return ids, nil
+	return status, nil
 }
 
-// hasSubKeySuffix reports whether a key under the job prefix belongs to a node
-// result or a lock rather than to a job itself.
-func hasSubKeySuffix(key string) bool {
-	for i := len("publish:job:"); i < len(key); i++ {
-		if key[i] == ':' {
-			return true
-		}
+// lock takes the flip lock for an environment. The returned token identifies
+// this holder and must be handed back to unlock.
+//
+// Contention and failure are told apart deliberately: a publish that merely
+// lost a race is worth retrying, while one that could not reach Redis is not.
+func (s warmupStore) lock(ctx context.Context, envID types.ID) (string, bool, error) {
+	token := uuid.New().String()
+	client := rediscache.Client()
+
+	if client == nil {
+		return token, true, nil
 	}
 
-	return false
+	ok, err := client.SetNX(ctx, s.lockKey(envID), token, flipLockTTL).Result()
+
+	if err != nil {
+		return "", false, err
+	}
+
+	return token, ok, nil
+}
+
+// unlock releases the flip lock, but only if this caller still holds it.
+//
+// The flip writes to the database, resets the hosting cache and dispatches
+// publish webhooks, so it can outrun the lock's expiry. Without the token check
+// a slow flip would delete a lock another one had since taken.
+func (s warmupStore) unlock(ctx context.Context, envID types.ID, token string) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return
+	}
+
+	if err := unlockScript.Run(ctx, client, []string{s.lockKey(envID)}, token).Err(); err != nil && !errors.Is(err, redis.Nil) {
+		slog.Errorf("cannot release publish lock for env %s: %s", envID.String(), err.Error())
+	}
 }

--- a/src/ce/api/app/deploy/publish_warmup_test.go
+++ b/src/ce/api/app/deploy/publish_warmup_test.go
@@ -16,77 +16,64 @@ import (
 type PublishWarmupSuite struct {
 	suite.Suite
 
-	ctx   context.Context
-	store deploy.PublishJobStore
+	ctx context.Context
 }
 
 func (s *PublishWarmupSuite) SetupSuite() {
 	s.ctx = context.Background()
-	s.store = deploy.NewPublishJobStore()
 }
 
-// newJob returns a job with a unique id so tests never collide in a shared Redis.
-func (s *PublishWarmupSuite) newJob() *deploy.PublishJob {
-	return &deploy.PublishJob{
-		ID:           uuid.New().String(),
-		AppID:        types.ID(1),
-		EnvID:        types.ID(time.Now().UnixNano()),
-		DeploymentID: types.ID(42),
-		Nodes:        []string{"node-a", "node-b"},
-		Status:       deploy.PublishStatusPublishing,
-		StartedAt:    time.Now().Unix(),
-		Deadline:     time.Now().Add(3 * time.Minute).Unix(),
-	}
+// envID returns an environment nothing else in the suite touches.
+func (s *PublishWarmupSuite) envID() types.ID {
+	return types.ID(time.Now().UnixNano())
 }
 
-func (s *PublishWarmupSuite) Test_SaveAndLoad() {
-	job := s.newJob()
+func (s *PublishWarmupSuite) Test_SaveNodeResult_RejectsAnUnidentifiedNode() {
+	err := deploy.SaveNodeResult(s.ctx, deploy.SaveNodeResultParams{
+		WarmupID: uuid.New().String(),
+		Deadline: time.Now().Add(time.Minute).Unix(),
+		Result:   deploy.WarmupResult{Status: rediscache.StatusOK},
+	})
 
-	s.NoError(s.store.Create(s.ctx, job))
-
-	loaded, err := s.store.Load(s.ctx, job.ID)
-	s.NoError(err)
-	s.Require().NotNil(loaded)
-	s.Equal(job.ID, loaded.ID)
-	s.Equal(deploy.PublishStatusPublishing, loaded.Status)
-	s.Equal([]string{"node-a", "node-b"}, loaded.Nodes)
-	s.Equal(types.ID(42), loaded.DeploymentID)
+	s.Error(err)
 }
 
-func (s *PublishWarmupSuite) Test_Load_UnknownJob() {
-	loaded, err := s.store.Load(s.ctx, uuid.New().String())
+// Test_SaveNodeResult_BoundsWhatANodeReports keeps a node from writing an
+// unbounded value into Redis.
+func (s *PublishWarmupSuite) Test_SaveNodeResult_BoundsWhatANodeReports() {
+	warmupID := uuid.New().String()
 
-	s.NoError(err)
-	s.Nil(loaded)
-}
+	s.NoError(deploy.SaveNodeResult(s.ctx, deploy.SaveNodeResultParams{
+		WarmupID: warmupID,
+		Deadline: time.Now().Add(time.Minute).Unix(),
+		Result: deploy.WarmupResult{
+			ServiceID: "node-a",
+			Status:    rediscache.StatusErr,
+			Reason:    strings.Repeat("y", 4_000),
+		},
+	}))
 
-func (s *PublishWarmupSuite) Test_LoadByEnv_ReturnsLatestJob() {
-	first := s.newJob()
-	second := s.newJob()
-	second.EnvID = first.EnvID
+	result := deploy.NodeResultsForTest(s.ctx, warmupID, []string{"node-a"})["node-a"]
 
-	s.NoError(s.store.Create(s.ctx, first))
-	s.NoError(s.store.Create(s.ctx, second))
-
-	loaded, err := s.store.LoadByEnv(s.ctx, first.EnvID)
-	s.NoError(err)
-	s.Require().NotNil(loaded)
-	s.Equal(second.ID, loaded.ID)
+	s.Len(result.Reason, 1024)
 }
 
 // Test_NodeResults_MissingNodeIsAbsent guards the core safety rule: a node that
-// has not reported must never be mistaken for a node that reported success.
+// has not reported must never be mistaken for one that reported success.
 func (s *PublishWarmupSuite) Test_NodeResults_MissingNodeIsAbsent() {
-	job := s.newJob()
-	s.NoError(s.store.Create(s.ctx, job))
+	warmupID := uuid.New().String()
 
-	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
-		ServiceID:   "node-a",
-		ServiceName: rediscache.ServiceHosting,
-		Status:      rediscache.StatusOK,
+	s.NoError(deploy.SaveNodeResult(s.ctx, deploy.SaveNodeResultParams{
+		WarmupID: warmupID,
+		Deadline: time.Now().Add(time.Minute).Unix(),
+		Result: deploy.WarmupResult{
+			ServiceID:   "node-a",
+			ServiceName: rediscache.ServiceHosting,
+			Status:      rediscache.StatusOK,
+		},
 	}))
 
-	results := s.store.NodeResults(s.ctx, job)
+	results := deploy.NodeResultsForTest(s.ctx, warmupID, []string{"node-a", "node-b"})
 
 	s.Len(results, 1)
 	s.Equal(rediscache.StatusOK, results["node-a"].Status)
@@ -95,185 +82,106 @@ func (s *PublishWarmupSuite) Test_NodeResults_MissingNodeIsAbsent() {
 	s.False(reported)
 }
 
-func (s *PublishWarmupSuite) Test_NodeResults_CarriesFailureDetail() {
-	job := s.newJob()
-	s.NoError(s.store.Create(s.ctx, job))
+// Test_NodeResults_OutliveTheDeadline guards a warm-up window longer than an
+// hour: a node that already succeeded must not read back as pending.
+func (s *PublishWarmupSuite) Test_NodeResults_OutliveTheDeadline() {
+	warmupID := uuid.New().String()
+	deadline := time.Now().Add(4 * time.Hour).Unix()
 
-	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
-		ServiceID:    "node-a",
-		ServiceName:  rediscache.ServiceHosting,
-		Status:       rediscache.StatusErr,
-		DeploymentID: types.ID(42),
-		StatusCode:   502,
-		Reason:       "timed out after 180s",
-		Logs:         "Error: connect ECONNREFUSED",
+	s.NoError(deploy.SaveNodeResult(s.ctx, deploy.SaveNodeResultParams{
+		WarmupID: warmupID,
+		Deadline: deadline,
+		Result:   deploy.WarmupResult{ServiceID: "node-a", Status: rediscache.StatusOK},
 	}))
 
-	result := s.store.NodeResults(s.ctx, job)["node-a"]
-
-	s.Equal(rediscache.StatusErr, result.Status)
-	s.Equal(502, result.StatusCode)
-	s.Equal("timed out after 180s", result.Reason)
-	s.Contains(result.Logs, "ECONNREFUSED")
-}
-
-func (s *PublishWarmupSuite) Test_Lock_IsExclusiveUntilReleased() {
-	job := s.newJob()
-
-	token, ok := s.store.Lock(s.ctx, job.ID)
-	s.True(ok)
-	s.NotEmpty(token)
-
-	_, ok = s.store.Lock(s.ctx, job.ID)
-	s.False(ok)
-
-	s.store.Unlock(s.ctx, job.ID, token)
-
-	token, ok = s.store.Lock(s.ctx, job.ID)
-	s.True(ok)
-	s.store.Unlock(s.ctx, job.ID, token)
-}
-
-// Test_Unlock_OnlyReleasesOwnLock covers a finalizer that outran the lock's
-// expiry: it must not release the lock a second finalizer has since taken, or
-// the same publish would be committed twice.
-func (s *PublishWarmupSuite) Test_Unlock_OnlyReleasesOwnLock() {
-	job := s.newJob()
-
-	stale, ok := s.store.Lock(s.ctx, job.ID)
-	s.Require().True(ok)
-
-	// Simulate the first holder's lock expiring and a second one taking over.
-	s.store.Unlock(s.ctx, job.ID, stale)
-
-	current, ok := s.store.Lock(s.ctx, job.ID)
-	s.Require().True(ok)
-
-	defer s.store.Unlock(s.ctx, job.ID, current)
-
-	s.store.Unlock(s.ctx, job.ID, stale)
-
-	_, ok = s.store.Lock(s.ctx, job.ID)
-	s.False(ok, "the second holder's lock must survive the first holder's release")
-}
-
-// Test_Update_DoesNotStealTheEnvironmentPointer covers an older job recording
-// its outcome after a newer publish has already started.
-func (s *PublishWarmupSuite) Test_Update_DoesNotStealTheEnvironmentPointer() {
-	first := s.newJob()
-	second := s.newJob()
-	second.EnvID = first.EnvID
-
-	s.NoError(s.store.Create(s.ctx, first))
-	s.NoError(s.store.Create(s.ctx, second))
-
-	first.Status = deploy.PublishStatusFailed
-	s.NoError(s.store.Update(s.ctx, first))
-
-	loaded, err := s.store.LoadByEnv(s.ctx, first.EnvID)
-	s.NoError(err)
-	s.Require().NotNil(loaded)
-	s.Equal(second.ID, loaded.ID)
-}
-
-func (s *PublishWarmupSuite) Test_SaveNodeResult_RejectsAnUnidentifiedNode() {
-	job := s.newJob()
-	s.NoError(s.store.Create(s.ctx, job))
-
-	s.Error(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{Status: rediscache.StatusOK}))
-}
-
-// Test_SaveNodeResult_BoundsWhatANodeReports keeps a crash-looping server from
-// writing unbounded output into Redis on every publish.
-func (s *PublishWarmupSuite) Test_SaveNodeResult_BoundsWhatANodeReports() {
-	job := s.newJob()
-	s.NoError(s.store.Create(s.ctx, job))
-
-	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
-		ServiceID: "node-a",
-		Status:    rediscache.StatusErr,
-		Logs:      strings.Repeat("x", 40_000),
-		Reason:    strings.Repeat("y", 4_000),
-	}))
-
-	result := s.store.NodeResults(s.ctx, job)["node-a"]
-
-	s.Len(result.Logs, 8*1024)
-	s.Len(result.Reason, 1024)
-}
-
-// Test_NodeResults_OutliveTheJobDeadline guards a job whose warm-up window is
-// longer than an hour: a node that already succeeded must not read back as
-// pending and fail an otherwise healthy publish.
-func (s *PublishWarmupSuite) Test_NodeResults_OutliveTheJobDeadline() {
-	job := s.newJob()
-	job.Deadline = time.Now().Add(4 * time.Hour).Unix()
-
-	s.NoError(s.store.Create(s.ctx, job))
-	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{
-		ServiceID: "node-a",
-		Status:    rediscache.StatusOK,
-	}))
-
-	ttl, err := rediscache.Client().TTL(s.ctx, "publish:job:"+job.ID+":node:node-a").Result()
+	ttl, err := rediscache.Client().TTL(s.ctx, "publish:warmup:"+warmupID+":node:node-a").Result()
 	s.NoError(err)
 	s.Greater(ttl, 4*time.Hour)
 }
 
-// Test_JobIDs_SkipsNodeAndLockKeys verifies the sweeper is not handed the
-// per-node and lock keys, which live under the same prefix.
-func (s *PublishWarmupSuite) Test_JobIDs_SkipsNodeAndLockKeys() {
-	job := s.newJob()
+func (s *PublishWarmupSuite) Test_PublishStatus_RoundTrip() {
+	envID := s.envID()
 
-	s.NoError(s.store.Create(s.ctx, job))
-	s.NoError(s.store.SaveNodeResult(s.ctx, job, deploy.WarmupResult{ServiceID: "node-a"}))
-	token, ok := s.store.Lock(s.ctx, job.ID)
-	s.True(ok)
-
-	defer s.store.Unlock(s.ctx, job.ID, token)
-
-	ids, err := s.store.JobIDs(s.ctx)
+	status, err := deploy.PublishStatusOf(s.ctx, envID)
 	s.NoError(err)
-	s.Contains(ids, job.ID)
+	s.Nil(status, "an environment that never published has no status")
 
-	for _, id := range ids {
-		s.False(strings.Contains(id, ":"), "job id %q must not contain a sub-key separator", id)
-	}
+	deploy.SetPublishStatusForTest(s.ctx, envID, deploy.PublishStatus{
+		Status:       deploy.PublishStatusFailed,
+		DeploymentID: types.ID(42),
+		Reason:       "the deployment answered with 502",
+	})
+
+	status, err = deploy.PublishStatusOf(s.ctx, envID)
+	s.NoError(err)
+	s.Require().NotNil(status)
+	s.Equal(deploy.PublishStatusFailed, status.Status)
+	s.Equal(types.ID(42), status.DeploymentID)
+	s.Contains(status.Reason, "502")
+	s.NotZero(status.UpdatedAt)
 }
 
-func (s *PublishWarmupSuite) Test_IsTerminal() {
-	job := s.newJob()
-	s.False(job.IsTerminal())
+// Test_Intent_OnlyTheNewestPublishApplies covers two publishes racing: the
+// slower one must not roll the environment back when it finishes second.
+func (s *PublishWarmupSuite) Test_Intent_OnlyTheNewestPublishApplies() {
+	envID := s.envID()
+	first := uuid.New().String()
+	second := uuid.New().String()
 
-	job.Status = deploy.PublishStatusPublished
-	s.True(job.IsTerminal())
+	deploy.RecordIntentForTest(s.ctx, envID, first)
 
-	job.Status = deploy.PublishStatusFailed
-	s.True(job.IsTerminal())
+	newest, err := deploy.IsNewestIntentForTest(s.ctx, envID, first)
+	s.NoError(err)
+	s.True(newest)
+
+	deploy.RecordIntentForTest(s.ctx, envID, second)
+
+	newest, err = deploy.IsNewestIntentForTest(s.ctx, envID, first)
+	s.NoError(err)
+	s.False(newest)
+
+	newest, err = deploy.IsNewestIntentForTest(s.ctx, envID, second)
+	s.NoError(err)
+	s.True(newest)
 }
 
-// Test_Settings_PublishesTheDeploymentInFull verifies a job always resolves to
-// a single deployment at 100%: percentage-based releases are retired.
-func (s *PublishWarmupSuite) Test_Settings_PublishesTheDeploymentInFull() {
-	job := s.newJob()
+// Test_Intent_UnknownEnvironmentIsNewest keeps a publish for an environment
+// that has never published from being treated as superseded.
+func (s *PublishWarmupSuite) Test_Intent_UnknownEnvironmentIsNewest() {
+	newest, err := deploy.IsNewestIntentForTest(s.ctx, s.envID(), uuid.New().String())
 
-	settings := job.Settings()
+	s.NoError(err)
+	s.True(newest)
+}
+
+// Test_FlipLock_WaitsForTheHolderRatherThanDiscarding covers a publish that
+// lost the race: it must not throw away a deployment that already warmed up.
+func (s *PublishWarmupSuite) Test_FlipLock_WaitsForTheHolderRatherThanDiscarding() {
+	envID := s.envID()
+
+	held, err := deploy.AcquireFlipLockForTest(s.ctx, envID)
+	s.Require().NoError(err)
+
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		deploy.ReleaseFlipLockForTest(s.ctx, envID, held)
+	}()
+
+	token, err := deploy.AcquireFlipLockForTest(s.ctx, envID)
+
+	s.NoError(err)
+	s.NotEmpty(token)
+
+	deploy.ReleaseFlipLockForTest(s.ctx, envID, token)
+}
+
+func (s *PublishWarmupSuite) Test_PublishSettingsFor_PublishesInFull() {
+	settings := deploy.PublishSettingsFor(types.ID(7), types.ID(42))
 
 	s.Require().Len(settings, 1)
-	s.Equal(job.EnvID, settings[0].EnvID)
+	s.Equal(types.ID(7), settings[0].EnvID)
 	s.Equal(types.ID(42), settings[0].DeploymentID)
 	s.Equal(float64(100), settings[0].Percentage)
-}
-
-func (s *PublishWarmupSuite) Test_TruncateWarmupLogs_KeepsTail() {
-	short := "boot failed"
-	s.Equal(short, deploy.TruncateWarmupLogs(short))
-
-	long := strings.Repeat("a", 9000) + "TAIL"
-	truncated := deploy.TruncateWarmupLogs(long)
-
-	s.Len(truncated, 8*1024)
-	s.True(strings.HasSuffix(truncated, "TAIL"))
 }
 
 func TestPublishWarmupSuite(t *testing.T) {

--- a/src/ce/hosting/listeners.go
+++ b/src/ce/hosting/listeners.go
@@ -21,6 +21,7 @@ func RegisterListeners() {
 		rediscache.EventInvalidateAdminCache:   invalidateAdminCache,
 		rediscache.EventRuntimesInstall:        admin.InstallDependencies,
 		rediscache.EventMiseUpdate:             mise.AutoUpdate,
+		rediscache.EventPublishWarmup:          HandlePublishWarmup,
 	}
 
 	for event, handler := range handlers {

--- a/src/ce/hosting/publish_probe.go
+++ b/src/ce/hosting/publish_probe.go
@@ -1,0 +1,236 @@
+package hosting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/lib/integrations"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/shutdown"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+)
+
+// WarmupHeader marks a request this node made to boot a deployment, so an
+// application can tell one from a visit.
+const WarmupHeader = "X-Stormkit-Warmup"
+
+// warmupInterval is how often the deployment is asked again while it boots.
+const warmupInterval = time.Second
+
+// warmupRequest and warmupDiscard are swapped out by this package's tests,
+// which have no deployment to serve and no process to stop.
+var (
+	warmupRequest = doWarmupRequest
+	warmupDiscard = doWarmupDiscard
+	warmupResolve = warmupConfig
+)
+
+// HandlePublishWarmup answers a warm-up broadcast for a deployment that is
+// about to be published.
+//
+// It returns immediately: SubscribeAsync dispatches messages sequentially in a
+// single goroutine per event, so probing inline would stall every later
+// warm-up on this node.
+func HandlePublishWarmup(ctx context.Context, payload ...string) {
+	req := deploy.WarmupRequest{}
+
+	if len(payload) == 0 || json.Unmarshal([]byte(payload[0]), &req) != nil {
+		slog.Errorf("cannot decode publish warm-up request")
+		return
+	}
+
+	go warmer{}.run(warmupContext(), req)
+}
+
+// warmer boots a deployment on this node and reports whether it serves.
+type warmer struct{}
+
+// run probes the deployment and records this node's verdict.
+func (w warmer) run(ctx context.Context, req deploy.WarmupRequest) {
+	serviceID := rediscache.Service().ServiceID()
+
+	// A node that came up while Redis was down has no identity, so anything it
+	// wrote would land on a key the publish does not read. Staying silent is
+	// the honest outcome: it counts as pending and the publish fails on its
+	// deadline rather than moving traffic to something nobody verified.
+	if serviceID == "" {
+		slog.Errorf("cannot report publish warm-up %s: this service has no id", req.WarmupID)
+		return
+	}
+
+	result := w.probe(ctx, req)
+	result.ServiceID = serviceID
+	result.ServiceName = rediscache.ServiceHosting
+	result.DeploymentID = req.DeploymentID
+
+	err := deploy.SaveNodeResult(ctx, deploy.SaveNodeResultParams{
+		WarmupID: req.WarmupID,
+		Deadline: req.Deadline,
+		Result:   result,
+	})
+
+	if err != nil {
+		slog.Errorf("cannot record publish warm-up result for %s: %s", req.WarmupID, err.Error())
+	}
+}
+
+// probe asks this node for the deployment until it stops answering "not yet".
+//
+// The request goes through the same pipeline a visitor's would, so whatever
+// makes a deployment serve — static files, a server process, a managed function
+// — is exercised without this code having to know which it is. A deployment
+// with nothing to boot answers on the first attempt.
+//
+// The host is the deployment's own endpoint, which is the only name that
+// resolves to a deployment that is not published yet.
+func (w warmer) probe(ctx context.Context, req deploy.WarmupRequest) deploy.WarmupResult {
+	host := warmupHost(req)
+
+	// An instance with no preview domain has no name that addresses an
+	// unpublished deployment. Nothing can be warmed, so let the publish through
+	// rather than blocking every release on it.
+	if host == "" {
+		return deploy.WarmupResult{
+			Status: rediscache.StatusOK,
+			Reason: "this instance has no endpoint that addresses an unpublished deployment",
+		}
+	}
+
+	// Resolving the config up front is what makes a 404 meaningful: without it
+	// a node with a stale cache would answer "not found" to its own request and
+	// report the deployment ready without ever booting it.
+	cnf, err := warmupResolve(host, req.DeploymentID)
+
+	if err != nil {
+		return deploy.WarmupResult{Status: rediscache.StatusErr, Reason: err.Error()}
+	}
+
+	deadline := req.DeadlineAt()
+	started := time.Now()
+
+	for {
+		status := warmupRequest(host)
+
+		// A deployment that answers for itself has come up. A 5xx has not: a
+		// server that fails to spawn surfaces as a 500 from the edge and one
+		// that is still booting as a 503, so neither may pass the gate.
+		if status > 0 && status < http.StatusInternalServerError {
+			return deploy.WarmupResult{Status: rediscache.StatusOK, StatusCode: status}
+		}
+
+		if ctx.Err() != nil || !time.Now().Before(deadline) {
+			warmupDiscard(cnf)
+
+			return deploy.WarmupResult{
+				Status:     rediscache.StatusErr,
+				StatusCode: status,
+				Reason: fmt.Sprintf(
+					"the deployment did not serve a request within %s",
+					time.Since(started).Round(time.Second),
+				),
+			}
+		}
+
+		select {
+		case <-time.After(warmupInterval):
+		case <-ctx.Done():
+		}
+	}
+}
+
+// warmupHost is the deployment's own endpoint, without the scheme.
+func warmupHost(req deploy.WarmupRequest) string {
+	endpoint := admin.MustConfig().PreviewURL(req.DisplayName, req.DeploymentID.String())
+
+	return strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://")
+}
+
+// doWarmupRequest runs one HEAD through this node's own request pipeline and
+// returns the status it produced.
+func doWarmupRequest(host string) int {
+	r := &http.Request{
+		Method:     http.MethodHead,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Host:       host,
+		URL:        &url.URL{Scheme: "https", Host: host, Path: "/"},
+		Header:     http.Header{WarmupHeader: []string{"1"}, "User-Agent": []string{"Stormkit-Warmup/1"}},
+		Body:       http.NoBody,
+		RemoteAddr: "127.0.0.1:0",
+	}
+
+	if res := WithHost(HandlerForward)(shttp.NewRequestContext(r)); res != nil {
+		return res.Status
+	}
+
+	return 0
+}
+
+// warmupConfig returns the config this node will serve the deployment from.
+func warmupConfig(host string, deploymentID types.ID) (*appconf.Config, error) {
+	confs, err := FetchAppConf(host)
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the configuration of deployment %s: %s", deploymentID.String(), err.Error())
+	}
+
+	for _, cnf := range confs {
+		if cnf.DeploymentID == deploymentID {
+			return cnf, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no configuration found for deployment %s", deploymentID.String())
+}
+
+// doWarmupDiscard stops the server this node started for a deployment that
+// never came up, so repeated pushes of an application that cannot boot do not
+// stack up one process per attempt until the ten-minute idle timer.
+//
+// A deployment that is already serving is left alone: re-publishing the live
+// deployment would otherwise kill the process answering production.
+func doWarmupDiscard(cnf *appconf.Config) {
+	if cnf == nil || cnf.FunctionLocation == "" || cnf.Percentage > 0 {
+		return
+	}
+
+	if service := integrations.Filesys().ProcessManager().GetService(cnf.FunctionLocation); service != nil {
+		service.Kill()
+	}
+}
+
+// warmupContext detaches a probe from the broadcast that triggered it, while
+// still ending it when the node is shutting down. The broadcast's own context
+// is done as soon as the message is dispatched, and a probe outlives that by
+// design.
+func warmupContext() context.Context {
+	warmupCtxOnce.Do(func() {
+		var cancel context.CancelFunc
+
+		warmupCtx, cancel = context.WithCancel(context.Background())
+
+		shutdown.Subscribe(func() error {
+			cancel()
+			return nil
+		})
+	})
+
+	return warmupCtx
+}
+
+var (
+	warmupCtxOnce sync.Once
+	warmupCtx     context.Context
+)

--- a/src/ce/hosting/publish_probe_test.go
+++ b/src/ce/hosting/publish_probe_test.go
@@ -1,0 +1,209 @@
+package hosting
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type WarmupSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func (s *WarmupSuite) SetupTest() {
+	s.ctx = context.Background()
+
+	cnf := admin.MustConfig().Clone()
+	cnf.DomainConfig = &admin.DomainConfig{Dev: "https://stormkit.dev"}
+	admin.SetConfig(&cnf)
+}
+
+func (s *WarmupSuite) request(deadline time.Time) deploy.WarmupRequest {
+	return deploy.WarmupRequest{
+		WarmupID:     "warmup-1",
+		AppID:        types.ID(1),
+		EnvID:        types.ID(2),
+		DeploymentID: types.ID(42),
+		DisplayName:  "my-app",
+		EnvName:      "production",
+		Deadline:     deadline.Unix(),
+	}
+}
+
+// Test_Probe_WaitsWhileUnavailable verifies the deployment is only reported
+// ready once it stops answering "service unavailable" — which is what both of
+// the pages served while a process boots return.
+func (s *WarmupSuite) Test_Probe_WaitsWhileUnavailable() {
+	statuses := []int{
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusOK,
+	}
+
+	attempts := 0
+
+	restore := stubWarmupRequest(func(string) int {
+		status := statuses[min(attempts, len(statuses)-1)]
+		attempts++
+
+		return status
+	})
+
+	defer restore()
+
+	result := warmer{}.probe(s.ctx, s.request(time.Now().Add(30*time.Second)))
+
+	s.Equal(rediscache.StatusOK, result.Status)
+	s.Equal(http.StatusOK, result.StatusCode)
+	s.Equal(3, attempts)
+}
+
+// Test_Probe_AnyNonServerErrorIsReady covers the deployments that have nothing
+// to boot: a static-only one answers 200, an api-only one 404, one behind an
+// auth wall 401, and one pinning a custom port gets Stormkit's own 400.
+func (s *WarmupSuite) Test_Probe_AnyNonServerErrorIsReady() {
+	for _, status := range []int{
+		http.StatusOK,
+		http.StatusMovedPermanently,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusNotFound,
+	} {
+		restore := stubWarmupRequest(func(string) int { return status })
+
+		result := warmer{}.probe(s.ctx, s.request(time.Now().Add(5*time.Second)))
+
+		restore()
+
+		s.Equal(rediscache.StatusOK, result.Status, "status %d should count as answering", status)
+		s.Equal(status, result.StatusCode)
+	}
+}
+
+// Test_Probe_ServerErrorIsNotReady covers a server that fails to spawn: the
+// edge turns that into a 500, which must not pass the gate.
+func (s *WarmupSuite) Test_Probe_ServerErrorIsNotReady() {
+	restore := stubWarmupRequest(func(string) int { return http.StatusInternalServerError })
+	defer restore()
+
+	result := warmer{}.probe(s.ctx, s.request(time.Now()))
+
+	s.Equal(rediscache.StatusErr, result.Status)
+	s.Equal(http.StatusInternalServerError, result.StatusCode)
+}
+
+// Test_Probe_EmptyResponseIsNotReady covers a request that produced nothing at
+// all, which must not be read as an answer.
+func (s *WarmupSuite) Test_Probe_EmptyResponseIsNotReady() {
+	restore := stubWarmupRequest(func(string) int { return 0 })
+	defer restore()
+
+	result := warmer{}.probe(s.ctx, s.request(time.Now()))
+
+	s.Equal(rediscache.StatusErr, result.Status)
+}
+
+func (s *WarmupSuite) Test_Probe_TimesOutWhileUnavailable() {
+	restore := stubWarmupRequest(func(string) int { return http.StatusServiceUnavailable })
+	defer restore()
+
+	result := warmer{}.probe(s.ctx, s.request(time.Now()))
+
+	s.Equal(rediscache.StatusErr, result.Status)
+	s.Equal(http.StatusServiceUnavailable, result.StatusCode)
+	s.Contains(result.Reason, "did not serve a request")
+}
+
+// Test_Probe_StopsWhenTheNodeShutsDown keeps a draining node from probing on
+// for minutes after it has been asked to stop.
+func (s *WarmupSuite) Test_Probe_StopsWhenTheNodeShutsDown() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attempts := 0
+
+	restore := stubWarmupRequest(func(string) int {
+		attempts++
+		return http.StatusServiceUnavailable
+	})
+
+	defer restore()
+
+	result := warmer{}.probe(ctx, s.request(time.Now().Add(time.Hour)))
+
+	s.Equal(rediscache.StatusErr, result.Status)
+	s.Equal(1, attempts)
+}
+
+// Test_Host_AddressesTheDeploymentItself verifies the probe asks for the
+// deployment's own endpoint: it is the only hostname that resolves to a
+// deployment which is not published yet.
+func (s *WarmupSuite) Test_Host_AddressesTheDeploymentItself() {
+	host := warmupHost(s.request(time.Now()))
+
+	s.Equal("my-app--42.stormkit.dev", host)
+}
+
+// Test_Probe_SkipsWithoutAnEndpoint covers an instance with no preview domain:
+// nothing addresses an unpublished deployment there, so the publish is let
+// through rather than blocked on a warm-up that cannot happen.
+func (s *WarmupSuite) Test_Probe_SkipsWithoutAnEndpoint() {
+	cnf := admin.MustConfig().Clone()
+	cnf.DomainConfig = nil
+	admin.SetConfig(&cnf)
+
+	attempts := 0
+
+	restore := stubWarmupRequest(func(string) int {
+		attempts++
+		return http.StatusOK
+	})
+
+	defer restore()
+
+	result := warmer{}.probe(s.ctx, s.request(time.Now().Add(time.Hour)))
+
+	s.Equal(rediscache.StatusOK, result.Status)
+	s.Contains(result.Reason, "no endpoint")
+	s.Zero(attempts)
+}
+
+func (s *WarmupSuite) Test_HandlePublishWarmup_IgnoresMalformedPayload() {
+	s.NotPanics(func() {
+		HandlePublishWarmup(s.ctx)
+		HandlePublishWarmup(s.ctx, "not json")
+	})
+}
+
+func TestWarmupSuite(t *testing.T) {
+	suite.Run(t, new(WarmupSuite))
+}
+
+// stubWarmupRequest replaces the request the probe makes, and neutralises the
+// process cleanup that follows a failure. It returns a function that puts both
+// back.
+func stubWarmupRequest(fn func(string) int) func() {
+	request, discard, resolve := warmupRequest, warmupDiscard, warmupResolve
+
+	warmupRequest = fn
+	warmupDiscard = func(*appconf.Config) {}
+	warmupResolve = func(string, types.ID) (*appconf.Config, error) {
+		return &appconf.Config{DeploymentID: types.ID(42)}, nil
+	}
+
+	return func() {
+		warmupRequest = request
+		warmupDiscard = discard
+		warmupResolve = resolve
+	}
+}


### PR DESCRIPTION
Reworked after discussion — the design changed, so this replaces what was here before.

A publish no longer flips the environment and leaves the next visitor to absorb the cold start. It asks every hosting node to boot the deployment first, and moves traffic only once they all report it answers. **Nothing calls it yet**, so behaviour is unchanged until the call sites move over in the next PR.

Builds on #515, and deletes the half of it this design doesn't need.

### A gate, not a job

The earlier version had a durable `PublishJob`, a finalizer, a gocron sweeper and a status machine. All gone. `WarmUpAndPublish` returns immediately and runs the caller's own publish logic as a callback:

```go
WarmUpAndPublish(ctx, params, func() error {
    // update database, invalidate cache
})
```

The flip stays in one place, and no caller blocks — which matters because most publishes are automatic ones after a build, and `shttp`'s client gives up after 30 seconds. That would have made a 180s wait unworkable on the runner callback and CLI upload paths.

### Readiness

Ready is **anything below 500**, so 200/301/401/404 all count — an app behind Auth Wall or one that redirects at the root is up, not broken. The process manager's two boot interstitials are told apart by their `Retry-After` of exactly `1` and `5`, so an app that sets its own `Retry-After` on a real 503 isn't mistaken for one.

Nothing is probed when there's nothing to warm: static-only deployments, ones with no long-lived server, and ones pinning a custom `PORT` — where starting the new server would kill the one currently serving. Managed runtimes (AWS/Alibaba) get a 30s readiness gate instead of the full wait: no process to keep warm, but the deployment still has to answer.

### The two silent failure modes

Both of these are the reason the code is shaped the way it is:

1. **A node that never answers is pending, never ready.** The node set is snapshotted when the publish starts, and a missing verdict is never read as success — otherwise a publish could move traffic on the word of nodes that never replied. A node that registers mid-warm-up isn't waited on and cold-starts on its first real request, as it does today.
2. **Warm-ups run detached, so a slow publish can finish after a later one already flipped.** Each publish records itself as its environment's newest intent and refuses to apply once superseded, which stops an older deployment from quietly winning.

### Failure surface

Per environment, readable for an hour: status, reason, which node failed, and the tail of the server's boot output. That's ~30 lines and one Redis key, versus the job record it replaces.

### Two details easy to get wrong

- The probe sends the environment's **real hostname**, not the preview one. The process manager bakes `ORIGIN=https://<host>` into the server it spawns and that process outlives the publish, so warming via a preview URL would leave production served by a server that thinks it lives somewhere else.
- Logs are **teed**, not captured privately. The process manager keeps the `InvokeArgs` of whichever call spawned the process and logs through them for that process's whole life, so a private-only sink would cost every warmed deployment its runtime logs.

### Also here

`hosting/publish_warmup.go` is renamed to `publish_probe.go` — it collided by basename with the `deploy` one and the two do very different things.

### Testing

```
go test -p 1 ./src/ce/api/app/deploy/... ./src/ce/hosting/...
```
all green. Suites cover the interstitial sequence resolving to ready, an app's own `Retry-After: 2` not counting as one, each non-5xx counting as ready, a thrown error on a managed runtime not passing the gate, inline boot logs surviving into the report, all four skip rules, cancellation, the missing-node rule, the size caps, the verdict lifetime, and the newest-intent guard.