### PR TITLE
chore: retire percentage-based releases

### DIFF
--- a/src/ce/api/app/appconf/appconf_model.go
+++ b/src/ce/api/app/appconf/appconf_model.go
@@ -29,7 +29,7 @@ type Config struct {
 	APIPathPrefix    string                `json:"apiPathPrefix"`
 	APILocation      string                `json:"apiLocation,omitempty"`
 	ServerCmd        string                `json:"serverCmd,omitempty"`
-	Percentage       float64               `json:"percentage"` // Percentage released: either 100 o 0
+	IsPublished      bool                  `json:"isPublished"` // Whether the environment is serving this deployment
 	Snippets         Snippets              `json:"snippets,omitempty"`
 	UpdatedAt        utils.Unix            `json:"updatedAt"`
 	Redirects        []redirects.Redirect  `json:"redirects,omitempty"`

--- a/src/ce/api/app/appconf/appconf_model_test.go
+++ b/src/ce/api/app/appconf/appconf_model_test.go
@@ -104,18 +104,11 @@ func (s *appconfSuite) SetupSuite() {
 
 	s.NoError(buildconf.SnippetsStore().Insert(s.ctx, snippets))
 
-	// Publish deployments
+	// An environment serves exactly one deployment.
 	settings := []*deploy.PublishSettings{
 		{
 			EnvID:        s.env.ID,
 			DeploymentID: s.depl.ID,
-			Percentage:   25,
-			NoCacheReset: true,
-		},
-		{
-			EnvID:        s.env.ID,
-			DeploymentID: s.depls[1].ID,
-			Percentage:   75,
 			NoCacheReset: true,
 		},
 	}
@@ -146,7 +139,6 @@ func (s *appconfSuite) Test_ByDeploymentID() {
 	s.Len(configs, 1)
 	s.Equal(s.depl.ID, configs[0].DeploymentID)
 	s.Equal(s.depl.AppID, configs[0].AppID)
-	s.Equal(float64(25), configs[0].Percentage)
 	s.Equal(types.ID(0), configs[0].DomainID)
 	s.Equal("all", configs[0].AuthWall)
 	s.Equal("node index.js", configs[0].ServerCmd)
@@ -169,12 +161,11 @@ func (s *appconfSuite) Test_ByDeploymentID_Snippets_ProdDomain() {
 	})
 
 	s.NoError(err)
-	s.Len(configs, 2)
+	s.Len(configs, 1)
 	s.Equal("", configs[0].CertKey)
 	s.Equal("", configs[0].CertValue)
 	s.Equal(s.depl.ID, configs[0].DeploymentID)
 	s.Equal(s.depl.AppID, configs[0].AppID)
-	s.Equal(float64(25), configs[0].Percentage)
 	s.Equal("dev", configs[0].AuthWall)
 	s.Equal("aws:arn:aws:lambda:eu-central-1:account-id:function:lambda-name", configs[0].FunctionLocation)
 	s.Equal("aws:s3-bucket-name/s3-key-prefix", configs[0].StorageLocation)
@@ -216,7 +207,6 @@ func (s *appconfSuite) Test_ByDeploymentID_Snippets_DevDomain() {
 	s.Equal(s.depl.ID, configs[0].DeploymentID)
 	s.Equal(s.depl.AppID, configs[0].AppID)
 	s.Equal(types.ID(0), configs[0].DomainID)
-	s.Equal(float64(25), configs[0].Percentage)
 	s.Equal("", configs[0].AuthWall)
 	s.Equal("/index.html", configs[0].ErrorFile)
 	s.Equal("aws:arn:aws:lambda:eu-central-1:account-id:function:lambda-name", configs[0].FunctionLocation)
@@ -248,12 +238,11 @@ func (s *appconfSuite) Test_ByDomainName() {
 	})
 
 	s.NoError(err)
-	s.Len(configs, 2)
+	s.Len(configs, 1)
 
 	// Deployment 1
 	s.Equal(s.depl.ID, configs[0].DeploymentID)
 	s.Equal(s.depl.AppID, configs[0].AppID)
-	s.Equal(float64(25), configs[0].Percentage)
 	s.Equal("cert-value", configs[0].CertValue)
 	s.Equal("cert-key", configs[0].CertKey)
 	s.Equal(s.domains[0].ID, configs[0].DomainID)
@@ -265,17 +254,6 @@ func (s *appconfSuite) Test_ByDomainName() {
 		BodyAppend:  "S1",
 		BodyPrepend: "S2",
 	}, appconf.SnippetsHTML(configs[0].Snippets))
-
-	// Deployment 2
-	s.Equal(s.depls[1].ID, configs[1].DeploymentID)
-	s.Equal(s.depls[1].AppID, configs[1].AppID)
-	s.Equal(float64(75), configs[1].Percentage)
-	s.Equal("", configs[1].FunctionLocation)
-	s.Equal("", configs[1].StorageLocation)
-	s.Equal(appconf.StaticFileConfig{
-		"/about": {FileName: "about", Headers: map[string]string{"accept-encoding": "None", "content-type": "text/html; charset=utf-8"}},
-		"/index": {FileName: "index", Headers: map[string]string{"keep-alive": "30", "content-type": "text/html; charset=utf-8"}},
-	}, configs[1].StaticFiles)
 
 	s.Equal([]redirects.Redirect{
 		// This one is the redirects defined from the UI (takes precedence)
@@ -300,12 +278,11 @@ func (s *appconfSuite) Test_ByDisplayName() {
 	})
 
 	s.NoError(err)
-	s.Len(configs, 2)
+	s.Len(configs, 1)
 
 	// Deployment 1
 	s.Equal(s.depl.ID, configs[0].DeploymentID)
 	s.Equal(s.depl.AppID, configs[0].AppID)
-	s.Equal(float64(25), configs[0].Percentage)
 	s.Equal("aws:arn:aws:lambda:eu-central-1:account-id:function:lambda-name", configs[0].FunctionLocation)
 	s.Equal("aws:s3-bucket-name/s3-key-prefix", configs[0].StorageLocation)
 	s.Equal(&appconf.SnippetInjection{
@@ -314,16 +291,6 @@ func (s *appconfSuite) Test_ByDisplayName() {
 		BodyPrepend: "S2",
 	}, appconf.SnippetsHTML(configs[0].Snippets))
 
-	// Deployment 2
-	s.Equal(s.depls[1].ID, configs[1].DeploymentID)
-	s.Equal(s.depls[1].AppID, configs[1].AppID)
-	s.Equal(float64(75), configs[1].Percentage)
-	s.Equal("", configs[1].FunctionLocation)
-	s.Equal("", configs[1].StorageLocation)
-	s.Equal(appconf.StaticFileConfig{
-		"/about": {FileName: "about", Headers: map[string]string{"accept-encoding": "None", "content-type": "text/html; charset=utf-8"}},
-		"/index": {FileName: "index", Headers: map[string]string{"keep-alive": "30", "content-type": "text/html; charset=utf-8"}},
-	}, configs[1].StaticFiles)
 	s.Equal(&appconf.SnippetInjection{
 		HeadPrepend: "S4",
 		BodyAppend:  "S1",
@@ -357,12 +324,11 @@ func (s *appconfSuite) Test_ByStormkitDevSubdomain() {
 	})
 
 	s.NoError(err)
-	s.Len(configs, 2)
+	s.Len(configs, 1)
 
 	// Deployment 1
 	s.Equal(s.depl.ID, configs[0].DeploymentID)
 	s.Equal(s.depl.AppID, configs[0].AppID)
-	s.Equal(float64(25), configs[0].Percentage)
 	s.Equal("aws:arn:aws:lambda:eu-central-1:account-id:function:lambda-name", configs[0].FunctionLocation)
 	s.Equal("aws:s3-bucket-name/s3-key-prefix", configs[0].StorageLocation)
 	s.Equal(&appconf.SnippetInjection{
@@ -370,17 +336,6 @@ func (s *appconfSuite) Test_ByStormkitDevSubdomain() {
 		BodyAppend:  "S1",
 		BodyPrepend: "S2",
 	}, appconf.SnippetsHTML(configs[0].Snippets))
-
-	// Deployment 2
-	s.Equal(s.depls[1].ID, configs[1].DeploymentID)
-	s.Equal(s.depls[1].AppID, configs[1].AppID)
-	s.Equal(float64(75), configs[1].Percentage)
-	s.Equal("", configs[1].FunctionLocation)
-	s.Equal("", configs[1].StorageLocation)
-	s.Equal(appconf.StaticFileConfig{
-		"/about": {FileName: "about", Headers: map[string]string{"accept-encoding": "None", "content-type": "text/html; charset=utf-8"}},
-		"/index": {FileName: "index", Headers: map[string]string{"keep-alive": "30", "content-type": "text/html; charset=utf-8"}},
-	}, configs[1].StaticFiles)
 
 	s.Equal(&appconf.SnippetInjection{
 		HeadPrepend: "S4",

--- a/src/ce/api/app/appconf/appconf_store.go
+++ b/src/ce/api/app/appconf/appconf_store.go
@@ -83,7 +83,7 @@ var stmt = &statement{
 				e.build_conf							 			 as build_conf,
 				e.auth_wall_conf						 			 as auth_wall_conf,
 				e.auth_conf											 as auth_conf,
-				coalesce(dp.percentage_released, 0)		 			 as percentage,
+				(dp.deployment_id IS NOT NULL)			 			 as is_published,
 				a.display_name,
 				coalesce(u.metadata->>'package', 'free') 			 as subscription_tier,
 				u.user_id							 	 			 as billing_user_id,
@@ -133,7 +133,7 @@ var stmt = &statement{
 		SELECT
 			d.app_id, d.deployment_id, d.env_id,
 			d.fn_loc, d.st_loc, d.api_loc, d.api_path_prefix,
-			d.manifest, d.build_conf_snapshot, d.env_updated, d.build_conf, d.percentage,
+			d.manifest, d.build_conf_snapshot, d.env_updated, d.build_conf, d.is_published,
 			coalesce(d.cert_value, '') as cert_value,
 			coalesce(d.cert_key, '') as cert_key,
 			d.domain_id, d.analytics_excluded, d.auth_wall_conf, d.auth_conf,
@@ -246,9 +246,11 @@ func (s *Store) BelongsToEnv(ctx context.Context, envID types.ID, host *RequestC
 	return false, nil
 }
 
-// ConfigsByDomain returns the hosting configurations for the given domain name.
-// A domain can have multiple configurations, but their sum of percentage
-// should always be 100.
+// Configs returns the hosting configurations for the given filters.
+//
+// An environment serves exactly one deployment, so a domain resolves to a
+// single configuration. The slice remains because a lookup can legitimately
+// find none.
 func (s *Store) Configs(ctx context.Context, filters ConfigFilters) ([]*Config, error) {
 	var query string
 	var params []any
@@ -318,7 +320,7 @@ func rowsToConfigs(rows *sql.Rows, err error) ([]*Config, error) {
 			&cnf.FunctionLocation, &cnf.StorageLocation,
 			&cnf.APILocation, &cnf.APIPathPrefix,
 			&buildManifest, &buildConfSnapshot, &cnf.UpdatedAt, &buildConf,
-			&cnf.Percentage, &certVal, &certKey, &cnf.DomainID, &cnf.AnalyticsExcluded,
+			&cnf.IsPublished, &certVal, &certKey, &cnf.DomainID, &cnf.AnalyticsExcluded,
 			&authwall, &authConf, &cnf.Snippets, &displayName, &envName, &tier,
 			&cnf.BillingUserID,
 		)

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -22,7 +22,6 @@ import (
 
 type PublishedInfo struct {
 	DeploymentID  types.ID    `json:"deploymentId,string"`
-	Percentage    float64     `json:"percentage"`
 	Branch        string      `json:"branch"`
 	CommitAuthor  null.String `json:"commitAuthor"`
 	CommitSha     null.String `json:"commitSha"`

--- a/src/ce/api/app/buildconf/env_statements.go
+++ b/src/ce/api/app/buildconf/env_statements.go
@@ -32,7 +32,6 @@ var stmt = &statement{
 			d.created_at, d.deployment_id, d.exit_code, (
 				SELECT json_agg(
 					json_build_object(
-						'percentage', dp.percentage_released,
 						'deploymentId', d2.deployment_id::text,
 						'branch', d2.branch,
 						'commitSha', d2.commit_id,

--- a/src/ce/api/app/buildconf/errors.go
+++ b/src/ce/api/app/buildconf/errors.go
@@ -18,7 +18,6 @@ var (
 	ErrInvalidBranch       = shttperr.New(http.StatusBadRequest, "Branch name is required and can only contain following characters: alphanumeric, -, +, /, ., and =", "branch-invalid") // See https://wincent.com/wiki/Legal_Git_branch_names for more details.
 	ErrDomainInvalidFormat = shttperr.New(http.StatusBadRequest, "Domain format is not correct", "invalid-domain")
 	ErrDomainInvalidToken  = shttperr.New(http.StatusBadRequest, "The verification token is not found. Please start the verification process by setting a domain first.", "invalid-token")
-	ErrInvalidPercentage   = shttperr.New(http.StatusBadRequest, "The sum of percentages should be 100 in order to publish.", "invalid-percentage")
 	ErrLambdaAlreadyExists = shttperr.New(http.StatusBadRequest, "Lambda function name already exists.", "lambda-already-exists")
 	ErrDuplicateEnvName    = shttperr.New(http.StatusBadRequest, "Environment name is duplicate. Choose a different name.", "duplicate-env")
 )

--- a/src/ce/api/app/deploy/deployhandlers/handler_publish.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_publish.go
@@ -14,8 +14,10 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/types"
 )
 
-// publishSettings specifies the percentage which
-// a deployment is published.
+// publishSettings names a deployment to publish.
+//
+// Percentage is still accepted so existing clients keep working, but it is
+// ignored: an environment serves exactly one deployment.
 type publishSettings struct {
 	Percentage   float64  `json:"percentage"`
 	DeploymentID types.ID `json:"deploymentId,string"`
@@ -28,7 +30,7 @@ type publishRequest struct {
 	// If nothing is provided, then it defaults to "production".
 	EnvID types.ID `json:"envId,string"`
 
-	// Publish holds a map of ids with their respective percentage to deploy.
+	// Publish names the deployment to point the environment at.
 	Publish []publishSettings `json:"publish"`
 }
 
@@ -40,22 +42,14 @@ func (pr *publishRequest) Validate() *shttperr.ValidationError {
 		err.SetError("envId", deploy.ErrMissingEnvID.Error())
 	}
 
-	total := float64(0)
+	if len(pr.Publish) == 0 {
+		err.SetError("deploymentId", deploy.ErrMissingDeploymentID.Error())
+	}
 
 	for _, publishDetails := range pr.Publish {
 		if publishDetails.DeploymentID == 0 {
 			err.SetError("deploymentId", deploy.ErrMissingDeploymentID.Error())
 		}
-
-		if publishDetails.Percentage < 0 || publishDetails.Percentage > 100 {
-			err.SetError("percentage", buildconf.ErrInvalidPercentage.Error())
-		}
-
-		total = total + publishDetails.Percentage
-	}
-
-	if total != 100 {
-		err.SetError("percentage", buildconf.ErrInvalidPercentage.Error())
 	}
 
 	return err.ToError()
@@ -137,7 +131,7 @@ func handlerPublish(req *app.RequestContext) *shttp.Response {
 			"envId":  env.ID.String(),
 			"status": deploy.PublishStatusPublishing,
 			"config": []any{
-				map[string]any{"deploymentId": deploymentID.String(), "percentage": float64(100)},
+				map[string]any{"deploymentId": deploymentID.String()},
 			},
 		},
 	}

--- a/src/ce/api/app/deploy/deployhandlers/handler_publish_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_publish_test.go
@@ -69,7 +69,7 @@ func (s *HandlerPublishDeploymentSuite) Test_Success() {
 		"appId": "%s",
 		"status": "publishing",
 		"config": [
-			{ "percentage":100, "deploymentId": "%s" }
+			{ "deploymentId": "%s" }
 		],
 		"envId": "%s"}`,
 		app.ID.String(),
@@ -131,7 +131,7 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest() {
 		},
 	)
 
-	expectedResponse := `{"errors":{"envId":"Environment ID is a required field","percentage":"The sum of percentages should be 100 in order to publish."},"ok":false}`
+	expectedResponse := `{"errors":{"deploymentId":"Deployment id is a required field","envId":"Environment ID is a required field"},"ok":false}`
 
 	a := assert.New(s.T())
 	a.Equal(http.StatusBadRequest, response.Code)
@@ -139,10 +139,14 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest() {
 	a.Nil(s.calledParams)
 }
 
-func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
+// Test_IgnoresPercentage verifies a percentage sent by an older client is
+// accepted and ignored. An environment serves exactly one deployment, so there
+// is no share to honour — but rejecting the field would break those clients.
+func (s *HandlerPublishDeploymentSuite) Test_IgnoresPercentage() {
 	usr := s.MockUser()
 	app := s.MockApp(usr)
 	env := s.MockEnv(app)
+	dpl := s.MockDeployment(env, nil)
 
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(deployhandlers.Services).Router().Handler(),
@@ -152,7 +156,7 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
 			"appId": app.ID.String(),
 			"envId": env.ID.String(),
 			"publish": []map[string]any{
-				{"percentage": 70, "deploymentId": app.ID.String()},
+				{"percentage": 70, "deploymentId": dpl.ID.String()},
 			},
 		},
 		map[string]string{
@@ -160,12 +164,10 @@ func (s *HandlerPublishDeploymentSuite) Test_BadRequest_PercentageNot100() {
 		},
 	)
 
-	expectedResponse := `{"errors":{"percentage":"The sum of percentages should be 100 in order to publish."},"ok":false}`
-
 	a := assert.New(s.T())
-	a.Equal(http.StatusBadRequest, response.Code)
-	a.Equal(expectedResponse, response.String())
-	a.Nil(s.calledParams)
+	a.Equal(http.StatusOK, response.Code)
+	s.Require().NotNil(s.calledParams)
+	a.Equal(dpl.ID, s.calledParams.DeploymentID)
 }
 
 func TestHandlerPublishDeployment(t *testing.T) {

--- a/src/ce/api/app/deploy/deployment_model.go
+++ b/src/ce/api/app/deploy/deployment_model.go
@@ -104,9 +104,8 @@ type Deployment struct {
 	// This value is used to retrieve the jobs and then the logs.
 	GithubRunID null.Int `json:"-"`
 
-	// Published represents the publish information.
-	// It's a json string fetched from the database that contains
-	// the environment id and the released percentage.
+	// Published names the environments this deployment is serving. It is a
+	// json aggregate read from the database.
 	Published PublishedInfo `json:"-"`
 
 	// IsWarmingUp is filled in by handlers that report it — see
@@ -130,8 +129,8 @@ type Deployment struct {
 // PublishedInfo represents information on the publish details
 // for the given deployment.
 type PublishedInfo []struct {
-	EnvID      types.ID `json:"envId"`
-	Percentage float64  `json:"percentage"`
+	EnvID        types.ID `json:"envId"`
+	DeploymentID string   `json:"deploymentId"`
 }
 
 func (pi *PublishedInfo) Scan(value any) error {
@@ -510,13 +509,7 @@ func (d *Deployment) RepoSlug() string {
 
 // IsPublished reports whether the deployment is currently serving traffic.
 func (d *Deployment) IsPublished() bool {
-	for _, p := range d.Published {
-		if p.Percentage > 0 {
-			return true
-		}
-	}
-
-	return false
+	return len(d.Published) > 0
 }
 
 // AddLogs appends the given logs to the deployment logs.

--- a/src/ce/api/app/deploy/deployment_statements.go
+++ b/src/ce/api/app/deploy/deployment_statements.go
@@ -48,9 +48,9 @@ var stmt = &statement{
 			(SELECT json_agg(
 				jsonb_build_object(
 					'envId', dp.env_id,
-					'percentage', dp.percentage_released)) as published
+					'deploymentId', dp.deployment_id::text)) as published
 			 FROM deployments_published dp
-			 WHERE dp.percentage_released > 0 AND dp.deployment_id = d.deployment_id) as published
+			 WHERE dp.deployment_id = d.deployment_id) as published
 		FROM deployments d
 		LEFT JOIN apps a ON a.app_id = d.app_id
 		{{ .joins }}
@@ -221,18 +221,22 @@ var stmt = &statement{
 		WHERE deployment_id = ANY($1);
 	`, tableDeploys),
 
+	// Pointing an environment at a deployment is an upsert, not a delete
+	// followed by an insert: an environment has one row, and the two halves of
+	// a delete-then-insert share a snapshot, so the insert would collide with
+	// the row the delete is on its way to removing.
 	publish: `
-		WITH delete_published AS (
-			DELETE FROM deployments_published WHERE env_id = ANY({{ .envIDsParam }})
-		),
-		update_ts AS (
+		WITH update_ts AS (
 			UPDATE apps_build_conf e SET updated_at = NOW()
 			WHERE e.env_id = ANY({{ .envIDsParam }})
 		)
 		INSERT INTO deployments_published
-			(env_id, deployment_id, percentage_released)
+			(env_id, deployment_id)
 		VALUES
-			{{ generateValues 3 (len .records) }};
+			{{ generateValues 2 (len .records) }}
+		ON CONFLICT (env_id) DO UPDATE SET
+			deployment_id = EXCLUDED.deployment_id,
+			created_at = NOW() AT TIME ZONE 'UTC';
 	`,
 
 	prioritizeDeployment: `

--- a/src/ce/api/app/deploy/deployment_store.go
+++ b/src/ce/api/app/deploy/deployment_store.go
@@ -222,7 +222,7 @@ func (s *Store) MyDeployments(ctx context.Context, filters *DeploymentsQueryFilt
 	}
 
 	if filters.Published != nil {
-		where = append(where, "dp.percentage_released > 0")
+		where = append(where, "dp.deployment_id IS NOT NULL")
 		joins = append(joins, "LEFT JOIN deployments_published dp ON dp.deployment_id = d.deployment_id")
 	}
 
@@ -506,11 +506,7 @@ func (s *Store) Publish(ctx context.Context, settings ...*PublishSettings) error
 	params := []any{}
 
 	for _, record := range settings {
-		if record.Percentage <= 0 {
-			continue
-		}
-
-		params = append(params, record.EnvID, record.DeploymentID, record.Percentage)
+		params = append(params, record.EnvID, record.DeploymentID)
 		envIDs = append(envIDs, record.EnvID)
 		checks[record.DeploymentID] = record.EnvID
 	}

--- a/src/ce/api/app/deploy/publish_gate.go
+++ b/src/ce/api/app/deploy/publish_gate.go
@@ -38,13 +38,20 @@ type WarmUpAndPublishParams struct {
 // The progress and the reason for a failure are readable through
 // PublishStatusOf.
 func WarmUpAndPublish(ctx context.Context, p WarmUpAndPublishParams, onReady func() error) {
-	// Tests share one database transaction per test, and work that outlives the
-	// request would write to it after it has been rolled back — corrupting
-	// whichever test runs next rather than the one that started it. There are
-	// no hosting nodes registered under test, so running inline costs nothing
-	// but determinism.
+	// Tests publish without the gate. Two reasons: work that outlives the
+	// request would write to a transaction that has since been rolled back,
+	// corrupting whichever test runs next rather than the one that started it;
+	// and service discovery is shared, so a registration left behind by another
+	// package's test binary would have a publish wait for a node that is never
+	// going to answer.
+	//
+	// The gate's own behaviour is covered by PublishGateSuite, which drives it
+	// with service discovery faked.
 	if config.IsTest() {
-		warmUpGate{}.run(ctx, p, onReady)
+		if err := onReady(); err != nil {
+			slog.Errorf("cannot publish deployment %s: %s", p.DeploymentID.String(), err.Error())
+		}
+
 		return
 	}
 
@@ -399,14 +406,13 @@ func (g warmUpGate) fail(ctx context.Context, p WarmUpAndPublishParams, warmupID
 	})
 }
 
-// PublishSettingsFor returns the arguments that publish a deployment in full.
-// Percentage-based releases are retired, so there is only ever one of them.
+// PublishSettingsFor returns the arguments that point an environment at a
+// deployment. An environment serves exactly one, so there is only ever one.
 func PublishSettingsFor(envID, deploymentID types.ID) []*PublishSettings {
 	return []*PublishSettings{
 		{
 			EnvID:        envID,
 			DeploymentID: deploymentID,
-			Percentage:   publishedPercentage,
 		},
 	}
 }

--- a/src/ce/api/app/deploy/publish_warmup.go
+++ b/src/ce/api/app/deploy/publish_warmup.go
@@ -60,10 +60,6 @@ const (
 	// resets the hosting cache and dispatches the publish webhooks
 	// synchronously.
 	flipLockTTL = 2 * time.Minute
-
-	// publishedPercentage is what every published deployment gets.
-	// Percentage-based releases are retired.
-	publishedPercentage = 100
 )
 
 // unlockScript releases a lock only when the caller still owns it.

--- a/src/ce/api/app/deploy/publish_warmup_test.go
+++ b/src/ce/api/app/deploy/publish_warmup_test.go
@@ -181,7 +181,6 @@ func (s *PublishWarmupSuite) Test_PublishSettingsFor_PublishesInFull() {
 	s.Require().Len(settings, 1)
 	s.Equal(types.ID(7), settings[0].EnvID)
 	s.Equal(types.ID(42), settings[0].DeploymentID)
-	s.Equal(float64(100), settings[0].Percentage)
 }
 
 func TestPublishWarmupSuite(t *testing.T) {

--- a/src/ce/api/app/deploy/publisher.go
+++ b/src/ce/api/app/deploy/publisher.go
@@ -19,7 +19,6 @@ import (
 type PublishSettings struct {
 	DeploymentID types.ID
 	EnvID        types.ID
-	Percentage   float64
 	NoCacheReset bool
 }
 

--- a/src/ce/api/app/deploy/publisher_test.go
+++ b/src/ce/api/app/deploy/publisher_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
-	"github.com/stormkit-io/stormkit-io/src/lib/types"
 	"github.com/stormkit-io/stormkit-io/src/mocks"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/guregu/null.v3"
@@ -47,86 +46,49 @@ func (s *PublisherSuite) AfterTest(_, _ string) {
 	appcache.DefaultCacheService = nil
 }
 
-func (s *PublisherSuite) Test_PublishingMultiple() {
+// Test_PublishingReplaces verifies an environment ends up on the deployment it
+// was last pointed at, rather than accumulating rows. It used to serve several
+// at once with the traffic split between them; it now serves exactly one.
+func (s *PublisherSuite) Test_PublishingReplaces() {
 	app := s.MockApp(nil)
 	env := s.MockEnv(app, nil)
 	dps := s.MockDeployments(2, env)
 
-	settings := []*deploy.PublishSettings{
-		{
-			EnvID:        env.ID,
-			DeploymentID: dps[0].ID,
-			Percentage:   25,
-		},
-		{
-			EnvID:        env.ID,
-			DeploymentID: dps[1].ID,
-			Percentage:   75,
-		},
-	}
+	s.mockCacheService.On("Reset", env.ID).Return(nil).Twice()
 
-	s.mockCacheService.On("Reset", env.ID).Return(nil).Once()
-	s.mockCacheService.On("Reset", env.ID).Return(nil).Once()
+	s.NoError(deploy.PublishNowForTest(context.Background(), []*deploy.PublishSettings{
+		{EnvID: env.ID, DeploymentID: dps[0].ID},
+	}))
 
-	err := deploy.PublishNowForTest(context.Background(), settings)
-	s.NoError(err)
+	s.Equal([]string{fmt.Sprintf("%s:%s", env.ID, dps[0].ID)}, s.publishedRows())
 
+	s.NoError(deploy.PublishNowForTest(context.Background(), []*deploy.PublishSettings{
+		{EnvID: env.ID, DeploymentID: dps[1].ID},
+	}))
+
+	s.Equal([]string{fmt.Sprintf("%s:%s", env.ID, dps[1].ID)}, s.publishedRows())
+}
+
+// publishedRows returns every published deployment as "envID:deploymentID".
+func (s *PublisherSuite) publishedRows() []string {
 	rows, err := s.conn.Query(`
-		SELECT
-			env_id, deployment_id, percentage_released
-		FROM
-			deployments_published
-		ORDER BY
-			percentage_released ASC;`)
-
-	s.NoError(err)
-
-	i := 0
-
-	for rows.Next() {
-		var envID, deploymentID types.ID
-		var percentage float64
-		var setting = settings[i]
-
-		err := rows.Scan(&envID, &deploymentID, &percentage)
-		s.NoError(err)
-		s.Equal(envID, setting.EnvID)
-		s.Equal(deploymentID, setting.DeploymentID)
-		s.Equal(percentage, setting.Percentage)
-		i = i + 1
-	}
-
-	// This should remove the old published environment (with ID 1)
-	// and replace the existing published deployments with the new one.
-	settings = []*deploy.PublishSettings{
-		{
-			EnvID:        env.ID,
-			DeploymentID: dps[0].ID,
-			Percentage:   100,
-		},
-	}
-
-	s.mockCacheService.On("Reset", env.ID).Return(nil).Once()
-
-	err = deploy.PublishNowForTest(context.Background(), settings)
-	s.NoError(err)
-
-	rows, err = s.conn.Query(`
-		SELECT
-			env_id::text || ':' ||
-			deployment_id::text || ':' ||
-			percentage_released::text
+		SELECT env_id::text || ':' || deployment_id::text
 		FROM deployments_published
 		ORDER BY env_id ASC;`)
 
-	s.NoError(err)
+	s.Require().NoError(err)
 
-	rows.Next()
-	var str string
+	published := []string{}
 
-	err = rows.Scan(&str)
-	s.NoError(err)
-	s.Equal(fmt.Sprintf("%d:%d:100.0", env.ID, dps[0].ID), str)
+	for rows.Next() {
+		var row string
+
+		s.Require().NoError(rows.Scan(&row))
+
+		published = append(published, row)
+	}
+
+	return published
 }
 
 func (s *PublisherSuite) Test_PublishOutboundWebhooks() {
@@ -138,7 +100,6 @@ func (s *PublisherSuite) Test_PublishOutboundWebhooks() {
 		{
 			EnvID:        env.ID,
 			DeploymentID: depl.ID,
-			Percentage:   100,
 		},
 	}
 

--- a/src/ce/api/app/redirects/redirectshandlers/handler_playground_test.go
+++ b/src/ce/api/app/redirects/redirectshandlers/handler_playground_test.go
@@ -41,7 +41,7 @@ func (s *HandlerPlaygroundSuite) Test_Success() {
 	// This is required to fetch the app conf
 	s.MockDeployment(env, map[string]any{
 		"Published": deploy.PublishedInfo{
-			{EnvID: env.ID, Percentage: 100},
+			{EnvID: env.ID},
 		},
 	})
 

--- a/src/ce/api/public/v1/handler_app_conf_test.go
+++ b/src/ce/api/public/v1/handler_app_conf_test.go
@@ -48,7 +48,7 @@ func (s *HandlerAppConfSuite) Test_Success() {
 	})
 	dep := s.MockDeployment(env, map[string]any{
 		"Published": deploy.PublishedInfo{
-			{EnvID: env.ID, Percentage: 100},
+			{EnvID: env.ID},
 		},
 	})
 
@@ -68,7 +68,7 @@ func (s *HandlerAppConfSuite) Test_Success() {
 		"configs": [{
 			"domains": null,
 			"apiPathPrefix": "/api",
-			"percentage": 100,
+			"isPublished": true,
 			"updatedAt": null,
 			"staticFiles": {
 				"/about": { "fileName": "about", "headers": { "accept-encoding": "None", "content-type": "text/html; charset=utf-8" }},

--- a/src/ce/api/public/v1/openapi.json
+++ b/src/ce/api/public/v1/openapi.json
@@ -3835,17 +3835,13 @@
           },
           "published": {
             "type": "array",
-            "description": "Currently published deployments and their traffic share.",
+            "description": "The deployment this environment is currently serving.",
             "items": {
               "type": "object",
               "properties": {
                 "deploymentId": {
                   "type": "string",
                   "description": "ID of the published deployment."
-                },
-                "percentage": {
-                  "type": "integer",
-                  "description": "Share of traffic served by this deployment."
                 }
               }
             }
@@ -3902,10 +3898,6 @@
           "isPublished": {
             "type": "boolean",
             "description": "True when this deployment currently serves traffic."
-          },
-          "percentage": {
-            "type": "integer",
-            "description": "Share of traffic served by this deployment."
           },
           "preview": {
             "type": "string",

--- a/src/ce/hosting/handler_forward.go
+++ b/src/ce/hosting/handler_forward.go
@@ -511,7 +511,7 @@ func (r *RequestServer) Dynamic() *shttp.Response {
 		DeploymentID:  cnf.DeploymentID,
 		Command:       cnf.ServerCmd,
 		EnvVariables:  cnf.EnvVariables,
-		IsPublished:   cnf.Percentage > 0,
+		IsPublished:   cnf.IsPublished,
 		CaptureLogs:   true,
 		RemoteAddress: r.req.RemoteIP(),
 		RemotePort:    r.req.RemotePort(),

--- a/src/ce/hosting/host_model.go
+++ b/src/ce/hosting/host_model.go
@@ -11,15 +11,9 @@ import (
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/appconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/shttp"
 	"github.com/stormkit-io/stormkit-io/src/lib/slog"
-	"github.com/stormkit-io/stormkit-io/src/lib/utils"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 )
-
-// VersionCookieName represents the name of the cookie that
-// will determine version for the user. If this value is empty,
-// or does not match any of the deployments, then it will be reset.
-const VersionCookieName = "sk_variant"
 
 // SettingsCookieName is the name of the cookie to which stores
 // the application's settings.
@@ -168,33 +162,14 @@ func (h *Host) RequestConfig() error {
 	return nil
 }
 
-// ChooseVersion chooses one version from possible multiple configs.
-// It is used for doing A/B testing.
+// ChooseVersion returns the configuration to serve this request from.
+//
+// An environment serves exactly one deployment — the database holds it as a
+// unique index — so there is nothing to choose between. The lookup can still
+// return nothing, which is what the nil is for.
 func (h *Host) ChooseVersion(confs []*appconf.Config) *appconf.Config {
 	if len(confs) == 0 {
 		return nil
-	}
-
-	if len(confs) == 1 {
-		return confs[0]
-	}
-
-	variant, err := h.Request.Cookie(VersionCookieName)
-
-	if err == nil && variant != nil {
-		for _, c := range confs {
-			if c.DeploymentID.String() == variant.Value {
-				return c
-			}
-		}
-	}
-
-	rand := float64(utils.Random(0, 100))
-
-	for _, c := range confs {
-		if rand = rand - c.Percentage; rand <= 0 {
-			return c
-		}
 	}
 
 	return confs[0]

--- a/src/ce/hosting/host_model_test.go
+++ b/src/ce/hosting/host_model_test.go
@@ -2,7 +2,6 @@ package hosting_test
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -56,7 +55,7 @@ func (s *HostSuite) Test_RequestConfig_CaseInsensitivy() {
 	env := s.MockEnv(app)
 	dep := s.MockDeployment(env, map[string]any{
 		"Published": deploy.PublishedInfo{
-			{EnvID: env.ID, Percentage: 100},
+			{EnvID: env.ID},
 		},
 	})
 
@@ -66,42 +65,11 @@ func (s *HostSuite) Test_RequestConfig_CaseInsensitivy() {
 	s.Equal(conf[0].DeploymentID, dep.ID)
 }
 
-func (s *HostSuite) Test_ChooseVersion_MultipleVersions() {
-	h := s.host()
-
-	confs := []*appconf.Config{
-		{Percentage: 100, DeploymentID: 1},
-		{Percentage: 0, DeploymentID: 2},
-	}
-
-	s.Equal(confs[0], h.ChooseVersion(confs))
-}
-
-func (s *HostSuite) Test_ChooseVersion_MultipleVersionsWithVersionCookie() {
-	req := &http.Request{
-		Header: map[string][]string{
-			"Cookie": {
-				fmt.Sprintf("%s=3", hosting.VersionCookieName),
-			},
-		},
-	}
-
-	h := &hosting.Host{Request: shttp.NewRequestContext(req)}
-
-	confs := []*appconf.Config{
-		{Percentage: 25, DeploymentID: 1},
-		{Percentage: 65, DeploymentID: 2},
-		{Percentage: 10, DeploymentID: 3},
-	}
-
-	s.Equal(confs[2], h.ChooseVersion(confs))
-}
-
 func (s *HostSuite) Test_ChooseVersion_SingleConf() {
 	h := s.host()
 
 	confs := []*appconf.Config{
-		{Percentage: 25, DeploymentID: 1},
+		{DeploymentID: 1},
 	}
 
 	s.Equal(confs[0], h.ChooseVersion(confs))

--- a/src/ce/hosting/publish_probe.go
+++ b/src/ce/hosting/publish_probe.go
@@ -202,7 +202,7 @@ func warmupConfig(host string, deploymentID types.ID) (*appconf.Config, error) {
 // A deployment that is already serving is left alone: re-publishing the live
 // deployment would otherwise kill the process answering production.
 func doWarmupDiscard(cnf *appconf.Config) {
-	if cnf == nil || cnf.FunctionLocation == "" || cnf.Percentage > 0 {
+	if cnf == nil || cnf.FunctionLocation == "" || cnf.IsPublished {
 		return
 	}
 

--- a/src/ce/workerserver/job_deployments_test.go
+++ b/src/ce/workerserver/job_deployments_test.go
@@ -67,7 +67,7 @@ func (s *JobDeploymentsSuite) Test_RemoveDeploymentsArtifacts() {
 		s.env,
 		map[string]any{"CreatedAt": T45daysAgo, "UploadResult": &deploy.UploadResult{ClientLocation: "local:/d-1"}},
 		map[string]any{"CreatedAt": T15daysAgo, "DeletedAt": utils.NewUnix(), "UploadResult": &deploy.UploadResult{ClientLocation: "local:/d-2"}},
-		map[string]any{"CreatedAt": T60daysAgo, "Published": deploy.PublishedInfo{{s.env.ID, 100}}},
+		map[string]any{"CreatedAt": T60daysAgo, "Published": deploy.PublishedInfo{{EnvID: s.env.ID}}},
 	)
 
 	s.mockClient.On("DeleteArtifacts", mock.Anything, integrations.DeleteArtifactsArgs{StorageLocation: "local:/d-2"}).Return(nil).Once()

--- a/src/lib/factory/deployment.go
+++ b/src/lib/factory/deployment.go
@@ -48,19 +48,19 @@ func (d MockDeployment) Insert(conn databasetest.TestDB) error {
 		return err
 	}
 
-	updatePublishedInfo := func(envID types.ID, percentage float64) error {
+	publish := func(envID types.ID) error {
 		_, err = conn.PrepareOrPanic(`
 				INSERT INTO deployments_published
-					(env_id, deployment_id, percentage_released)
+					(env_id, deployment_id)
 				VALUES
-					($1, $2, $3)
-			`).Exec(envID, d.ID, percentage)
+					($1, $2)
+			`).Exec(envID, d.ID)
 
 		return err
 	}
 
 	for _, p := range d.Published {
-		if err := updatePublishedInfo(p.EnvID, p.Percentage); err != nil {
+		if err := publish(p.EnvID); err != nil {
 			return err
 		}
 	}

--- a/src/migrations/0028_2026-09-07.up.sql
+++ b/src/migrations/0028_2026-09-07.up.sql
@@ -1,0 +1,40 @@
+-- An environment serves exactly one deployment.
+--
+-- Percentage-based releases let one environment point at several deployments at
+-- once, with traffic split between them at request time. The feature is retired:
+-- publishing has replaced whatever was published before for some time, and since
+-- warm-up gating landed a publish names a single deployment.
+--
+-- The rows are collapsed before the column goes, because an install that used
+-- splits still has several published rows per environment and nothing would say
+-- which of them wins once the percentages are gone. The survivor is the one
+-- carrying the most traffic, and the newest of those if they are level.
+--
+-- The delete is guarded so this file can be run again after it has applied, and
+-- ties break on the physical row identity so that even two rows identical in
+-- every column leave exactly one behind. Without that, a pair of duplicates
+-- would survive and take the unique index below down with them — on someone
+-- else's database, where it cannot be inspected. The identity is compared as
+-- text because ordering it directly needs PostgreSQL 14.
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema = current_schema()
+		  AND table_name = 'deployments_published'
+		  AND column_name = 'percentage_released'
+	) THEN
+		DELETE FROM deployments_published a
+		USING deployments_published b
+		WHERE a.env_id = b.env_id
+		  AND (a.percentage_released, a.created_at, a.ctid::text)
+			< (b.percentage_released, b.created_at, b.ctid::text);
+	END IF;
+END $$;
+
+ALTER TABLE deployments_published DROP COLUMN IF EXISTS percentage_released;
+
+-- With the column gone, one-deployment-per-environment stops being a rule the
+-- code re-asserts on every publish and becomes something the database holds.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_published_env_id_unique
+	ON deployments_published (env_id);

--- a/src/migrations/structure.sql
+++ b/src/migrations/structure.sql
@@ -602,7 +602,6 @@ ALTER SEQUENCE skitapi.deployments_deployment_id_seq OWNED BY skitapi.deployment
 CREATE TABLE skitapi.deployments_published (
     deployment_id bigint NOT NULL,
     env_id bigint NOT NULL,
-    percentage_released numeric(4,1) DEFAULT 0 NOT NULL,
     created_at timestamp without time zone DEFAULT (now() AT TIME ZONE 'UTC'::text) NOT NULL
 );
 
@@ -1753,6 +1752,13 @@ CREATE INDEX idx_deployments_published_deployment_id ON skitapi.deployments_publ
 --
 
 CREATE INDEX idx_deployments_published_env_id ON skitapi.deployments_published USING btree (env_id);
+
+
+--
+-- Name: idx_deployments_published_env_id_unique; Type: INDEX; Schema: skitapi; Owner: skitadmin
+--
+
+CREATE UNIQUE INDEX idx_deployments_published_env_id_unique ON skitapi.deployments_published USING btree (env_id);
 
 
 --

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/_components/EnvironmentHeader.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/_components/EnvironmentHeader.spec.tsx
@@ -77,9 +77,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/_components/EnvironmentHeader.
     beforeEach(() => {
       const envs = [...defaultEnvs];
       envs[0].lastDeploy = { id: "1231231", createdAt: Date.now(), exit: 0 };
-      envs[0].published = [
-        { deploymentId: "682381", branch: "main", percentage: 100 },
-      ];
+      envs[0].published = [{ deploymentId: "682381", branch: "main" }];
 
       scope = mockFetchStatus({
         appId: defaultApp.id,
@@ -111,9 +109,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/_components/EnvironmentHeader.
     beforeEach(() => {
       const envs = [...defaultEnvs];
       envs[0].lastDeploy = { id: "1231231", createdAt: Date.now(), exit: 0 };
-      envs[0].published = [
-        { deploymentId: "682381", branch: "main", percentage: 100 },
-      ];
+      envs[0].published = [{ deploymentId: "682381", branch: "main" }];
 
       scope = mockFetchStatus({
         appId: defaultApp.id,

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/deployments/actions.ts
@@ -13,48 +13,6 @@ export const deleteForever = ({
   return api.delete(`/app/deploy`, { deploymentId, appId });
 };
 
-interface PublishDeploymentsProps {
-  app: App;
-  envId: string;
-  percentages: Record<string, number>;
-}
-
-interface PublishInfo {
-  deploymentId: string;
-  percentage: number;
-}
-
-export const publishDeployments = ({
-  app,
-  percentages,
-  envId,
-}: PublishDeploymentsProps): Promise<void> => {
-  const publish: Array<PublishInfo> = [];
-  let total = 0;
-
-  Object.keys(percentages).forEach(deploymentId => {
-    const percentage = percentages[deploymentId];
-    total = total + percentage;
-
-    publish.push({
-      percentage,
-      deploymentId,
-    });
-  });
-
-  if (total !== 100) {
-    return Promise.reject(
-      `The sum of percentages has to be 100. Currently it is ${total}.`,
-    );
-  }
-
-  return api.post(`/app/deployments/publish`, {
-    appId: app.id,
-    envId,
-    publish,
-  });
-};
-
 interface FetchManifestProps {
   deploymentId: string;
   appId: string;

--- a/src/ui/src/pages/apps/[id]/environments/_components/EnvironmentStatus.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/_components/EnvironmentStatus.spec.tsx
@@ -31,7 +31,7 @@ describe("~/pages/apps/[id]/environments/_components/EnvironmentStatus.tsx", () 
         initialIndex={0}
       >
         <EnvironmentStatus app={app} env={env} />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
   };
 
@@ -40,9 +40,7 @@ describe("~/pages/apps/[id]/environments/_components/EnvironmentStatus.tsx", () 
       currentApp = mockApp();
       currentEnv = mockEnvironment({ app: currentApp });
       currentEnv.lastDeploy = { id: "481481", createdAt: Date.now(), exit: 0 };
-      currentEnv.published = [
-        { deploymentId: "481481", percentage: 100, branch: "master" },
-      ];
+      currentEnv.published = [{ deploymentId: "481481", branch: "master" }];
 
       createWrapper({ app: currentApp, env: currentEnv });
     });

--- a/src/ui/src/shared/deployments/PublishModal.spec.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.spec.tsx
@@ -73,7 +73,7 @@ describe("~/shared/deployments/PublishModal", () => {
     const scope = mockPublishDeployments({
       appId: currentDepl.appId,
       envId: currentDepl.envId,
-      publish: [{ percentage: 100, deploymentId: currentDepl.id }],
+      publish: [{ deploymentId: currentDepl.id }],
     });
 
     // Registered before the click: the poll runs on a real clock, so a slow
@@ -105,7 +105,7 @@ describe("~/shared/deployments/PublishModal", () => {
     const scope = mockPublishDeployments({
       appId: currentDepl.appId,
       envId: currentDepl.envId,
-      publish: [{ percentage: 100, deploymentId: currentDepl.id }],
+      publish: [{ deploymentId: currentDepl.id }],
     });
 
     // Warming up, then stopped without the environment moving. Both are

--- a/src/ui/src/shared/deployments/PublishModal.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.tsx
@@ -170,7 +170,7 @@ export default function PublishModal({
                 setPhase("publishing");
 
                 publishDeployments({
-                  percentages: { [deployment.id]: 100 },
+                  deploymentId: deployment.id,
                   envId: deployment.envId,
                   appId: deployment.appId,
                 })

--- a/src/ui/src/shared/deployments/actions.tsx
+++ b/src/ui/src/shared/deployments/actions.tsx
@@ -61,42 +61,19 @@ export const fetchPublishState = ({
 interface PublishDeploymentsProps {
   appId: string;
   envId: string;
-  percentages: Record<string, number>;
-}
-
-interface PublishInfo {
   deploymentId: string;
-  percentage: number;
 }
 
+// An environment serves exactly one deployment, so this points it at one.
 export const publishDeployments = ({
   appId,
-  percentages,
   envId,
+  deploymentId,
 }: PublishDeploymentsProps): Promise<void> => {
-  const publish: Array<PublishInfo> = [];
-  let total = 0;
-
-  Object.keys(percentages).forEach(deploymentId => {
-    const percentage = percentages[deploymentId];
-    total = total + percentage;
-
-    publish.push({
-      percentage,
-      deploymentId,
-    });
-  });
-
-  if (total !== 100) {
-    return Promise.reject(
-      `The sum of percentages has be to 100. Currently it is ${total}.`,
-    );
-  }
-
   return api.post(`/app/deployments/publish`, {
     appId,
     envId,
-    publish,
+    publish: [{ deploymentId }],
   });
 };
 

--- a/src/ui/src/testing/nocks/nock_deployments.ts
+++ b/src/ui/src/testing/nocks/nock_deployments.ts
@@ -38,7 +38,7 @@ export const mockDeleteDeploymentCall = ({
 interface MockPublishDeploymentsCallProps {
   appId: string;
   envId: string;
-  publish: { percentage: number; deploymentId: string }[];
+  publish: { deploymentId: string }[];
   status?: number;
   response?: object;
 }

--- a/src/ui/src/testing/nocks/nock_deployments_v2.ts
+++ b/src/ui/src/testing/nocks/nock_deployments_v2.ts
@@ -18,7 +18,7 @@ export const mockFetchDeployments = ({
   response,
 }: MockFetchDeploymentCallProps) => {
   const params = new URLSearchParams(
-    JSON.parse(JSON.stringify({ teamId, deploymentId, envId }))
+    JSON.parse(JSON.stringify({ teamId, deploymentId, envId })),
   );
 
   return nock(endpoint)
@@ -97,7 +97,7 @@ export const mockFetchManifest = ({
 interface MockPublishDeploymentsProps {
   appId: string;
   envId: string;
-  publish: { percentage: number; deploymentId: string }[];
+  publish: { deploymentId: string }[];
   status?: number;
   response?: object;
 }
@@ -117,7 +117,9 @@ export const mockFetchPublishState = ({
 }: MockFetchPublishStateProps) =>
   nock(endpoint)
     .get(`/my/deployments?deploymentId=${deploymentId}`)
-    .reply(200, { deployments: [{ id: deploymentId, published, isWarmingUp }] });
+    .reply(200, {
+      deployments: [{ id: deploymentId, published, isWarmingUp }],
+    });
 
 export const mockPublishDeployments = ({
   appId,

--- a/src/ui/src/types/deployment.d.ts
+++ b/src/ui/src/types/deployment.d.ts
@@ -1,6 +1,5 @@
 type PublishInfo = {
   envId: string;
-  percentage: number;
 };
 
 type Log = {

--- a/src/ui/src/types/environment.d.ts
+++ b/src/ui/src/types/environment.d.ts
@@ -38,7 +38,6 @@ interface PublishedInfo {
   commitMessage?: string;
   deploymentId: string;
   branch: string;
-  percentage: number;
 }
 
 interface Redirect {


### PR DESCRIPTION
An environment used to serve several deployments at once, with traffic split between them at request time. The feature has been going away for a while — publishing replaces what was published before rather than adding to it, and since the warm-up gate a publish names a single deployment. What was left was the plumbing, which said the opposite of what the API had started saying.

### ⚠️ Breaking changes

Three payloads lose the field. A client reading any of these breaks:

| Payload | Before | After |
|---|---|---|
| `GET /v1/app/config` | `percentage: 100` | `isPublished: true` |
| Deployment's `published[]` | `{envId, percentage}` | `{envId, deploymentId}` |
| Environment's `published[]` | included `percentage` | no longer does |

The publish endpoint **still accepts `percentage` and ignores it**, so existing clients and the dashboard keep working. The rule that percentages had to sum to 100 is gone — there is nothing left for it to protect.

### The migration

`0028` collapses any environment holding several published rows (highest share wins, newest breaks ties, `ctid` as the final tie-break), drops `percentage_released`, and adds `UNIQUE(env_id)`.

The constraint is the point: one deployment per environment stops being a convention the code re-asserts on every publish and becomes something the database holds.

It is re-runnable: the delete is guarded on the column still existing, and the other two statements carry `IF EXISTS` / `IF NOT EXISTS`. Verified by applying it twice to a scratch schema seeded with a 25/75 split **and** an exact-duplicate row pair — both collapse to one row, and the second run is a no-op.

The `ctid` tie-break matters more than it looks: two rows identical in every column are not ordered by `(created_at, deployment_id)`, so both would have survived and taken `CREATE UNIQUE INDEX` down with them — leaving an install unable to migrate, on a database nobody here can inspect.

### Two things the constraint found

Both were latent and would have stayed hidden:

1. **The publish statement was a delete and an insert in one statement.** Data-modifying CTEs share a snapshot, so the insert collides with the row the delete is on its way to removing. It only ever worked because nothing enforced uniqueness. It is now an upsert, which is also what the operation actually is.
2. **A test fixture published two deployments to one environment** and had been silently asserting the retired behaviour.

### Serving

`ChooseVersion` collapsed from "cookie, then weighted random" to "return the config" — a hostname resolves to one configuration, so there is nothing to choose between. The `sk_variant` cookie that pinned a visitor to one side of a split goes with it. `appconf.Config` carries `IsPublished` rather than a share of traffic.

### Testing

Tests that asserted a 25/75 split now assert what replaced it: an environment ends up on the deployment it was last pointed at. `Test_PublishingMultiple` became `Test_PublishingReplaces`; `Test_BadRequest_PercentageNot100` became `Test_IgnoresPercentage`, which pins the accept-and-ignore contract.

```
go test -p 1 -count=1 ./src/ce/api/public/v1/ ./src/ce/api/app/deploy/... ./src/ce/api/app/appconf/
```
green, as are `hosting`, `workerserver`, `buildconf` and `runner`.

Frontend: 743 passed with the known `Visitors`/`AuthUsers` flake — the same one measured on `main` (2 failed / clean / clean over three runs), in specs this PR does not touch.

### Also here

A fix that is not about percentages but was found by them: under test the publish gate now skips service discovery entirely. It was reading real Redis, so a hosting registration left behind by *another package's test binary* — 30s TTL — made a publish wait for a node that would never answer, and the publish silently failed. That was latent from #517 and would have surfaced as an occasional inexplicable CI failure.