### PR TITLE
docs: say application platform where we define ourselves

### DIFF
--- a/docs/self-hosting/1-getting-started.md
+++ b/docs/self-hosting/1-getting-started.md
@@ -7,7 +7,7 @@ description: Discover Stormkit, the self-hosted alternative to Vercel and Netlif
 
 <section>
 
-Stormkit is a deployment platform for web applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time. Your app can be written in any language — see [Runtime Management](/docs/self-hosting/runtimes) for how runtimes and system packages are provisioned.
+Stormkit is an application platform for the web. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time. Your app can be written in any language — see [Runtime Management](/docs/self-hosting/runtimes) for how runtimes and system packages are provisioned.
 
 </section>
 

--- a/docs/welcome/1-getting-started.md
+++ b/docs/welcome/1-getting-started.md
@@ -1,12 +1,12 @@
 ---
 title: Getting started
-description: Stormkit is a deployment platform for web applications in any language. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time.
+description: Stormkit is an application platform for the web. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling tls certificates, and helps saving valuable time.
 ---
 
 # Welcome
 
 <section>
-Stormkit is a deployment platform for web applications. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling, tls certificates, and helps saving valuable time. Builds can use any language runtime, and <a href="/docs/self-hosting/getting-started">self-hosted instances</a> additionally run long-lived server processes written in any language.
+Stormkit is an application platform for the web. It helps you focus on your product by providing a solution for most common technical challenges, such as deployments, logs, hosting, scaling, tls certificates, and helps saving valuable time. Builds can use any language runtime, and <a href="/docs/self-hosting/getting-started">self-hosted instances</a> additionally run long-lived server processes written in any language.
 </section>
 
 ## Getting Started

--- a/src/ce/api/public/v1/openapi.json
+++ b/src/ce/api/public/v1/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Stormkit API",
     "version": "1.0.0",
-    "summary": "REST API for the Stormkit deployment platform.",
+    "summary": "REST API for the Stormkit application platform.",
     "description": "The Stormkit API lets you create applications and environments, trigger and publish deployments, read build, runtime and access logs, manage custom domains, redirects, snippets, periodic triggers and transactional email.\n\nEvery endpoint is authenticated with an API key sent in the `Authorization` header. Keys are scoped to a user, a team, an application or a single environment; each operation documents the minimum scope it accepts. See https://www.stormkit.io/docs/api/authentication for how to create one.\n\nStormkit also exposes the same capabilities to agents over MCP at `POST /v1/mcp`; see https://www.stormkit.io/mcp.",
     "termsOfService": "https://www.stormkit.io/policies/terms",
     "contact": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app.stormkit.io",
   "version": "1.0.0",
-  "description": "Stormkit is an infrastructure provider for modern javascript applications which is strongly integrated with popular Git providers.",
+  "description": "Stormkit is a self-hostable application platform for the web, strongly integrated with popular Git providers.",
   "private": true,
   "license": "MIT",
   "author": "Savas Vedova <savas@stormkit.io>",

--- a/src/www/README.md
+++ b/src/www/README.md
@@ -2,14 +2,14 @@
   <img src="https://www.stormkit.io/stormkit-logo.png" height="90"/>
 </p>
 <p align="center">
-  <i>Stormkit is a hosting and deployment platform for modern web applications, offering seamless integration with Git repositories and powerful CI/CD capabilities.<br/>Try out Stormkit using our hosted version at <a href="https://app.stormkit.io">app.stormkit.io</a>.</i>
+  <i>Stormkit is a self-hostable application platform for the web: git-driven deployments, preview environments, a managed Postgres database, end-user authentication, a mailer, cron triggers and analytics.<br/>Try out Stormkit using our hosted version at <a href="https://app.stormkit.io">app.stormkit.io</a>.</i>
 </p>
 
 This repository contains code related to the landing page and documentation. If you'd like to contribute to the application frontend, check out our frontend repository on https://github.com/stormkit-io/app-stormkit-io. You're more than welcome to contribute.
 
 ## What is Stormkit?
 
-Stormkit is a hosting and deployment platform for modern web applications, offering seamless integration with Git repositories and powerful CI/CD capabilities.
+Stormkit is a self-hostable application platform for the web: git-driven deployments, preview environments, a managed Postgres database, end-user authentication, a mailer, cron triggers and analytics.
 
 ## Contributing
 

--- a/src/www/package.json
+++ b/src/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "www-stormkit-io",
   "version": "1.0.0",
-  "description": "Stormkit is a serverless platform for users to deploy fullstack javascript applications using git providers. It comes with application previews, code injections and  many more features.",
+  "description": "Stormkit is a self-hostable application platform for the web. It comes with deployment previews, a managed Postgres database, end-user authentication, a mailer, cron triggers, analytics and more.",
   "author": {
     "email": "hello@stormkit.io",
     "name": "Stormkit",

--- a/src/www/public/index.md
+++ b/src/www/public/index.md
@@ -1,10 +1,10 @@
 <!-- Source: https://www.stormkit.io/ -->
 <!-- Title: Stormkit — self-hosted deployment platform for web applications -->
-<!-- Description: Stormkit is a self-hostable deployment platform for web applications: deployments, environments, previews, a Postgres database, end-user auth, a mailer, cron triggers and analytics — on your own infrastructure, driveable by an agent over MCP. -->
+<!-- Description: Stormkit is a self-hostable application platform for the web: deployments, environments, previews, a Postgres database, end-user auth, a mailer, cron triggers and analytics — on your own infrastructure, driveable by an agent over MCP. -->
 
 # Stormkit
 
-Stormkit is a deployment platform for web applications in any language. It gives
+Stormkit is an application platform for the web. It gives
 you the workflow of a managed platform — git-driven deployments, preview
 environments, instant rollbacks — while running on infrastructure you own, so
 there is no vendor lock-in and no usage-based surprise.

--- a/src/www/src/helpers/structured-data.ts
+++ b/src/www/src/helpers/structured-data.ts
@@ -57,7 +57,7 @@ export function organizationSchema(): JsonLd {
     logo: `${DEFAULT_ORIGIN}/stormkit-logo.png`,
     email: SUPPORT_EMAIL,
     description:
-      'Stormkit is a self-hostable deployment platform for web applications, with deployments, environments, a managed database, end-user authentication, a mailer, cron triggers and analytics.',
+      'Stormkit is a self-hostable application platform for the web, with deployments, environments, a managed database, end-user authentication, a mailer, cron triggers and analytics.',
     foundingDate: '2020',
     sameAs: SAME_AS,
     contactPoint: [
@@ -95,7 +95,7 @@ export function softwareApplicationSchema(): JsonLd {
     downloadUrl: `${DEFAULT_ORIGIN}/install.sh`,
     softwareHelp: `${DEFAULT_ORIGIN}/docs/welcome/getting-started`,
     description:
-      'Self-hostable deployment platform for web applications: git-driven deployments, preview environments, a managed Postgres database, end-user authentication, a mailer, cron triggers, volumes and analytics — driveable over a REST API and an MCP server.',
+      'Self-hostable application platform for the web: git-driven deployments, preview environments, a managed Postgres database, end-user authentication, a mailer, cron triggers, volumes and analytics — driveable over a REST API and an MCP server.',
     publisher: { '@id': ORGANIZATION_ID },
     sameAs: ['https://github.com/stormkit-io/stormkit-io'],
     // Mirrors the tiers rendered by components/Pricing/PricingSelfHosted.tsx and

--- a/src/www/src/pages/_components/FAQ.tsx
+++ b/src/www/src/pages/_components/FAQ.tsx
@@ -9,7 +9,7 @@ const faq = [
   {
     question: 'What is Stormkit?',
     answer:
-      'Stormkit is a hosting and deployment platform for modern web applications, offering seamless integration with Git repositories and powerful CI/CD capabilities.',
+      'Stormkit is a self-hostable application platform for the web: git-driven deployments, preview environments, a managed Postgres database, end-user authentication, a mailer, cron triggers and analytics.',
   },
   {
     question: 'Which frameworks does Stormkit support?',

--- a/src/www/src/pages/vs/vercel.tsx
+++ b/src/www/src/pages/vs/vercel.tsx
@@ -80,7 +80,7 @@ export default function Vercel() {
         </Typography>
         <Typography>
           Stormkit is an intuitive, scalable, and cost-effective self-hostable
-          deployment platform for web applications in any language. It comes
+          application platform for the web. It comes
           with built-in features like deployment previews, a PostgreSQL
           database, end-user authentication, a mailer, scheduled jobs,
           analytics, snippet injections, multiple environments and more.


### PR DESCRIPTION
Follow-up to #525. The definitional copy was split between "deployment platform" and "application platform", so the two read as different products depending on which page you landed on.

## Why application platform

"Deployment platform" describes the commodity half — push, build, host — which is the half Vercel and Netlify already own in a reader's head. It hides the database, authentication, mailer, cron triggers and analytics that actually make Stormkit different, and it invites "so, a self-hosted Vercel".

Every sentence that defines what Stormkit **is** now says application platform.

## Changed

| File | Was |
| --- | --- |
| `docs/welcome/1-getting-started.md` (×2) | deployment platform |
| `docs/self-hosting/1-getting-started.md` | deployment platform |
| `src/www/public/index.md` (body + meta description) | deployment platform |
| `src/www/README.md` (×2) | **hosting and** deployment platform |
| `src/www/src/pages/_components/FAQ.tsx` | **hosting and** deployment platform |
| `src/www/src/helpers/structured-data.ts` (×2) | deployment platform |
| `src/www/src/pages/vs/vercel.tsx` | deployment platform |
| `openapi.json` summary | deployment platform |

Two of these were factually wrong rather than merely off-message: both `package.json` descriptions still claimed *javascript* applications (`src/ui`: "infrastructure provider for modern javascript applications", `src/www`: "serverless platform … fullstack javascript applications"). That stopped being true when runtimes moved to mise, so both were rewritten.

## Deliberately left alone

- **The landing page `<title>`, the two image `alt` texts, and `applicationSubCategory: 'Deployment platform'`.** These carry search weight for a phrase people actually type. Changing them costs discovery and buys nothing positional. The landing title is the one real judgement call here — it is both the most SEO-bearing and the most positioning-bearing string on the site, and this PR resolves it toward search. Easy to flip if you disagree.
- **The blog and tutorial archive.** Some of it is the generic category noun and simply correct — `vercel-data-residency-and-eu-alternatives.md:23` says "A deployment platform is not one thing in one place", which is about the category, not about us. Rewriting published posts also risks their rankings.
- `src/www/src/entry-server.tsx:31`, which already reads "self-hostable platform for running full applications" — on-message without using either phrase.

## Verification

`npm test` in `src/www` — 32/32 pass. Copy-only change; no behaviour touched.