### PR TITLE
fix: drop cached files when a deployment folder goes

### DIFF
--- a/src/lib/integrations/file_cache.go
+++ b/src/lib/integrations/file_cache.go
@@ -3,6 +3,7 @@ package integrations
 import (
 	"container/list"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/stormkit-io/stormkit-io/src/lib/utils"
@@ -79,6 +80,32 @@ func (fc *fileCache) get(key string) (*GetFileResult, bool) {
 	fc.order.MoveToFront(element)
 
 	return element.Value.(*fileCacheEntry).file, true
+}
+
+// dropDeployment removes every entry belonging to a deployment.
+//
+// Without it the only way out of the cache is eviction pressure, so a
+// deployment nobody serves any more holds its share of the budget until
+// something else needs the room.
+func (fc *fileCache) dropDeployment(deploymentID string) {
+	if fc == nil {
+		return
+	}
+
+	prefix := deploymentID + ":"
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	for key, element := range fc.entries {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		fc.used -= element.Value.(*fileCacheEntry).size
+		fc.order.Remove(element)
+		delete(fc.entries, key)
+	}
 }
 
 // put stores a file, evicting least recently used entries to stay inside the

--- a/src/lib/integrations/file_cache_test.go
+++ b/src/lib/integrations/file_cache_test.go
@@ -91,6 +91,45 @@ func (s *FileCacheSuite) Test_ZeroBudgetDisablesIt() {
 	s.False(ok, "a zero budget is how the cache is turned off without a release")
 }
 
+func (s *FileCacheSuite) Test_DropDeploymentRemovesOnlyThatDeployment() {
+	s.cache.put("10:/index.html", s.file(10))
+	s.cache.put("10:/app.js", s.file(10))
+	s.cache.put("11:/index.html", s.file(10))
+
+	s.cache.dropDeployment("10")
+
+	_, hasOld := s.cache.get("10:/index.html")
+	_, hasOldTwo := s.cache.get("10:/app.js")
+	_, hasOther := s.cache.get("11:/index.html")
+
+	s.False(hasOld)
+	s.False(hasOldTwo)
+	s.True(hasOther, "a different deployment keeps its entries")
+}
+
+func (s *FileCacheSuite) Test_DropDeploymentReclaimsTheBudget() {
+	s.cache.put("10:/index.html", s.file(30))
+	s.cache.put("11:/index.html", s.file(30))
+
+	s.cache.dropDeployment("10")
+
+	s.Equal(int64(30), s.cache.used, "the freed bytes go back to the budget")
+}
+
+// Prefixes must not be confused: dropping 1 must not touch 10.
+func (s *FileCacheSuite) Test_DropDeploymentDoesNotMatchIdPrefixes() {
+	s.cache.put("1:/index.html", s.file(10))
+	s.cache.put("10:/index.html", s.file(10))
+
+	s.cache.dropDeployment("1")
+
+	_, hasOne := s.cache.get("1:/index.html")
+	_, hasTen := s.cache.get("10:/index.html")
+
+	s.False(hasOne)
+	s.True(hasTen, "deployment 10 is not deployment 1")
+}
+
 func TestFileCache(t *testing.T) {
 	suite.Run(t, &FileCacheSuite{})
 }

--- a/src/lib/integrations/zip_manager.go
+++ b/src/lib/integrations/zip_manager.go
@@ -51,6 +51,11 @@ func (z *Zip) RemoveFolder() {
 		return
 	}
 
+	// The files go with the folder. Holding them would keep a deployment
+	// nobody serves any more inside the byte budget, and would let bad bytes
+	// in memory outlive the fix of deleting the folder.
+	z.manager.files.dropDeployment(z.cacheKey)
+
 	slog.Debug(slog.LogOpts{
 		Msg:   "Removing folder after inactivity",
 		Level: slog.DL2,

--- a/src/lib/integrations/zip_manager_test.go
+++ b/src/lib/integrations/zip_manager_test.go
@@ -80,6 +80,10 @@ func (s *ZipManagerSuite) Test_Download() {
 // than once per request. Deleting the file between calls is the check: if the
 // second call still answers, it never touched the disk.
 func (s *ZipManagerSuite) Test_GetFile_ServesFromMemory() {
+	// Pinned rather than inherited: the budget is read from the environment,
+	// and a machine with the cache switched off would fail this confusingly.
+	s.T().Setenv("STORMKIT_FILE_CACHE_BYTES", "1048576")
+
 	var location string
 
 	zipManager := integrations.NewZipManager(func(deploymentID, bucketname, keyprefix string) (string, error) {


### PR DESCRIPTION
Follow-up to #536.

Eviction pressure and a process restart were the only ways out of the cache.
A deployment nobody serves any more held its share of the byte budget until
something else needed the room, which on a quiet host is indefinite. After a
deploy it meant two generations competing for the same budget until the old
one aged out.

It also meant cached bytes outlived the files they came from. Deleting a
deployment folder forced a fresh download but not fresh content, because the
memory hit skips the read, so the old remedy for bad bytes on disk stopped
working until a restart.

## What changes

Removing a deployment folder now drops that deployment's entries.

The removal already runs under the per-deployment lock, so this hangs off it
rather than introducing any new synchronisation. Matching is on the identifier
plus its separator, so dropping deployment 1 leaves deployment 10 alone, which
is covered by a test.

## Also

The serve-from-memory test read the real environment for the budget, so it
failed confusingly on a machine with the cache switched off. It now pins the
value.

## Not included

This reclaims the budget when a folder is removed after six hours of
inactivity, not at the moment of a deploy. Hooking the publish event would
free it immediately, which is the more valuable half for anyone deploying
often. Worth doing, but it is a different trigger in a different package and
this one is the fix for the finding.

From the review of #536, deliberately not addressed: a budget configured
smaller than the per-file cap, and a non-numeric budget parsing to zero. Both
are configuration errors and were judged not worth handling yet. The
object-storage-only scope is tracked separately.

Passing: integrations, hosting.