### PR TITLE
feat: skip unchanged monorepo build roots

### DIFF
--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/dlclark/regexp2"
@@ -32,6 +33,8 @@ type TriggerDeployInput struct {
 	EventType         string
 	CommitSha         string
 	PullRequestNumber int64
+	ChangedFiles      []string
+	ChangesComplete   bool
 
 	payload any // The payload that is sent by the provider - we store this in the database.
 }
@@ -177,6 +180,10 @@ func FilterDeployCandidates(input TriggerDeployInput, dcs []*app.DeployCandidate
 
 	// All candidates have auto_deploy turned on
 	for _, dc := range dcs {
+		if !buildRootChanged(input, dc) {
+			continue
+		}
+
 		patternBranches := dc.AutoDeployBranches.ValueOrZero()
 		patternCommits := dc.AutoDeployCommits.ValueOrZero()
 
@@ -209,6 +216,35 @@ func FilterDeployCandidates(input TriggerDeployInput, dcs []*app.DeployCandidate
 	}
 
 	return filtered
+}
+
+// buildRootChanged reports whether a deploy candidate can be affected by the
+// changed paths. Unknown change sets preserve the existing deploy behavior.
+func buildRootChanged(input TriggerDeployInput, dc *app.DeployCandidate) bool {
+	if !input.ChangesComplete || len(input.ChangedFiles) == 0 || dc.BuildConfig == nil {
+		return true
+	}
+
+	workDir := strings.Trim(path.Clean(strings.TrimSpace(dc.BuildConfig.WorkDir)), "/")
+
+	if workDir == "" || workDir == "." {
+		return true
+	}
+
+	for _, file := range input.ChangedFiles {
+		changedPath := strings.Trim(path.Clean(strings.TrimSpace(file)), "/")
+
+		// Repository-root files may affect every workspace in a monorepo.
+		if changedPath != "" && !strings.Contains(changedPath, "/") {
+			return true
+		}
+
+		if changedPath == workDir || strings.HasPrefix(changedPath, workDir+"/") {
+			return true
+		}
+	}
+
+	return false
 }
 
 // commitHasBeenBuilt checks whether there is already a build for the commit or not.

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_github.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_github.go
@@ -17,6 +17,8 @@ var whiteList = []string{
 	string(github.CheckSuiteEvent),
 }
 
+const githubPushCommitLimit = 2048
+
 // processGithubPayload processes a github payload and starts a new deployment.
 func processGithubPayload(req *shttp.RequestContext) (*TriggerDeployInput, error) {
 	hook, _ := github.New()
@@ -56,6 +58,13 @@ func processGithubPayload(req *shttp.RequestContext) (*TriggerDeployInput, error
 		input.CheckoutRepo = fmt.Sprintf("github/%s", event.Repository.FullName)
 		input.EventType = typeCommit
 		input.IsFork = false
+		input.ChangesComplete = len(event.Commits) > 0 && len(event.Commits) < githubPushCommitLimit
+
+		for _, commit := range event.Commits {
+			input.ChangedFiles = append(input.ChangedFiles, commit.Added...)
+			input.ChangedFiles = append(input.ChangedFiles, commit.Modified...)
+			input.ChangedFiles = append(input.ChangedFiles, commit.Removed...)
+		}
 
 		// Pushed something else: for instance a tag.
 		if input.Message == "" {

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_github_test.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_github_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apphandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deployservice"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
@@ -200,6 +201,35 @@ func (s *InboundGithubSuite) Test_PushEventSuccess_BranchNameMatches() {
 				a.Equal(int64(0), _depl.PullRequestNumber.ValueOrZero())
 		}),
 	)
+}
+
+func (s *InboundGithubSuite) Test_PushEvent_BuildRootUnchanged() {
+	appl := s.app(map[string]any{
+		"Data": &buildconf.BuildConf{WorkDir: "apps/frontend"},
+	})
+
+	payload := map[string]any{}
+	s.Require().NoError(json.Unmarshal([]byte(githubPushExample), &payload))
+	payload["commits"] = []map[string]any{
+		{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		},
+	}
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(apphandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		fmt.Sprintf("/app/webhooks/github/%s", appl.Secret()),
+		payload,
+		map[string]string{
+			"X-Github-Event":  "push",
+			"X-Hub-Signature": fmt.Sprintf("sha1=%s", hex.EncodeToString(githubMac(payload).Sum(nil))),
+		},
+	)
+
+	s.Equal(http.StatusNoContent, response.Code)
+	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
 }
 
 func (s *InboundGithubSuite) Test_PushEvent_BranchNameDoesNotMatch() {

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_gitlab.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_gitlab.go
@@ -40,6 +40,13 @@ func processGitlabPayload(req *shttp.RequestContext) (*TriggerDeployInput, error
 		input.EventType = typeCommit
 		input.Message = strings.Split(event.Commits[0].Message, "\n")[0]
 		input.IsFork = false
+		input.ChangesComplete = len(event.Commits) > 0 && int64(len(event.Commits)) == event.TotalCommitsCount
+
+		for _, commit := range event.Commits {
+			input.ChangedFiles = append(input.ChangedFiles, commit.Added...)
+			input.ChangedFiles = append(input.ChangedFiles, commit.Modified...)
+			input.ChangedFiles = append(input.ChangedFiles, commit.Removed...)
+		}
 
 		// Do not build commits that were not in default branch because:
 		// 1. If the commit is made into a pull request - we'll receive the event anyways.

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_gitlab_test.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_gitlab_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apphandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deployservice"
 	"github.com/stormkit-io/stormkit-io/src/lib/database/databasetest"
@@ -93,14 +94,16 @@ func (s *InboundGitlabSuite) AfterTest(_, _ string) {
 	deployservice.MockDeployer = nil
 }
 
-func (s *InboundGitlabSuite) app(autoDeploy bool) *factory.MockApp {
+func (s *InboundGitlabSuite) app(autoDeploy bool, envOverwrites ...map[string]any) *factory.MockApp {
 	app := s.MockApp(nil, map[string]any{
 		"Repo": "gitlab/stormkit-test-acc/test-repo",
 	})
 
-	s.MockEnv(app, map[string]any{
+	overwrites := []map[string]any{{
 		"AutoDeploy": autoDeploy,
-	})
+	}}
+	overwrites = append(overwrites, envOverwrites...)
+	s.MockEnv(app, overwrites...)
 
 	return app
 }
@@ -154,6 +157,35 @@ func (s *InboundGitlabSuite) TestPushEventSuccess() {
 				a.Equal(int64(0), _depl.PullRequestNumber.ValueOrZero())
 		}),
 	)
+}
+
+func (s *InboundGitlabSuite) Test_PushEvent_BuildRootUnchanged() {
+	appl := s.app(true, map[string]any{
+		"Data": &buildconf.BuildConf{WorkDir: "apps/frontend"},
+	})
+
+	payload := map[string]any{}
+	s.Require().NoError(json.Unmarshal([]byte(gitlabPushExample), &payload))
+	payload["total_commits_count"] = 1
+	payload["commits"] = []map[string]any{
+		{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		},
+	}
+
+	response := shttptest.RequestWithHeaders(
+		shttp.NewRouter().RegisterService(apphandlers.Services).Router().Handler(),
+		shttp.MethodPost,
+		fmt.Sprintf("/app/webhooks/gitlab/%s", appl.Secret()),
+		payload,
+		map[string]string{
+			"X-Gitlab-Event": "Push Hook",
+		},
+	)
+
+	s.Equal(http.StatusNoContent, response.Code)
+	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
 }
 
 func (s *InboundGitlabSuite) TestMergeRequestOpened() {

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_test.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/apphandlers"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/lib/factory"
 )
 
@@ -214,6 +215,61 @@ func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_AutoDeployCommitsConf
 	}, list)
 
 	s.Len(c, 0)
+}
+
+func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_BuildRootChanged() {
+	myApp := &app.MyApp{
+		App: &app.App{},
+	}
+
+	list := []*app.DeployCandidate{
+		{
+			MyApp:            myApp,
+			EnvName:          "infrastructure",
+			EnvDefaultBranch: "main",
+			BuildConfig:      &buildconf.BuildConf{WorkDir: "/apps/infrastructure/"},
+		},
+		{
+			MyApp:            myApp,
+			EnvName:          "frontend",
+			EnvDefaultBranch: "main",
+			BuildConfig:      &buildconf.BuildConf{WorkDir: "apps/frontend"},
+		},
+		{
+			MyApp:            myApp,
+			EnvName:          "repository-root",
+			EnvDefaultBranch: "main",
+			BuildConfig:      &buildconf.BuildConf{},
+		},
+	}
+
+	input := apphandlers.TriggerDeployInput{
+		Branch:          "main",
+		ChangedFiles:    []string{"apps/infrastructure/main.tf"},
+		ChangesComplete: true,
+	}
+
+	candidates := apphandlers.FilterDeployCandidates(input, list)
+
+	s.Len(candidates, 2)
+	s.Equal("infrastructure", candidates[0].EnvName)
+	s.Equal("repository-root", candidates[1].EnvName)
+
+	input.ChangedFiles = []string{"package-lock.json"}
+	candidates = apphandlers.FilterDeployCandidates(input, list)
+
+	s.Len(candidates, 3)
+
+	input.ChangedFiles = []string{"apps/infrastructure-docs/readme.md"}
+	candidates = apphandlers.FilterDeployCandidates(input, list)
+
+	s.Len(candidates, 1)
+	s.Equal("repository-root", candidates[0].EnvName)
+
+	input.ChangesComplete = false
+	candidates = apphandlers.FilterDeployCandidates(input, list)
+
+	s.Len(candidates, 3)
 }
 
 func TestIncomingWebhooks(t *testing.T) {


### PR DESCRIPTION
Closes #520.

## What changed

Stormkit now uses changed-file data from GitHub and GitLab push webhooks when filtering auto-deploy candidates that have a Build root configured.

- Deploys a candidate when a changed path is inside its `build.workDir`.
- Treats repository-root files as global changes because manifests, lockfiles, and root configuration can affect every workspace.
- Preserves the current behavior for empty Build roots and unknown or incomplete change sets.
- Normalizes leading and trailing slashes and matches complete path segments.
- Counts added, modified, and removed files.

## Why the fallback is conservative

GitHub caps push webhook commit data at 2048 commits, while GitLab exposes the total commit count. At those limits, Stormkit keeps all otherwise matching candidates instead of risking a false skip.

Pull request events and Bitbucket remain unchanged because their current webhook models do not expose a reliable complete changed-path list. Supporting those events would require provider API requests and is intentionally outside this minimal change.

## Verification

- `go vet ./src/ce/api/app/apphandlers`
- `go test -c -o /tmp/stormkit-apphandlers.test ./src/ce/api/app/apphandlers`
- Focused filter harness covering matching roots, root-level files, path boundaries, and incomplete-data fallback

The database-backed HTTP suites compile successfully but could not be executed locally because the Docker daemon is unavailable to the current user; CI will run them with PostgreSQL and Redis.