### PR TITLE
docs: document isPublished on the app config response

### DIFF
--- a/docs/api/2-apps.md
+++ b/docs/api/2-apps.md
@@ -305,7 +305,7 @@ Returns an array of configuration objects for all matching published deployments
 | `deploymentId`  | string     | ID of the published deployment.                                                |
 | `appId`         | string     | ID of the application.                                                         |
 | `envId`         | string     | ID of the environment.                                                         |
-| `percentage`    | number     | Traffic percentage routed to this deployment (0–100).                          |
+| `isPublished`   | boolean    | Whether the environment is currently serving this deployment.                  |
 | `apiPathPrefix` | string     | URL path prefix under which serverless API functions are served.               |
 | `domains`       | `string[]` | Custom domains associated with this deployment. `null` if none are configured. |
 | `staticFiles`   | object     | Map of URL paths to static file metadata.                                      |
@@ -336,7 +336,7 @@ curl -X GET \
       "deploymentId": "8241",
       "appId": "1510",
       "envId": "305",
-      "percentage": 100,
+      "isPublished": true,
       "apiPathPrefix": "/api",
       "domains": null,
       "staticFiles": {


### PR DESCRIPTION
`docs/api/2-apps.md` documented a `percentage` field on the `Config` object returned by `GET /v1/app/config`, in both the field table and the example response.

That field does not exist. `appconf.Config` has no `percentage`, and percentage-based releases were retired in #519. Meanwhile `isPublished` — the field an integrator actually reads to tell whether an environment is serving a given deployment — was not documented at all.

The last commit to touch this file predates the async-publish work, so the drift went unnoticed.

## What changed

- Config table: `percentage` → `isPublished` (boolean, "Whether the environment is currently serving this deployment")
- Example response JSON: `"percentage": 100` → `"isPublished": true`

Docs only, no code change. The OpenAPI spec already had `isPublished` and no `percentage`, and a sweep of `docs/` turned up no other stale references.