### PR TITLE
feat: make monorepo build root filter opt-in

### DIFF
--- a/docs/api/3-environments.md
+++ b/docs/api/3-environments.md
@@ -107,6 +107,8 @@ Creates a new environment for an application.
 | `redirectsFile`      | string                  | No       | Path to a file containing redirect/rewrite rules.                                                           |
 | `serverCmd`          | string                  | No       | Command to start the server (self-hosted only).                                                             |
 | `statusChecks`       | `StatusCheck[]`         | No       | Post-deployment commands to run. See `StatusCheck` object below.                                            |
+| `skipUnchangedBuildRoot` | boolean             | No       | Monorepo path filtering. When `true`, a push only auto-deploys this environment if it changes a file inside `workDir`, inside one of `watchPaths`, or at the repository root. Off unless enabled. GitHub and GitLab push events only. |
+| `watchPaths`         | `string[]`              | No       | Extra paths, relative to the repository root, that count as changes for this environment — typically shared workspace packages that live outside `workDir`. Only read when `skipUnchangedBuildRoot` is enabled. |
 | `workDir`            | string                  | No       | Working directory relative to the repository root where install/build commands run. Defaults to repo root.  |
 
 **`StatusCheck` object:**
@@ -189,6 +191,8 @@ All fields are **optional**. Only the fields you include will be updated.
 | `redirectsFile`      | string                  | Path to a file containing redirect/rewrite rules.                                                                                            |
 | `serverCmd`          | string                  | Command to start the server (self-hosted only).                                                                                              |
 | `statusChecks`       | `StatusCheck[]`         | Post-deployment commands to run. Replaces all existing checks. See `StatusCheck` in `POST /v1/env`.                                          |
+| `skipUnchangedBuildRoot` | boolean             | Monorepo path filtering. When `true`, a push only auto-deploys this environment if it changes a file inside `workDir`, inside one of `watchPaths`, or at the repository root. Off unless enabled. GitHub and GitLab push events only.          |
+| `watchPaths`         | `string[]`              | Extra paths, relative to the repository root, that count as changes for this environment — typically shared workspace packages that live outside `workDir`. Replaces the existing list; pass `[]` to clear it.                                 |
 | `workDir`            | string                  | Working directory relative to the repository root where install/build commands run. Defaults to repo root.                                   |
 
 ### Response — 200 OK

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stormkit-io/stormkit-io/src/ce/api/admin"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app"
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deploy"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/app/deployservice"
 	"github.com/stormkit-io/stormkit-io/src/ce/api/oauth/github"
@@ -219,32 +220,95 @@ func FilterDeployCandidates(input TriggerDeployInput, dcs []*app.DeployCandidate
 }
 
 // buildRootChanged reports whether a deploy candidate can be affected by the
-// changed paths. Unknown change sets preserve the existing deploy behavior.
+// changed paths. Path filtering is opt-in per environment, and unknown change
+// sets always preserve the existing deploy behavior.
 func buildRootChanged(input TriggerDeployInput, dc *app.DeployCandidate) bool {
-	if !input.ChangesComplete || len(input.ChangedFiles) == 0 || dc.BuildConfig == nil {
+	if dc.BuildConfig == nil || !dc.BuildConfig.SkipUnchangedBuildRoot.ValueOrZero() {
 		return true
 	}
 
-	workDir := strings.Trim(path.Clean(strings.TrimSpace(dc.BuildConfig.WorkDir)), "/")
+	if !input.ChangesComplete || len(input.ChangedFiles) == 0 {
+		return true
+	}
 
-	if workDir == "" || workDir == "." {
+	matcher := newChangedPathMatcher(dc.BuildConfig)
+
+	// An environment that builds from the repository root is affected by every
+	// change, so there is nothing to filter out. Watch paths are additive and
+	// must never narrow that down.
+	if matcher.matchAll {
 		return true
 	}
 
 	for _, file := range input.ChangedFiles {
-		changedPath := strings.Trim(path.Clean(strings.TrimSpace(file)), "/")
-
-		// Repository-root files may affect every workspace in a monorepo.
-		if changedPath != "" && !strings.Contains(changedPath, "/") {
-			return true
-		}
-
-		if changedPath == workDir || strings.HasPrefix(changedPath, workDir+"/") {
+		if matcher.matches(file) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// changedPathMatcher decides whether a path reported by a push webhook affects
+// an environment. Paths on both sides are relative to the repository root.
+type changedPathMatcher struct {
+	roots []string
+
+	// matchAll is set when the build root is the repository root itself, which
+	// no path can fall outside of.
+	matchAll bool
+}
+
+func newChangedPathMatcher(bc *buildconf.BuildConf) *changedPathMatcher {
+	m := &changedPathMatcher{matchAll: normalizeRepoPath(bc.WorkDir) == ""}
+
+	if m.matchAll {
+		return m
+	}
+
+	for _, p := range append([]string{bc.WorkDir}, bc.WatchPaths...) {
+		if root := normalizeRepoPath(p); root != "" {
+			m.roots = append(m.roots, root)
+		}
+	}
+
+	return m
+}
+
+// matches reports whether the changed path falls under one of the watched
+// roots. Repository-root files match everything because shared manifests,
+// lockfiles and root configuration can affect every workspace in a monorepo.
+func (m *changedPathMatcher) matches(file string) bool {
+	changed := normalizeRepoPath(file)
+
+	if changed == "" {
+		return false
+	}
+
+	if !strings.Contains(changed, "/") {
+		return true
+	}
+
+	for _, root := range m.roots {
+		if changed == root || strings.HasPrefix(changed, root+"/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// normalizeRepoPath strips surrounding whitespace and slashes so that
+// "apps/web", "/apps/web" and "apps/web/" compare equal. It returns an empty
+// string for paths that address the repository root itself.
+func normalizeRepoPath(p string) string {
+	cleaned := strings.Trim(path.Clean(strings.TrimSpace(p)), "/")
+
+	if cleaned == "." {
+		return ""
+	}
+
+	return cleaned
 }
 
 // commitHasBeenBuilt checks whether there is already a build for the commit or not.

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_github_test.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_github_test.go
@@ -203,20 +203,16 @@ func (s *InboundGithubSuite) Test_PushEventSuccess_BranchNameMatches() {
 	)
 }
 
-func (s *InboundGithubSuite) Test_PushEvent_BuildRootUnchanged() {
-	appl := s.app(map[string]any{
-		"Data": &buildconf.BuildConf{WorkDir: "apps/frontend"},
-	})
-
+// githubPushPayload builds a push payload carrying the given commits.
+func (s *InboundGithubSuite) githubPushPayload(commits []map[string]any) map[string]any {
 	payload := map[string]any{}
 	s.Require().NoError(json.Unmarshal([]byte(githubPushExample), &payload))
-	payload["commits"] = []map[string]any{
-		{
-			"message":  "Update infrastructure",
-			"modified": []string{"apps/infrastructure/main.tf"},
-		},
-	}
+	payload["commits"] = commits
 
+	return payload
+}
+
+func (s *InboundGithubSuite) githubPush(appl *factory.MockApp, payload map[string]any) int {
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(apphandlers.Services).Router().Handler(),
 		shttp.MethodPost,
@@ -228,8 +224,88 @@ func (s *InboundGithubSuite) Test_PushEvent_BuildRootUnchanged() {
 		},
 	)
 
-	s.Equal(http.StatusNoContent, response.Code)
+	return response.Code
+}
+
+func (s *InboundGithubSuite) Test_PushEvent_BuildRootUnchanged() {
+	appl := s.app(map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+
+	code := s.githubPush(appl, s.githubPushPayload([]map[string]any{
+		{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		},
+	}))
+
+	s.Equal(http.StatusNoContent, code)
 	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
+}
+
+// A push inside the build root still deploys, which also proves the added,
+// modified and removed paths are read off the payload.
+func (s *InboundGithubSuite) Test_PushEvent_BuildRootChanged() {
+	appl := s.app(map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+
+	code := s.githubPush(appl, s.githubPushPayload([]map[string]any{
+		{"message": "Add a page", "added": []string{"apps/frontend/page.tsx"}},
+		{"message": "Rename a page", "removed": []string{"apps/frontend/old.tsx"}},
+	}))
+
+	s.Equal(http.StatusOK, code)
+	s.mockDeployer.AssertCalled(s.T(), "Deploy", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// GitHub caps the push payload at 2048 commits. At that point the change set is
+// incomplete, so every otherwise matching candidate has to be kept.
+func (s *InboundGithubSuite) Test_PushEvent_TruncatedCommitsDeploys() {
+	appl := s.app(map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+
+	commits := make([]map[string]any, 2048)
+
+	for i := range commits {
+		commits[i] = map[string]any{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		}
+	}
+
+	code := s.githubPush(appl, s.githubPushPayload(commits))
+
+	s.Equal(http.StatusOK, code)
+	s.mockDeployer.AssertCalled(s.T(), "Deploy", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// The filter is opt-in, so an environment with a build root but no filter
+// enabled keeps deploying on every push.
+func (s *InboundGithubSuite) Test_PushEvent_BuildRootFilterIsOptIn() {
+	appl := s.app(map[string]any{
+		"Data": &buildconf.BuildConf{WorkDir: "apps/frontend"},
+	})
+
+	code := s.githubPush(appl, s.githubPushPayload([]map[string]any{
+		{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		},
+	}))
+
+	s.Equal(http.StatusOK, code)
+	s.mockDeployer.AssertCalled(s.T(), "Deploy", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (s *InboundGithubSuite) Test_PushEvent_BranchNameDoesNotMatch() {

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_gitlab_test.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_gitlab_test.go
@@ -159,21 +159,19 @@ func (s *InboundGitlabSuite) TestPushEventSuccess() {
 	)
 }
 
-func (s *InboundGitlabSuite) Test_PushEvent_BuildRootUnchanged() {
-	appl := s.app(true, map[string]any{
-		"Data": &buildconf.BuildConf{WorkDir: "apps/frontend"},
-	})
-
+// gitlabPushPayload builds a push payload carrying the given commits.
+// totalCommits mirrors GitLab's total_commits_count, which is how a truncated
+// commit list is detected.
+func (s *InboundGitlabSuite) gitlabPushPayload(commits []map[string]any, totalCommits int) map[string]any {
 	payload := map[string]any{}
 	s.Require().NoError(json.Unmarshal([]byte(gitlabPushExample), &payload))
-	payload["total_commits_count"] = 1
-	payload["commits"] = []map[string]any{
-		{
-			"message":  "Update infrastructure",
-			"modified": []string{"apps/infrastructure/main.tf"},
-		},
-	}
+	payload["commits"] = commits
+	payload["total_commits_count"] = totalCommits
 
+	return payload
+}
+
+func (s *InboundGitlabSuite) gitlabPush(appl *factory.MockApp, payload map[string]any) int {
 	response := shttptest.RequestWithHeaders(
 		shttp.NewRouter().RegisterService(apphandlers.Services).Router().Handler(),
 		shttp.MethodPost,
@@ -184,8 +182,69 @@ func (s *InboundGitlabSuite) Test_PushEvent_BuildRootUnchanged() {
 		},
 	)
 
-	s.Equal(http.StatusNoContent, response.Code)
+	return response.Code
+}
+
+func (s *InboundGitlabSuite) Test_PushEvent_BuildRootUnchanged() {
+	appl := s.app(true, map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+
+	code := s.gitlabPush(appl, s.gitlabPushPayload([]map[string]any{
+		{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		},
+	}, 1))
+
+	s.Equal(http.StatusNoContent, code)
 	s.mockDeployer.AssertNotCalled(s.T(), "Deploy")
+}
+
+// A change to a watched shared package deploys even though it sits outside the
+// build root.
+func (s *InboundGitlabSuite) Test_PushEvent_WatchPathChanged() {
+	appl := s.app(true, map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			WatchPaths:             []string{"packages/ui"},
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+
+	code := s.gitlabPush(appl, s.gitlabPushPayload([]map[string]any{
+		{
+			"message":  "Restyle the button",
+			"modified": []string{"packages/ui/button.tsx"},
+		},
+	}, 1))
+
+	s.Equal(http.StatusOK, code)
+	s.mockDeployer.AssertCalled(s.T(), "Deploy", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// GitLab caps the commit list but reports the real total. A mismatch means the
+// change set is incomplete, so the candidate has to be kept.
+func (s *InboundGitlabSuite) Test_PushEvent_TruncatedCommitsDeploys() {
+	appl := s.app(true, map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+
+	code := s.gitlabPush(appl, s.gitlabPushPayload([]map[string]any{
+		{
+			"message":  "Update infrastructure",
+			"modified": []string{"apps/infrastructure/main.tf"},
+		},
+	}, 25))
+
+	s.Equal(http.StatusOK, code)
+	s.mockDeployer.AssertCalled(s.T(), "Deploy", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (s *InboundGitlabSuite) TestMergeRequestOpened() {

--- a/src/ce/api/app/apphandlers/handler_inbound_webhooks_test.go
+++ b/src/ce/api/app/apphandlers/handler_inbound_webhooks_test.go
@@ -217,31 +217,44 @@ func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_AutoDeployCommitsConf
 	s.Len(c, 0)
 }
 
-func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_BuildRootChanged() {
+func (s *InboundWebhooksSuite) buildRootList() []*app.DeployCandidate {
 	myApp := &app.MyApp{
 		App: &app.App{},
 	}
 
-	list := []*app.DeployCandidate{
+	return []*app.DeployCandidate{
 		{
 			MyApp:            myApp,
 			EnvName:          "infrastructure",
 			EnvDefaultBranch: "main",
-			BuildConfig:      &buildconf.BuildConf{WorkDir: "/apps/infrastructure/"},
+			BuildConfig: &buildconf.BuildConf{
+				WorkDir:                "/apps/infrastructure/",
+				SkipUnchangedBuildRoot: null.BoolFrom(true),
+			},
 		},
 		{
 			MyApp:            myApp,
 			EnvName:          "frontend",
 			EnvDefaultBranch: "main",
-			BuildConfig:      &buildconf.BuildConf{WorkDir: "apps/frontend"},
+			BuildConfig: &buildconf.BuildConf{
+				WorkDir:                "apps/frontend",
+				WatchPaths:             []string{"packages/ui"},
+				SkipUnchangedBuildRoot: null.BoolFrom(true),
+			},
 		},
 		{
 			MyApp:            myApp,
 			EnvName:          "repository-root",
 			EnvDefaultBranch: "main",
-			BuildConfig:      &buildconf.BuildConf{},
+			BuildConfig: &buildconf.BuildConf{
+				SkipUnchangedBuildRoot: null.BoolFrom(true),
+			},
 		},
 	}
+}
+
+func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_BuildRootChanged() {
+	list := s.buildRootList()
 
 	input := apphandlers.TriggerDeployInput{
 		Branch:          "main",
@@ -270,6 +283,82 @@ func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_BuildRootChanged() {
 	candidates = apphandlers.FilterDeployCandidates(input, list)
 
 	s.Len(candidates, 3)
+}
+
+// Path filtering is opt-in: an environment that has a build root but has not
+// enabled the filter keeps deploying on every push.
+func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_BuildRootFilterIsOptIn() {
+	list := s.buildRootList()
+
+	for _, dc := range list {
+		dc.BuildConfig.SkipUnchangedBuildRoot = null.Bool{}
+	}
+
+	candidates := apphandlers.FilterDeployCandidates(apphandlers.TriggerDeployInput{
+		Branch:          "main",
+		ChangedFiles:    []string{"apps/infrastructure/main.tf"},
+		ChangesComplete: true,
+	}, list)
+
+	s.Len(candidates, 3)
+}
+
+// Shared workspace packages live outside the build root, so a change to one of
+// them has to keep the environments that watch it.
+func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_WatchPaths() {
+	list := s.buildRootList()
+
+	candidates := apphandlers.FilterDeployCandidates(apphandlers.TriggerDeployInput{
+		Branch:          "main",
+		ChangedFiles:    []string{"packages/ui/button.tsx"},
+		ChangesComplete: true,
+	}, list)
+
+	s.Len(candidates, 2)
+	s.Equal("frontend", candidates[0].EnvName)
+	s.Equal("repository-root", candidates[1].EnvName)
+
+	// A sibling directory sharing the prefix must not match.
+	candidates = apphandlers.FilterDeployCandidates(apphandlers.TriggerDeployInput{
+		Branch:          "main",
+		ChangedFiles:    []string{"packages/ui-legacy/button.tsx"},
+		ChangesComplete: true,
+	}, list)
+
+	s.Len(candidates, 1)
+	s.Equal("repository-root", candidates[0].EnvName)
+}
+
+// Watch paths are additive. An environment building from the repository root
+// is affected by every change, so adding a watch path must not start filtering
+// out the directories it used to deploy on.
+func (s *InboundWebhooksSuite) Test_FilterDeployCandidates_RepoRootBuildRootIgnoresWatchPaths() {
+	myApp := &app.MyApp{
+		App: &app.App{},
+	}
+
+	for _, workDir := range []string{"", "./", "/", "."} {
+		list := []*app.DeployCandidate{
+			{
+				MyApp:            myApp,
+				EnvName:          "root",
+				EnvDefaultBranch: "main",
+				BuildConfig: &buildconf.BuildConf{
+					WorkDir:                workDir,
+					WatchPaths:             []string{"packages/ui"},
+					SkipUnchangedBuildRoot: null.BoolFrom(true),
+				},
+			},
+		}
+
+		candidates := apphandlers.FilterDeployCandidates(apphandlers.TriggerDeployInput{
+			Branch:          "main",
+			ChangedFiles:    []string{"apps/unrelated/main.go"},
+			ChangesComplete: true,
+		}, list)
+
+		s.Len(candidates, 1, "workDir %q must keep deploying on every change", workDir)
+	}
 }
 
 func TestIncomingWebhooks(t *testing.T) {

--- a/src/ce/api/app/buildconf/buildconfhandlers/handler_env_get_test.go
+++ b/src/ce/api/app/buildconf/buildconfhandlers/handler_env_get_test.go
@@ -62,6 +62,7 @@ func (s *HandlerEnvGetSuite) Test_Success() {
 			  "markdown": null,
 			  "markdownConvert": null,
 			  "previewLinks": null,
+			  "skipUnchangedBuildRoot": null,
 			  "vars":{
 				 "NODE_ENV":""
 			  }

--- a/src/ce/api/app/buildconf/env_model.go
+++ b/src/ce/api/app/buildconf/env_model.go
@@ -374,6 +374,16 @@ type BuildConf struct {
 	StatusChecks    []StatusCheck        `json:"statusChecks,omitempty"`    // StatusChecks is an array of commands that will be executed after the deployment is complete.
 	PriorityPattern string               `json:"priorityPattern,omitempty"` // PriorityPattern is a regex matched against the commit message to auto-prioritize deployments.
 	CacheDirs       []string             `json:"cacheDirs,omitempty"`       // CacheDirs is a list of directories (relative to the working directory) restored before install and snapshotted after a successful build.
+
+	// SkipUnchangedBuildRoot opts an environment into monorepo path filtering. When enabled, a push
+	// only triggers an auto deployment if it changes a file inside WorkDir, inside one of WatchPaths,
+	// or at the repository root. Off unless enabled, so existing environments keep deploying on every push.
+	SkipUnchangedBuildRoot null.Bool `json:"skipUnchangedBuildRoot,omitempty"`
+
+	// WatchPaths lists additional paths (relative to the repository root) that count as changes for
+	// this environment. Shared workspace packages that live outside WorkDir belong here. Only read
+	// when SkipUnchangedBuildRoot is enabled.
+	WatchPaths []string `json:"watchPaths,omitempty"`
 }
 
 type InterpolatedVarsOpts struct {
@@ -495,6 +505,7 @@ func Validate(env *Env) []string {
 
 	if env.Data != nil {
 		errors = append(errors, ValidateCacheDirs(env.Data.CacheDirs)...)
+		errors = append(errors, ValidateWatchPaths(env.Data.WatchPaths)...)
 	}
 
 	if len(errors) == 0 {
@@ -548,6 +559,49 @@ func ValidateCacheDirs(dirs []string) []string {
 
 		if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 			errors = append(errors, fmt.Sprintf("Cache directory %q must point inside the working directory", dir))
+		}
+	}
+
+	return errors
+}
+
+// NormalizeWatchPaths trims each entry and drops empty ones, so callers can
+// accept a raw list (e.g. a textarea split by newlines) before validation.
+func NormalizeWatchPaths(paths []string) []string {
+	normalized := make([]string, 0, len(paths))
+
+	for _, p := range paths {
+		if p = strings.TrimSpace(p); p != "" {
+			normalized = append(normalized, p)
+		}
+	}
+
+	return normalized
+}
+
+// ValidateWatchPaths ensures every watch path is a relative path that stays
+// inside the repository. Watch paths are matched against the paths reported by
+// push webhooks, which are always relative to the repository root.
+func ValidateWatchPaths(paths []string) []string {
+	errors := []string{}
+
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+
+		if p == "" {
+			errors = append(errors, "Watch paths cannot be empty")
+			continue
+		}
+
+		if strings.HasPrefix(p, "~") {
+			errors = append(errors, fmt.Sprintf("Watch path %q must be relative to the repository root", p))
+			continue
+		}
+
+		cleaned := path.Clean(strings.Trim(p, "/"))
+
+		if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			errors = append(errors, fmt.Sprintf("Watch path %q must point inside the repository", p))
 		}
 	}
 

--- a/src/ce/api/app/buildconf/watch_paths_test.go
+++ b/src/ce/api/app/buildconf/watch_paths_test.go
@@ -1,0 +1,42 @@
+package buildconf_test
+
+import (
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/api/app/buildconf"
+	"github.com/stretchr/testify/suite"
+)
+
+type WatchPathsSuite struct {
+	suite.Suite
+}
+
+func (s *WatchPathsSuite) Test_ValidPaths() {
+	s.Empty(buildconf.ValidateWatchPaths(nil))
+	s.Empty(buildconf.ValidateWatchPaths([]string{}))
+	s.Empty(buildconf.ValidateWatchPaths([]string{"packages/ui", "/packages/config/", "./shared", "a/b/c"}))
+}
+
+func (s *WatchPathsSuite) Test_InvalidPaths() {
+	for _, p := range []string{"", " ", "~/home", "..", "../escape", "a/../../b"} {
+		s.NotEmpty(buildconf.ValidateWatchPaths([]string{p}), "expected %q to be invalid", p)
+	}
+}
+
+func (s *WatchPathsSuite) Test_MixedPaths_ReportsOnlyInvalid() {
+	errs := buildconf.ValidateWatchPaths([]string{"packages/ui", "../escape"})
+
+	s.Len(errs, 1)
+	s.Contains(errs[0], "../escape")
+}
+
+func (s *WatchPathsSuite) Test_Normalize_TrimsAndDropsEmpty() {
+	s.Equal(
+		[]string{"packages/ui", "packages/config"},
+		buildconf.NormalizeWatchPaths([]string{" packages/ui ", "", "  ", "packages/config"}),
+	)
+}
+
+func TestWatchPathsSuite(t *testing.T) {
+	suite.Run(t, new(WatchPathsSuite))
+}

--- a/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
+++ b/src/ce/api/app/deploy/deployhandlers/handler_my_deployments_test.go
@@ -73,6 +73,7 @@ func (s *HandlerMyDeploymentsSuite) responseTemplate() (*template.Template, erro
 							"markdown": null,
 							"markdownConvert": null,
 							"previewLinks": null,
+							"skipUnchangedBuildRoot": null,
 							"statusChecks": [{
 								"cmd": "npm run e2e",
 								"name": "run e2e tests",

--- a/src/ce/api/public/v1/handler_env_add.go
+++ b/src/ce/api/public/v1/handler_env_add.go
@@ -38,6 +38,9 @@ type EnvAddRequest struct {
 	ServerCmd          string                  `json:"serverCmd,omitempty"`
 	StatusChecks       []buildconf.StatusCheck `json:"statusChecks,omitempty"`
 	CacheDirs          []string                `json:"cacheDirs,omitempty"`
+
+	SkipUnchangedBuildRoot null.Bool `json:"skipUnchangedBuildRoot,omitempty"`
+	WatchPaths             []string  `json:"watchPaths,omitempty"`
 }
 
 func handlerEnvAdd(req *RequestContext) *shttp.Response {
@@ -73,6 +76,9 @@ func handlerEnvAdd(req *RequestContext) *shttp.Response {
 			Vars:            data.EnvVars,
 			StatusChecks:    data.StatusChecks,
 			CacheDirs:       buildconf.NormalizeCacheDirs(data.CacheDirs),
+
+			SkipUnchangedBuildRoot: data.SkipUnchangedBuildRoot,
+			WatchPaths:             buildconf.NormalizeWatchPaths(data.WatchPaths),
 		},
 		Name:        data.Name,
 		AppID:       req.App.ID,

--- a/src/ce/api/public/v1/handler_env_update.go
+++ b/src/ce/api/public/v1/handler_env_update.go
@@ -41,6 +41,9 @@ type EnvUpdateRequest struct {
 	PriorityPattern    *string                 `json:"priorityPattern,omitempty"`
 	EnvVars            *map[string]string      `json:"envVars,omitempty"`
 	CacheDirs          *[]string               `json:"cacheDirs,omitempty"`
+
+	SkipUnchangedBuildRoot *bool     `json:"skipUnchangedBuildRoot,omitempty"`
+	WatchPaths             *[]string `json:"watchPaths,omitempty"`
 }
 
 func handlerEnvUpdate(req *RequestContext) *shttp.Response {
@@ -179,6 +182,14 @@ func handlerEnvUpdate(req *RequestContext) *shttp.Response {
 
 	if data.CacheDirs != nil {
 		env.Data.CacheDirs = buildconf.NormalizeCacheDirs(*data.CacheDirs)
+	}
+
+	if data.SkipUnchangedBuildRoot != nil {
+		env.Data.SkipUnchangedBuildRoot = null.BoolFrom(*data.SkipUnchangedBuildRoot)
+	}
+
+	if data.WatchPaths != nil {
+		env.Data.WatchPaths = buildconf.NormalizeWatchPaths(*data.WatchPaths)
 	}
 
 	if errs := buildconf.Validate(env); len(errs) > 0 {

--- a/src/ce/api/public/v1/handler_mcp_test.go
+++ b/src/ce/api/public/v1/handler_mcp_test.go
@@ -733,6 +733,83 @@ func (s *HandlerMCPSuite) Test_UpdateEnvironment_SetsMarkdown() {
 	s.True(updated.Data.Markdown.ValueOrZero())
 }
 
+// Monorepo path filtering is bulk multi-environment wiring, which is exactly
+// the kind of setup an agent drives rather than a person clicking per
+// environment, so both settings have to be reachable over MCP.
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_SetsBuildRootFilter() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"Data": &buildconf.BuildConf{WorkDir: "apps/frontend"},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":                  mockEnv.ID.String(),
+		"skipUnchangedBuildRoot": true,
+		"watchPaths":             []any{"packages/ui", " packages/config ", ""},
+	}))
+
+	s.rpcOK(resp)
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+
+	s.Require().NoError(err)
+	s.True(updated.Data.SkipUnchangedBuildRoot.ValueOrZero())
+	s.Equal([]string{"packages/ui", "packages/config"}, updated.Data.WatchPaths)
+}
+
+// Leaving the settings out of the call must not disturb what is stored.
+func (s *HandlerMCPSuite) Test_UpdateEnvironment_KeepsBuildRootFilterWhenOmitted() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	mockEnv := s.MockEnv(appl, map[string]any{
+		"Data": &buildconf.BuildConf{
+			WorkDir:                "apps/frontend",
+			WatchPaths:             []string{"packages/ui"},
+			SkipUnchangedBuildRoot: null.BoolFrom(true),
+		},
+	})
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "update_environment", map[string]any{
+		"envId":  mockEnv.ID.String(),
+		"branch": "develop",
+	}))
+
+	s.rpcOK(resp)
+
+	updated, err := buildconf.NewStore().EnvironmentByID(context.Background(), mockEnv.ID)
+
+	s.Require().NoError(err)
+	s.True(updated.Data.SkipUnchangedBuildRoot.ValueOrZero())
+	s.Equal([]string{"packages/ui"}, updated.Data.WatchPaths)
+}
+
+func (s *HandlerMCPSuite) Test_CreateEnvironment_SetsBuildRootFilter() {
+	usr := s.MockUser()
+	appl := s.MockApp(usr)
+	key := s.userKey(usr)
+
+	resp := s.post(key.Value, mcpToolCall(1, "create_environment", map[string]any{
+		"appId":                  appl.ID.String(),
+		"name":                   "frontend",
+		"branch":                 "main",
+		"workDir":                "apps/frontend",
+		"skipUnchangedBuildRoot": true,
+		"watchPaths":             []any{"packages/ui"},
+	}))
+
+	s.rpcOK(resp)
+
+	created, err := buildconf.NewStore().Environment(context.Background(), appl.ID, "frontend")
+
+	s.Require().NoError(err)
+	s.Require().NotNil(created)
+	s.True(created.Data.SkipUnchangedBuildRoot.ValueOrZero())
+	s.Equal([]string{"packages/ui"}, created.Data.WatchPaths)
+}
+
 func (s *HandlerMCPSuite) Test_UpdateEnvironment_Forbidden_NotMember() {
 	usr1 := s.MockUser()
 	usr2 := s.MockUser()

--- a/src/ce/api/public/v1/handler_mcp_tools.go
+++ b/src/ce/api/public/v1/handler_mcp_tools.go
@@ -287,6 +287,15 @@ func mcpAllTools() []mcpToolDef {
 						"description": "Directories (relative to the build working directory) restored before install and snapshotted after a successful build. Best for compiler caches like .next/cache or .turbo. Requires a premium or ultimate subscription on Stormkit Cloud; always enabled on self-hosted.",
 						"items":       map[string]any{"type": "string"},
 					},
+					"skipUnchangedBuildRoot": map[string]any{
+						"type":        "boolean",
+						"description": "Monorepo path filtering. When true, a push only auto-deploys this environment if it changes a file inside workDir, inside one of watchPaths, or at the repository root. Off unless enabled. Has no effect when the build root is the repository root, and applies to GitHub and GitLab push events only.",
+					},
+					"watchPaths": map[string]any{
+						"type":        "array",
+						"description": "Extra paths, relative to the repository root, that count as changes for this environment - typically shared workspace packages that live outside workDir. Only read when skipUnchangedBuildRoot is enabled.",
+						"items":       map[string]any{"type": "string"},
+					},
 				},
 				"required":             []string{"appId", "name", "branch"},
 				"additionalProperties": false,
@@ -353,6 +362,15 @@ func mcpAllTools() []mcpToolDef {
 					"cacheDirs": map[string]any{
 						"type":        "array",
 						"description": "Directories (relative to the build working directory) restored before install and snapshotted after a successful build. Best for compiler caches like .next/cache or .turbo. Pass an empty array to disable caching. Requires a premium or ultimate subscription on Stormkit Cloud; always enabled on self-hosted.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"skipUnchangedBuildRoot": map[string]any{
+						"type":        "boolean",
+						"description": "Monorepo path filtering. When true, a push only auto-deploys this environment if it changes a file inside workDir, inside one of watchPaths, or at the repository root. Off unless enabled. Has no effect when the build root is the repository root, and applies to GitHub and GitLab push events only.",
+					},
+					"watchPaths": map[string]any{
+						"type":        "array",
+						"description": "Extra paths, relative to the repository root, that count as changes for this environment - typically shared workspace packages that live outside workDir. Only read when skipUnchangedBuildRoot is enabled.",
 						"items":       map[string]any{"type": "string"},
 					},
 				},
@@ -1030,6 +1048,11 @@ func mcpCreateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 
 	body.StatusChecks = parseStatusChecksArg(args)
 	body.CacheDirs, _ = stringArrayArg(args, "cacheDirs")
+	body.WatchPaths, _ = stringArrayArg(args, "watchPaths")
+
+	if raw, ok := args["skipUnchangedBuildRoot"].(bool); ok {
+		body.SkipUnchangedBuildRoot = null.BoolFrom(raw)
+	}
 
 	resp := req.setBody(id, body)
 
@@ -1200,6 +1223,12 @@ func mcpUpdateEnvironment(req *RequestContextMCP, id any, args map[string]any) *
 	if dirs, ok := stringArrayArg(args, "cacheDirs"); ok {
 		update.CacheDirs = &dirs
 	}
+
+	if paths, ok := stringArrayArg(args, "watchPaths"); ok {
+		update.WatchPaths = &paths
+	}
+
+	setBool("skipUnchangedBuildRoot", &update.SkipUnchangedBuildRoot)
 
 	if resp := req.setBody(id, update); resp != nil {
 		return resp

--- a/src/ce/api/public/v1/openapi.json
+++ b/src/ce/api/public/v1/openapi.json
@@ -3802,6 +3802,17 @@
             "items": {
               "type": "string"
             }
+          },
+          "skipUnchangedBuildRoot": {
+            "type": "boolean",
+            "description": "Monorepo path filtering. When true, a push only auto-deploys this environment if it changes a file inside `workDir`, inside one of `watchPaths`, or at the repository root. Off unless enabled. GitHub and GitLab push events only."
+          },
+          "watchPaths": {
+            "type": "array",
+            "description": "Extra paths, relative to the repository root, that count as changes for this environment - typically shared workspace packages that live outside `workDir`. Only read when `skipUnchangedBuildRoot` is enabled.",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.spec.tsx
@@ -104,6 +104,8 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
           distFolder: "./dist",
           workDir: "./",
           cacheDirs: [".next/cache", "node_modules"],
+          skipUnchangedBuildRoot: false,
+          watchPaths: [],
         },
         status: 200,
         response: { ok: true },
@@ -114,6 +116,71 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBu
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
         expect(setRefreshToken).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("build root path filtering", () => {
+    beforeEach(() => {
+      currentApp = mockApp();
+      currentEnv = mockEnvironments({ app: currentApp })[0];
+      currentEnv.build.installCmd = "";
+      currentEnv.build.buildCmd = "";
+      currentEnv.build.distFolder = "";
+      currentEnv.build.vars = {};
+
+      createWrapper({ environment: currentEnv });
+    });
+
+    it("keeps typed watch paths when the filter is toggled off and on", async () => {
+      await userEvent.click(
+        wrapper.getByLabelText("Deploy only when the build root changes")
+      );
+
+      fireEvent.change(wrapper.getByLabelText("Watch paths"), {
+        target: { value: "packages/ui" },
+      });
+
+      // Toggling the switch must not discard what the user typed.
+      await userEvent.click(
+        wrapper.getByLabelText("Deploy only when the build root changes")
+      );
+      await userEvent.click(
+        wrapper.getByLabelText("Deploy only when the build root changes")
+      );
+
+      expect(
+        (wrapper.getByLabelText("Watch paths") as HTMLTextAreaElement).value
+      ).toBe("packages/ui");
+    });
+
+    it("sends the filter and the watch paths", async () => {
+      await userEvent.click(
+        wrapper.getByLabelText("Deploy only when the build root changes")
+      );
+
+      fireEvent.change(wrapper.getByLabelText("Watch paths"), {
+        target: { value: "packages/ui\npackages/config" },
+      });
+
+      const scope = mockUpdateEnvironment({
+        payload: {
+          installCmd: "",
+          buildCmd: "",
+          distFolder: "./",
+          workDir: "./",
+          cacheDirs: [],
+          skipUnchangedBuildRoot: true,
+          watchPaths: ["packages/ui", "packages/config"],
+        },
+        status: 200,
+        response: { ok: true },
+      });
+
+      fireEvent.click(wrapper.getByText("Save"));
+
+      await waitFor(() => {
+        expect(scope.isDone()).toBe(true);
       });
     });
   });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabConfigBuild.tsx
@@ -3,6 +3,9 @@ import { useContext, useState } from "react";
 import Box from "@mui/material/Box";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import { AuthContext } from "~/pages/auth/Auth.context";
 import { RootContext } from "~/pages/Root.context";
 import Card from "~/components/Card";
@@ -32,6 +35,12 @@ export default function TabConfigGeneral({
   const [success, setSuccess] = useState<string>();
   const [isLoading, setLoading] = useState(false);
   const [root, setRoot] = useState(env?.build?.workDir || "./");
+  const [skipUnchangedBuildRoot, setSkipUnchangedBuildRoot] = useState(
+    env?.build?.skipUnchangedBuildRoot === true,
+  );
+
+  // A build root pointing at the repository root cannot filter anything out.
+  const isRepoRoot = ["", ".", "./", "/"].includes(root.trim());
 
   // Build caching is available on self-hosted instances and for premium or
   // ultimate subscriptions on Stormkit Cloud.
@@ -54,11 +63,17 @@ export default function TabConfigGeneral({
       onSubmit={e => {
         e.preventDefault();
 
-        // workDir is a controlled input (no form name), so feed it in directly.
+        // workDir and the path filter switch are controlled inputs (no form
+        // name), so feed them in directly.
         const values: FormValues = buildFormValues(
           env,
           e.target as HTMLFormElement,
-          { "build.workDir": root }
+          {
+            "build.workDir": root,
+            "build.skipUnchangedBuildRoot": skipUnchangedBuildRoot
+              ? "on"
+              : "off",
+          }
         );
 
         const build = prepareBuildObject(values);
@@ -72,6 +87,8 @@ export default function TabConfigGeneral({
             distFolder: build.distFolder,
             workDir: build.workDir,
             cacheDirs: build.cacheDirs,
+            skipUnchangedBuildRoot: build.skipUnchangedBuildRoot,
+            watchPaths: build.watchPaths,
           },
           setError,
           setLoading,
@@ -154,6 +171,44 @@ export default function TabConfigGeneral({
           fullWidth
           placeholder="Defaults to `./`"
           helperText={"The working directory relative to the Repository root."}
+        />
+      </Box>
+      <Box sx={{ bgcolor: "container.paper", p: 1.75, pt: 1, mb: 4 }}>
+        <FormControlLabel
+          sx={{ pl: 0, ml: 0 }}
+          label="Deploy only when the build root changes"
+          control={
+            <Switch
+              color="secondary"
+              checked={skipUnchangedBuildRoot}
+              onChange={e => {
+                setSkipUnchangedBuildRoot(e.target.checked);
+              }}
+            />
+          }
+          labelPlacement="start"
+        />
+        <Typography sx={{ opacity: 0.5 }}>
+          For monorepos. When turned on, a push only deploys this environment if
+          it touches the build root, one of the watch paths below, or a file at
+          the repository root. Available for GitHub and GitLab push events.
+          {isRepoRoot &&
+            " This environment builds from the repository root, so every change" +
+              " already affects it and the filter has no effect."}
+        </Typography>
+      </Box>
+      <Box sx={{ mb: 4, display: skipUnchangedBuildRoot ? "block" : "none" }}>
+        <TextField
+          label="Watch paths"
+          variant="filled"
+          autoComplete="off"
+          multiline
+          minRows={2}
+          defaultValue={env?.build.watchPaths?.join("\n") || ""}
+          fullWidth
+          name="build.watchPaths"
+          placeholder={"packages/ui\npackages/config"}
+          helperText="One path per line, relative to the repository root. Add the shared workspace packages this environment depends on, so a change to them still triggers a deployment."
         />
       </Box>
       <Box sx={{ mb: 4 }}>

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/actions.ts
@@ -73,6 +73,24 @@ export const prepareBuildObject = (values: FormValues): BuildConfig => {
       .filter(Boolean);
   }
 
+  // One path per line; an empty textarea clears the list.
+  let watchPaths: string[] | undefined;
+
+  if (values["build.watchPaths"] !== undefined) {
+    watchPaths = values["build.watchPaths"]
+      .split("\n")
+      .map(p => p.trim())
+      .filter(Boolean);
+  }
+
+  // Only sent by the section that owns the switch, so that a form which does
+  // not carry it (the new environment modal) leaves the setting untouched.
+  let skipUnchangedBuildRoot: boolean | undefined;
+
+  if (values["build.skipUnchangedBuildRoot"] !== undefined) {
+    skipUnchangedBuildRoot = values["build.skipUnchangedBuildRoot"] === "on";
+  }
+
   const build: BuildConfig = {
     buildCmd: values["build.buildCmd"]?.trim() || "",
     serverCmd: values["build.serverCmd"]?.trim() || "",
@@ -90,6 +108,8 @@ export const prepareBuildObject = (values: FormValues): BuildConfig => {
     statusChecks,
     redirects,
     cacheDirs,
+    watchPaths,
+    skipUnchangedBuildRoot,
     vars,
   };
 
@@ -148,6 +168,10 @@ export const buildFormValues = (
     "build.installCmd": env.build.installCmd,
     "build.distFolder": env.build.distFolder,
     "build.workDir": env.build.workDir,
+    "build.watchPaths": env.build.watchPaths?.join("\n") || "",
+    "build.skipUnchangedBuildRoot": env.build.skipUnchangedBuildRoot
+      ? "on"
+      : "off",
     "build.redirects": JSON.stringify(env.build.redirects),
     "build.vars": Object.keys(env.build?.vars || {})
       .filter(key => env.build.vars[key])
@@ -166,6 +190,7 @@ interface ControlledFormValues {
   "build.headers"?: string;
   "build.statusChecks"?: string;
   "build.workDir"?: string;
+  "build.skipUnchangedBuildRoot"?: "on" | "off";
 }
 
 // EnvUpdatePayload is a partial environment update: each config section sends
@@ -197,6 +222,8 @@ export interface EnvUpdatePayload {
   redirects?: Redirect[];
   envVars?: Record<string, string>;
   cacheDirs?: string[];
+  skipUnchangedBuildRoot?: boolean;
+  watchPaths?: string[];
 }
 
 export interface FormValues {
@@ -215,6 +242,8 @@ export interface FormValues {
   "build.distFolder"?: string;
   "build.workDir"?: string;
   "build.cacheDirs"?: string;
+  "build.watchPaths"?: string;
+  "build.skipUnchangedBuildRoot"?: "on" | "off";
   "build.headers"?: string;
   "build.headersFile"?: string;
   "build.errorFile"?: string;

--- a/src/ui/src/types/environment.d.ts
+++ b/src/ui/src/types/environment.d.ts
@@ -23,6 +23,8 @@ declare type BuildConfig = {
   statusChecks?: StatusCheck[];
   priorityPattern?: string;
   cacheDirs?: string[]; // Directories restored before install and snapshotted after a successful build
+  skipUnchangedBuildRoot?: boolean; // Only auto deploy when the push touches the build root, a watch path, or the repository root
+  watchPaths?: string[]; // Extra paths (relative to the repository root) that count as changes for this environment
   vars: Record<string, string>;
 };
 


### PR DESCRIPTION
Follow-ups to #521, which shipped monorepo path filtering for GitHub and GitLab push webhooks.

## Why

#521 applied the filter to every environment that had a Build root set. Two problems came out of reviewing it:

1. **Shared workspace code was invisible to the filter.** Only the build root counted as a change. A monorepo app rooted at `apps/web` that imports `packages/ui` would silently stop redeploying when that shared package changed — the customer merges, sees no deployment, and production keeps serving the old bundle.
2. **It was on by default with no way off.** Existing customers relying on "every push deploys everything" would lose deployments after an upgrade, with no switch to flip back.

## What changed

Two new environment build settings:

| Setting | Type | Behaviour |
| --- | --- | --- |
| `skipUnchangedBuildRoot` | boolean | Opts the environment into path filtering. Off unless enabled. |
| `watchPaths` | `string[]` | Extra paths, relative to the repository root, that count as changes. Only read when the filter is on. |

With the filter on, a push deploys the environment when it touches the build root, one of the watch paths, or a file at the repository root. With it off — the default — behaviour is exactly what it was before #521.

Exposed through `POST /v1/env`, `PUT /v1/env`, the OpenAPI spec, the API docs, and the Build settings tab (a switch, plus a watch-paths textarea that appears only when the switch is on).

## Test coverage

Also fills the gaps left by #521:

- GitHub: the 2048-commit truncation cap falls back to deploying; a push *inside* the build root deploys, which proves added/modified/removed paths are read off the payload.
- GitLab: a `total_commits_count` mismatch falls back to deploying; a watch-path change deploys.
- Unit: opt-in default, watch-path matching, and that a prefix sibling (`packages/ui-legacy`) does not match `packages/ui`.
- New validation suite for `watchPaths` — rejects `..`, `~` and empty entries, trims whitespace.

## Verification

- `go test -p 1 ./src/ce/api/app/apphandlers/ ./src/ce/api/app/buildconf/ ./src/ce/api/public/v1/` — all pass
- `go vet ./src/ce/...` — clean
- UI: 88 tests pass across the environment config suite

## Not addressed

Force-push tree divergence, a log line for skipped candidates, and narrowing the "any root-level file is global" heuristic were reviewed and deliberately left out of scope.