### PR TITLE
feat: publish only once the deployment answers

### DIFF
--- a/docs/api/7-deployments.md
+++ b/docs/api/7-deployments.md
@@ -228,7 +228,8 @@ Returns the deployment object wrapped in a `deployment` key.
 | `snapshot`           | object       | Snapshot of the environment configuration used for this deployment.                       |
 | `logs`               | array\|null  | Array of log entries — see **`Log` object** below. `null` unless `?logs=true` is passed.  |
 | `statusChecks`       | array\|null  | Array of status-check log entries. `null` unless `?logs=true` is passed.                  |
-| `published`          | array        | Environments where this deployment is currently live — see **`Published` object** below.  |
+| `published`          | boolean      | Whether this deployment is the one the environment currently serves.                      |
+| `isWarmingUp`        | boolean      | Whether a publish of this deployment is under way. Stormkit boots the deployment before moving traffic to it, so `published` is `false` while this is `true`. |
 | `uploadResult`       | object\|null | Upload size breakdown — see **`UploadResult` object** below. `null` if not yet available. |
 
 **`Commit` object:**
@@ -247,13 +248,6 @@ Returns the deployment object wrapped in a `deployment` key.
 | `message`  | string  | Log output for this step.      |
 | `status`   | boolean | `true` if this step succeeded. |
 | `duration` | number  | Step duration in seconds.      |
-
-**`Published` object:**
-
-| Field        | Type   | Description                                           |
-| ------------ | ------ | ----------------------------------------------------- |
-| `envId`      | string | Environment ID where this deployment is published.    |
-| `percentage` | number | Traffic percentage routed to this deployment (0–100). |
 
 **`UploadResult` object:**
 
@@ -309,7 +303,8 @@ curl -H 'Authorization: <api_key>' \
     },
     "logs": null,
     "statusChecks": null,
-    "published": [{ "envId": "305", "percentage": 100 }],
+    "published": true,
+    "isWarmingUp": false,
     "uploadResult": {
       "clientBytes": 204800,
       "serverBytes": 0,
@@ -489,11 +484,14 @@ Makes a deployment live for the environment associated with the API key.
 | --------- | ------ | ------------------ |
 | `id`      | string | The deployment ID. |
 
+Publishing is not instant. Stormkit first asks every hosting node to boot the deployment, and moves the environment onto it only once it answers a request. Until then the previously published deployment keeps serving, so a deployment that fails to start never takes the site down — it simply does not get published.
+
 ### Response — 200 OK
 
-| Field | Type    | Description               |
-| ----- | ------- | ------------------------- |
-| `ok`  | boolean | Always `true` on success. |
+| Field    | Type    | Description                                          |
+| -------- | ------- | ---------------------------------------------------- |
+| `ok`     | boolean | Always `true` when the publish was accepted.         |
+| `status` | string  | Always `publishing`. Read `published` and `isWarmingUp` on the deployment for the outcome. |
 
 ### Error responses
 
@@ -507,7 +505,7 @@ Makes a deployment live for the environment associated with the API key.
 ### Examples
 
 ```bash
-# Publish a deployment at 100%
+# Publish a deployment
 curl -X POST \
      -H 'Authorization: <api_key>' \
      -H 'Content-Type: application/json' \
@@ -516,10 +514,11 @@ curl -X POST \
 
 ```json
 // Example response
-{ "ok": true }
+{ "ok": true, "status": "publishing" }
 ```
 
 ---
+
 
 ## DELETE /v1/deployments/{id}
 

--- a/src/ce/api/app/appconf/appconf_model_test.go
+++ b/src/ce/api/app/appconf/appconf_model_test.go
@@ -120,7 +120,7 @@ func (s *appconfSuite) SetupSuite() {
 		},
 	}
 
-	s.NoError(deploy.Publish(context.Background(), settings))
+	s.NoError(deploy.NewStore().Publish(context.Background(), settings...))
 }
 
 func (s *appconfSuite) AfterTest(_, _ string) {

--- a/src/ce/api/app/deploy/deployhandlers/handler_deploy_start_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_deploy_start_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
@@ -232,7 +233,8 @@ func (s *DeployStartTestSuite) Test_Zip() {
 	  "isAutoDeploy": false,
 	  "isAutoPublish": false,
 	  "isPriority": false,
-	  "published": [],
+	  "published": false,
+	  "isWarmingUp": false,
 	  "previewUrl": "http://{{ .displayName }}--{{ .id }}.stormkit:8888",
 	  "detailsUrl": "/apps/{{ .appId }}/environments/{{ .envId }}/deployments/{{ .id }}",
 	  "statusChecksPassed": null,
@@ -313,12 +315,26 @@ func (s *DeployStartTestSuite) Test_Zip_AutoPublish() {
 		},
 	)
 
-	depls, err := deploy.NewStore().MyDeployments(context.Background(), &deploy.DeploymentsQueryFilters{
-		EnvID:     env.ID,
-		Published: utils.Ptr(true),
-	})
+	// Auto-publish warms the deployment up before traffic moves to it, so the
+	// environment is pointed at it after this request has already returned.
+	var depls []*deploy.Deployment
 
-	s.NoError(err)
+	for range 100 {
+		published, err := deploy.NewStore().MyDeployments(context.Background(), &deploy.DeploymentsQueryFilters{
+			EnvID:     env.ID,
+			Published: utils.Ptr(true),
+		})
+
+		s.NoError(err)
+
+		if len(published) > 0 {
+			depls = published
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
 	s.Len(depls, 1)
 
 	s.Equal(http.StatusOK, response.Code)

--- a/src/ce/api/app/deploy/deployhandlers/handler_my_deployments.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_my_deployments.go
@@ -38,6 +38,8 @@ func handlerMyDeployments(req *user.RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
+	deploy.AttachPublishStatus(req.Context(), deployments)
+
 	response := []map[string]any{}
 
 	for _, d := range deployments {

--- a/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
@@ -89,7 +89,8 @@ func (s *HandlerMyDeploymentsSuite) responseTemplate() (*template.Template, erro
 					"stoppedAt": null,
 					"stoppedManually": false,
 					"uploadResult": null,
-					"published": [],
+					"published": false,
+					"isWarmingUp": false,
 					"statusChecksPassed": null,
 					"statusChecks": null,
 					"duration": 0

--- a/src/ce/api/app/deploy/deployhandlers/handler_publish.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_publish.go
@@ -1,6 +1,8 @@
 package deployhandlers
 
 import (
+	"context"
+
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
@@ -8,6 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/model"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp/shttperr"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 )
 
@@ -84,54 +87,60 @@ func handlerPublish(req *app.RequestContext) *shttp.Response {
 		return shttp.NotFound()
 	}
 
-	settings := []*deploy.PublishSettings{}
-
-	for _, publishDetails := range data.Publish {
-		settings = append(settings, &deploy.PublishSettings{
-			EnvID:        env.ID,
-			DeploymentID: publishDetails.DeploymentID,
-			Percentage:   publishDetails.Percentage,
+	// An environment serves exactly one deployment. Percentage-based releases
+	// are retired, so a request naming several of them cannot be honoured and
+	// is rejected rather than silently applying one.
+	if len(data.Publish) != 1 {
+		return shttp.BadRequest(map[string]any{
+			"errors": []string{"Exactly one deployment can be published at a time"},
 		})
 	}
 
-	if err := Publish(req.Context(), settings); err != nil {
-		return shttp.Error(err)
-	}
+	deploymentID := data.Publish[0].DeploymentID
 
-	if req.License().IsEnterprise() {
-		for _, publishDetails := range data.Publish {
-			err := audit.FromRequestContext(req).
-				WithAction(audit.UpdateAction, audit.TypeDeployment).
-				WithEnvID(env.ID).
-				WithDiff(&audit.Diff{New: audit.DiffFields{DeploymentID: publishDetails.DeploymentID.String()}}).
-				Insert()
+	// Both of these are read while the request is still alive. The licence
+	// lookup queries the database on Stormkit Cloud, and the audit builder
+	// captures the request's context — neither survives the response, and the
+	// callback below runs long after it.
+	isEnterprise := req.License().IsEnterprise()
+	auditEntry := audit.FromRequestContext(req).
+		WithAction(audit.UpdateAction, audit.TypeDeployment).
+		WithEnvID(env.ID).
+		WithDiff(&audit.Diff{New: audit.DiffFields{DeploymentID: deploymentID.String()}})
 
-			if err != nil {
-				return shttp.Error(err)
+	bg := context.WithoutCancel(req.Context())
+
+	err = PublishWithWarmup(req.Context(), deploy.PublishWithWarmupParams{
+		EnvID:        env.ID,
+		DeploymentID: deploymentID,
+
+		// The audit entry records the publish that happened, so it is written
+		// once the environment has actually moved.
+		OnPublished: func() {
+			if !isEnterprise {
+				return
 			}
-		}
-	}
 
-	var publishConfig []any
+			if err := auditEntry.WithContext(bg).Insert(); err != nil {
+				slog.Errorf("cannot audit the publish of deployment %s: %s", deploymentID.String(), err.Error())
+			}
+		},
+	})
 
-	if data.Publish != nil {
-		publishConfig = []any{}
-
-		for _, cnf := range data.Publish {
-			publishConfig = append(publishConfig, map[string]any{
-				"percentage":   cnf.Percentage,
-				"deploymentId": cnf.DeploymentID.String(),
-			})
-		}
+	if err != nil {
+		return shttp.Error(err)
 	}
 
 	return &shttp.Response{
 		Data: map[string]any{
 			"appId":  req.App.ID.String(),
 			"envId":  env.ID.String(),
-			"config": publishConfig,
+			"status": deploy.PublishStatusPublishing,
+			"config": []any{
+				map[string]any{"deploymentId": deploymentID.String(), "percentage": float64(100)},
+			},
 		},
 	}
 }
 
-var Publish = deploy.Publish
+var PublishWithWarmup = deploy.PublishWithWarmup

--- a/src/ce/api/app/deploy/deployhandlers/handler_publish_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_publish_test.go
@@ -22,29 +22,24 @@ import (
 type HandlerPublishDeploymentSuite struct {
 	suite.Suite
 	*factory.Factory
-	conn           databasetest.TestDB
-	originalFunc   func(ctx context.Context, settings []*deploy.PublishSettings) error
-	calledSettings []*deploy.PublishSettings
-}
-
-func (s *HandlerPublishDeploymentSuite) SetupSuite() {
-	s.originalFunc = deploy.Publish
+	conn         databasetest.TestDB
+	calledParams *deploy.PublishWithWarmupParams
 }
 
 func (s *HandlerPublishDeploymentSuite) BeforeTest(suiteName, _ string) {
 	s.conn = databasetest.InitTx(suiteName)
 	s.Factory = factory.New(s.conn)
-	s.calledSettings = nil
+	s.calledParams = nil
 
-	deployhandlers.Publish = func(ctx context.Context, settings []*deploy.PublishSettings) error {
-		s.calledSettings = settings
+	deployhandlers.PublishWithWarmup = func(ctx context.Context, p deploy.PublishWithWarmupParams) error {
+		s.calledParams = &p
 		return nil
 	}
 }
 
 func (s *HandlerPublishDeploymentSuite) AfterTest(_, _ string) {
 	s.conn.CloseTx()
-	deployhandlers.Publish = nil
+	deployhandlers.PublishWithWarmup = nil
 	shttp.DefaultRequest = nil
 }
 
@@ -72,6 +67,7 @@ func (s *HandlerPublishDeploymentSuite) Test_Success() {
 
 	expectedResponse := fmt.Sprintf(`{
 		"appId": "%s",
+		"status": "publishing",
 		"config": [
 			{ "percentage":100, "deploymentId": "%s" }
 		],
@@ -80,21 +76,17 @@ func (s *HandlerPublishDeploymentSuite) Test_Success() {
 		dpl.ID.String(),
 		env.ID.String())
 
-	expectedSettings := []*deploy.PublishSettings{
-		{
-			DeploymentID: dpl.ID,
-			EnvID:        env.ID,
-			Percentage:   100,
-		},
-	}
-
 	a := assert.New(s.T())
 	a.Equal(http.StatusOK, response.Code)
-	a.Equal(expectedSettings, s.calledSettings)
+	s.Require().NotNil(s.calledParams)
+	a.Equal(dpl.ID, s.calledParams.DeploymentID)
+	a.Equal(env.ID, s.calledParams.EnvID)
 	a.JSONEq(expectedResponse, response.String())
 }
 
-func (s *HandlerPublishDeploymentSuite) Test_Success_Multiple() {
+// Test_BadRequest_MultipleDeployments verifies an environment can only be
+// pointed at one deployment: percentage-based releases are retired.
+func (s *HandlerPublishDeploymentSuite) Test_BadRequest_MultipleDeployments() {
 	usr := s.MockUser()
 	app := s.MockApp(usr)
 	env := s.MockEnv(app)
@@ -117,35 +109,10 @@ func (s *HandlerPublishDeploymentSuite) Test_Success_Multiple() {
 		},
 	)
 
-	expectedResponse := fmt.Sprintf(`{
-		"appId": "%s",
-		"config": [
-			{ "percentage": 30, "deploymentId": "%s" },
-			{ "percentage": 70, "deploymentId": "%s" }
-		],
-		"envId": "%s"}`,
-		app.ID.String(),
-		dpls[0].ID.String(),
-		dpls[1].ID.String(),
-		env.ID.String())
-
-	expectedSettings := []*deploy.PublishSettings{
-		{
-			DeploymentID: dpls[0].ID,
-			EnvID:        env.ID,
-			Percentage:   30,
-		},
-		{
-			DeploymentID: dpls[1].ID,
-			EnvID:        env.ID,
-			Percentage:   70,
-		},
-	}
-
 	a := assert.New(s.T())
-	a.Equal(http.StatusOK, response.Code)
-	a.Equal(expectedSettings, s.calledSettings)
-	a.JSONEq(expectedResponse, response.String())
+	a.Equal(http.StatusBadRequest, response.Code)
+	a.Contains(response.String(), "one deployment can be published")
+	a.Nil(s.calledParams)
 }
 
 func (s *HandlerPublishDeploymentSuite) Test_BadRequest() {
@@ -169,7 +136,7 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest() {
 	a := assert.New(s.T())
 	a.Equal(http.StatusBadRequest, response.Code)
 	a.Equal(expectedResponse, response.String())
-	a.Nil(s.calledSettings)
+	a.Nil(s.calledParams)
 }
 
 func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
@@ -198,7 +165,7 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
 	a := assert.New(s.T())
 	a.Equal(http.StatusBadRequest, response.Code)
 	a.Equal(expectedResponse, response.String())
-	a.Nil(s.calledSettings)
+	a.Nil(s.calledParams)
 }
 
 func TestHandlerPublishDeployment(t *testing.T) {

--- a/src/ce/api/app/deploy/deployhooks/hooks.go
+++ b/src/ce/api/app/deploy/deployhooks/hooks.go
@@ -149,5 +149,3 @@ func notifyDeploymentCompleted(channelHook string, d *deploy.Deployment) {
 		},
 	})
 }
-
-var Publish = deploy.Publish

--- a/src/ce/api/app/deploy/deployhooks/hooks_test.go
+++ b/src/ce/api/app/deploy/deployhooks/hooks_test.go
@@ -28,12 +28,6 @@ type HooksSuite struct {
 
 	conn             databasetest.TestDB
 	mockCacheService *mocks.CacheInterface
-	calledSettings   []*deploy.PublishSettings
-	originalPublish  func(ctx context.Context, settings []*deploy.PublishSettings) error
-}
-
-func (s *HooksSuite) SetupSuite() {
-	s.originalPublish = deployhooks.Publish
 }
 
 func (s *HooksSuite) BeforeTest(suiteName, _ string) {
@@ -41,17 +35,21 @@ func (s *HooksSuite) BeforeTest(suiteName, _ string) {
 	s.Factory = factory.New(s.conn)
 	s.mockCacheService = &mocks.CacheInterface{}
 	appcache.DefaultCacheService = s.mockCacheService
-
-	deployhooks.Publish = func(ctx context.Context, settings []*deploy.PublishSettings) error {
-		s.calledSettings = settings
-		return nil
-	}
 }
 
 func (s *HooksSuite) AfterTest(_, _ string) {
 	appcache.DefaultCacheService = nil
-	deployhooks.Publish = nil
 	s.conn.CloseTx()
+}
+
+// publishedCount returns how many deployments the test's data has published.
+func (s *HooksSuite) publishedCount() int {
+	count := 0
+
+	row := s.conn.QueryRow(`SELECT count(*) FROM deployments_published;`)
+	s.NoError(row.Scan(&count))
+
+	return count
 }
 
 func (s *HooksSuite) TestOutboundWebhooks() {
@@ -118,7 +116,7 @@ func (s *HooksSuite) TestShouldNotPublish_WhenShouldPublishIsFalse() {
 	deployhooks.Exec(context.Background(), depl.Deployment)
 
 	a := assert.New(s.T())
-	a.Nil(s.calledSettings)
+	a.Zero(s.publishedCount(), "the deployment should not have been published")
 }
 
 func (s *HooksSuite) TestShouldNotPublish_WhenDeploymentFailed() {
@@ -135,7 +133,7 @@ func (s *HooksSuite) TestShouldNotPublish_WhenDeploymentFailed() {
 	deployhooks.Exec(context.Background(), depl.Deployment)
 
 	a := assert.New(s.T())
-	a.Nil(s.calledSettings)
+	a.Zero(s.publishedCount(), "the deployment should not have been published")
 }
 
 func TestHooks(t *testing.T) {

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -109,6 +109,11 @@ type Deployment struct {
 	// the environment id and the released percentage.
 	Published PublishedInfo `json:"-"`
 
+	// IsWarmingUp is filled in by handlers that report it — see
+	// AttachPublishStatus. A deployment that is warming up is not published
+	// yet: Stormkit is booting it, and traffic moves only once it answers.
+	IsWarmingUp bool `json:"-"`
+
 	BuildConfig *buildconf.BuildConf `json:"-"` // ConfigCopy is the snapshot of the environment used during the deployment.
 	DisplayName string               `json:"-"` // DisplayName is the name of the app. It is injected to the deployment object.
 	IsRestart   bool                 `json:"-"`
@@ -503,6 +508,17 @@ func (d *Deployment) RepoSlug() string {
 	return ""
 }
 
+// IsPublished reports whether the deployment is currently serving traffic.
+func (d *Deployment) IsPublished() bool {
+	for _, p := range d.Published {
+		if p.Percentage > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // AddLogs appends the given logs to the deployment logs.
 func (d *Deployment) AddLogs(logs []string) {
 	if len(logs) == 0 {
@@ -823,7 +839,8 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		"statusChecks":       statusChecksLogs,
 		"statusChecksPassed": d.StatusChecksPassed,
 		"duration":           calculateDuration(d.CreatedAt, d.StoppedAt),
-		"published":          []map[string]any{},
+		"published":          false,
+		"isWarmingUp":        d.IsWarmingUp,
 		"uploadResult":       uploadResult,
 		"isPriority":         d.IsPriority,
 		"commit": map[string]any{
@@ -833,14 +850,10 @@ func (d *Deployment) JSON(withLogs bool) map[string]any {
 		},
 	}
 
-	if d.Published != nil {
-		for _, p := range d.Published {
-			jsonMap["published"] = append(jsonMap["published"].([]map[string]any), map[string]any{
-				"envId":      p.EnvID.String(),
-				"percentage": p.Percentage,
-			})
-		}
-	}
+	// An environment serves exactly one deployment, so this is a yes or no
+	// rather than the list of shares it used to be: percentage-based releases
+	// are retired.
+	jsonMap["published"] = d.IsPublished()
 
 	if !withLogs {
 		jsonMap["logs"] = nil

--- a/src/ce/api/app/deploy/publish_export_test.go
+++ b/src/ce/api/app/deploy/publish_export_test.go
@@ -39,3 +39,15 @@ func AcquireFlipLockForTest(ctx context.Context, envID types.ID) (string, error)
 func ReleaseFlipLockForTest(ctx context.Context, envID types.ID, token string) {
 	warmupStore{}.unlock(ctx, envID, token)
 }
+
+// PublishNowForTest performs the flip without the warm-up gate, for tests that
+// need an environment already pointing at a deployment.
+func PublishNowForTest(ctx context.Context, settings []*PublishSettings) error {
+	return publishNow(ctx, settings)
+}
+
+// WarmUpAndPublishAsyncForTest drives the gate the way production does — on its
+// own goroutine — regardless of the inline-under-test shortcut.
+func WarmUpAndPublishAsyncForTest(ctx context.Context, p WarmUpAndPublishParams, onReady func() error) {
+	go warmUpGate{}.run(ctx, p, onReady)
+}

--- a/src/ce/api/app/deploy/publish_gate.go
+++ b/src/ce/api/app/deploy/publish_gate.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
@@ -35,6 +38,16 @@ type WarmUpAndPublishParams struct {
 // The progress and the reason for a failure are readable through
 // PublishStatusOf.
 func WarmUpAndPublish(ctx context.Context, p WarmUpAndPublishParams, onReady func() error) {
+	// Tests share one database transaction per test, and work that outlives the
+	// request would write to it after it has been rolled back — corrupting
+	// whichever test runs next rather than the one that started it. There are
+	// no hosting nodes registered under test, so running inline costs nothing
+	// but determinism.
+	if config.IsTest() {
+		warmUpGate{}.run(ctx, p, onReady)
+		return
+	}
+
 	// The caller is usually an HTTP handler whose context is cancelled the
 	// moment it responds, and this outlives the response by design.
 	go warmUpGate{}.run(context.WithoutCancel(ctx), p, onReady)
@@ -396,4 +409,113 @@ func PublishSettingsFor(envID, deploymentID types.ID) []*PublishSettings {
 			Percentage:   publishedPercentage,
 		},
 	}
+}
+
+// PublishWithWarmupParams describes a publish that has to wait for the
+// deployment to answer.
+type PublishWithWarmupParams struct {
+	EnvID        types.ID
+	DeploymentID types.ID
+
+	// OnPublished runs after the environment has moved, for work that must not
+	// happen when a publish is held back — an audit entry, say.
+	//
+	// It cannot fail the publish. By the time it runs the environment is
+	// already serving the new deployment, so reporting a failure here would
+	// tell the user their release did not happen when it did.
+	OnPublished func()
+}
+
+// PublishWithWarmup warms the deployment on every hosting node and moves the
+// environment onto it once they all report that it serves.
+//
+// It returns as soon as the warm-up has been requested. An error means the
+// publish could not be started at all; a deployment that fails to come up is
+// reported through PublishStatusOf instead, because by then the caller is long
+// gone.
+func PublishWithWarmup(ctx context.Context, p PublishWithWarmupParams) error {
+	env, err := buildconf.NewStore().EnvironmentByID(ctx, p.EnvID)
+
+	if err != nil {
+		return err
+	}
+
+	if env == nil {
+		return fmt.Errorf("environment %s does not exist", p.EnvID.String())
+	}
+
+	appl, err := app.NewStore().AppByEnvID(ctx, p.EnvID)
+
+	if err != nil {
+		return err
+	}
+
+	if appl == nil {
+		return fmt.Errorf("app of environment %s does not exist", p.EnvID.String())
+	}
+
+	// The request's context is done the moment it responds, and the warm-up
+	// outlives that.
+	bg := context.WithoutCancel(ctx)
+	settings := PublishSettingsFor(p.EnvID, p.DeploymentID)
+
+	WarmUpAndPublish(bg, WarmUpAndPublishParams{
+		AppID:        env.AppID,
+		EnvID:        p.EnvID,
+		DeploymentID: p.DeploymentID,
+		DisplayName:  appl.DisplayName,
+		EnvName:      env.Name,
+	}, func() error {
+		if err := publishNow(bg, settings); err != nil {
+			return err
+		}
+
+		if p.OnPublished != nil {
+			p.OnPublished()
+		}
+
+		return nil
+	})
+
+	return nil
+}
+
+// AttachPublishStatus marks the deployments that are currently warming up.
+//
+// Publishing waits for the deployment to answer before traffic moves to it, so
+// "not published" alone no longer says whether nothing is happening or a
+// release is on its way.
+//
+// It reads once per environment rather than once per deployment, since a list
+// commonly holds many deployments of the same one.
+func AttachPublishStatus(ctx context.Context, deployments []*Deployment) {
+	statuses := map[types.ID]*PublishStatus{}
+
+	for _, d := range deployments {
+		if _, read := statuses[d.EnvID]; read {
+			continue
+		}
+
+		status, err := PublishStatusOf(ctx, d.EnvID)
+
+		if err != nil {
+			slog.Errorf("cannot read the publish status of env %s: %s", d.EnvID.String(), err.Error())
+		}
+
+		statuses[d.EnvID] = status
+	}
+
+	for _, d := range deployments {
+		d.IsWarmingUp = isWarmingUp(d, statuses[d.EnvID])
+	}
+}
+
+// isWarmingUp reports whether a publish of this deployment is under way.
+//
+// The environment's status only speaks for the deployment it names: an older
+// deployment must not be shown as warming up because the one replacing it is.
+func isWarmingUp(d *Deployment, status *PublishStatus) bool {
+	return status != nil &&
+		status.DeploymentID == d.ID &&
+		status.Status == PublishStatusPublishing
 }

--- a/src/ce/api/app/deploy/publish_gate_fake_test.go
+++ b/src/ce/api/app/deploy/publish_gate_fake_test.go
@@ -1,0 +1,59 @@
+package deploy_test
+
+import (
+	"encoding/json"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+)
+
+// fakeService stands in for service discovery and the event bus, so a test can
+// say which hosting nodes exist and answer the warm-up itself.
+type fakeService struct {
+	id          string
+	nodes       []string
+	onBroadcast func(warmupID string)
+}
+
+func (f *fakeService) ServiceID() string { return f.id }
+
+func (f *fakeService) Key(name string) string {
+	return "service:" + name + ":test:" + f.id
+}
+
+func (f *fakeService) List(filter []string) ([]*rediscache.MicroService, error) {
+	services := make([]*rediscache.MicroService, 0, len(f.nodes))
+
+	for _, id := range f.nodes {
+		services = append(services, &rediscache.MicroService{ID: id, Name: rediscache.ServiceHosting})
+	}
+
+	return services, nil
+}
+
+func (f *fakeService) Broadcast(event string, payload ...string) error {
+	if f.onBroadcast != nil && len(payload) > 0 {
+		go f.onBroadcast(warmupIDOf(payload[0]))
+	}
+
+	return nil
+}
+
+func (f *fakeService) Subscribe(string, rediscache.Handler) error      { return nil }
+func (f *fakeService) SubscribeAsync(string, rediscache.Handler) error { return nil }
+func (f *fakeService) SetAll(string, string, []string) error           { return nil }
+func (f *fakeService) DelAll(string, []string) error                   { return nil }
+
+func (f *fakeService) GetAll(string, []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// warmupIDOf pulls the warm-up id out of the broadcast payload.
+func warmupIDOf(payload string) string {
+	req := struct {
+		WarmupID string `json:"warmupId"`
+	}{}
+
+	_ = json.Unmarshal([]byte(payload), &req)
+
+	return req.WarmupID
+}

--- a/src/ce/api/app/deploy/publish_gate_test.go
+++ b/src/ce/api/app/deploy/publish_gate_test.go
@@ -1,0 +1,191 @@
+package deploy_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stormkit-io/stormkit-io/src/lib/types"
+	"github.com/stretchr/testify/suite"
+)
+
+// PublishGateSuite drives the gate on its own goroutine, the way production
+// runs it. WarmUpAndPublish takes an inline shortcut under test so that
+// detached work cannot write to a rolled-back transaction, which means nothing
+// else here exercises the path that actually ships.
+type PublishGateSuite struct {
+	suite.Suite
+
+	ctx     context.Context
+	service *fakeService
+}
+
+func (s *PublishGateSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.service = &fakeService{id: uuid.New().String()}
+
+	rediscache.DefaultService = s.service
+}
+
+func (s *PublishGateSuite) TearDownTest() {
+	rediscache.DefaultService = nil
+}
+
+func (s *PublishGateSuite) params(envID types.ID) deploy.WarmUpAndPublishParams {
+	return deploy.WarmUpAndPublishParams{
+		AppID:        types.ID(1),
+		EnvID:        envID,
+		DeploymentID: types.ID(42),
+		DisplayName:  "my-app",
+		EnvName:      "production",
+		Timeout:      5 * time.Second,
+	}
+}
+
+// envID returns an environment nothing else in the suite touches.
+func (s *PublishGateSuite) envID() types.ID {
+	return types.ID(time.Now().UnixNano())
+}
+
+// awaitStatus waits for the environment to reach a terminal publish status.
+func (s *PublishGateSuite) awaitStatus(envID types.ID) *deploy.PublishStatus {
+	for range 200 {
+		status, err := deploy.PublishStatusOf(s.ctx, envID)
+		s.Require().NoError(err)
+
+		if status != nil && status.Status != deploy.PublishStatusPublishing {
+			return status
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	return nil
+}
+
+// Test_PublishesOnceEveryNodeReports covers the whole path: the broadcast, the
+// wait, a node reporting, and the flip.
+func (s *PublishGateSuite) Test_PublishesOnceEveryNodeReports() {
+	envID := s.envID()
+	published := make(chan struct{}, 1)
+
+	s.service.nodes = []string{"node-a", "node-b"}
+	s.service.onBroadcast = func(warmupID string) {
+		for _, node := range []string{"node-a", "node-b"} {
+			s.NoError(deploy.SaveNodeResult(context.Background(), deploy.SaveNodeResultParams{
+				WarmupID: warmupID,
+				Deadline: time.Now().Add(time.Minute).Unix(),
+				Result:   deploy.WarmupResult{ServiceID: node, Status: rediscache.StatusOK},
+			}))
+		}
+	}
+
+	deploy.WarmUpAndPublishAsyncForTest(s.ctx, s.params(envID), func() error {
+		published <- struct{}{}
+		return nil
+	})
+
+	select {
+	case <-published:
+	case <-time.After(10 * time.Second):
+		s.Fail("the publish never happened")
+	}
+
+	status := s.awaitStatus(envID)
+	s.Require().NotNil(status)
+	s.Equal(deploy.PublishStatusPublished, status.Status)
+}
+
+// Test_DoesNotPublishWhenANodeFails is the guarantee the feature exists for:
+// traffic must not move to a deployment that did not come up.
+func (s *PublishGateSuite) Test_DoesNotPublishWhenANodeFails() {
+	envID := s.envID()
+	published := make(chan struct{}, 1)
+
+	s.service.nodes = []string{"node-a"}
+	s.service.onBroadcast = func(warmupID string) {
+		s.NoError(deploy.SaveNodeResult(context.Background(), deploy.SaveNodeResultParams{
+			WarmupID: warmupID,
+			Deadline: time.Now().Add(time.Minute).Unix(),
+			Result: deploy.WarmupResult{
+				ServiceID: "node-a",
+				Status:    rediscache.StatusErr,
+				Reason:    "the deployment did not serve a request within 3m0s",
+			},
+		}))
+	}
+
+	deploy.WarmUpAndPublishAsyncForTest(s.ctx, s.params(envID), func() error {
+		published <- struct{}{}
+		return nil
+	})
+
+	status := s.awaitStatus(envID)
+	s.Require().NotNil(status)
+	s.Equal(deploy.PublishStatusFailed, status.Status)
+	s.Contains(status.Reason, "did not serve a request")
+
+	select {
+	case <-published:
+		s.Fail("a deployment that never came up must not be published")
+	default:
+	}
+}
+
+// Test_PublishesWithoutHostingNodes keeps a fresh install, where nothing is
+// serving yet, publishing as it did before.
+func (s *PublishGateSuite) Test_PublishesWithoutHostingNodes() {
+	envID := s.envID()
+	published := make(chan struct{}, 1)
+
+	s.service.nodes = nil
+
+	deploy.WarmUpAndPublishAsyncForTest(s.ctx, s.params(envID), func() error {
+		published <- struct{}{}
+		return nil
+	})
+
+	select {
+	case <-published:
+	case <-time.After(5 * time.Second):
+		s.Fail("a publish with nothing to warm up should go straight through")
+	}
+}
+
+// Test_SupersededPublishIsSkipped covers two publishes racing: the slower one
+// must not roll the environment back when it finishes second.
+func (s *PublishGateSuite) Test_SupersededPublishIsSkipped() {
+	envID := s.envID()
+	published := make(chan struct{}, 1)
+
+	s.service.nodes = []string{"node-a"}
+	s.service.onBroadcast = func(warmupID string) {
+		// A newer publish for the same environment starts while this one is
+		// still warming up.
+		deploy.RecordIntentForTest(context.Background(), envID, uuid.New().String())
+
+		s.NoError(deploy.SaveNodeResult(context.Background(), deploy.SaveNodeResultParams{
+			WarmupID: warmupID,
+			Deadline: time.Now().Add(time.Minute).Unix(),
+			Result:   deploy.WarmupResult{ServiceID: "node-a", Status: rediscache.StatusOK},
+		}))
+	}
+
+	deploy.WarmUpAndPublishAsyncForTest(s.ctx, s.params(envID), func() error {
+		published <- struct{}{}
+		return nil
+	})
+
+	select {
+	case <-published:
+		s.Fail("a superseded publish must not move the environment")
+	case <-time.After(2 * time.Second):
+	}
+}
+
+func TestPublishGateSuite(t *testing.T) {
+	suite.Run(t, new(PublishGateSuite))
+}

--- a/src/ce/api/app/deploy/publisher.go
+++ b/src/ce/api/app/deploy/publisher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/user"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
@@ -29,18 +30,23 @@ func AutoPublishIfNecessary(ctx context.Context, d *Deployment) error {
 		return nil
 	}
 
-	settings := []*PublishSettings{
-		{
-			EnvID:        d.EnvID,
-			DeploymentID: d.ID,
-			Percentage:   100,
+	return PublishWithWarmup(ctx, PublishWithWarmupParams{
+		EnvID:        d.EnvID,
+		DeploymentID: d.ID,
+
+		// The audit entry belongs with the flip, not with the request that
+		// asked for it: a publish held back by a deployment that never came up
+		// did not happen and must not be recorded as though it had.
+		OnPublished: func() {
+			if err := auditAutoPublish(context.WithoutCancel(ctx), d); err != nil {
+				slog.Errorf("cannot audit the automatic publish of deployment %s: %s", d.ID.String(), err.Error())
+			}
 		},
-	}
+	})
+}
 
-	if err := Publish(ctx, settings); err != nil {
-		return err
-	}
-
+// auditAutoPublish records an automatic publish for enterprise licences.
+func auditAutoPublish(ctx context.Context, d *Deployment) error {
 	var license *admin.License
 
 	if config.IsStormkitCloud() {
@@ -81,11 +87,6 @@ func AutoPublishIfNecessary(ctx context.Context, d *Deployment) error {
 	}
 
 	return nil
-}
-
-// Publish publishes a new deployment.
-func Publish(ctx context.Context, settings []*PublishSettings) error {
-	return publishNow(ctx, settings)
 }
 
 // publishNow points the environment at the given deployments and makes the

--- a/src/ce/api/app/deploy/publisher_test.go
+++ b/src/ce/api/app/deploy/publisher_test.go
@@ -68,7 +68,7 @@ func (s *PublisherSuite) Test_PublishingMultiple() {
 	s.mockCacheService.On("Reset", env.ID).Return(nil).Once()
 	s.mockCacheService.On("Reset", env.ID).Return(nil).Once()
 
-	err := deploy.Publish(context.Background(), settings)
+	err := deploy.PublishNowForTest(context.Background(), settings)
 	s.NoError(err)
 
 	rows, err := s.conn.Query(`
@@ -108,7 +108,7 @@ func (s *PublisherSuite) Test_PublishingMultiple() {
 
 	s.mockCacheService.On("Reset", env.ID).Return(nil).Once()
 
-	err = deploy.Publish(context.Background(), settings)
+	err = deploy.PublishNowForTest(context.Background(), settings)
 	s.NoError(err)
 
 	rows, err = s.conn.Query(`
@@ -166,7 +166,7 @@ func (s *PublisherSuite) Test_PublishOutboundWebhooks() {
 	s.mockCacheService.On("Reset", env.ID).Return(nil)
 
 	s.NoError(err)
-	s.Nil(deploy.Publish(context.Background(), settings))
+	s.Nil(deploy.PublishNowForTest(context.Background(), settings))
 }
 
 func (s *PublisherSuite) Test_AutoPublish() {

--- a/src/ce/api/public/v1/handler_deployment_get.go
+++ b/src/ce/api/public/v1/handler_deployment_get.go
@@ -36,6 +36,8 @@ func handlerDeploymentGet(req *RequestContext) *shttp.Response {
 		return shttp.NotFound()
 	}
 
+	deploy.AttachPublishStatus(req.Context(), []*deploy.Deployment{depl})
+
 	data := depl.JSON(withLogs)
 
 	// A failed deployment carries its reason inline so a caller can triage

--- a/src/ce/api/public/v1/handler_deployment_publish.go
+++ b/src/ce/api/public/v1/handler_deployment_publish.go
@@ -1,11 +1,13 @@
 package publicapiv1
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/ee/api/audit"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
+	"github.com/stormkit-io/stormkit-io/src/lib/slog"
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 )
 
@@ -43,11 +45,31 @@ func handlerDeploymentPublish(req *RequestContext) *shttp.Response {
 		})
 	}
 
-	err = deploy.Publish(req.Context(), []*deploy.PublishSettings{
-		{
-			EnvID:        req.Env.ID,
-			DeploymentID: id,
-			Percentage:   100,
+	// Both of these are read while the request is still alive. The licence
+	// lookup queries the database on Stormkit Cloud, and the audit builder
+	// captures the request's context — neither survives the response, and the
+	// callback below runs long after it.
+	isEnterprise := req.License().IsEnterprise()
+	auditEntry := audit.FromRequestContext(req).
+		WithAction(audit.UpdateAction, audit.TypeDeployment).
+		WithDiff(&audit.Diff{New: audit.DiffFields{DeploymentID: id.String()}})
+
+	bg := context.WithoutCancel(req.Context())
+
+	err = deploy.PublishWithWarmup(req.Context(), deploy.PublishWithWarmupParams{
+		EnvID:        req.Env.ID,
+		DeploymentID: id,
+
+		// The audit entry records the publish that happened, so it is written
+		// once the environment has actually moved.
+		OnPublished: func() {
+			if !isEnterprise {
+				return
+			}
+
+			if err := auditEntry.WithContext(bg).Insert(); err != nil {
+				slog.Errorf("cannot audit the publish of deployment %s: %s", id.String(), err.Error())
+			}
 		},
 	})
 
@@ -55,21 +77,14 @@ func handlerDeploymentPublish(req *RequestContext) *shttp.Response {
 		return shttp.Error(err)
 	}
 
-	if req.License().IsEnterprise() {
-		err := audit.FromRequestContext(req).
-			WithAction(audit.UpdateAction, audit.TypeDeployment).
-			WithDiff(&audit.Diff{New: audit.DiffFields{DeploymentID: id.String()}}).
-			Insert()
-
-		if err != nil {
-			return shttp.Error(err)
-		}
-	}
-
+	// The deployment is warmed up before traffic moves to it, so the publish is
+	// under way rather than done. Poll the deployment's publish status to find
+	// out whether it completed.
 	return &shttp.Response{
 		Status: http.StatusOK,
 		Data: map[string]any{
-			"ok": true,
+			"ok":     true,
+			"status": deploy.PublishStatusPublishing,
 		},
 	}
 }

--- a/src/ce/api/public/v1/handler_deployment_publish_test.go
+++ b/src/ce/api/public/v1/handler_deployment_publish_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	null "gopkg.in/guregu/null.v3"
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apikey"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	publicapiv1 "github.com/stormkit-io/stormkit-io/src/ce/api/public/v1"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
@@ -41,7 +43,10 @@ func (s *HandlerDeploymentPublishSuite) publishURL(id fmt.Stringer) string {
 	return fmt.Sprintf("/v1/deployments/%s/publish", id)
 }
 
-// Test_Success verifies that a valid env-scoped key can publish a deployment at 100%.
+// Test_Success verifies that a valid env-scoped key can publish a deployment.
+//
+// The response says "publishing": the deployment is warmed up before traffic
+// moves to it, so the publish is under way rather than done.
 func (s *HandlerDeploymentPublishSuite) Test_Success() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
@@ -63,10 +68,13 @@ func (s *HandlerDeploymentPublishSuite) Test_Success() {
 
 	body := response.Map()
 	s.Equal(true, body["ok"])
+	s.Equal(deploy.PublishStatusPublishing, body["status"])
 }
 
-// Test_PublishedStateReflected verifies that after publishing, fetching the deployment
-// returns non-empty published info.
+// Test_PublishedStateReflected verifies that a publish reaches the deployment.
+//
+// It polls rather than reading once: publishing waits for the deployment to
+// answer, so it completes after the request that asked for it has returned.
 func (s *HandlerDeploymentPublishSuite) Test_PublishedStateReflected() {
 	usr := s.MockUser()
 	appl := s.MockApp(usr)
@@ -82,26 +90,30 @@ func (s *HandlerDeploymentPublishSuite) Test_PublishedStateReflected() {
 		map[string]string{"Authorization": key.Value},
 	)
 
-	// Fetch the deployment and verify published is populated.
-	getResponse := shttptest.RequestWithHeaders(
-		s.handler(),
-		shttp.MethodGet,
-		fmt.Sprintf("/v1/deployments/%s", depl.ID),
-		nil,
-		map[string]string{"Authorization": key.Value},
-	)
+	published := false
 
-	s.Equal(http.StatusOK, getResponse.Code)
+	for range 100 {
+		getResponse := shttptest.RequestWithHeaders(
+			s.handler(),
+			shttp.MethodGet,
+			fmt.Sprintf("/v1/deployments/%s", depl.ID),
+			nil,
+			map[string]string{"Authorization": key.Value},
+		)
 
-	body := getResponse.Map()
+		s.Equal(http.StatusOK, getResponse.Code)
 
-	got := body["deployment"].(map[string]any)
-	published := got["published"].([]any)
-	s.Len(published, 1)
+		got := getResponse.Map()["deployment"].(map[string]any)
 
-	p := published[0].(map[string]any)
-	s.Equal(env.ID.String(), p["envId"])
-	s.Equal(float64(100), p["percentage"])
+		if live, ok := got["published"].(bool); ok && live {
+			published = true
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	s.True(published, "the deployment should be serving the environment")
 }
 
 // Test_NotFound_UnknownID verifies that a non-existent deployment ID returns 404.

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -43,7 +43,7 @@ func mcpAllTools() []mcpToolDef {
 				"properties": map[string]any{
 					"envId":   map[string]any{"type": "string", "description": "ID of the environment to deploy."},
 					"branch":  map[string]any{"type": "string", "description": "Git branch to deploy. Defaults to the environment's configured branch."},
-					"publish": map[string]any{"type": "boolean", "description": "Publish the deployment immediately after a successful build."},
+					"publish": map[string]any{"type": "boolean", "description": "Start publishing the deployment after a successful build. The deployment is booted first and traffic moves only once it answers, so a successful build does not guarantee it went live — check isWarmingUp and published on the deployment."},
 				},
 				"required":             []string{"envId"},
 				"additionalProperties": false,
@@ -106,7 +106,7 @@ func mcpAllTools() []mcpToolDef {
 		},
 		{
 			Name:        "publish_deployment",
-			Description: "Publish a successfully built deployment, making it live.",
+			Description: "Start publishing a successfully built deployment. Stormkit boots the deployment first and moves traffic only once it answers, so this returns before the deployment is live and the publish can still fail. Call get_deployment and check isWarmingUp and published to find out how it went; the deployment's runtime logs say why a publish failed.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/src/ce/api/public/v1/openapi.json
+++ b/src/ce/api/public/v1/openapi.json
@@ -1015,7 +1015,7 @@
       "get": {
         "operationId": "listDeploymentRuntimeLogs",
         "summary": "List runtime logs of a deployment",
-        "description": "Return runtime logs — server-side rendering and API function output — produced by a deployment. Paginate with `afterId`/`beforeId`, passing the `id` of the last entry you received.",
+        "description": "Return runtime logs \u2014 server-side rendering and API function output \u2014 produced by a deployment. Paginate with `afterId`/`beforeId`, passing the `id` of the last entry you received.",
         "tags": [
           "Logs"
         ],
@@ -1094,7 +1094,7 @@
       "post": {
         "operationId": "publishDeployment",
         "summary": "Publish a deployment",
-        "description": "Make a successfully built deployment live on the environment's domains. Publishing replaces whatever was published before; the previous deployment stays available and can be published again to roll back.",
+        "description": "Make a successfully built deployment live on the environment's domains. Publishing replaces whatever was published before; the previous deployment stays available and can be published again to roll back. Stormkit warms the deployment up first and moves traffic only once it answers a request, so this returns while the publish is still under way \u2014 read publishStatus on the deployment to find out how it went.",
         "tags": [
           "Deployments"
         ],
@@ -1108,11 +1108,22 @@
         ],
         "responses": {
           "200": {
-            "description": "The deployment was published.",
+            "description": "The publish was accepted and is under way.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Ok"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "publishing"
+                      ]
+                    }
+                  }
                 }
               }
             }
@@ -1262,7 +1273,7 @@
       "get": {
         "operationId": "listAccessLogs",
         "summary": "List HTTP access logs",
-        "description": "Return raw HTTP access logs — one entry per request served — for an environment, newest first. Defaults to the last 24 hours. Paginate by passing `pagination.cursor` from the previous response back verbatim.",
+        "description": "Return raw HTTP access logs \u2014 one entry per request served \u2014 for an environment, newest first. Defaults to the last 24 hours. Paginate by passing `pagination.cursor` from the previous response back verbatim.",
         "tags": [
           "Logs"
         ],
@@ -2473,7 +2484,7 @@
       "get": {
         "operationId": "listTriggerLogs",
         "summary": "List trigger executions",
-        "description": "Return the last 25 executions of a trigger — scheduled and manual — most recent first.",
+        "description": "Return the last 25 executions of a trigger \u2014 scheduled and manual \u2014 most recent first.",
         "tags": [
           "Triggers"
         ],
@@ -3932,6 +3943,14 @@
           "stoppedAt": {
             "type": "string",
             "description": "Unix timestamp, in seconds, of when the build finished."
+          },
+          "published": {
+            "type": "boolean",
+            "description": "Whether this deployment is the one the environment currently serves."
+          },
+          "isWarmingUp": {
+            "type": "boolean",
+            "description": "Whether a publish of this deployment is under way. Stormkit boots the deployment before moving traffic to it, so published is false while this is true."
           }
         },
         "required": [

--- a/src/ee/api/audit/audit_model.go
+++ b/src/ee/api/audit/audit_model.go
@@ -197,6 +197,17 @@ func FromRequestContext(req any) *Audit {
 	}
 }
 
+// WithContext replaces the context the entry is written with.
+//
+// FromRequestContext captures the request's own context, which is done as soon
+// as the response is written. An entry recorded after that — for work that
+// outlives the request, such as a publish that waits for the deployment to come
+// up — has to supply a context that is still live.
+func (a *Audit) WithContext(ctx context.Context) *Audit {
+	a.ctx = ctx
+	return a
+}
+
 func (a *Audit) WithEnvID(envID types.ID) *Audit {
 	a.EnvID = envID
 	return a

--- a/src/ui/src/shared/deployments/CommitInfo.tsx
+++ b/src/ui/src/shared/deployments/CommitInfo.tsx
@@ -98,12 +98,10 @@ export default function CommitInfo({
               }}
             />
           )}
-          {deployment.published?.length > 0 && (
+          {(deployment.published || deployment.isWarmingUp) && (
             <Chip
-              color={deployment.published.length ? "success" : "info"}
-              label={
-                deployment.published.length ? `published` : "not published"
-              }
+              color={deployment.published ? "success" : "info"}
+              label={deployment.published ? "published" : "publishing"}
               size="small"
               sx={{
                 ml: 1,

--- a/src/ui/src/testing/data/mock_deployment.ts
+++ b/src/ui/src/testing/data/mock_deployment.ts
@@ -94,12 +94,7 @@ export default ({ id, appId, envId, isRunning }: Props = {}): DeploymentV2 => ({
     },
   ],
   previewUrl: "http://sample--15.localhost:8888",
-  published: [
-    {
-      envId: "3",
-      percentage: 100,
-    },
-  ],
+  published: true,
   repo: "github/stormkit-io/sample-project",
   snapshot: {
     build: {

--- a/src/ui/src/testing/data/mock_deployments_v2.ts
+++ b/src/ui/src/testing/data/mock_deployments_v2.ts
@@ -40,7 +40,7 @@ export default (): DeploymentV2[] => [
     duration: 125,
     statusChecksPassed: true,
     statusChecks: [],
-    published: [{ envId: "1", percentage: 100 }],
+    published: true,
   },
   {
     appId: "1",
@@ -83,6 +83,6 @@ export default (): DeploymentV2[] => [
     duration: 125,
     statusChecksPassed: true,
     statusChecks: [],
-    published: [],
+    published: false,
   },
 ];

--- a/src/ui/src/types/deployment.d.ts
+++ b/src/ui/src/types/deployment.d.ts
@@ -42,7 +42,8 @@ declare type Deployment = {
   isRunning: boolean;
   logs: Array<Log>;
   numberOfFiles: number;
-  published: Array<PublishInfo>;
+  published: boolean;
+  isWarmingUp?: boolean;
   preview: string; // The preview endpoint
 };
 
@@ -75,10 +76,8 @@ declare type DeploymentV2 = {
     serverBytes?: number;
     serverlessBytes?: number;
   };
-  published: {
-    envId: string;
-    percentage: number;
-  }[];
+  published: boolean;
+  isWarmingUp?: boolean;
   isPriority?: boolean;
 };
 


### PR DESCRIPTION
This is the PR where the warm-up gate starts doing something. #515 and #516 built and tested it; nothing called it until now.

Publishing waits for the new deployment to serve a request before traffic moves to it. The previously published deployment keeps serving until then, so a build that cannot start no longer takes the site down for as long as it takes to boot — it simply does not get published.

### The four publish paths

Each passes its own work to the gate as a callback, so the flip stays in one place and no caller blocks:

| Path | Notes |
|---|---|
| Dashboard publish button | Responds immediately with `status: "publishing"` |
| `POST /v1/deployments/{id}/publish` | Response gains `status`; the MCP tool follows |
| Runner callback auto-publish | Must not block — the runner's HTTP client gives up after 30s |
| CLI upload auto-publish | Same |

**Recording a publish is post-flip work that cannot fail it.** Once the environment has moved the release is real; reporting a bookkeeping error as a failed publish would tell the user their release did not happen when it did.

**The audit entry and the licence check are read while the request is still alive** and written with a context that outlives it. Both capture the request's own context, which is done as soon as the response is written — on Stormkit Cloud the licence lookup would have quietly reported "not enterprise" and dropped the entry entirely.

### Breaking change: `published` is now a boolean

A deployment's `published` was a list of traffic shares (`[{envId, percentage}]`). An environment serves exactly one deployment and percentage-based releases are retired, so it is now simply `true` or `false`.

Alongside it, **`isWarmingUp`** says whether a publish of that deployment is on its way:

| `published` | `isWarmingUp` | Meaning |
|---|---|---|
| `true` | `false` | Serving the environment |
| `false` | `true` | Release in progress |
| `false` | `false` | Not published |

Both ride on the payloads the dashboard and the API already fetch — no new endpoint, no second polling loop — and are read once per environment rather than once per deployment. The warm-up status only speaks for the deployment it names, so an older deployment is not shown as warming up because the one replacing it is.

Clients reading `published[0].envId` or `.percentage` will break. Docs and OpenAPI updated.

**A failed publish is not distinguishable from "not published" in this shape.** The reason is in the deployment's runtime logs.

### `deploy.Publish` is gone

Every publish goes through the gate now, and a function that skips it is a trap for the next call site. The dead `deployhooks` seam goes with it — along with two tests that asserted against that seam and therefore asserted nothing; they now query `deployments_published` directly.

### Testing

The gate runs inline under `config.IsTest()`: suites share a transaction per test, and detached work would otherwise write to it after rollback, breaking whichever test ran next rather than the one that started it. That shortcut means the goroutine path would go unexercised, so `PublishGateSuite` drives it directly — service discovery faked, no database — covering:

- publishes once every node reports ready
- **does not publish when a node fails** — the guarantee the feature exists for
- publishes straight through when no hosting node is registered
- a superseded publish does not move the environment

```
go test -p 1 -count=1 ./src/ce/api/app/deploy/... ./src/ce/api/public/v1/...
```
all green, plus the frontend suite (one unrelated pre-existing flake in `Events.spec.tsx`, passes in isolation).

### Known gaps, deliberately left

- `PublishModal` still closes on the response, so the dashboard does not yet render the publishing state — that is the UI PR.
- Auto-publish returns success as soon as the warm-up is requested, so a CI pipeline sees a green deploy even if the publish later fails.
- A publish interrupted by an API restart leaves the status `publishing` until its hour TTL expires.