### PR TITLE
feat: show a spinner while a deployment is publishing

### DIFF
--- a/src/ui/src/shared/deployments/CommitInfo.spec.tsx
+++ b/src/ui/src/shared/deployments/CommitInfo.spec.tsx
@@ -26,7 +26,7 @@ describe("~/shared/deployments/CommitInfo.tsx", () => {
           showProject={showProject}
           clickable={clickable}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
   };
 
@@ -35,6 +35,22 @@ describe("~/shared/deployments/CommitInfo.tsx", () => {
     expect(toHumanTime(61)).toBe("1m 1s");
     expect(toHumanTime(120)).toBe("2m 0s");
     expect(toHumanTime(121)).toBe("2m 1s");
+  });
+
+  // A publish waits for the deployment to answer before traffic moves to it,
+  // so the badge has to say the release is on its way rather than done.
+  it("shows a deployment that is being published", () => {
+    const deployment = mockDeployments()[0];
+    deployment.published = false;
+    deployment.isWarmingUp = true;
+
+    createWrapper({ deployment });
+
+    expect(wrapper.getByText("publishing...")).toBeTruthy();
+    expect(wrapper.queryByText("published")).toBeNull();
+    expect(
+      wrapper.container.querySelector(".MuiCircularProgress-root"),
+    ).toBeTruthy();
   });
 
   it("should display information properly", () => {
@@ -46,11 +62,11 @@ describe("~/shared/deployments/CommitInfo.tsx", () => {
     expect(wrapper.getByText("published")).toBeTruthy();
 
     expect(
-      wrapper.getByText("chore: update packages").getAttribute("href")
+      wrapper.getByText("chore: update packages").getAttribute("href"),
     ).toBe("/my-test/url");
 
     expect(wrapper.getByText("sample-project").getAttribute("href")).toBe(
-      "/apps/1/environments/1/deployments"
+      "/apps/1/environments/1/deployments",
     );
   });
 
@@ -58,7 +74,7 @@ describe("~/shared/deployments/CommitInfo.tsx", () => {
     createWrapper({ deployment: mockDeployments()[0], clickable: false });
 
     expect(
-      wrapper.getByText("chore: update packages").getAttribute("href")
+      wrapper.getByText("chore: update packages").getAttribute("href"),
     ).toBe(null);
   });
 

--- a/src/ui/src/shared/deployments/CommitInfo.tsx
+++ b/src/ui/src/shared/deployments/CommitInfo.tsx
@@ -5,6 +5,7 @@ import Link from "@mui/material/Link";
 import AltRoute from "@mui/icons-material/AltRoute";
 import Tooltip from "@mui/material/Tooltip";
 import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
 import Span from "~/components/Span";
 import Dot from "~/components/Dot";
 import Sha from "./Sha";
@@ -101,8 +102,16 @@ export default function CommitInfo({
           {(deployment.published || deployment.isWarmingUp) && (
             <Chip
               color={deployment.published ? "success" : "info"}
-              label={deployment.published ? "published" : "publishing"}
+              label={deployment.published ? "published" : "publishing..."}
               size="small"
+              // A publish waits for the deployment to answer before traffic
+              // moves to it, which takes as long as the deployment takes to
+              // boot. The spinner says the wait is expected rather than stuck.
+              icon={
+                deployment.published ? undefined : (
+                  <CircularProgress size={9} color="inherit" sx={{ ml: 1 }} />
+                )
+              }
               sx={{
                 ml: 1,
                 fontSize: 11,


### PR DESCRIPTION
The badge said "publishing" and then sat there. A publish waits for the deployment to answer before traffic moves to it, which takes as long as the deployment takes to boot — long enough that a static badge reads as stuck rather than as working.

It now spins and says "publishing...", so the wait looks like progress.

Small change: a `CircularProgress` as the `Chip`'s icon, shown only while `isWarmingUp`. The published badge is unchanged.

### Testing

`CommitInfo.spec.tsx` had no coverage of the warming state at all, so this adds it: a deployment with `isWarmingUp` shows the spinner and the new label, and does not show "published".

`npx vitest run src/shared/deployments/` — 42 passed.