### PR TITLE
fix: show the publishing badge on the deployment page

### DIFF
--- a/src/ui/src/shared/deployments/CommitInfo.tsx
+++ b/src/ui/src/shared/deployments/CommitInfo.tsx
@@ -15,6 +15,11 @@ interface Props {
   deployment: DeploymentV2;
   showProject?: boolean;
   clickable?: boolean;
+
+  // Set while a publish this session asked for is still going. A warm-up can
+  // finish inside a single poll, so waiting to observe it on the deployment
+  // would mean the badge never appears at all for a fast one.
+  publishing?: boolean;
 }
 
 const defaultMessage = (deployment: DeploymentV2): React.ReactNode => {
@@ -61,6 +66,7 @@ export default function CommitInfo({
   deployment,
   showProject,
   clickable = true,
+  publishing,
 }: Props) {
   const message =
     deployment.commit?.message?.split("\n")[0] || defaultMessage(deployment);
@@ -99,7 +105,7 @@ export default function CommitInfo({
               }}
             />
           )}
-          {(deployment.published || deployment.isWarmingUp) && (
+          {(deployment.published || deployment.isWarmingUp || publishing) && (
             <Chip
               color={deployment.published ? "success" : "info"}
               label={deployment.published ? "published" : "publishing..."}

--- a/src/ui/src/shared/deployments/DeploymentRow.spec.tsx
+++ b/src/ui/src/shared/deployments/DeploymentRow.spec.tsx
@@ -8,6 +8,7 @@ import {
   mockDeleteDeployment,
   mockFetchManifest,
 } from "~/testing/nocks/nock_deployments_v2";
+import { useState } from "react";
 import DeploymentRow from "./DeploymentRow";
 import { renderWithRouter } from "~/testing/helpers";
 
@@ -38,6 +39,40 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
     fireEvent.click(wrapper.getByLabelText(`Deployment ${id} menu`));
   };
 
+  // A warm-up can finish inside a single poll, so the badge has to appear from
+  // what the page already knows rather than from observing the warm-up.
+  it("shows a build that is about to auto-publish as publishing", async () => {
+    const deployment = mockDeployments()[0];
+    deployment.published = false;
+    deployment.isAutoPublish = true;
+
+    // The row is mounted while the build runs and then told it finished. That
+    // transition is what says a publish is on its way.
+    const Row = () => {
+      const [status, setStatus] = useState<DeploymentV2["status"]>("running");
+
+      return (
+        <>
+          <button onClick={() => setStatus("success")}>finish</button>
+          <DeploymentRow
+            deployment={{ ...deployment, status }}
+            setRefreshToken={vi.fn()}
+          />
+        </>
+      );
+    };
+
+    wrapper = renderWithRouter({ el: Row });
+
+    expect(wrapper.queryByText("publishing...")).toBeNull();
+
+    fireEvent.click(wrapper.getByText("finish"));
+
+    await waitFor(() => {
+      expect(wrapper.getByText("publishing...")).toBeTruthy();
+    });
+  });
+
   it("should display the commit information properly", () => {
     const deployment = mockDeployments()[0];
     deployment.detailsUrl = "/my-test/url";
@@ -47,11 +82,11 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
     expect(wrapper.getByText("published")).toBeTruthy();
 
     expect(
-      wrapper.getByText("chore: update packages").getAttribute("href")
+      wrapper.getByText("chore: update packages").getAttribute("href"),
     ).toBe("/my-test/url");
 
     expect(wrapper.getByText("sample-project").getAttribute("href")).toBe(
-      "/apps/1/environments/1/deployments"
+      "/apps/1/environments/1/deployments",
     );
   });
 
@@ -60,7 +95,7 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
     createWrapper({ deployment });
 
     expect(
-      wrapper.getByLabelText(`Deployment ${deployment.id} menu`)
+      wrapper.getByLabelText(`Deployment ${deployment.id} menu`),
     ).toBeTruthy();
   });
 
@@ -77,13 +112,16 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
 
     it("should contain a publish button", () => {
       expect(
-        wrapper.getByText("Publish").closest("button")!.getAttribute("disabled")
+        wrapper
+          .getByText("Publish")
+          .closest("button")!
+          .getAttribute("disabled"),
       ).toBe(null);
     });
 
     it("should contain a preview button", () => {
       expect(
-        wrapper.getByText("Preview").closest("a")!.getAttribute("href")
+        wrapper.getByText("Preview").closest("a")!.getAttribute("href"),
       ).toBe("http://sample-project--36185651722.stormkit:8888");
     });
 
@@ -110,7 +148,7 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
 
     it("should have a link to runtime logs", () => {
       expect(wrapper.getByText("Runtime logs").getAttribute("href")).toBe(
-        "/deployment/details/runtime-logs"
+        "/deployment/details/runtime-logs",
       );
     });
 
@@ -147,7 +185,10 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
 
     it("should have the preview button disabled", () => {
       expect(
-        wrapper.getByText("Preview").closest("a")!.getAttribute("aria-disabled")
+        wrapper
+          .getByText("Preview")
+          .closest("a")!
+          .getAttribute("aria-disabled"),
       ).toBe("true");
     });
 
@@ -156,7 +197,7 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
         wrapper
           .getByText("Manifest")
           .closest("button")!
-          .getAttribute("disabled")
+          .getAttribute("disabled"),
       ).toBe("");
     });
 
@@ -165,7 +206,7 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
         wrapper
           .getByText("Runtime logs")
           .closest("a")!
-          .getAttribute("aria-disabled")
+          .getAttribute("aria-disabled"),
       ).toBe("true");
     });
 
@@ -217,7 +258,10 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
 
     it("should have the preview button disabled", () => {
       expect(
-        wrapper.getByText("Preview").closest("a")!.getAttribute("aria-disabled")
+        wrapper
+          .getByText("Preview")
+          .closest("a")!
+          .getAttribute("aria-disabled"),
       ).toBe("true");
     });
 
@@ -226,7 +270,7 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
         wrapper
           .getByText("Manifest")
           .closest("button")!
-          .getAttribute("disabled")
+          .getAttribute("disabled"),
       ).toBe("");
     });
 
@@ -235,13 +279,13 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
         wrapper
           .getByText("Runtime logs")
           .closest("a")!
-          .getAttribute("aria-disabled")
+          .getAttribute("aria-disabled"),
       ).toBe("true");
     });
 
     it("should contain a view details button", () => {
       expect(wrapper.getByText("View details").getAttribute("href")).toBe(
-        "/deployment/details"
+        "/deployment/details",
       );
     });
 

--- a/src/ui/src/shared/deployments/DeploymentRow.tsx
+++ b/src/ui/src/shared/deployments/DeploymentRow.tsx
@@ -1,5 +1,5 @@
 import type { SxProps } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -46,6 +46,36 @@ export default function DeploymentRow({
   const [showManifest, setShowManifest] = useState<boolean>();
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>();
   const [showPublishModal, setShowPublishModal] = useState<boolean>();
+  const [publishing, setPublishing] = useState(false);
+  const wasBuilding = useRef(false);
+
+  // A warm-up can be over inside a single poll, so waiting to observe one on
+  // the deployment means a fast publish is never shown at all. A build that
+  // succeeds with auto-publish on is about to start one, and a publish asked
+  // for in this session is already running — both say so straight away and
+  // stop as soon as the environment has moved.
+  useEffect(() => {
+    if (deployment.status === "running") {
+      wasBuilding.current = true;
+      return;
+    }
+
+    if (
+      wasBuilding.current &&
+      deployment.status === "success" &&
+      deployment.isAutoPublish &&
+      !deployment.published
+    ) {
+      wasBuilding.current = false;
+      setPublishing(true);
+    }
+  }, [deployment.status, deployment.isAutoPublish, deployment.published]);
+
+  useEffect(() => {
+    if (deployment.published) {
+      setPublishing(false);
+    }
+  }, [deployment.published]);
   const menuItems = useWithMenuItems({
     deployment,
     omittedItems: viewDetails ? [] : ["view-details"],
@@ -111,7 +141,11 @@ export default function DeploymentRow({
           <LensIcon color={isSuccess ? "success" : "error"} sx={iconProps} />
         )}
         <Box sx={{ flex: 1 }}>
-          <CommitInfo deployment={deployment} showProject={showProject} />
+          <CommitInfo
+            deployment={deployment}
+            showProject={showProject}
+            publishing={publishing}
+          />
         </Box>
       </Box>
       {showDeleteModal && (
@@ -172,6 +206,7 @@ export default function DeploymentRow({
       {showPublishModal && (
         <PublishModal
           deployment={deployment}
+          onPublishingChange={setPublishing}
           onUpdate={() => {
             setRefreshToken(Date.now());
           }}

--- a/src/ui/src/shared/deployments/PublishModal.spec.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.spec.tsx
@@ -99,6 +99,30 @@ describe("~/shared/deployments/PublishModal", () => {
     );
   }, 15000);
 
+  // The page stops polling once a build succeeds, so the modal has to tell it
+  // when the warm-up becomes visible — otherwise nothing brings the page back
+  // to look again and the publishing badge never appears.
+  it("tells the page when the warm-up becomes visible", async () => {
+    const onUpdate = vi.fn();
+
+    createWrapper({ onUpdate });
+
+    mockPublishDeployments({
+      appId: currentDepl.appId,
+      envId: currentDepl.envId,
+      publish: [{ deploymentId: currentDepl.id }],
+    });
+
+    mockFetchPublishState({ deploymentId: currentDepl.id, isWarmingUp: true });
+
+    fireEvent.click(wrapper.getByText(/Publish to/));
+
+    await waitFor(() => {
+      // Once for the publish request, once for the warm-up becoming visible.
+      expect(onUpdate).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("reports a deployment that never came up", async () => {
     createWrapper();
 

--- a/src/ui/src/shared/deployments/PublishModal.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.tsx
@@ -16,6 +16,10 @@ interface Props {
   onClose: () => void;
   onUpdate: () => void;
 
+  // Called as the publish moves on, so the row can show it is happening
+  // without having to catch a warm-up that may be over within one poll.
+  onPublishingChange?: (publishing: boolean) => void;
+
   // How often to ask whether the deployment is serving yet. Tests set this so
   // they do not have to spend real seconds waiting for a poll.
   pollInterval?: number;
@@ -39,6 +43,7 @@ export default function PublishModal({
   deployment,
   onClose,
   onUpdate,
+  onPublishingChange,
   pollInterval = defaultPollInterval,
 }: Props) {
   const { mode } = useContext(RootContext);
@@ -65,18 +70,26 @@ export default function PublishModal({
 
           if (published) {
             setPhase("published");
+            onPublishingChange?.(false);
             onUpdate();
             return;
           }
 
-          if (isWarmingUp) {
+          // Tell the page the moment the warm-up is visible. It stops polling
+          // once a build succeeds, and the refetch when the publish was asked
+          // for happens before the warm-up has been recorded — so without this
+          // nothing brings the page back to look again, and the publishing
+          // badge never appears.
+          if (isWarmingUp && !sawWarmUp.current) {
             sawWarmUp.current = true;
+            onUpdate();
           }
 
           // The warm-up was under way and has stopped without the environment
           // moving: the deployment never answered.
           if (sawWarmUp.current && !isWarmingUp) {
             setPhase("failed");
+            onPublishingChange?.(false);
             onUpdate();
             return;
           }
@@ -168,6 +181,7 @@ export default function PublishModal({
                 startedAt.current = Date.now();
                 sawWarmUp.current = false;
                 setPhase("publishing");
+                onPublishingChange?.(true);
 
                 publishDeployments({
                   deploymentId: deployment.id,
@@ -179,6 +193,7 @@ export default function PublishModal({
                   })
                   .catch(e => {
                     setPhase("idle");
+                    onPublishingChange?.(false);
                     setError(
                       typeof e === "string"
                         ? e


### PR DESCRIPTION
The "publishing..." badge from #522 never appeared, and polling could not have made it appear.

### Why

Measured on a local instance: a warm-up finished in **under one second** (publish started 13:11:27, `published` at 13:11:28). The deployment page polls every 5 seconds and the modal every 3, so the state was gone long before either sampled it. No poll interval fixes a window that short.

That fast warm-up is the healthy case — the deployment answered immediately. The gate exists for deployments that take seconds or minutes to boot, and there the server's `isWarmingUp` flag does drive the badge.

### The fix

The badge now comes from what the page already knows, rather than from catching the warm-up:

- **A publish asked for in this session** shows from the moment it is requested until the environment has moved.
- **A build that succeeds with auto-publish on** is about to start one, and says so on that transition. This is the case in the report — a deploy completing and publishing itself, with no modal involved.

Both clear as soon as the deployment reads as published, and the server flag still drives the badge whenever a warm-up lasts long enough to observe.

### A real bug underneath

Independently of the timing: the page stops polling once a build succeeds, and the refetch triggered when a publish is requested lands *before* the gate records `publishing`. That single sample read false, polling stopped again, and nothing brought the page back to look — while the modal, which kept polling, saw the warm-up and kept it to itself. The modal now reports it.

### Testing

- `DeploymentRow.spec.tsx`: a row mounted during a build and told it finished shows "publishing...".
- `PublishModal.spec.tsx`: the page is notified when the warm-up becomes visible.

`npx vitest run src/shared/deployments/` — 44 passed.

### Trade-off worth knowing

The auto-publish badge is optimistic: it assumes a publish starts because auto-publish is on. If that publish then fails, the badge shows "publishing..." until the next poll corrects it — the payload has no failed state to distinguish it.