### PR TITLE
test: stop specs racing the mock instead of the DOM

### DIFF
--- a/src/ui/src/pages/admin/Git/Git.spec.tsx
+++ b/src/ui/src/pages/admin/Git/Git.spec.tsx
@@ -115,11 +115,16 @@ describe("~/pages/admin/Git/Git.tsx", () => {
       expect(scope.isDone()).toBe(true);
     });
 
-    // Check that check icons are displayed for configured providers
-    const checkIcons = wrapper.container.querySelectorAll(
-      '[data-testid="CheckIcon"]'
-    );
-    expect(checkIcons.length).toBe(3); // One for each provider
+    // Wait on the rendered output rather than the request: nock reports a call
+    // as done the moment it matches, which is before React has re-rendered with
+    // the response.
+    await waitFor(() => {
+      const checkIcons = wrapper.container.querySelectorAll(
+        '[data-testid="CheckIcon"]'
+      );
+
+      expect(checkIcons.length).toBe(3); // One for each provider
+    });
   });
 
   it("should handle git details fetch error", async () => {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/AuthUsers.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/skauth/AuthUsers.spec.tsx
@@ -53,6 +53,13 @@ describe("~/pages/apps/[id]/environments/[env-id]/skauth/AuthUsers.tsx", () => {
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
     });
+
+    // Wait for the row itself: nock reports the call as done as soon as it
+    // matches, which is before React has rendered the response, so every test
+    // body would otherwise race the first paint of the user list.
+    await waitFor(() => {
+      expect(wrapper.getByLabelText("User actions")).toBeTruthy();
+    });
   };
 
   beforeEach(async () => {

--- a/src/ui/src/testing/setup.tsx
+++ b/src/ui/src/testing/setup.tsx
@@ -1,6 +1,12 @@
 import { afterEach, vi } from "vitest";
 import fetch, { Headers, Request, Response } from "node-fetch";
+import { configure } from "@testing-library/react";
 import nock from "nock";
+
+// Test files run in parallel, so a render waiting on a mocked request competes
+// for CPU with every other file. The 1s default left specs failing on timing
+// alone under load; the vitest testTimeout still catches a genuine hang.
+configure({ asyncUtilTimeout: 5000 });
 
 (global as any).fetch = fetch;
 (global as any).Headers = Headers;
@@ -111,10 +117,23 @@ afterEach(() => {
   nock.enableNetConnect("127.0.0.1");
 });
 
-// FAIL LOUDLY on unhandled promise rejections / errors
+// FAIL LOUDLY on unhandled promise rejections / errors.
+//
+// This setup file runs once per test file against a process that every test
+// file in the worker shares, so registering unconditionally leaked a listener
+// per file ("MaxListenersExceededWarning: 11 unhandledRejection listeners")
+// and let one file's stray rejection throw into whichever file was running.
+const rejectionFlag = "__skUnhandledRejectionHooked";
+
 // @ts-ignore
-process.on("unhandledRejection", reason => {
-  // eslint-disable-next-line no-console
-  console.log(`FAILED TO HANDLE PROMISE REJECTION`);
-  throw reason;
-});
+if (!(globalThis as any)[rejectionFlag]) {
+  // @ts-ignore
+  (globalThis as any)[rejectionFlag] = true;
+
+  // @ts-ignore
+  process.on("unhandledRejection", reason => {
+    // eslint-disable-next-line no-console
+    console.log(`FAILED TO HANDLE PROMISE REJECTION`);
+    throw reason;
+  });
+}

--- a/src/ui/vitest.config.ts
+++ b/src/ui/vitest.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["src/testing/setup.tsx"],
     retry: 2,
+
+    // Comfortably above the testing-library asyncUtilTimeout set in
+    // src/testing/setup.tsx, so a slow wait under load still fails as a real
+    // hang rather than being cut off mid-wait.
+    testTimeout: 20000,
     browser: {
       name: "Chrome",
       viewport: {


### PR DESCRIPTION
The frontend suite fails intermittently in CI — a different spec each time (`AuthWallConfig`, `SentEmails`, `AuthUsers`, `Events`, `Git`), always passing when run in isolation.

## The mechanism

Specs gate readiness on `scope.isDone()`. Nock marks a call done the moment the request **matches**, which is before React has rendered the response. Under parallel load that gap widens and the test body runs against an unpainted DOM.

Two failures were reproduced and their error text confirms it:

- `AuthUsers` → `Unable to find a label with the text of: User actions` on the test's **first line** — `createWrapper` waited only for the request, so every test in the file raced first paint.
- `Git` → `expected +0 to be 3` — waited for `scope.isDone()`, then asserted on the DOM synchronously.

Running with `--no-file-parallelism` passed 3/3, which is what pointed at contention rather than any single spec's logic.

## What changed

| Change | Why |
| --- | --- |
| `AuthUsers.spec.tsx` — wait for the user row | Fixes the race for all three tests in the file |
| `Git.spec.tsx` — assert icons inside `waitFor` | The DOM assertion was outside the wait |
| `setup.tsx` — register `unhandledRejection` once | It ran per test file against a shared `process`, producing `MaxListenersExceededWarning: 11 unhandledRejection listeners` in CI and letting one file's stray rejection `throw` into another |
| `asyncUtilTimeout` 1s → 5s, `testTimeout` 20s | 1s is tight with 125 spec files competing for CPU; the 20s test timeout keeps a genuine hang failing loudly |

## This reduces the flakiness — it does not eliminate it

Being explicit, because the numbers matter more than the diff:

- Before: roughly 1 run in 3 failed.
- After the first two fixes: 5 of 6 clean, then a 10-run sample still had **4 failures**.
- After the `AuthUsers` fix, 4 of 4 clean — but that is a small sample on a less loaded machine, and load is the variable. **I would not call this fixed.**

There is a shared-state problem between concurrently running files that this PR does not identify — most likely nock's global HTTP interception being cleaned by one file's `afterEach` while another file's request is in flight.

**Six further specs use the same readiness gate** and are untouched, none having failed in any run here: `Analytics`, `FunctionTriggerModal`, `ProviderSettings`, team `Deployments`, `ConnectedAccounts`, `DomainSelector`.

Worth merging as real fixes to three genuine defects; worth keeping the underlying flakiness open as its own issue.