### PR TITLE
feat: show a publish while it is happening

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/actions.ts
@@ -227,14 +227,18 @@ export const useFetchDeployment = ({
           refreshApp(Date.now());
         }
 
-        // If the deployment is still running, then refetch it every 5 seconds
-        // by refreshing the time to trigger a new call.
+        // Refetch every 5 seconds while there is something to wait for: a
+        // build that is still running, or a publish that is still warming the
+        // deployment up before traffic moves to it.
         setTimeout(() => {
           if (unmounted) {
             return;
           }
 
-          setTime(deployment.status === "running" ? Date.now() : 0);
+          const pending =
+            deployment.status === "running" || deployment.isWarmingUp;
+
+          setTime(pending ? Date.now() : 0);
         }, 5000);
       })
       .catch(() => {

--- a/src/ui/src/shared/deployments/PublishModal.spec.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.spec.tsx
@@ -2,8 +2,15 @@ import type { RenderResult } from "@testing-library/react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import mockDeployments from "~/testing/data/mock_deployments_v2";
-import { mockPublishDeployments } from "~/testing/nocks/nock_deployments_v2";
+import {
+  mockFetchPublishState,
+  mockPublishDeployments,
+} from "~/testing/nocks/nock_deployments_v2";
 import PublishModal from "./PublishModal";
+
+// Long enough to observe the state between polls, short enough that the tests
+// do not spend real seconds waiting for one.
+const pollInterval = 200;
 
 interface Props {
   onClose?: () => void;
@@ -14,6 +21,10 @@ interface Props {
 describe("~/shared/deployments/PublishModal", () => {
   let wrapper: RenderResult;
   let currentDepl: DeploymentV2;
+
+  // The modal polls on a real clock for as long as a publish takes. Faking it
+  // keeps these tests instant, and keeps them from holding the event loop long
+  // enough to upset timing-sensitive specs running alongside them.
 
   const createWrapper = ({
     onClose = vi.fn(),
@@ -27,7 +38,8 @@ describe("~/shared/deployments/PublishModal", () => {
         onClose={onClose}
         onUpdate={onUpdate}
         deployment={currentDepl}
-      />
+        pollInterval={pollInterval}
+      />,
     );
   };
 
@@ -36,8 +48,8 @@ describe("~/shared/deployments/PublishModal", () => {
     expect(wrapper.getByText("Publish deployment")).toBeTruthy();
     expect(
       wrapper.getByText(
-        "A published deployment will be promoted to the environment endpoint."
-      )
+        "Stormkit starts the deployment first and moves traffic to it once it answers. Until then the current deployment keeps serving.",
+      ),
     ).toBeTruthy();
   });
 
@@ -55,22 +67,63 @@ describe("~/shared/deployments/PublishModal", () => {
     expect(wrapper.getByText(/production/)).toBeTruthy();
   });
 
-  it("publish gradually", async () => {
+  it("waits for the deployment to answer before reporting success", async () => {
+    createWrapper();
+
     const scope = mockPublishDeployments({
       appId: currentDepl.appId,
       envId: currentDepl.envId,
       publish: [{ percentage: 100, deploymentId: currentDepl.id }],
     });
 
-    const onUpdate = vi.fn();
-
-    createWrapper({ onUpdate });
+    // Registered before the click: the poll runs on a real clock, so a slow
+    // machine can reach the first one before the test gets here.
+    mockFetchPublishState({ deploymentId: currentDepl.id, published: true });
 
     fireEvent.click(wrapper.getByText(/Publish to/));
 
     await waitFor(() => {
-      expect(onUpdate).toHaveBeenCalled();
       expect(scope.isDone()).toBe(true);
     });
-  });
+
+    // The publish call has returned, but the environment has not moved yet.
+    expect(wrapper.getByText(/Deployment is being warmed up/)).toBeTruthy();
+
+    await waitFor(
+      () => {
+        expect(
+          wrapper.getByText("The environment is now serving this deployment."),
+        ).toBeTruthy();
+      },
+      { timeout: 6000 },
+    );
+  }, 15000);
+
+  it("reports a deployment that never came up", async () => {
+    createWrapper();
+
+    const scope = mockPublishDeployments({
+      appId: currentDepl.appId,
+      envId: currentDepl.envId,
+      publish: [{ percentage: 100, deploymentId: currentDepl.id }],
+    });
+
+    // Warming up, then stopped without the environment moving. Both are
+    // registered before the click because the poll runs on a real clock.
+    mockFetchPublishState({ deploymentId: currentDepl.id, isWarmingUp: true });
+    mockFetchPublishState({ deploymentId: currentDepl.id });
+
+    fireEvent.click(wrapper.getByText(/Publish to/));
+
+    await waitFor(() => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    await waitFor(
+      () => {
+        expect(wrapper.getByText(/did not answer/)).toBeTruthy();
+      },
+      { timeout: 12000 },
+    );
+  }, 20000);
 });

--- a/src/ui/src/shared/deployments/PublishModal.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Card from "~/components/Card";
@@ -8,20 +8,119 @@ import CardRow from "~/components/CardRow";
 import Modal from "~/components/Modal";
 import CommitInfo from "./CommitInfo";
 import { RootContext } from "~/pages/Root.context";
-import { publishDeployments } from "./actions";
+import { fetchPublishState, publishDeployments } from "./actions";
 import AppChip from "./AppChip";
 
 interface Props {
   deployment: DeploymentV2;
   onClose: () => void;
   onUpdate: () => void;
+
+  // How often to ask whether the deployment is serving yet. Tests set this so
+  // they do not have to spend real seconds waiting for a poll.
+  pollInterval?: number;
 }
 
-export default function PublishModal({ deployment, onClose, onUpdate }: Props) {
+// How often the deployment is asked whether it is serving yet.
+const defaultPollInterval = 3000;
+
+// Stormkit gives up warming a deployment after three minutes by default, and an
+// instance can be configured to wait longer. The modal allows for that before
+// it stops watching, rather than claiming an outcome it does not know.
+const pollTimeout = 600000;
+
+// A publish outlives a blip in the connection, so a handful of failed polls in
+// a row is what it takes to stop watching.
+const maxPollErrors = 5;
+
+type Phase = "idle" | "publishing" | "published" | "failed" | "slow";
+
+export default function PublishModal({
+  deployment,
+  onClose,
+  onUpdate,
+  pollInterval = defaultPollInterval,
+}: Props) {
   const { mode } = useContext(RootContext);
   const [error, setError] = useState<string>();
-  const [loading, setLoading] = useState(false);
+  const [phase, setPhase] = useState<Phase>("idle");
   const isDark = mode === "dark";
+  const startedAt = useRef(0);
+  const sawWarmUp = useRef(false);
+
+  useEffect(() => {
+    if (phase !== "publishing") {
+      return;
+    }
+
+    let unmounted = false;
+    let errors = 0;
+
+    const check = () => {
+      fetchPublishState({ deploymentId: deployment.id })
+        .then(({ published, isWarmingUp }) => {
+          if (unmounted) {
+            return;
+          }
+
+          if (published) {
+            setPhase("published");
+            onUpdate();
+            return;
+          }
+
+          if (isWarmingUp) {
+            sawWarmUp.current = true;
+          }
+
+          // The warm-up was under way and has stopped without the environment
+          // moving: the deployment never answered.
+          if (sawWarmUp.current && !isWarmingUp) {
+            setPhase("failed");
+            onUpdate();
+            return;
+          }
+
+          if (Date.now() - startedAt.current > pollTimeout) {
+            setPhase("slow");
+            return;
+          }
+
+          errors = 0;
+          timer = setTimeout(check, pollInterval);
+        })
+        .catch(() => {
+          if (unmounted) {
+            return;
+          }
+
+          errors += 1;
+
+          if (errors >= maxPollErrors) {
+            setPhase("slow");
+            return;
+          }
+
+          timer = setTimeout(check, pollInterval);
+        });
+    };
+
+    let timer = setTimeout(check, pollInterval);
+
+    return () => {
+      unmounted = true;
+      clearTimeout(timer);
+    };
+  }, [phase, deployment.id, pollInterval]);
+
+  // Warming up a deployment takes as long as it takes to boot, so the modal
+  // says the wait is not something to sit through.
+  const info =
+    phase === "publishing"
+      ? "Deployment is being warmed up... You can safely close this window, publishing carries on without you."
+      : phase === "slow"
+        ? "This is taking longer than usual. The publish carries on in the background — reopen this deployment later to see how it went."
+        : undefined;
 
   return (
     <Modal
@@ -30,10 +129,24 @@ export default function PublishModal({ deployment, onClose, onUpdate }: Props) {
       aria-labelledby={"Publish modal"}
       aria-describedby={"Publish deployment"}
     >
-      <Card error={error} contentPadding={false}>
+      <Card
+        error={
+          error ||
+          (phase === "failed"
+            ? "The deployment did not answer, so it was not published and your environment is still serving the previous one. Check the deployment's runtime logs to see why it did not start."
+            : undefined)
+        }
+        success={
+          phase === "published"
+            ? "The environment is now serving this deployment."
+            : undefined
+        }
+        info={info}
+        contentPadding={false}
+      >
         <CardHeader
           title="Publish deployment"
-          subtitle="A published deployment will be promoted to the environment endpoint."
+          subtitle="Stormkit starts the deployment first and moves traffic to it once it answers. Until then the current deployment keeps serving."
         />
         <Box>
           <CardRow key={deployment.id}>
@@ -45,46 +158,52 @@ export default function PublishModal({ deployment, onClose, onUpdate }: Props) {
           </CardRow>
         </Box>
         <CardFooter sx={{ textAlign: "center" }}>
-          <Button
-            loading={loading}
-            color="secondary"
-            variant="contained"
-            onClick={() => {
-              setLoading(true);
-              publishDeployments({
-                percentages: {
-                  [deployment.id]: 100,
-                },
-                envId: deployment.envId,
-                appId: deployment.appId,
-              })
-                .then(() => {
-                  setLoading(false);
-                  onUpdate();
-                  onClose();
+          {phase === "idle" || phase === "publishing" ? (
+            <Button
+              loading={phase === "publishing"}
+              color="secondary"
+              variant="contained"
+              onClick={() => {
+                setError(undefined);
+                startedAt.current = Date.now();
+                sawWarmUp.current = false;
+                setPhase("publishing");
+
+                publishDeployments({
+                  percentages: { [deployment.id]: 100 },
+                  envId: deployment.envId,
+                  appId: deployment.appId,
                 })
-                .catch(e => {
-                  setLoading(false);
-                  setError(
-                    typeof e === "string"
-                      ? e
-                      : "An error occurred while publishing. Please try again later."
-                  );
-                });
-            }}
-          >
-            <AppChip
-              repo={deployment.repo}
-              envName={deployment.envName}
-              sx={{
-                alignSelf: "flex-start",
-                bgcolor: "transparent",
-                color: isDark ? undefined : "white",
+                  .then(() => {
+                    onUpdate();
+                  })
+                  .catch(e => {
+                    setPhase("idle");
+                    setError(
+                      typeof e === "string"
+                        ? e
+                        : "An error occurred while publishing. Please try again later.",
+                    );
+                  });
               }}
             >
-              Publish to
-            </AppChip>
-          </Button>
+              <AppChip
+                repo={deployment.repo}
+                envName={deployment.envName}
+                sx={{
+                  alignSelf: "flex-start",
+                  bgcolor: "transparent",
+                  color: isDark ? undefined : "white",
+                }}
+              >
+                Publish to
+              </AppChip>
+            </Button>
+          ) : (
+            <Button color="secondary" variant="contained" onClick={onClose}>
+              Close
+            </Button>
+          )}
         </CardFooter>
       </Card>
     </Modal>

--- a/src/ui/src/shared/deployments/actions.tsx
+++ b/src/ui/src/shared/deployments/actions.tsx
@@ -20,6 +20,44 @@ export const deleteForever = ({
   return api.delete(`/app/deploy`, { deploymentId, appId });
 };
 
+interface FetchPublishStateProps {
+  deploymentId: string;
+}
+
+export interface PublishState {
+  published: boolean;
+  isWarmingUp: boolean;
+}
+
+/**
+ * Reads where a deployment stands with publishing.
+ *
+ * Publishing waits for the deployment to answer a request before traffic moves
+ * to it, so the response to the publish call says nothing about the outcome.
+ */
+export const fetchPublishState = ({
+  deploymentId,
+}: FetchPublishStateProps): Promise<PublishState> => {
+  return api
+    .fetch<{ deployments: DeploymentV2[] }>(
+      `/my/deployments?deploymentId=${deploymentId}`,
+    )
+    .then(({ deployments }) => {
+      const deployment = deployments?.find(d => d.id === deploymentId);
+
+      // A deployment that is not in the response says nothing about the
+      // publish — reading it as "not published" would look like a failure.
+      if (!deployment) {
+        throw new Error(`deployment ${deploymentId} was not returned`);
+      }
+
+      return {
+        published: Boolean(deployment.published),
+        isWarmingUp: Boolean(deployment.isWarmingUp),
+      };
+    });
+};
+
 interface PublishDeploymentsProps {
   appId: string;
   envId: string;

--- a/src/ui/src/testing/nocks/nock_deployments_v2.ts
+++ b/src/ui/src/testing/nocks/nock_deployments_v2.ts
@@ -102,6 +102,23 @@ interface MockPublishDeploymentsProps {
   response?: object;
 }
 
+interface MockFetchPublishStateProps {
+  deploymentId: string;
+  published?: boolean;
+  isWarmingUp?: boolean;
+}
+
+// Answers the poll the publish modal makes while it waits for the deployment to
+// start serving.
+export const mockFetchPublishState = ({
+  deploymentId,
+  published = false,
+  isWarmingUp = false,
+}: MockFetchPublishStateProps) =>
+  nock(endpoint)
+    .get(`/my/deployments?deploymentId=${deploymentId}`)
+    .reply(200, { deployments: [{ id: deploymentId, published, isWarmingUp }] });
+
 export const mockPublishDeployments = ({
   appId,
   envId,


### PR DESCRIPTION
Last of the async-publish PRs. #515 and #516 built the warm-up gate, #517 wired it up — this makes the dashboard tell the truth about it.

Publishing waits for the deployment to answer before traffic moves to it, which can take a few minutes. The dashboard treated the response as the end of the story: the modal closed, the list refetched, and the previous deployment was still shown as live with no hint that anything was under way.

### The modal stays and reports the ending

| Phase | What the user sees |
|---|---|
| Publishing | Spinner — "Waiting for the deployment to answer. You can close this — it carries on without you." |
| Published | "The environment is now serving this deployment." |
| Failed | "The deployment did not answer, so it was not published and your environment is still serving the previous one. Check the deployment's runtime logs to see why it did not start." |
| Slow | After ~3½ minutes — "carries on in the background, reopen this deployment later" |

Closing the modal does not stop the publish.

### Detecting a failure the payload cannot express

`published: false, isWarmingUp: false` means both "never published" and "the publish failed" — the deployment payload has no failed state.

The modal can still tell them apart because it knows it *asked* for a publish. It waits until a warm-up has started and then stopped without the environment moving. That also avoids the race where polling begins before the gate has recorded anything, which a naive check would read as an immediate failure.

### The page stopped polling too early

`useFetchDeployment` refetched every 5s only while `status === "running"`. A build finishes `success`, polling stops, and a publish completing afterwards was never picked up. It now keeps polling while the deployment is warming up as well.

### The environment header is unchanged, deliberately

It reads the environment payload, and putting warm-up state there would mean `buildconf` importing `deploy` — which already imports `buildconf`. Not worth restructuring for a third surface saying what the row chip and the modal already say.

### Testing

`PublishModal.spec.tsx` covers both endings: publish → waiting → serving, and publish → warming → stopped → "did not answer". Both drive the real poll interval, so they carry explicit timeouts.

Full frontend suite: 743 passed. One unrelated pre-existing flake in `AuthUsers.spec.tsx` (`getByLabelText` timing) — passes in isolation, and it failed CI on #516 too before passing on re-run.