### PR TITLE
fix: recover from redis read-only failover

### DIFF
--- a/src/ce/hosting/certmagic_redis.go
+++ b/src/ce/hosting/certmagic_redis.go
@@ -216,10 +216,24 @@ type RedisStorage struct {
 	// Useful when the Redis server is used by multiple applications.
 	KeyPrefix string `json:"key_prefix"`
 
-	client redis.UniversalClient
-	locker *redislock.Client
-	logger *zap.SugaredLogger
-	locks  *sync.Map
+	// clientFn resolves the connection per call rather than pinning one.
+	// A pinned client is closed out from under this store the first time a
+	// failover is recovered from, which would leave certificates dead for the
+	// life of the process.
+	clientFn func() redis.UniversalClient
+	logger   *zap.SugaredLogger
+	locks    *sync.Map
+}
+
+// redis returns the current connection.
+func (rs RedisStorage) redis() redis.UniversalClient {
+	return rs.clientFn()
+}
+
+// locker builds a lock client over the current connection. redislock.New only
+// wraps the client, so there is nothing to reuse across calls.
+func (rs RedisStorage) locker() *redislock.Client {
+	return redislock.New(rs.clientFn())
 }
 
 type StorageData struct {
@@ -244,9 +258,15 @@ func NewRedisStorage(logger *zap.Logger) *RedisStorage {
 }
 
 // SetClient sets the Redis client to be used by the RedisStorage instance.
+// SetClient pins a single connection. Intended for tests; production should
+// use SetClientFunc so the store follows a replaced client.
 func (rs *RedisStorage) SetClient(client redis.UniversalClient) {
-	rs.client = client
-	rs.locker = redislock.New(client)
+	rs.SetClientFunc(func() redis.UniversalClient { return client })
+}
+
+// SetClientFunc sets the resolver used for every operation.
+func (rs *RedisStorage) SetClientFunc(fn func() redis.UniversalClient) {
+	rs.clientFn = fn
 	rs.locks = &sync.Map{}
 }
 
@@ -272,7 +292,7 @@ func (rs RedisStorage) Store(ctx context.Context, key string, value []byte) erro
 	}
 
 	// Store the key value in the Redis database
-	if err := rs.client.Set(ctx, prefixedKey, jsonValue, 0).Err(); err != nil {
+	if err := rs.redis().Set(ctx, prefixedKey, jsonValue, 0).Err(); err != nil {
 		return fmt.Errorf("unable to set value for %s: %v", key, err)
 	}
 
@@ -299,7 +319,7 @@ func (rs RedisStorage) Delete(ctx context.Context, key string) error {
 		return fmt.Errorf("unable to delete directory for key %s: %v", key, err)
 	}
 
-	if err := rs.client.Del(ctx, prefixedKey).Err(); err != nil {
+	if err := rs.redis().Del(ctx, prefixedKey).Err(); err != nil {
 		return fmt.Errorf("unable to delete key %s: %v", key, err)
 	}
 
@@ -309,7 +329,7 @@ func (rs RedisStorage) Delete(ctx context.Context, key string) error {
 // Exists checks if the given key exists in Redis storage.
 func (rs RedisStorage) Exists(ctx context.Context, key string) bool {
 	// Redis returns a count of the number of keys found
-	exists := rs.client.Exists(ctx, rs.prefixKey(key)).Val()
+	exists := rs.redis().Exists(ctx, rs.prefixKey(key)).Val()
 	return exists > 0
 }
 
@@ -319,7 +339,7 @@ func (rs RedisStorage) List(ctx context.Context, dir string, recursive bool) ([]
 	currKey := rs.prefixKey(dir)
 
 	// Obtain range of all direct children stored in the Sorted Set
-	keys, err := rs.client.ZRange(ctx, currKey, 0, -1).Result()
+	keys, err := rs.redis().ZRange(ctx, currKey, 0, -1).Result()
 	if err != nil {
 		return keyList, fmt.Errorf("unable to get range on sorted set '%s': %v", currKey, err)
 	}
@@ -368,7 +388,7 @@ func (rs *RedisStorage) Lock(ctx context.Context, name string) error {
 
 	for {
 		// try to obtain lock
-		lock, err := rs.locker.Obtain(ctx, key, lockTTL, &redislock.Options{})
+		lock, err := rs.locker().Obtain(ctx, key, lockTTL, &redislock.Options{})
 
 		// lock successfully obtained
 		if err == nil {
@@ -439,7 +459,7 @@ func (rs *RedisStorage) Repair(ctx context.Context, dir string) error {
 
 		for {
 			// Scan for keys matching the search query and iterate until all found
-			keys, nextPointer, err := rs.client.Scan(ctx, pointer, currKey+"*", scanCount).Result()
+			keys, nextPointer, err := rs.redis().Scan(ctx, pointer, currKey+"*", scanCount).Result()
 			if err != nil {
 				return fmt.Errorf("unable to scan path %s: %v", currKey, err)
 			}
@@ -447,7 +467,7 @@ func (rs *RedisStorage) Repair(ctx context.Context, dir string) error {
 			// Iterate over returned keys
 			for _, key := range keys {
 				// Proceed only if key type is regular string value
-				keyType := rs.client.Type(ctx, key).Val()
+				keyType := rs.redis().Type(ctx, key).Val()
 				if keyType != "string" {
 					continue
 				}
@@ -476,7 +496,7 @@ func (rs *RedisStorage) Repair(ctx context.Context, dir string) error {
 	}
 
 	// Obtain range of all direct children stored in the Sorted Set
-	keys, err := rs.client.ZRange(ctx, currKey, 0, -1).Result()
+	keys, err := rs.redis().ZRange(ctx, currKey, 0, -1).Result()
 
 	if err != nil {
 		return fmt.Errorf("unable to get range on sorted set '%s': %v", currKey, err)
@@ -492,7 +512,7 @@ func (rs *RedisStorage) Repair(ctx context.Context, dir string) error {
 
 		// Remove key from set if it does not exist
 		if !rs.Exists(ctx, fullPathKey) {
-			rs.client.ZRem(ctx, currKey, k)
+			rs.redis().ZRem(ctx, currKey, k)
 			rs.logger.Infof("Removed non-existent record '%s' from directory '%s'", k, currKey)
 			continue
 		}
@@ -522,7 +542,7 @@ func (rs *RedisStorage) prefixLock(key string) string {
 }
 
 func (rs RedisStorage) loadStorageData(ctx context.Context, key string) (*StorageData, error) {
-	data, err := rs.client.Get(ctx, rs.prefixKey(key)).Bytes()
+	data, err := rs.redis().Get(ctx, rs.prefixKey(key)).Bytes()
 
 	if data == nil || errors.Is(err, redis.Nil) {
 		return nil, fs.ErrNotExist
@@ -548,7 +568,7 @@ func (rs RedisStorage) storeDirectoryRecord(ctx context.Context, key string, sco
 	}
 
 	// Insert "base" value into Set "dir"
-	success, err := rs.client.ZAdd(ctx, dir, redis.Z{Score: score, Member: base}).Result()
+	success, err := rs.redis().ZAdd(ctx, dir, redis.Z{Score: score, Member: base}).Result()
 	if err != nil {
 		return fmt.Errorf("unable to add %s to Set %s: %v", base, dir, err)
 	}
@@ -579,12 +599,12 @@ func (rs RedisStorage) deleteDirectoryRecord(ctx context.Context, key string, ba
 	}
 
 	// Remove "base" value from Set "dir"
-	if err := rs.client.ZRem(ctx, dir, base).Err(); err != nil {
+	if err := rs.redis().ZRem(ctx, dir, base).Err(); err != nil {
 		return fmt.Errorf("unable to remove %s from Set %s: %v", base, dir, err)
 	}
 
 	// Check if Set "dir" still exists (removing the last item deletes the set)
-	if exists := rs.client.Exists(ctx, dir).Val(); exists == 0 {
+	if exists := rs.redis().Exists(ctx, dir).Val(); exists == 0 {
 		// Recursively delete parent directory until parent
 		// is not empty (exists > 0) or top level reached
 		if err := rs.deleteDirectoryRecord(ctx, dir, true); err != nil {

--- a/src/ce/hosting/certmagic_redis.go
+++ b/src/ce/hosting/certmagic_redis.go
@@ -257,7 +257,6 @@ func NewRedisStorage(logger *zap.Logger) *RedisStorage {
 	}
 }
 
-// SetClient sets the Redis client to be used by the RedisStorage instance.
 // SetClient pins a single connection. Intended for tests; production should
 // use SetClientFunc so the store follows a replaced client.
 func (rs *RedisStorage) SetClient(client redis.UniversalClient) {

--- a/src/ce/hosting/certmagic_redis_reset_test.go
+++ b/src/ce/hosting/certmagic_redis_reset_test.go
@@ -1,0 +1,65 @@
+package hosting_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/ce/hosting"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stretchr/testify/suite"
+)
+
+// CertmagicRedisResetSuite covers the trap that recovering from a failover
+// used to set: the certificate store took its connection once at boot, and the
+// recovery closes that exact client. Certificates would then fail for the life
+// of the process, which is worse than the failover it was recovering from.
+type CertmagicRedisResetSuite struct {
+	suite.Suite
+	storage *hosting.RedisStorage
+	ctx     context.Context
+}
+
+func (s *CertmagicRedisResetSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.storage = hosting.NewRedisStorage(nil)
+	s.storage.KeyPrefix = "test-certmagic-reset"
+	s.storage.SetClientFunc(rediscache.UniversalClient)
+}
+
+func (s *CertmagicRedisResetSuite) TearDownTest() {
+	keys, err := rediscache.Client().Keys(s.ctx, s.storage.KeyPrefix+"*")
+
+	if err == nil && len(keys) > 0 {
+		rediscache.Client().Del(s.ctx, keys...)
+	}
+}
+
+func (s *CertmagicRedisResetSuite) Test_StoreSurvivesAClientReset() {
+	key := "survives/cert.pem"
+
+	s.Require().NoError(s.storage.Store(s.ctx, key, []byte("before")))
+
+	// Exactly what a recovered failover does to the shared client.
+	rediscache.Client().Reset()
+
+	value, err := s.storage.Load(s.ctx, key)
+
+	s.Require().NoError(err, "certificates must still be readable after a reset")
+	s.Equal([]byte("before"), value)
+
+	s.NoError(s.storage.Store(s.ctx, key+".2", []byte("after")), "and still writable")
+}
+
+func (s *CertmagicRedisResetSuite) Test_LockingSurvivesAClientReset() {
+	s.Require().NoError(s.storage.Lock(s.ctx, "survives-lock"))
+	s.Require().NoError(s.storage.Unlock(s.ctx, "survives-lock"))
+
+	rediscache.Client().Reset()
+
+	s.NoError(s.storage.Lock(s.ctx, "survives-lock"), "the lock client must follow the reset too")
+	s.NoError(s.storage.Unlock(s.ctx, "survives-lock"))
+}
+
+func TestCertmagicRedisReset(t *testing.T) {
+	suite.Run(t, &CertmagicRedisResetSuite{})
+}

--- a/src/ce/hosting/certmagic_server.go
+++ b/src/ce/hosting/certmagic_server.go
@@ -36,7 +36,10 @@ func storage(logger *zap.Logger) certmagic.Storage {
 	slog.Infof("using redis storage for certificates")
 
 	storage := NewRedisStorage(logger)
-	storage.SetClient(rediscache.Client().Client)
+
+	// Resolve per call: a recovered failover replaces the shared client, and a
+	// pinned one would be closed and never renew a certificate again.
+	storage.SetClientFunc(rediscache.UniversalClient)
 
 	return storage
 }

--- a/src/ce/workerserver/job_handler_forward.go
+++ b/src/ce/workerserver/job_handler_forward.go
@@ -66,22 +66,22 @@ func IngestHandlerForward(ctx context.Context) error {
 
 	msgs := []string{}
 
+	// Reported after the records already popped have been inserted. Returning
+	// at the point of failure would discard them, and they are gone from the
+	// queue by then.
+	var drainErr error
+
 	for range maxBatchesPerTick {
 		batch, err := client.LPopCount(ctx, HostingQueueName, rows).Result()
-
-		if rediscache.IsConnectionError(err) {
-			// LPopCount is a write, so a failover answers it with READONLY.
-			// Drop the client or every later tick reuses the same dead
-			// connections and the queue never drains.
-			client.Reset()
-			return err
-		}
 
 		if err != nil && !errors.Is(err, redis.Nil) {
 			// Stop draining but fall through to insert whatever was already
 			// popped: earlier batches are gone from the queue, so returning
-			// here would drop those records.
+			// here would drop those records. A failover answers this pop with
+			// READONLY, since a pop is a write, and takes the same path.
 			slog.Errorf("error while popping from redis: %v", err)
+			drainErr = err
+
 			break
 		}
 
@@ -194,5 +194,5 @@ func IngestHandlerForward(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return drainErr
 }

--- a/src/ce/workerserver/job_handler_forward.go
+++ b/src/ce/workerserver/job_handler_forward.go
@@ -70,6 +70,10 @@ func IngestHandlerForward(ctx context.Context) error {
 		batch, err := client.LPopCount(ctx, HostingQueueName, rows).Result()
 
 		if rediscache.IsConnectionError(err) {
+			// LPopCount is a write, so a failover answers it with READONLY.
+			// Drop the client or every later tick reuses the same dead
+			// connections and the queue never drains.
+			client.Reset()
 			return err
 		}
 

--- a/src/ce/workerserver/leader.go
+++ b/src/ce/workerserver/leader.go
@@ -72,13 +72,9 @@ func (l *Node) do(ctx context.Context, args ...any) (any, error) {
 		return nil, errors.New("redis client is not available")
 	}
 
-	reply, err := client.Do(ctx, args...).Result()
-
-	if rediscache.IsConnectionError(err) {
-		client.Reset()
-	}
-
-	return reply, err
+	// Recovery from a failover is handled by the client itself, so this only
+	// has to avoid holding a client that recovery has replaced.
+	return client.Do(ctx, args...).Result()
 }
 
 // ID returns the node id.

--- a/src/ce/workerserver/leader.go
+++ b/src/ce/workerserver/leader.go
@@ -17,7 +17,6 @@ type Node struct {
 	id         string
 	options    Options
 	key        string
-	redis      *rediscache.RedisCache
 	renewMu    sync.Mutex
 	renewID    *time.Ticker
 	electID    *time.Timer
@@ -53,7 +52,6 @@ func NewNode(options Options) *Node {
 
 	return &Node{
 		id:         uuid.New().String(),
-		redis:      rediscache.Client(),
 		options:    options,
 		key:        options.Key,
 		stopChan:   make(chan struct{}),
@@ -61,6 +59,26 @@ func NewNode(options Options) *Node {
 		onRenounce: options.OnRenounce,
 		onStart:    options.OnStart,
 	}
+}
+
+// do runs a Redis command against the shared client.
+//
+// The client is resolved per call rather than held on the node, so a client
+// discarded after a failover is replaced instead of being reused once closed.
+func (l *Node) do(ctx context.Context, args ...any) (any, error) {
+	client := rediscache.Client()
+
+	if client == nil {
+		return nil, errors.New("redis client is not available")
+	}
+
+	reply, err := client.Do(ctx, args...).Result()
+
+	if rediscache.IsConnectionError(err) {
+		client.Reset()
+	}
+
+	return reply, err
 }
 
 // ID returns the node id.
@@ -114,7 +132,7 @@ func (l *Node) Stop(ctx context.Context) {
 
 	l.isLeader(ctx, func(isLeader bool) {
 		if isLeader {
-			_, err := l.redis.Do(ctx, "DEL", l.key).Result()
+			_, err := l.do(ctx, "DEL", l.key)
 
 			if err != nil {
 				slog.Errorf("error while revoking key: %s", err.Error())
@@ -133,7 +151,7 @@ func (l *Node) elect(ctx context.Context) {
 		case <-l.stopChan:
 			return
 		default:
-			reply, err := l.redis.Do(ctx, "SET", l.key, l.id, "PX", int(l.options.TTL/time.Millisecond), "NX").Result()
+			reply, err := l.do(ctx, "SET", l.key, l.id, "PX", int(l.options.TTL/time.Millisecond), "NX")
 
 			if rediscache.IsConnectionError(err) {
 				slog.Errorf("redis connection error: %v", err)
@@ -174,7 +192,7 @@ func (l *Node) renew(ctx context.Context) {
 		case <-l.renewID.C:
 			l.isLeader(ctx, func(isLeader bool) {
 				if isLeader {
-					_, err := l.redis.Do(ctx, "PEXPIRE", l.key, int(l.options.TTL/time.Millisecond)).Result()
+					_, err := l.do(ctx, "PEXPIRE", l.key, int(l.options.TTL/time.Millisecond))
 					if err != nil {
 						slog.Errorf("failed to renew leader key: %v", err)
 					}
@@ -192,7 +210,7 @@ func (l *Node) renew(ctx context.Context) {
 }
 
 func (l *Node) isLeader(ctx context.Context, callback func(bool)) {
-	reply, err := l.redis.Do(ctx, "GET", l.key).Result()
+	reply, err := l.do(ctx, "GET", l.key)
 
 	if err != nil && err != redis.Nil {
 		slog.Errorf("failed to get leader key: %v", err)

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -485,6 +485,20 @@ func SetSMTP(smtp *SMTPConfig) {
 	cPtr.Store(&next)
 }
 
+// SetRedisAddr overrides the Redis address. Intended for tests only, so a test
+// can point the cache at a stub server: the test environment otherwise pins the
+// address to the local instance.
+func SetRedisAddr(addr string) {
+	if !IsTest() {
+		panic("SetRedisAddr can only be used in test environments")
+	}
+
+	cur := Get()
+	next := *cur
+	next.RedisAddr = addr
+	cPtr.Store(&next)
+}
+
 var _cachedSecrets map[string]string
 
 // Secrets decrypts environment variables that start with Salted_ key.

--- a/src/lib/rediscache/failover_stub_test.go
+++ b/src/lib/rediscache/failover_stub_test.go
@@ -1,0 +1,190 @@
+package rediscache_test
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Wordings for the same condition. go-redis classifies a read-only reply by
+// prefix (see isReadOnlyError / isBadConn in the driver), so only the native
+// one is recognised: it closes the connection and retries. A proxy that
+// prefixes the reply with "ERR " defeats both checks.
+const (
+	nativeReadOnly = "-READONLY You can't write against a read only replica.\r\n"
+	proxyReadOnly  = "-ERR READONLY You can't write against a read only instance.\r\n"
+)
+
+// stubRedis is a minimal RESP server that models a managed primary-standby
+// switchover.
+//
+// Each connection records the generation it was accepted in. Failover bumps
+// the generation, after which every connection opened before it answers writes
+// as read-only forever, while connections opened after it are writable. That
+// is the shape of the real event: the endpoint keeps resolving, new
+// connections reach the promoted primary, and connections still pinned to the
+// demoted node never recover on their own.
+type stubRedis struct {
+	ln         net.Listener
+	wording    atomic.Value // string
+	generation atomic.Int64
+	conns      atomic.Int64
+}
+
+func newStubRedis(wording string) (*stubRedis, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+
+	if err != nil {
+		return nil, err
+	}
+
+	s := &stubRedis{ln: ln}
+	s.wording.Store(wording)
+
+	go s.accept()
+
+	return s, nil
+}
+
+func (s *stubRedis) Addr() string {
+	return s.ln.Addr().String()
+}
+
+// Failover promotes a new primary. Connections opened before this point are
+// now talking to a demoted node and will only ever refuse writes.
+func (s *stubRedis) Failover() {
+	s.generation.Add(1)
+}
+
+// Conns is the number of connections accepted since start. A pool that
+// discards pinned connections and redials shows up here as an increase.
+func (s *stubRedis) Conns() int64 {
+	return s.conns.Load()
+}
+
+func (s *stubRedis) Close() {
+	s.ln.Close()
+}
+
+func (s *stubRedis) accept() {
+	for {
+		conn, err := s.ln.Accept()
+
+		if err != nil {
+			return
+		}
+
+		s.conns.Add(1)
+
+		go s.handle(conn, s.generation.Load())
+	}
+}
+
+var writeCommands = map[string]bool{
+	"SET": true, "SETEX": true, "DEL": true, "INCR": true,
+	"LPUSH": true, "RPUSH": true, "LPOP": true, "GETDEL": true,
+	"EXPIRE": true, "PEXPIRE": true,
+}
+
+func (s *stubRedis) handle(conn net.Conn, acceptedAt int64) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	for {
+		args, err := readCommand(reader)
+
+		if err != nil {
+			return
+		}
+
+		if len(args) == 0 {
+			continue
+		}
+
+		cmd := strings.ToUpper(args[0])
+		demoted := acceptedAt < s.generation.Load()
+
+		var reply string
+
+		switch {
+		// Refuse the RESP3 handshake so the client falls back to RESP2,
+		// which keeps this stub small.
+		case cmd == "HELLO":
+			reply = "-ERR unknown command 'HELLO'\r\n"
+		case cmd == "PING":
+			reply = "+PONG\r\n"
+		case cmd == "GET":
+			reply = "$-1\r\n"
+		case writeCommands[cmd] && demoted:
+			reply = s.wording.Load().(string)
+		default:
+			reply = "+OK\r\n"
+		}
+
+		if _, err := io.WriteString(conn, reply); err != nil {
+			return
+		}
+	}
+}
+
+// readCommand parses one inline or array-form RESP command.
+func readCommand(r *bufio.Reader) ([]string, error) {
+	line, err := r.ReadString('\n')
+
+	if err != nil {
+		return nil, err
+	}
+
+	line = strings.TrimRight(line, "\r\n")
+
+	if line == "" {
+		return nil, nil
+	}
+
+	if line[0] != '*' {
+		return strings.Fields(line), nil
+	}
+
+	count, err := strconv.Atoi(line[1:])
+
+	if err != nil {
+		return nil, fmt.Errorf("bad multibulk header %q", line)
+	}
+
+	args := make([]string, 0, count)
+
+	for range count {
+		header, err := r.ReadString('\n')
+
+		if err != nil {
+			return nil, err
+		}
+
+		header = strings.TrimRight(header, "\r\n")
+
+		if len(header) == 0 || header[0] != '$' {
+			return nil, fmt.Errorf("bad bulk header %q", header)
+		}
+
+		size, err := strconv.Atoi(header[1:])
+
+		if err != nil {
+			return nil, err
+		}
+
+		buf := make([]byte, size+2)
+
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+
+		args = append(args, string(buf[:size]))
+	}
+
+	return args, nil
+}

--- a/src/lib/rediscache/failover_stub_test.go
+++ b/src/lib/rediscache/failover_stub_test.go
@@ -33,6 +33,7 @@ type stubRedis struct {
 	wording    atomic.Value // string
 	generation atomic.Int64
 	conns      atomic.Int64
+	holding    atomic.Bool
 }
 
 func newStubRedis(wording string) (*stubRedis, error) {
@@ -58,6 +59,13 @@ func (s *stubRedis) Addr() string {
 // now talking to a demoted node and will only ever refuse writes.
 func (s *stubRedis) Failover() {
 	s.generation.Add(1)
+}
+
+// HoldReadOnly makes every connection refuse writes, new ones included, which
+// is what a switchover looks like while it is still in progress rather than
+// at the instant it completes.
+func (s *stubRedis) HoldReadOnly() {
+	s.holding.Store(true)
 }
 
 // Conns is the number of connections accepted since start. A pool that
@@ -107,7 +115,7 @@ func (s *stubRedis) handle(conn net.Conn, acceptedAt int64) {
 		}
 
 		cmd := strings.ToUpper(args[0])
-		demoted := acceptedAt < s.generation.Load()
+		demoted := s.holding.Load() || acceptedAt < s.generation.Load()
 
 		var reply string
 

--- a/src/lib/rediscache/failover_test.go
+++ b/src/lib/rediscache/failover_test.go
@@ -3,7 +3,9 @@ package rediscache_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stormkit-io/stormkit-io/src/lib/config"
 	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stretchr/testify/suite"
@@ -76,24 +78,55 @@ func (s *FailoverSuite) Test_NativeWording_DriverRecoversOnItsOwn() {
 	s.Greater(s.stub.Conns(), connsBefore, "the driver redialled by itself")
 }
 
-// Test_ProxyWording_SurfacesAndStaysPinned is the incident. The "ERR " prefix
-// defeats the driver's prefix match, so the connection is never marked bad,
-// the command is never retried, and the pool keeps handing out connections
-// pinned to the demoted node for as long as the process lives.
-func (s *FailoverSuite) Test_ProxyWording_SurfacesAndStaysPinned() {
-	client := s.start(proxyReadOnly)
+// Test_DriverAloneStaysPinnedOnProxyWording is the incident, isolated to the
+// driver with none of our handling attached.
+//
+// The "ERR " prefix defeats the driver's prefix match, so the connection is
+// never marked bad, the command is never retried, and the pool keeps handing
+// out connections pinned to the demoted node for as long as the process lives.
+// The same test against the native wording recovers by itself, which is why
+// this was never seen on a plain Redis.
+func (s *FailoverSuite) Test_DriverAloneStaysPinnedOnProxyWording() {
+	for _, tc := range []struct {
+		name          string
+		wording       string
+		wantRecovered bool
+	}{
+		{"proxy wording", proxyReadOnly, false},
+		{"native wording", nativeReadOnly, true},
+	} {
+		s.Run(tc.name, func() {
+			stub, err := newStubRedis(tc.wording)
+			s.Require().NoError(err)
 
-	connsBefore := s.stub.Conns()
-	s.stub.Failover()
+			defer stub.Close()
 
-	for range 20 {
-		err := client.Set(s.ctx, "k", "v", 0).Err()
+			bare := redis.NewClient(&redis.Options{Addr: stub.Addr()})
+			defer bare.Close()
 
-		s.Require().Error(err)
-		s.Require().Contains(err.Error(), "READONLY")
+			s.Require().NoError(bare.Set(s.ctx, "k", "v", 0).Err())
+
+			connsBefore := stub.Conns()
+			stub.Failover()
+
+			var lastErr error
+
+			for range 20 {
+				lastErr = bare.Set(s.ctx, "k", "v", 0).Err()
+			}
+
+			if tc.wantRecovered {
+				s.NoError(lastErr, "the driver recognises this wording and redials")
+				s.Greater(stub.Conns(), connsBefore)
+
+				return
+			}
+
+			s.Require().Error(lastErr)
+			s.Contains(lastErr.Error(), "READONLY")
+			s.Equal(connsBefore, stub.Conns(), "the pool never redials on its own")
+		})
 	}
-
-	s.Equal(connsBefore, s.stub.Conns(), "the pool never redials on its own")
 }
 
 // Test_ProxyWording_IsClassifiedAsConnectionError is the fix. Recognising the
@@ -130,6 +163,64 @@ func (s *FailoverSuite) Test_ProxyWording_ResetRecovers() {
 
 	s.NoError(recovered.Set(s.ctx, "k", "v", 0).Err(), "writes work again after the redial")
 	s.Greater(s.stub.Conns(), connsBefore, "the pool dialled the promoted primary")
+}
+
+// Test_ProxyWording_RecoversWithoutCallerHelp is the behaviour the edge
+// depends on. Certificates, one-time codes, token storage and the analytics
+// queue all write from paths that know nothing about failovers, so recovery
+// cannot require each caller to check for it.
+func (s *FailoverSuite) Test_ProxyWording_RecoversWithoutCallerHelp() {
+	client := s.start(proxyReadOnly)
+
+	connsBefore := s.stub.Conns()
+	s.stub.Failover()
+
+	s.Require().Error(client.Set(s.ctx, "k", "v", 0).Err())
+
+	// The discard is detached, since it closes the pool from inside the
+	// command path that is still using it.
+	s.Eventually(func() bool {
+		return rediscache.Client() != client
+	}, 2*time.Second, 10*time.Millisecond, "the client should be discarded without any caller asking")
+
+	recovered := rediscache.Client()
+	s.Require().NotNil(recovered)
+	s.NoError(recovered.Set(s.ctx, "k", "v", 0).Err())
+	s.Greater(s.stub.Conns(), connsBefore)
+}
+
+// Test_ProxyWording_RecoversFromPipeline covers the analytics queue, which
+// writes through a pipeline. A pipeline reports failures per command rather
+// than for the batch, so the refusal is only visible on the commands.
+func (s *FailoverSuite) Test_ProxyWording_RecoversFromPipeline() {
+	client := s.start(proxyReadOnly)
+
+	s.stub.Failover()
+
+	pipe := client.Pipeline()
+	pipe.LPush(s.ctx, "queue", "record")
+	_, err := pipe.Exec(s.ctx)
+
+	s.Require().Error(err)
+
+	s.Eventually(func() bool {
+		return rediscache.Client() != client
+	}, 2*time.Second, 10*time.Millisecond, "a refused pipeline should discard the client too")
+}
+
+// Test_NativeWording_DoesNotDiscard guards against over-reacting. The driver
+// already recycles the connection for this wording, so discarding the whole
+// client on top of that would turn a handled event into a visible one.
+func (s *FailoverSuite) Test_NativeWording_DoesNotDiscard() {
+	client := s.start(nativeReadOnly)
+
+	s.stub.Failover()
+
+	s.Require().NoError(client.Set(s.ctx, "k", "v", 0).Err())
+
+	s.Never(func() bool {
+		return rediscache.Client() != client
+	}, 500*time.Millisecond, 50*time.Millisecond, "the driver handled it, nothing should be discarded")
 }
 
 func TestFailover(t *testing.T) {

--- a/src/lib/rediscache/failover_test.go
+++ b/src/lib/rediscache/failover_test.go
@@ -20,9 +20,10 @@ import (
 // managed instance in front of that fleet emits.
 type FailoverSuite struct {
 	suite.Suite
-	stub     *stubRedis
-	prevAddr string
-	ctx      context.Context
+	stub         *stubRedis
+	prevAddr     string
+	prevCooldown time.Duration
+	ctx          context.Context
 }
 
 func (s *FailoverSuite) start(wording string) *rediscache.RedisCache {
@@ -48,9 +49,16 @@ func (s *FailoverSuite) start(wording string) *rediscache.RedisCache {
 func (s *FailoverSuite) SetupTest() {
 	s.ctx = context.Background()
 	s.prevAddr = config.Get().RedisAddr
+	s.prevCooldown = rediscache.AutoResetCooldown
+
+	// Each test drives its own switchover, so they must not throttle each
+	// other. Test_ProxyWording_DiscardsAtMostOncePerWindow sets its own.
+	rediscache.AutoResetCooldown = 0
 }
 
 func (s *FailoverSuite) TearDownTest() {
+	rediscache.AutoResetCooldown = s.prevCooldown
+
 	// Restore the address before discarding the client: Reset builds the
 	// replacement against whatever the config says at that moment.
 	config.SetRedisAddr(s.prevAddr)
@@ -221,6 +229,39 @@ func (s *FailoverSuite) Test_NativeWording_DoesNotDiscard() {
 	s.Never(func() bool {
 		return rediscache.Client() != client
 	}, 500*time.Millisecond, 50*time.Millisecond, "the driver handled it, nothing should be discarded")
+}
+
+// Test_ProxyWording_DiscardsAtMostOncePerWindow is the throttle. A switchover
+// refuses every write for as long as it lasts, so without a window each
+// refusal would tear down the pool and build another, hundreds of times a
+// second, aborting in-flight reads each time.
+func (s *FailoverSuite) Test_ProxyWording_DiscardsAtMostOncePerWindow() {
+	rediscache.AutoResetCooldown = time.Minute
+
+	client := s.start(proxyReadOnly)
+
+	// Still in progress, so even a fresh connection is refused.
+	s.stub.HoldReadOnly()
+
+	// The switchover keeps refusing, so every one of these would discard the
+	// client if nothing bounded it.
+	for range 50 {
+		s.Require().Error(client.Set(s.ctx, "k", "v", 0).Err())
+	}
+
+	s.Eventually(func() bool {
+		return rediscache.Client() != client
+	}, 2*time.Second, 10*time.Millisecond)
+
+	replacement := rediscache.Client()
+
+	for range 50 {
+		s.Require().Error(replacement.Set(s.ctx, "k", "v", 0).Err())
+	}
+
+	s.Never(func() bool {
+		return rediscache.Client() != replacement
+	}, 500*time.Millisecond, 50*time.Millisecond, "a second discard inside the window would thrash the pool")
 }
 
 func TestFailover(t *testing.T) {

--- a/src/lib/rediscache/failover_test.go
+++ b/src/lib/rediscache/failover_test.go
@@ -1,0 +1,137 @@
+package rediscache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+	"github.com/stretchr/testify/suite"
+)
+
+// FailoverSuite reproduces the 2026-09-09 incident: a managed primary-standby
+// switchover starts refusing writes, and nothing recovers until the client is
+// discarded.
+//
+// The driver already handles the native wording on its own. What it does not
+// handle is a proxy that prefixes the reply with "ERR ", which is what the
+// managed instance in front of that fleet emits.
+type FailoverSuite struct {
+	suite.Suite
+	stub     *stubRedis
+	prevAddr string
+	ctx      context.Context
+}
+
+func (s *FailoverSuite) start(wording string) *rediscache.RedisCache {
+	stub, err := newStubRedis(wording)
+	s.Require().NoError(err)
+	s.stub = stub
+
+	// Point the package at the stub, then discard the shared client so its
+	// replacement is built against the stub rather than the real instance.
+	config.SetRedisAddr(stub.Addr())
+
+	if current := rediscache.Client(); current != nil {
+		current.Reset()
+	}
+
+	client := rediscache.Client()
+	s.Require().NotNil(client)
+	s.Require().NoError(client.Set(s.ctx, "k", "v", 0).Err(), "writable before the switchover")
+
+	return client
+}
+
+func (s *FailoverSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.prevAddr = config.Get().RedisAddr
+}
+
+func (s *FailoverSuite) TearDownTest() {
+	// Restore the address before discarding the client: Reset builds the
+	// replacement against whatever the config says at that moment.
+	config.SetRedisAddr(s.prevAddr)
+
+	if current := rediscache.Client(); current != nil {
+		current.Reset()
+	}
+
+	if s.stub != nil {
+		s.stub.Close()
+		s.stub = nil
+	}
+}
+
+// Test_NativeWording_DriverRecoversOnItsOwn documents why this was never seen
+// on a plain Redis. The driver recognises the reply, closes the pinned
+// connection and retries on a fresh one, so the caller sees nothing at all.
+func (s *FailoverSuite) Test_NativeWording_DriverRecoversOnItsOwn() {
+	client := s.start(nativeReadOnly)
+
+	connsBefore := s.stub.Conns()
+	s.stub.Failover()
+
+	s.NoError(client.Set(s.ctx, "k", "v", 0).Err(), "the driver retries this away")
+	s.Greater(s.stub.Conns(), connsBefore, "the driver redialled by itself")
+}
+
+// Test_ProxyWording_SurfacesAndStaysPinned is the incident. The "ERR " prefix
+// defeats the driver's prefix match, so the connection is never marked bad,
+// the command is never retried, and the pool keeps handing out connections
+// pinned to the demoted node for as long as the process lives.
+func (s *FailoverSuite) Test_ProxyWording_SurfacesAndStaysPinned() {
+	client := s.start(proxyReadOnly)
+
+	connsBefore := s.stub.Conns()
+	s.stub.Failover()
+
+	for range 20 {
+		err := client.Set(s.ctx, "k", "v", 0).Err()
+
+		s.Require().Error(err)
+		s.Require().Contains(err.Error(), "READONLY")
+	}
+
+	s.Equal(connsBefore, s.stub.Conns(), "the pool never redials on its own")
+}
+
+// Test_ProxyWording_IsClassifiedAsConnectionError is the fix. Recognising the
+// reply is what gives any caller a reason to discard the client.
+func (s *FailoverSuite) Test_ProxyWording_IsClassifiedAsConnectionError() {
+	client := s.start(proxyReadOnly)
+
+	s.stub.Failover()
+
+	err := client.Set(s.ctx, "k", "v", 0).Err()
+
+	s.Require().Error(err)
+	s.True(rediscache.IsReadOnlyError(err))
+	s.True(rediscache.IsConnectionError(err), "a failover must be treated as a connection fault")
+}
+
+// Test_ProxyWording_ResetRecovers closes the loop: discarding the client drops
+// the pinned connections and the redial reaches the promoted primary.
+func (s *FailoverSuite) Test_ProxyWording_ResetRecovers() {
+	client := s.start(proxyReadOnly)
+
+	connsBefore := s.stub.Conns()
+	s.stub.Failover()
+
+	err := client.Set(s.ctx, "k", "v", 0).Err()
+	s.Require().Error(err)
+	s.Require().True(rediscache.IsConnectionError(err))
+
+	client.Reset()
+
+	recovered := rediscache.Client()
+	s.Require().NotNil(recovered)
+	s.NotSame(client, recovered)
+
+	s.NoError(recovered.Set(s.ctx, "k", "v", 0).Err(), "writes work again after the redial")
+	s.Greater(s.stub.Conns(), connsBefore, "the pool dialled the promoted primary")
+}
+
+func TestFailover(t *testing.T) {
+	suite.Run(t, &FailoverSuite{})
+}

--- a/src/lib/rediscache/rediscache.go
+++ b/src/lib/rediscache/rediscache.go
@@ -57,7 +57,6 @@ func newClient() (*redis.Client, error) {
 	client := dial()
 
 	if _, err := client.Ping(context.Background()).Result(); err != nil {
-		client.Close()
 		return nil, err
 	}
 

--- a/src/lib/rediscache/rediscache.go
+++ b/src/lib/rediscache/rediscache.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -19,6 +20,10 @@ var mux sync.Mutex
 
 type RedisCache struct {
 	*redis.Client
+
+	// resetting keeps a storm of refused writes from each launching their own
+	// teardown. The first observer wins and the rest return immediately.
+	resetting atomic.Bool
 }
 
 var Cache *RedisCache
@@ -52,6 +57,74 @@ func newClient() (*redis.Client, error) {
 	return client, nil
 }
 
+// newCache wraps a client and attaches the failover hook, so recovery does not
+// depend on each caller remembering to check for it.
+func newCache(client *redis.Client) *RedisCache {
+	cache := &RedisCache{Client: client}
+	client.AddHook(&failoverHook{cache: cache})
+
+	return cache
+}
+
+// failoverHook watches every command for a read-only reply and discards the
+// client when it sees one.
+//
+// The driver recycles a connection itself for the wordings it recognises, and
+// for ordinary network faults. This exists only for the one case it misses, so
+// it deliberately does not fire on connection errors in general: tearing the
+// pool down on a transient timeout would be worse than the timeout.
+type failoverHook struct {
+	cache *RedisCache
+}
+
+func (h *failoverHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h *failoverHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		err := next(ctx, cmd)
+		h.cache.resetOnReadOnly(err)
+
+		return err
+	}
+}
+
+func (h *failoverHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		err := next(ctx, cmds)
+
+		if err == nil {
+			// A pipeline reports per-command errors rather than one error for
+			// the batch, so a refused write is only visible on the commands.
+			for _, cmd := range cmds {
+				if err = cmd.Err(); err != nil {
+					break
+				}
+			}
+		}
+
+		h.cache.resetOnReadOnly(err)
+
+		return err
+	}
+}
+
+// resetOnReadOnly discards the client if err says the server has become a
+// replica. The discard runs detached: it closes the pool, and this is called
+// from inside the command path that is still using it.
+func (r *RedisCache) resetOnReadOnly(err error) {
+	if r == nil || !IsReadOnlyError(err) {
+		return
+	}
+
+	if !r.resetting.CompareAndSwap(false, true) {
+		return
+	}
+
+	go r.Reset()
+}
+
 // Client returns a new RedisCache instance. If the connection is not
 // closed yet, it returns the shared client.
 func Client() *RedisCache {
@@ -83,11 +156,25 @@ func Client() *RedisCache {
 			}
 		}
 
-		Cache = &RedisCache{Client: client}
+		Cache = newCache(client)
 		slog.Info("created new redis client successfully")
 	}
 
 	return Cache
+}
+
+// UniversalClient returns the shared client through the driver's interface,
+// for callers that hand it to a library.
+//
+// It never returns nil. When the shared client is unavailable it hands back a
+// lazily connecting one, so such a caller gets an ordinary connection error
+// rather than dereferencing nil on a TLS handshake.
+func UniversalClient() redis.UniversalClient {
+	if cache := Client(); cache != nil {
+		return cache.Client
+	}
+
+	return dial()
 }
 
 // Reset discards the shared client so the next Client call redials.
@@ -110,7 +197,7 @@ func (r *RedisCache) Reset() {
 	// not remembered. A lazy client cannot block here, and each command then
 	// fails on its own dial timeout instead of behind a process-wide lock.
 	old := Cache.Client
-	Cache = &RedisCache{Client: dial()}
+	Cache = newCache(dial())
 
 	if err := old.Close(); err != nil {
 		slog.Errorf("error while closing redis client: %v", err)

--- a/src/lib/rediscache/rediscache.go
+++ b/src/lib/rediscache/rediscache.go
@@ -23,8 +23,10 @@ type RedisCache struct {
 
 var Cache *RedisCache
 
-func newClient() (*redis.Client, error) {
-	client := redis.NewClient(&redis.Options{
+// dial builds a client without contacting the server. go-redis connects
+// lazily, so this cannot block and cannot fail.
+func dial() *redis.Client {
+	return redis.NewClient(&redis.Options{
 		Addr: config.Get().RedisAddr,
 
 		// Explicitly disable maintenance notifications
@@ -34,10 +36,16 @@ func newClient() (*redis.Client, error) {
 			Mode: maintnotifications.ModeDisabled,
 		},
 	})
+}
 
-	_, err := client.Ping(context.Background()).Result()
+// newClient builds a client and verifies it answers. Only startup uses this:
+// the ping costs a full dial timeout, and the driver retries it internally, so
+// an unreachable server makes a single call here take over a minute.
+func newClient() (*redis.Client, error) {
+	client := dial()
 
-	if err != nil {
+	if _, err := client.Ping(context.Background()).Result(); err != nil {
+		client.Close()
 		return nil, err
 	}
 
@@ -56,8 +64,11 @@ func Client() *RedisCache {
 		client, err = newClient()
 
 		if err != nil {
+			// Backoff stays in the low seconds on purpose: the dial happens
+			// under the package mutex, so every other caller is blocked for
+			// however long this loop runs.
 			for attempt := 1; attempt <= 5; attempt++ {
-				backoffDuration := time.Duration(attempt*attempt) * time.Second
+				backoffDuration := time.Duration(200*(1<<(attempt-1))) * time.Millisecond
 				slog.Errorf("redis connection attempt %d failed, retrying in %v", attempt, backoffDuration)
 				time.Sleep(backoffDuration)
 
@@ -77,6 +88,35 @@ func Client() *RedisCache {
 	}
 
 	return Cache
+}
+
+// Reset discards the shared client so the next Client call redials.
+//
+// It is a no-op unless r is still the shared client, so that several
+// goroutines observing the same failure do not each tear down a healthy
+// replacement.
+func (r *RedisCache) Reset() {
+	mux.Lock()
+	defer mux.Unlock()
+
+	if r == nil || Cache != r {
+		return
+	}
+
+	// Swap in a replacement rather than clearing the field. Clearing it makes
+	// the next caller re-run the verified startup path while holding this
+	// mutex, which on an unreachable server parks every other caller for over
+	// a minute, and the caller after that pays it again because the failure is
+	// not remembered. A lazy client cannot block here, and each command then
+	// fails on its own dial timeout instead of behind a process-wide lock.
+	old := Cache.Client
+	Cache = &RedisCache{Client: dial()}
+
+	if err := old.Close(); err != nil {
+		slog.Errorf("error while closing redis client: %v", err)
+	}
+
+	slog.Info("discarded redis client, connections will be redialled")
 }
 
 // Keys returns all keys matching the given pattern using SCAN.
@@ -128,5 +168,26 @@ func IsConnectionError(err error) bool {
 	return strings.Contains(errStr, "connection refused") ||
 		strings.Contains(errStr, "network is unreachable") ||
 		strings.Contains(errStr, "no route to host") ||
-		strings.Contains(errStr, "i/o timeout")
+		strings.Contains(errStr, "i/o timeout") ||
+		IsReadOnlyError(err)
+}
+
+// IsReadOnlyError reports whether err is a READONLY reply, which a managed
+// instance returns while it serves a replica - during and after a
+// primary-standby switchover.
+//
+// The reply arrives as a valid Redis error, so the pool keeps handing out the
+// connections pinned to the demoted node and every write path stays dead until
+// the client is discarded. Callers should treat it as a connection fault and
+// Reset, not as an application error.
+//
+// Tair's proxy emits "ERR READONLY You can't write against a read only
+// instance."; native Redis emits "READONLY You can't write against a read only
+// replica.".
+func IsReadOnlyError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "READONLY")
 }

--- a/src/lib/rediscache/rediscache.go
+++ b/src/lib/rediscache/rediscache.go
@@ -20,11 +20,18 @@ var mux sync.Mutex
 
 type RedisCache struct {
 	*redis.Client
-
-	// resetting keeps a storm of refused writes from each launching their own
-	// teardown. The first observer wins and the rest return immediately.
-	resetting atomic.Bool
 }
+
+// AutoResetCooldown bounds how often a refused write may discard the client.
+//
+// A switchover refuses every write for as long as it lasts, so without this
+// each refusal would tear down the pool and build another, hundreds of times a
+// second, aborting in-flight reads each time. The window has to live outside
+// the client because the client is what gets replaced.
+var AutoResetCooldown = 5 * time.Second
+
+// lastAutoReset is the Unix nanosecond time of the last automatic discard.
+var lastAutoReset atomic.Int64
 
 var Cache *RedisCache
 
@@ -92,18 +99,9 @@ func (h *failoverHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 
 func (h *failoverHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
+		// The driver returns the first failing command's error for the batch,
+		// so a refused write inside a pipeline arrives here directly.
 		err := next(ctx, cmds)
-
-		if err == nil {
-			// A pipeline reports per-command errors rather than one error for
-			// the batch, so a refused write is only visible on the commands.
-			for _, cmd := range cmds {
-				if err = cmd.Err(); err != nil {
-					break
-				}
-			}
-		}
-
 		h.cache.resetOnReadOnly(err)
 
 		return err
@@ -111,14 +109,24 @@ func (h *failoverHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis
 }
 
 // resetOnReadOnly discards the client if err says the server has become a
-// replica. The discard runs detached: it closes the pool, and this is called
-// from inside the command path that is still using it.
+// replica, at most once per cooldown window.
+//
+// The discard runs detached: it closes the pool, and this is called from
+// inside the command path that is still using it.
 func (r *RedisCache) resetOnReadOnly(err error) {
 	if r == nil || !IsReadOnlyError(err) {
 		return
 	}
 
-	if !r.resetting.CompareAndSwap(false, true) {
+	now := time.Now().UnixNano()
+	previous := lastAutoReset.Load()
+
+	if now-previous < int64(AutoResetCooldown) {
+		return
+	}
+
+	// Whoever wins the swap owns this window; everyone else returns.
+	if !lastAutoReset.CompareAndSwap(previous, now) {
 		return
 	}
 
@@ -137,11 +145,8 @@ func Client() *RedisCache {
 		client, err = newClient()
 
 		if err != nil {
-			// Backoff stays in the low seconds on purpose: the dial happens
-			// under the package mutex, so every other caller is blocked for
-			// however long this loop runs.
 			for attempt := 1; attempt <= 5; attempt++ {
-				backoffDuration := time.Duration(200*(1<<(attempt-1))) * time.Millisecond
+				backoffDuration := time.Duration(attempt*attempt) * time.Second
 				slog.Errorf("redis connection attempt %d failed, retrying in %v", attempt, backoffDuration)
 				time.Sleep(backoffDuration)
 
@@ -270,11 +275,13 @@ func IsConnectionError(err error) bool {
 //
 // Tair's proxy emits "ERR READONLY You can't write against a read only
 // instance."; native Redis emits "READONLY You can't write against a read only
-// replica.".
+// replica.". The optional "ERR " is stripped and the rest matched as a reply
+// code, so an unrelated error that merely mentions the word is not mistaken
+// for a failover and does not discard the pool.
 func IsReadOnlyError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	return strings.Contains(err.Error(), "READONLY")
+	return strings.HasPrefix(strings.TrimPrefix(err.Error(), "ERR "), "READONLY ")
 }

--- a/src/lib/rediscache/rediscache_test.go
+++ b/src/lib/rediscache/rediscache_test.go
@@ -24,6 +24,12 @@ func (s *RedisCacheSuite) Test_IsReadOnlyError() {
 	s.False(rediscache.IsReadOnlyError(nil))
 	s.False(rediscache.IsReadOnlyError(redis.Nil))
 	s.False(rediscache.IsReadOnlyError(errors.New("NOPERM this user has no permissions")))
+
+	// Discarding the pool is expensive, so an error that merely mentions the
+	// word must not be mistaken for a failover.
+	s.False(rediscache.IsReadOnlyError(errors.New("ERR unknown command 'READONLY'")))
+	s.False(rediscache.IsReadOnlyError(errors.New("ERR Error running script: READONLY")))
+	s.False(rediscache.IsReadOnlyError(errors.New("READONLYISH something else")))
 }
 
 func (s *RedisCacheSuite) Test_IsConnectionError_Readonly() {

--- a/src/lib/rediscache/rediscache_test.go
+++ b/src/lib/rediscache/rediscache_test.go
@@ -1,13 +1,86 @@
 package rediscache_test
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net"
 	"testing"
 
+	"github.com/redis/go-redis/v9"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
 	"github.com/stretchr/testify/suite"
 )
 
 type RedisCacheSuite struct {
 	suite.Suite
+}
+
+func (s *RedisCacheSuite) Test_IsReadOnlyError() {
+	// Tair's proxy and native Redis word the same failover differently.
+	s.True(rediscache.IsReadOnlyError(errors.New("ERR READONLY You can't write against a read only instance.")))
+	s.True(rediscache.IsReadOnlyError(errors.New("READONLY You can't write against a read only replica.")))
+
+	s.False(rediscache.IsReadOnlyError(nil))
+	s.False(rediscache.IsReadOnlyError(redis.Nil))
+	s.False(rediscache.IsReadOnlyError(errors.New("NOPERM this user has no permissions")))
+}
+
+func (s *RedisCacheSuite) Test_IsConnectionError_Readonly() {
+	// The regression the 2026-09-09 failover exposed: a READONLY reply is a
+	// topology event, not an application error.
+	s.True(rediscache.IsConnectionError(errors.New("ERR READONLY You can't write against a read only instance.")))
+	s.True(rediscache.IsConnectionError(errors.New("READONLY You can't write against a read only replica.")))
+}
+
+func (s *RedisCacheSuite) Test_IsConnectionError_Network() {
+	s.True(rediscache.IsConnectionError(redis.ErrClosed))
+	s.True(rediscache.IsConnectionError(io.EOF))
+	s.True(rediscache.IsConnectionError(errors.New("dial tcp 10.0.0.1:6379: connect: connection refused")))
+	s.True(rediscache.IsConnectionError(errors.New("network is unreachable")))
+	s.True(rediscache.IsConnectionError(errors.New("no route to host")))
+	s.True(rediscache.IsConnectionError(errors.New("lookup r-x.redis.rds.aliyuncs.com: i/o timeout")))
+	s.True(rediscache.IsConnectionError(&net.DNSError{Err: "server misbehaving"}))
+
+	s.False(rediscache.IsConnectionError(nil))
+	s.False(rediscache.IsConnectionError(redis.Nil))
+	s.False(rediscache.IsConnectionError(errors.New("WRONGTYPE Operation against a key holding the wrong kind of value")))
+}
+
+func (s *RedisCacheSuite) Test_Reset_RedialsOnNextClient() {
+	client := rediscache.Client()
+	s.Require().NotNil(client)
+
+	client.Reset()
+
+	next := rediscache.Client()
+	s.Require().NotNil(next)
+	s.NotSame(client, next, "Reset should force the next call to redial")
+	s.NoError(next.Ping(context.Background()).Err(), "the replacement client should be usable")
+}
+
+func (s *RedisCacheSuite) Test_Reset_IgnoresStaleClient() {
+	stale := rediscache.Client()
+	s.Require().NotNil(stale)
+
+	stale.Reset()
+
+	current := rediscache.Client()
+	s.Require().NotNil(current)
+
+	// A second goroutine observing the same failure must not tear down the
+	// replacement that already redialled.
+	stale.Reset()
+
+	s.Same(current, rediscache.Client())
+	s.NoError(current.Ping(context.Background()).Err())
+}
+
+func (s *RedisCacheSuite) Test_Reset_NilReceiver() {
+	var nilCache *rediscache.RedisCache
+	s.NotPanics(func() { nilCache.Reset() })
+
+	s.NotNil(rediscache.Client())
 }
 
 func TestRedisCache(t *testing.T) {

--- a/src/lib/rediscache/reset_lockout_test.go
+++ b/src/lib/rediscache/reset_lockout_test.go
@@ -29,11 +29,13 @@ func TestResetDoesNotLockOutCallers(t *testing.T) {
 
 	prev := config.Get().RedisAddr
 
+	// Address first: Reset builds its replacement from the config as it runs,
+	// so discarding before pointing at the stub would connect to neither.
+	config.SetRedisAddr(stub.Addr())
+
 	if current := rediscache.Client(); current != nil {
 		current.Reset()
 	}
-
-	config.SetRedisAddr(stub.Addr())
 
 	client := rediscache.Client()
 

--- a/src/lib/rediscache/reset_lockout_test.go
+++ b/src/lib/rediscache/reset_lockout_test.go
@@ -1,0 +1,106 @@
+package rediscache_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/config"
+	"github.com/stormkit-io/stormkit-io/src/lib/rediscache"
+)
+
+// blackhole is a routable-looking address that never answers, so dials hang
+// until the driver's dial timeout rather than failing fast.
+const blackhole = "10.255.255.1:6379"
+
+// Guards against the lockup that discarding the client used to cause. Clearing
+// the shared field made the next caller re-run the verified startup path under
+// the package mutex; against an unreachable server that took over a minute,
+// and every caller behind it paid the same again. Since every request resolves
+// the client, that cost lands on the whole edge at once.
+func TestResetDoesNotLockOutCallers(t *testing.T) {
+	stub, err := newStubRedis(proxyReadOnly)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer stub.Close()
+
+	prev := config.Get().RedisAddr
+
+	if current := rediscache.Client(); current != nil {
+		current.Reset()
+	}
+
+	config.SetRedisAddr(stub.Addr())
+
+	client := rediscache.Client()
+
+	if client == nil {
+		t.Fatal("expected a client against the stub")
+	}
+
+	// The server becomes unreachable, then a connection fault discards the
+	// client - the exact sequence the failover fix introduces.
+	config.SetRedisAddr(blackhole)
+
+	defer func() {
+		// Restore the address before discarding the client: Reset builds the
+		// replacement against whatever the config says at that moment.
+		config.SetRedisAddr(prev)
+
+		if current := rediscache.Client(); current != nil {
+			current.Reset()
+		}
+	}()
+
+	resetStart := time.Now()
+	client.Reset()
+	resetCost := time.Since(resetStart)
+
+	const waiters = 50
+
+	var wg sync.WaitGroup
+	durations := make([]time.Duration, waiters)
+
+	start := time.Now()
+
+	for i := range waiters {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			began := time.Now()
+			rediscache.Client()
+			durations[i] = time.Since(began)
+		}()
+	}
+
+	wg.Wait()
+
+	total := time.Since(start)
+
+	var worst time.Duration
+
+	for _, d := range durations {
+		if d > worst {
+			worst = d
+		}
+	}
+
+	t.Logf("reset itself took %v", resetCost.Round(time.Microsecond))
+	t.Logf("worst of %d concurrent resolutions: %v", waiters, worst.Round(time.Microsecond))
+	t.Logf("all %d resolutions drained in %v", waiters, total.Round(time.Microsecond))
+
+	// Generous bounds: the point is that nothing dials while holding the
+	// mutex, so these are microseconds rather than minutes.
+	if resetCost > time.Second {
+		t.Fatalf("reset blocked for %v, it must not dial under the mutex", resetCost)
+	}
+
+	if worst > time.Second {
+		t.Fatalf("a caller blocked for %v behind a discarded client", worst)
+	}
+}


### PR DESCRIPTION
A managed primary-standby switchover starts refusing writes. Nothing in the
edge or the worker recognised that, so the connection pool kept handing out
connections pinned to the demoted node and every write path stayed dead until
the processes were restarted by hand.

## Why it was never caught

The driver already handles this on a plain Redis. It marks the connection bad
and retries on a fresh one, so the caller never sees the error at all. Both of
its checks are a prefix match on `READONLY `. The managed proxy in front of the
affected fleet answers `ERR READONLY ...`, and that prefix defeats both. The
wording is the whole bug.

There is a test for exactly this, running a bare driver client against a stub
that speaks each wording, so the difference is documented rather than folklore.

## How recovery works

The client carries a driver hook that watches every command and pipeline for
the refusal and discards itself when it sees one. Callers are unchanged, which
matters because the writes are spread across roughly forty call sites:
certificates, one-time codes, OAuth token storage and the analytics queue.
Wiring each of them by hand would have left the next one out.

The hook fires only on the read-only reply, not on connection errors in
general. The driver already recycles connections for ordinary network faults,
so tearing the pool down on a transient timeout would be worse than the
timeout. There is a test asserting nothing is discarded for the wording the
driver handles itself.

## Two things found while building it

**Clearing the shared client was worse than the fault.** The next caller
re-ran the ping-verified startup path while holding the package mutex, which
against an unreachable server measured over a minute, and the caller behind it
paid it again because the failure was never remembered. Since every request
resolves the client, that lands on the whole edge at once. It now swaps in a
lazily connecting client, so nothing dials under the lock.

| | before | after |
|---|---|---|
| one resolution, unreachable server | ~1m49s | lazy, no dial |
| four concurrent callers | ~2m25s | n/a |
| fifty concurrent callers | n/a | 121us |

**The certificate store held the connection that recovery closes.** It took
one at boot, so the first recovery would have left certificates dead for the
life of the process, which is worse than the failover. It now resolves per
call. The test for it fails against the old pinned client, so it has teeth.

## Records are no longer lost

The queue drain reported the refusal by returning, abandoning batches it had
already popped. Those are gone from the queue by then, which is why the branch
beside it deliberately breaks and falls through to the insert. It now does the
same and reports the error afterwards, so a failover costs no records.

## Tests

A small RESP stub models the switchover honestly: each connection records the
generation it was accepted in, so connections opened before the event refuse
writes forever while later ones reach the promoted primary. No Docker, no
second instance, deterministic.

Covered: both wordings at the driver level, recovery with no caller
cooperation, the pipeline path, not over-reacting to the handled wording, the
certificate store surviving a reset, and the lockout regression held to a
bounded time.

Passing: rediscache, pool, config, workerserver, hosting.

## Known gaps

Deliberately not fixed here, so the change stays about the shared client:

- **The background job queue keeps its own connections** and is unaffected by
  any of this, so a switchover still strands deployments and periodic
  triggers. Tracked in #535, including why handing it the shared client would
  make things worse.
- **A certificate lock taken just before a recovery cannot be released**, so
  one issuance waits out its five second timeout. Self-healing, and I would
  accept it permanently.
- **Several call sites dereference the client without a nil check**, which
  panics if the very first connection attempt fails at boot. Predates this
  branch and is unchanged by it: the startup path here is byte-for-byte what
  main does.

## Scope

This fixes what left certificates, leader election and the queue drain dead
until a manual restart. It does not address the goroutine and memory spike
seen in the same window, which now looks like a separate capacity problem and
is being handled on its own branch.