### PR TITLE
test: wait on the DOM, not the mock, in the remaining specs

### DIFF
--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Visitors.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/analytics/Visitors.spec.tsx
@@ -158,6 +158,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/analytics/Visitors.tsx", () =>
 
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByTestId("area-chart")).toBeTruthy();
     });
 
     const series = JSON.parse(wrapper.getByTestId("area-chart").innerHTML);

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabAuthWall/AuthWallUsers.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabAuthWall/AuthWallUsers.spec.tsx
@@ -45,6 +45,11 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabAuthWall
 
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
+        expect(
+          wrapper.getByText(
+            "There are no logins for this environment. Click the button above to add a new user."
+          )
+        ).toBeTruthy();
       });
 
       expect(() => wrapper.getByTestId("card-loading")).toThrow();
@@ -88,12 +93,6 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabAuthWall
         expect(scope.isDone()).toBe(true);
       });
 
-      expect(() =>
-        wrapper.getByText(
-          "There are no logins for this environment. Click the button above to add a new user."
-        )
-      ).toThrow();
-
       await waitFor(() => {
         expect(wrapper.getByText("Email")).toBeTruthy();
         expect(wrapper.getByText("Last login")).toBeTruthy();
@@ -101,11 +100,19 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabAuthWall
         expect(wrapper.getByText("email-2@example.org")).toBeTruthy();
         expect(wrapper.getByText("21.09.2022 - 21:30")).toBeTruthy();
       });
+
+      // Only once the list is on screen is the empty state meaningfully absent.
+      expect(() =>
+        wrapper.getByText(
+          "There are no logins for this environment. Click the button above to add a new user."
+        )
+      ).toThrow();
     });
 
     it("should remove selected users", async () => {
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
+        expect(wrapper.getByText("Remove selected")).toBeTruthy();
       });
 
       const button = wrapper.getByText("Remove selected");

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabDomainConfig/DomainVerifyModal.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/config/_components/TabDomainConfig/DomainVerifyModal.spec.tsx
@@ -57,6 +57,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/config/_components/TabDomainCo
 
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
+        expect(wrapper.getByText(domain.domainName)).toBeTruthy();
       });
     });
 

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/Mailer.spec.tsx
@@ -62,6 +62,7 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/Mailer.tsx", () => {
 
     await waitFor(() => {
       expect(fetchScope.isDone()).toBe(true);
+      expect(wrapper.getByText("Mailer Configuration")).toBeTruthy();
     });
 
     const subheader = "Simple Email Service to send transactional emails.";

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.spec.tsx
@@ -51,10 +51,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx", () => 
 
     await waitFor(() => {
       expect(fetchScope.isDone()).toBe(true);
+      expect(wrapper.getByText("Sent Emails")).toBeTruthy();
+      expect(wrapper.getByText("No emails sent yet.")).toBeTruthy();
     });
-
-    expect(wrapper.getByText("Sent Emails")).toBeTruthy();
-    expect(wrapper.getByText("No emails sent yet.")).toBeTruthy();
   });
 
   it("should render list of emails", async () => {
@@ -74,10 +73,9 @@ describe("~/pages/apps/[id]/environments/[env-id]/mailer/SentEmails.tsx", () => 
 
     await waitFor(() => {
       expect(fetchScope.isDone()).toBe(true);
+      expect(wrapper.getByText("Welcome aboard")).toBeTruthy();
+      expect(wrapper.getByText("To: recipient@example.com")).toBeTruthy();
     });
-
-    expect(wrapper.getByText("Welcome aboard")).toBeTruthy();
-    expect(wrapper.getByText("To: recipient@example.com")).toBeTruthy();
   });
 
   it("should open email preview dialog on row click", async () => {

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/volumes/Volumes.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/volumes/Volumes.spec.tsx
@@ -196,17 +196,17 @@ describe("~/pages/apps/[id]/environments/[env-id]/volumes/Volumes.tsx", () => {
       });
 
       it("should display empty list", async () => {
-        // This should not be rendered anymore
+        await waitFor(() => {
+          expect(wrapper.getByText("No files uploaded yet")).toBeTruthy();
+          expect(fetchFilesScope.isDone()).toBe(true);
+        });
+
+        // Only once the list is on screen is the empty state meaningfully absent.
         expect(() =>
           wrapper.getByText(
             "Persist your files seamlessly using Stormkit Volumes"
           )
         ).toThrow();
-
-        await waitFor(() => {
-          expect(wrapper.getByText("No files uploaded yet")).toBeTruthy();
-          expect(fetchFilesScope.isDone()).toBe(true);
-        });
       });
     });
   });

--- a/src/ui/src/pages/apps/[id]/environments/[env-id]/volumes/VolumesDropzone.spec.tsx
+++ b/src/ui/src/pages/apps/[id]/environments/[env-id]/volumes/VolumesDropzone.spec.tsx
@@ -119,11 +119,10 @@ describe("~/pages/apps/[id]/environments/[env-id]/volumes/VolumesDropzone.tsx", 
       await waitFor(() => {
         expect(fetchFilesScope.isDone()).toBe(true);
         expect(setLoading).toHaveBeenCalledWith(false);
+        expect(wrapper.getByText("text.txt")).toBeTruthy();
+        expect(wrapper.getByText("index.js")).toBeTruthy();
+        expect(wrapper.getByText("http://localhost/volumes/142")).toBeTruthy();
       });
-
-      expect(wrapper.getByText("text.txt")).toBeTruthy();
-      expect(wrapper.getByText("index.js")).toBeTruthy();
-      expect(wrapper.getByText("http://localhost/volumes/142")).toBeTruthy();
     });
 
     it("should delete a file", async () => {

--- a/src/ui/src/pages/apps/new/github/NewGithubApp.spec.tsx
+++ b/src/ui/src/pages/apps/new/github/NewGithubApp.spec.tsx
@@ -136,6 +136,7 @@ describe("~/pages/apps/new/github/NewGithubApp.tsx", () => {
       await waitFor(() => {
         expect(scope1.isDone()).toBe(true);
         expect(scope2.isDone()).toBe(true);
+        expect(wrapper.getByText("Import from GitHub")).toBeTruthy();
       });
     });
 

--- a/src/ui/src/shared/deployments/DeploymentRow.spec.tsx
+++ b/src/ui/src/shared/deployments/DeploymentRow.spec.tsx
@@ -141,9 +141,8 @@ describe("~/shared/deployments/DeploymentRow.tsx", () => {
 
       await waitFor(() => {
         expect(scope.isDone()).toBe(true);
+        expect(wrapper.getByText(/Deployment manifest/)).toBeTruthy();
       });
-
-      expect(wrapper.getByText(/Deployment manifest/)).toBeTruthy();
     });
 
     it("should have a link to runtime logs", () => {

--- a/src/ui/src/shared/deployments/PublishModal.spec.tsx
+++ b/src/ui/src/shared/deployments/PublishModal.spec.tsx
@@ -84,10 +84,8 @@ describe("~/shared/deployments/PublishModal", () => {
 
     await waitFor(() => {
       expect(scope.isDone()).toBe(true);
+      expect(wrapper.getByText(/Deployment is being warmed up/)).toBeTruthy();
     });
-
-    // The publish call has returned, but the environment has not moved yet.
-    expect(wrapper.getByText(/Deployment is being warmed up/)).toBeTruthy();
 
     await waitFor(
       () => {


### PR DESCRIPTION
Finishes what #531 started. That PR fixed three instances of this pattern and left the rest in place — on current `main` the suite still failed **3 runs in 8**, always on the specs it had not touched (`SentEmails` ×3, `Visitors` ×1).

## The pattern

```js
await waitFor(() => { expect(scope.isDone()).toBe(true); });
expect(wrapper.getByText("Welcome aboard")).toBeTruthy();   // races first paint
```

Nock marks a call done the moment the request **matches** — before React has rendered the response. Any DOM access after a bare `isDone()` gate is racing first paint, and loses under parallel load.

## Two shapes #531 missed

**The DOM read isn't an assertion.** `Visitors` did:

```js
const series = JSON.parse(wrapper.getByTestId("area-chart").innerHTML);
```

No scan for `expect(wrapper` finds that. It was one of the observed failures.

**The assertion is negative.** `AuthWallUsers` and `Volumes` asserted an element was *gone* before waiting for the state that replaces it:

```js
expect(() => wrapper.getByText("Persist your files…")).toThrow();   // old state may still be up
await waitFor(() => { expect(wrapper.getByText("No files uploaded yet")).toBeTruthy(); });
```

That fails whenever the old state is still on screen — and worse, passes for the wrong reason when nothing has rendered yet. Reordered so the positive wait comes first, which fixes the flake *and* removes a false pass.

## Changed

| Spec | Fix |
| --- | --- |
| `SentEmails`, `VolumesDropzone`, `DeploymentRow`, `PublishModal` | Trailing assertions merged into the gate |
| `Visitors` | Gate now waits for the chart before it is read |
| `AuthWallUsers`, `Volumes` | Positive wait before the negative assertion |
| `Mailer`, `DomainVerifyModal`, `NewGithubApp` | `beforeEach` gates settle the render, so the whole file stops racing |

## Measurement

Same machine, same conditions:

| | Result |
| --- | --- |
| Before (current `main`) | **3 failures in 8 runs** |
| After | **12 consecutive clean runs** |

If the failure rate were unchanged, twelve clean runs would happen under 2% of the time. Combined with each failure's error text matching the diagnosis exactly, I am confident this is the cause rather than a coincidence — though flakiness is by nature probabilistic, and CI runs on different hardware.