### PR TITLE
chore: block assistant attribution in history

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Rejects a commit message carrying AI-assistant attribution.
+set -eu
+
+hooks_dir=$(dirname "$0")
+exec "$hooks_dir/forbidden-attribution.sh" "$1"

--- a/.githooks/forbidden-attribution.sh
+++ b/.githooks/forbidden-attribution.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Shared matcher for AI-assistant attribution that must never reach the
+# public history or a pull request.
+#
+# Usage: forbidden-attribution.sh <file>
+# Exits 0 when the file is clean, 1 when it matches, printing the offenders.
+
+set -eu
+
+target="${1:?usage: forbidden-attribution.sh <file>}"
+
+# -i so casing does not matter, -E for alternation. Each pattern is anchored
+# to how the attribution actually appears rather than to the vendor name
+# alone, so prose that legitimately discusses these tools still passes.
+pattern='claude-session:|claude-code-session:|co-authored-by:[[:space:]]*claude|generated with[[:space:]]*\[?claude|https://claude\.ai/code/session|noreply@anthropic\.com|🤖[[:space:]]*generated with'
+
+if matches=$(grep -inE "$pattern" "$target"); then
+	echo "Refusing: assistant attribution found." >&2
+	echo >&2
+	echo "$matches" >&2
+	echo >&2
+	echo "This repository is public. Remove these lines and try again." >&2
+	exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Rejects a push whose commits carry AI-assistant attribution.
+#
+# commit-msg only sees messages written through this clone. This catches
+# everything actually leaving it: amended commits, rebases, cherry-picks and
+# anything authored elsewhere.
+set -eu
+
+hooks_dir=$(dirname "$0")
+zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+status=0
+
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+	# Branch deletion has nothing to inspect.
+	[ "$local_sha" = "$zero" ] && continue
+
+	if [ "$remote_sha" = "$zero" ]; then
+		# New branch: check only what it adds on top of the other refs,
+		# so an old commit already on the remote is not re-litigated.
+		range=$(git rev-list "$local_sha" --not --remotes)
+	else
+		range=$(git rev-list "$remote_sha..$local_sha")
+	fi
+
+	for sha in $range; do
+		msg=$(mktemp)
+		git log -1 --format=%B "$sha" >"$msg"
+
+		if ! "$hooks_dir/forbidden-attribution.sh" "$msg" 2>/tmp/attr.$$; then
+			echo "Refusing to push $(git log -1 --oneline "$sha")" >&2
+			sed 's/^/  /' /tmp/attr.$$ >&2
+			status=1
+		fi
+
+		rm -f "$msg" /tmp/attr.$$
+	done
+done
+
+exit $status

--- a/.github/workflows/no-assistant-attribution.yml
+++ b/.github/workflows/no-assistant-attribution.yml
@@ -1,0 +1,36 @@
+name: No Assistant Attribution
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+# The local hooks cover commit messages. This covers what they cannot see:
+# the pull request title and body, which never pass through git.
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages
+        run: |
+          git log --format=%B "origin/${{ github.base_ref }}..HEAD" > /tmp/commits.txt
+          ./.githooks/forbidden-attribution.sh /tmp/commits.txt
+
+      - name: Check pull request title and body
+        env:
+          # Passed through the environment, never interpolated into the
+          # script, so that title or body content cannot run as shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" > /tmp/pr.txt
+          ./.githooks/forbidden-attribution.sh /tmp/pr.txt

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ endif
 help:
 	@echo "Available targets:"
 	@echo "  check-deps    - Verify all dependencies are installed and running"
+	@echo "  hooks         - Enable the versioned git hooks (run once per clone)"
 	@echo "  start         - Start Docker services (db, redis)"
 	@echo "  dev           - Run check-deps and start services"
 	@echo "  print-env     - Display environment variables for debugging"
@@ -214,6 +215,11 @@ print-env:
 	@echo "============================"
 
 # Check all dependencies
+# Point git at the versioned hooks. Run once per clone.
+hooks:
+	git config core.hooksPath .githooks
+	@echo "git hooks enabled from .githooks"
+
 check-deps:
 	@echo "Checking dependencies on $(DETECTED_OS)..."
 	@$(call check_command,docker,$(DOCKER_ERROR),$(DOCKER_OK))


### PR DESCRIPTION
This repository is public, so AI-assistant trailers should never reach it.
Some assistants add them by default and some are instructed to, so relying on
remembering is not enough.

## Three layers, one matcher

| Layer | Covers |
|---|---|
| `commit-msg` | A message as it is written |
| `pre-push` | Anything leaving the clone: amends, rebases, cherry-picks, commits authored elsewhere |
| Workflow | The pull request title and body, which never pass through git and so no hook can see them |

All three call `.githooks/forbidden-attribution.sh`, so there is one place to
change when a new form shows up.

## What it matches

The pattern is anchored to how the attribution actually appears, not to a
vendor name. A commit that legitimately discusses these tools still passes,
which matters here because the repository ships a plugin for one of them.

Verified against the session trailer, the co-author line with the noreply
address, and the generated-with footer, plus a negative case mentioning the
product by name in both subject and body.

## Setup

`core.hooksPath` has to be set once per clone, so `make hooks` does it and the
help text advertises it. The workflow needs no setup and is the backstop for
anyone who skips that step.