### PR TITLE
feat: keep filesystem deployment files in memory

### DIFF
--- a/src/lib/integrations/client_filesystem.go
+++ b/src/lib/integrations/client_filesystem.go
@@ -25,6 +25,11 @@ type FilesysClient struct {
 	pm  *ProcessManager
 	mjs *template.Template
 	cjs *template.Template
+
+	// files holds file contents in memory, so serving one costs a read per
+	// file rather than a read per request. A deployment writes to its own
+	// directory, so an entry never goes stale.
+	files *fileCache
 }
 
 var _filesys *FilesysClient
@@ -36,6 +41,8 @@ func Filesys() *FilesysClient {
 
 	if _filesys == nil {
 		_filesys = &FilesysClient{
+			files: newFileCache().configure(),
+
 			mjs: template.Must(template.New("mjs").Parse(strings.Join(strings.Fields(`
 				const log = (r) => r && console.log(JSON.stringify(r)) || process.exit(0);
 				const err = (e) => console.log({ body: e && e.message ? e.message : e, status: 500 }) || process.exit(1);
@@ -175,12 +182,28 @@ func (c *FilesysClient) DeleteArtifacts(ctx context.Context, args DeleteArtifact
 		return nil
 	}
 
-	return os.RemoveAll(c.getDeploymentPath(location))
+	deploymentPath := c.getDeploymentPath(location)
+
+	// The files go with the folder. Holding them would keep a deployment
+	// nobody serves any more inside the byte budget.
+	c.files.dropPrefix(deploymentPath)
+
+	return os.RemoveAll(deploymentPath)
 }
 
 // GetFile returns a file from the Filesystem.
+//
+// Content already in memory is returned without touching the disk. Callers
+// share the stored value and MUST NOT modify its content.
 func (c *FilesysClient) GetFile(args GetFileArgs) (*GetFileResult, error) {
 	filePath := path.Join(strings.TrimPrefix(args.Location, "local:"), args.FileName)
+
+	// Keyed on the resolved path: it is unique, and it starts with the
+	// deployment directory, so deleting a deployment drops its entries.
+	if file, ok := c.files.get(filePath); ok {
+		return file, nil
+	}
+
 	stat, err := os.Stat(filePath)
 
 	if os.IsNotExist(err) {
@@ -197,11 +220,15 @@ func (c *FilesysClient) GetFile(args GetFileArgs) (*GetFileResult, error) {
 		return nil, err
 	}
 
-	return &GetFileResult{
+	result := &GetFileResult{
 		ContentType: DetectContentType(filePath, data),
 		Size:        stat.Size(),
 		Content:     data,
-	}, nil
+	}
+
+	c.files.put(filePath, result)
+
+	return result, nil
 }
 
 // Upload a file to the file system. Use the DistDir argument to specify

--- a/src/lib/integrations/client_filesystem_test.go
+++ b/src/lib/integrations/client_filesystem_test.go
@@ -177,6 +177,59 @@ func (s *FilesysSuite) Test_GetFile() {
 	s.Equal("text/html; charset=utf-8", file.ContentType)
 }
 
+// Test_GetFile_ServesFromMemory proves the read happens once per file rather
+// than once per request. Deleting the file between calls is the check: if the
+// second call still answers, it never touched the disk.
+func (s *FilesysSuite) Test_GetFile_ServesFromMemory() {
+	s.T().Setenv("STORMKIT_FILE_CACHE_BYTES", "1048576")
+
+	client := integrations.Filesys()
+	filePath := path.Join(s.tmpdir, "client", "index.html")
+	args := integrations.GetFileArgs{Location: fmt.Sprintf("local:%s", filePath)}
+
+	first, err := client.GetFile(args)
+
+	s.Require().NoError(err)
+	s.Equal("Hello world", string(first.Content))
+
+	s.Require().NoError(os.Remove(filePath))
+
+	second, err := client.GetFile(args)
+
+	s.Require().NoError(err, "a cached file must not need the one on disk")
+	s.Equal("Hello world", string(second.Content))
+	s.Same(first, second, "the same bytes are shared rather than re-allocated per request")
+}
+
+// Test_DeleteArtifacts_DropsCachedFiles makes sure deleting a deployment
+// reclaims its share of the budget, and that nothing outlives the files it
+// came from.
+func (s *FilesysSuite) Test_DeleteArtifacts_DropsCachedFiles() {
+	s.T().Setenv("STORMKIT_FILE_CACHE_BYTES", "1048576")
+
+	client := integrations.Filesys()
+	clientDir := path.Join(s.tmpdir, "client")
+	filePath := path.Join(clientDir, "index.html")
+	args := integrations.GetFileArgs{Location: fmt.Sprintf("local:%s", filePath)}
+
+	_, err := client.GetFile(args)
+	s.Require().NoError(err)
+
+	s.Require().NoError(client.DeleteArtifacts(context.Background(), integrations.DeleteArtifactsArgs{
+		StorageLocation: fmt.Sprintf("local:%s", filePath),
+	}))
+
+	// Same path, different content. A stale entry would answer with the old
+	// bytes instead.
+	s.Require().NoError(os.MkdirAll(clientDir, 0774))
+	s.Require().NoError(os.WriteFile(filePath, []byte("Redeployed"), 0664))
+
+	after, err := client.GetFile(args)
+
+	s.Require().NoError(err)
+	s.Equal("Redeployed", string(after.Content), "the cached copy must not outlive the deployment")
+}
+
 func (s *FilesysSuite) Test_Invoke() {
 	client := integrations.Filesys()
 	reqURL := &url.URL{}

--- a/src/lib/integrations/file_cache.go
+++ b/src/lib/integrations/file_cache.go
@@ -88,11 +88,16 @@ func (fc *fileCache) get(key string) (*GetFileResult, bool) {
 // deployment nobody serves any more holds its share of the budget until
 // something else needs the room.
 func (fc *fileCache) dropDeployment(deploymentID string) {
-	if fc == nil {
+	fc.dropPrefix(deploymentID + ":")
+}
+
+// dropPrefix removes every entry whose key starts with prefix. Callers keying
+// on a path pass the deployment directory; callers keying on an id pass it
+// with its separator, so dropping 1 cannot match 10.
+func (fc *fileCache) dropPrefix(prefix string) {
+	if fc == nil || prefix == "" {
 		return
 	}
-
-	prefix := deploymentID + ":"
 
 	fc.mu.Lock()
 	defer fc.mu.Unlock()

--- a/src/lib/integrations/file_cache_test.go
+++ b/src/lib/integrations/file_cache_test.go
@@ -130,6 +130,33 @@ func (s *FileCacheSuite) Test_DropDeploymentDoesNotMatchIdPrefixes() {
 	s.True(hasTen, "deployment 10 is not deployment 1")
 }
 
+func (s *FileCacheSuite) Test_DropPrefixMatchesPaths() {
+	s.cache.put("/deployments/deployment-10/client/index.html", s.file(10))
+	s.cache.put("/deployments/deployment-10/client/app.js", s.file(10))
+	s.cache.put("/deployments/deployment-11/client/index.html", s.file(10))
+
+	s.cache.dropPrefix("/deployments/deployment-10")
+
+	_, hasOne := s.cache.get("/deployments/deployment-10/client/index.html")
+	_, hasTwo := s.cache.get("/deployments/deployment-10/client/app.js")
+	_, hasOther := s.cache.get("/deployments/deployment-11/client/index.html")
+
+	s.False(hasOne)
+	s.False(hasTwo)
+	s.True(hasOther, "a different deployment keeps its entries")
+	s.Equal(int64(10), s.cache.used)
+}
+
+func (s *FileCacheSuite) Test_DropPrefixIgnoresAnEmptyPrefix() {
+	s.cache.put("a", s.file(10))
+
+	s.cache.dropPrefix("")
+
+	_, ok := s.cache.get("a")
+
+	s.True(ok, "an empty prefix must not empty the cache")
+}
+
 func TestFileCache(t *testing.T) {
 	suite.Run(t, &FileCacheSuite{})
 }


### PR DESCRIPTION
Closes #538. Follow-up to #536 and #537.

The in-memory cache covered the object storage path only. Installs whose
storage client is the local filesystem still read the whole file from disk and
allocated a fresh copy on every request, which is the behaviour that turns a
traffic spike into a page-cache collapse.

Which client is used depends on the storage provider, not on whether Stormkit
is self-hosted, so this is the gap for anyone running without object storage.

## Keying

Entries are keyed on the resolved path. Each deployment uploads into its own
`deployment-<id>` directory, so the path already names one fixed set of files
and an entry cannot go stale.

The path is also what makes the key unique, which matters here because the
deployment identifier is not always meaningful on this path, unlike the
archive one where it is used to find the folder.

## Eviction

Deleting a deployment drops its entries, so the budget is reclaimed rather
than waiting for eviction pressure, and nothing outlives the files it came
from.

This generalises what #537 added rather than adding a second mechanism.
Dropping by deployment identifier is now dropping by prefix with the separator
attached, so the archive path behaves exactly as before and both callers share
one implementation.

The test for it fails with the drop removed, returning the old bytes after a
redeploy to the same path, so it is not passing by accident.

## Scope

Both clients hold their own cache. Only one of them is ever used in a given
process, so there is nothing to share and no reason to couple them.

The two configuration findings from the review of #536 are still deliberately
unhandled: a budget configured smaller than the per-file cap, and a
non-numeric budget parsing to zero.

## One consequence worth knowing

With the local deployer in development, editing files under a deployment
directory by hand no longer shows up until the entry is evicted. Production
deployments are unaffected, since each one writes to a new directory. Setting
the budget to zero turns the cache off.

Passing: integrations, hosting.