### PR TITLE
feat: keep deployment files in memory

### DIFF
--- a/src/lib/integrations/file_cache.go
+++ b/src/lib/integrations/file_cache.go
@@ -1,0 +1,122 @@
+package integrations
+
+import (
+	"container/list"
+	"os"
+	"sync"
+
+	"github.com/stormkit-io/stormkit-io/src/lib/utils"
+)
+
+const (
+	defaultFileCacheBudget  = 256 << 20 // 256 MiB
+	defaultFileCacheMaxItem = 1 << 20   // 1 MiB
+)
+
+// fileCache keeps deployment files in memory so serving one does not read from
+// disk and allocate a fresh copy on every request.
+//
+// Without it a busy host grows its heap with the number of in-flight requests,
+// and that growth comes out of the kernel's page cache, which turns reads that
+// were free into real disk I/O and slows everything further.
+//
+// Entries are immutable: a deployment id names one fixed set of files, so a
+// new deployment writes new keys rather than invalidating old ones. Callers
+// share the stored value and MUST NOT modify its content.
+type fileCache struct {
+	mu      sync.Mutex
+	budget  int64
+	maxItem int64
+	used    int64
+	entries map[string]*list.Element
+	order   *list.List // front is most recently used
+}
+
+type fileCacheEntry struct {
+	key  string
+	file *GetFileResult
+	size int64
+}
+
+func newFileCache() *fileCache {
+	return &fileCache{
+		budget:  int64(utils.StringToInt(os.Getenv("STORMKIT_FILE_CACHE_BYTES"))),
+		maxItem: int64(utils.StringToInt(os.Getenv("STORMKIT_FILE_CACHE_MAX_FILE_BYTES"))),
+		entries: map[string]*list.Element{},
+		order:   list.New(),
+	}
+}
+
+// configure applies defaults for anything not set in the environment. A budget
+// of zero disables the cache, which is the way to turn it off without a
+// release.
+func (fc *fileCache) configure() *fileCache {
+	if os.Getenv("STORMKIT_FILE_CACHE_BYTES") == "" {
+		fc.budget = defaultFileCacheBudget
+	}
+
+	if fc.maxItem <= 0 {
+		fc.maxItem = defaultFileCacheMaxItem
+	}
+
+	return fc
+}
+
+func (fc *fileCache) get(key string) (*GetFileResult, bool) {
+	if fc == nil || fc.budget <= 0 {
+		return nil, false
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	element, ok := fc.entries[key]
+
+	if !ok {
+		return nil, false
+	}
+
+	fc.order.MoveToFront(element)
+
+	return element.Value.(*fileCacheEntry).file, true
+}
+
+// put stores a file, evicting least recently used entries to stay inside the
+// budget. Files over the per-item cap are not stored: one large asset must not
+// be able to push the whole working set out.
+func (fc *fileCache) put(key string, file *GetFileResult) {
+	if fc == nil || fc.budget <= 0 || file == nil {
+		return
+	}
+
+	size := int64(len(file.Content))
+
+	if size > fc.maxItem {
+		return
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	if element, ok := fc.entries[key]; ok {
+		fc.used -= element.Value.(*fileCacheEntry).size
+		fc.order.Remove(element)
+		delete(fc.entries, key)
+	}
+
+	for fc.used+size > fc.budget {
+		oldest := fc.order.Back()
+
+		if oldest == nil {
+			return
+		}
+
+		entry := oldest.Value.(*fileCacheEntry)
+		fc.used -= entry.size
+		fc.order.Remove(oldest)
+		delete(fc.entries, entry.key)
+	}
+
+	fc.entries[key] = fc.order.PushFront(&fileCacheEntry{key: key, file: file, size: size})
+	fc.used += size
+}

--- a/src/lib/integrations/file_cache_test.go
+++ b/src/lib/integrations/file_cache_test.go
@@ -1,0 +1,96 @@
+package integrations
+
+import (
+	"container/list"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type FileCacheSuite struct {
+	suite.Suite
+	cache *fileCache
+}
+
+func (s *FileCacheSuite) SetupTest() {
+	s.cache = &fileCache{
+		budget:  100,
+		maxItem: 40,
+		entries: map[string]*list.Element{},
+		order:   list.New(),
+	}
+}
+
+func (s *FileCacheSuite) file(size int) *GetFileResult {
+	return &GetFileResult{Content: make([]byte, size), Size: int64(size)}
+}
+
+func (s *FileCacheSuite) Test_StoresAndReturnsTheSameValue() {
+	stored := s.file(10)
+	s.cache.put("a", stored)
+
+	got, ok := s.cache.get("a")
+
+	s.True(ok)
+	s.Same(stored, got, "callers share the entry rather than getting a copy")
+}
+
+func (s *FileCacheSuite) Test_MissIsNotAnError() {
+	got, ok := s.cache.get("absent")
+
+	s.False(ok)
+	s.Nil(got)
+}
+
+func (s *FileCacheSuite) Test_RefusesFilesOverThePerItemCap() {
+	s.cache.put("big", s.file(41))
+
+	_, ok := s.cache.get("big")
+
+	s.False(ok, "one large file must not be able to push out the working set")
+}
+
+func (s *FileCacheSuite) Test_StaysInsideTheBudget() {
+	for _, key := range []string{"a", "b", "c", "d"} {
+		s.cache.put(key, s.file(30))
+	}
+
+	s.LessOrEqual(s.cache.used, s.cache.budget)
+	s.LessOrEqual(int64(len(s.cache.entries)), s.cache.budget/30)
+}
+
+func (s *FileCacheSuite) Test_EvictsLeastRecentlyUsed() {
+	s.cache.put("a", s.file(30))
+	s.cache.put("b", s.file(30))
+	s.cache.put("c", s.file(30))
+
+	// Touching "a" makes "b" the coldest.
+	s.cache.get("a")
+	s.cache.put("d", s.file(30))
+
+	_, hasA := s.cache.get("a")
+	_, hasB := s.cache.get("b")
+
+	s.True(hasA, "recently used entries survive")
+	s.False(hasB, "the coldest entry is the one evicted")
+}
+
+func (s *FileCacheSuite) Test_ReplacingAKeyDoesNotDoubleCount() {
+	s.cache.put("a", s.file(30))
+	s.cache.put("a", s.file(10))
+
+	s.Equal(int64(10), s.cache.used)
+}
+
+func (s *FileCacheSuite) Test_ZeroBudgetDisablesIt() {
+	disabled := &fileCache{entries: map[string]*list.Element{}, order: list.New()}
+
+	disabled.put("a", s.file(1))
+	_, ok := disabled.get("a")
+
+	s.False(ok, "a zero budget is how the cache is turned off without a release")
+}
+
+func TestFileCache(t *testing.T) {
+	suite.Run(t, &FileCacheSuite{})
+}

--- a/src/lib/integrations/zip_manager.go
+++ b/src/lib/integrations/zip_manager.go
@@ -86,10 +86,15 @@ type ZipManager struct {
 	// well under 1 MB per ~30k distinct deployments seen by the process,
 	// and process restarts on upgrade reset the map.
 	locks sync.Map // deploymentID (string) -> *sync.Mutex
+
+	// files holds file contents in memory. A deployment id names one fixed
+	// set of files, so entries never go stale: a new deployment writes new
+	// keys and the old ones fall out by least-recently-used.
+	files *fileCache
 }
 
 func NewZipManager(download DownloadFunc) *ZipManager {
-	return &ZipManager{download: download}
+	return &ZipManager{download: download, files: newFileCache().configure()}
 }
 
 func (zm *ZipManager) didLock(did string) *sync.Mutex {
@@ -115,12 +120,19 @@ func (zm *ZipManager) folderDoesNotExist(folder string) bool {
 // qualified location name in the form "aws:<bucket>/<key-prefix>".
 //
 // Flow:
+//
 //  1. Acquire the per-deployment lock.
+//
 //  2. Check the cache; download the zip on a miss. Other readers of the
 //     same deployment wait. Different deployments are independent.
+//
 //  3. Reset the inactivity timer.
+//
 //  4. Release the lock and read the file with no lock held — large reads
 //     do not block other readers of the same deployment.
+//
+//  5. Serve the content from memory when it is there, so the read and the
+//     allocation happen once per file rather than once per request.
 func (zm *ZipManager) GetFile(args GetFileArgs) (*GetFileResult, error) {
 	did := args.DeploymentID.String()
 	pieces := strings.Split(strings.TrimPrefix(args.Location, "aws:"), "/")
@@ -159,6 +171,14 @@ func (zm *ZipManager) GetFile(args GetFileArgs) (*GetFileResult, error) {
 	location := z.Location
 	lock.Unlock()
 
+	// Looked up after the folder is resolved, not before, so removing a
+	// deployment folder still triggers the re-download it always did.
+	cacheKey := did + ":" + args.FileName
+
+	if file, ok := zm.files.get(cacheKey); ok {
+		return file, nil
+	}
+
 	filePath := filepath.Join(location, args.FileName)
 
 	// Defense in depth: reject paths that escape the deployment directory.
@@ -180,9 +200,13 @@ func (zm *ZipManager) GetFile(args GetFileArgs) (*GetFileResult, error) {
 		return nil, err
 	}
 
-	return &GetFileResult{
+	file := &GetFileResult{
 		Content:     data,
 		ContentType: DetectContentType(filePath, data),
 		Size:        stat.Size(),
-	}, nil
+	}
+
+	zm.files.put(cacheKey, file)
+
+	return file, nil
 }

--- a/src/lib/integrations/zip_manager_test.go
+++ b/src/lib/integrations/zip_manager_test.go
@@ -76,6 +76,37 @@ func (s *ZipManagerSuite) Test_Download() {
 	s.Equal(2, called)
 }
 
+// Test_GetFile_ServesFromMemory proves the read happens once per file rather
+// than once per request. Deleting the file between calls is the check: if the
+// second call still answers, it never touched the disk.
+func (s *ZipManagerSuite) Test_GetFile_ServesFromMemory() {
+	var location string
+
+	zipManager := integrations.NewZipManager(func(deploymentID, bucketname, keyprefix string) (string, error) {
+		location = s.createFiles()
+		return location, nil
+	})
+
+	args := integrations.GetFileArgs{
+		Location:     "my-bucket/my-key-prefix",
+		FileName:     "/index.html",
+		DeploymentID: types.ID(20),
+	}
+
+	first, err := zipManager.GetFile(args)
+
+	s.Require().NoError(err)
+	s.Equal("Hello world", string(first.Content))
+
+	s.Require().NoError(os.Remove(path.Join(location, "index.html")))
+
+	second, err := zipManager.GetFile(args)
+
+	s.Require().NoError(err, "a cached file must not need the one on disk")
+	s.Equal("Hello world", string(second.Content))
+	s.Same(first, second, "the same bytes are shared rather than re-allocated per request")
+}
+
 func (s *ZipManagerSuite) Test_Download_NotFound() {
 	zipManager := integrations.NewZipManager(func(deploymentID, bucketname, keyprefix string) (string, error) {
 		s.createFiles()


### PR DESCRIPTION
Every static hit reads the whole file from disk and allocates a fresh copy of
its bytes, then compresses it. On a busy host the heap grows with the number of
requests in flight, that growth comes out of the kernel's page cache, and reads
that had been free become real disk I/O, which slows serving and puts still
more requests in flight.

A host with two cores and four gigabytes went from zero disk read all day to
eighty two megabytes a second inside that loop, with process memory tripling
and load reaching four times the core count.

## What this does

Keeps file contents in memory, so the read and the allocation happen once per
file rather than once per request.

A deployment identifier names one fixed set of files, so entries never go
stale. A new deployment writes new keys and the old ones fall out by
least-recently-used. There is no invalidation to get wrong and no expiry to
tune.

## Bounds

Bounded by total bytes rather than entry count, since bytes are what ran out.
A per-file cap keeps one large asset from pushing out the working set; files
over it are read from disk exactly as they are today.

| Variable | Default |
|---|---|
| `STORMKIT_FILE_CACHE_BYTES` | 256 MiB |
| `STORMKIT_FILE_CACHE_MAX_FILE_BYTES` | 1 MiB |

Setting the budget to zero disables it, so it can be turned off on a host
without a release.

## What is deliberately not here

Serving pre-compressed bytes is the processor half of the same problem and
needs the compression middleware bypassed for cached content, which is a real
change to how responses are written. Separate PR.

Collapsing concurrent misses so a cold deployment causes one read instead of
several is worth doing, but its absence is today's behaviour, not a
regression.

Admission control is the safety fix rather than the efficiency one, and it
changes what people see under load. Separate branch, separate decision.

## On sharing the bytes

Callers get the stored value, not a copy. That is the allocation being
removed, so it is the point rather than an oversight. Nothing in the serving
path modifies the content: snippet and header injection build new slices, and
image optimisation returns a new one.

## Behaviour

The lookup happens after the deployment folder is resolved rather than before,
so removing a folder still triggers the re-download it always did.

Tests cover storing and sharing, misses, the per-file cap, staying inside the
budget, evicting the coldest entry, replacing a key without double counting,
and a zero budget disabling it. One test proves a second read never touches
the disk by deleting the file between calls.

Passing: integrations, hosting.